### PR TITLE
Benny/edit nft endpoint

### DIFF
--- a/glry_core/glry_utils.go
+++ b/glry_core/glry_utils.go
@@ -1,6 +1,10 @@
 package glry_core
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+
 	gfcore "github.com/gloflow/gloflow/go/gf_core"
 )
 
@@ -18,5 +22,27 @@ func Validate(pInput interface{},
 		return gErr
 	}
 
+	return nil
+}
+
+//-------------------------------------------------------------
+// UNMARSHALL BODY
+// input must be a pointer to a struct with json tags
+func UnmarshalBody(pInput interface{}, body io.Reader, pRuntime *Runtime) *gfcore.Gf_error {
+	buf := &bytes.Buffer{}
+
+	_, err := io.Copy(buf, body)
+	if err != nil {
+		return gfcore.Error__create("unable to read bytes of body",
+			"io_reader_error",
+			map[string]interface{}{}, err, "glry_core", pRuntime.RuntimeSys)
+	}
+
+	err = json.Unmarshal(buf.Bytes(), pInput)
+	if err != nil {
+		return gfcore.Error__create("unable to unmarshal body into struct",
+			"io_reader_error",
+			map[string]interface{}{}, err, "glry_core", pRuntime.RuntimeSys)
+	}
 	return nil
 }

--- a/glry_db/glry_auth.go
+++ b/glry_db/glry_auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+
 	gf_core "github.com/gloflow/gloflow/go/gf_core"
 	"github.com/mikeydub/go-gallery/glry_core"
 	"github.com/mitchellh/mapstructure"

--- a/glry_db/glry_nft.go
+++ b/glry_db/glry_nft.go
@@ -155,10 +155,35 @@ func NFTgetByID(pIDstr string, pCtx context.Context, pRuntime *glry_core.Runtime
 	if err := cur.All(pCtx, &result); err != nil {
 		return nil, gfcore.Error__create("nft id not found in query values",
 			"mongodb_cursor_all",
-			map[string]interface{}{}, err, "glry_core", pRuntime.RuntimeSys)
+			map[string]interface{}{}, err, "glry_db", pRuntime.RuntimeSys)
 	}
 
 	return result, nil
+
+}
+
+//-------------------------------------------------------------
+
+// NOTE: there is no gfcore mongo func for update... using default mongo lib for now
+func NFTupdateById(pIDstr string, updatedNft *GLRYnft, pCtx context.Context, pRuntime *glry_core.Runtime) *gfcore.Gf_error {
+
+	opts := &options.FindOptions{}
+	if deadline, ok := pCtx.Deadline(); ok {
+		dur := time.Until(deadline)
+		opts.MaxTime = &dur
+	}
+
+	col := pRuntime.RuntimeSys.Mongo_db.Collection("glry_nfts")
+
+	updateResult, err := col.UpdateOne(pCtx, bson.D{{"_id", pIDstr}}, bson.D{{"$set", updatedNft}})
+
+	if err != nil || updateResult.ModifiedCount == 0 {
+		return gfcore.Error__create("unable to update nft",
+			"mongodb_update_error",
+			map[string]interface{}{}, err, "glry_db", pRuntime.RuntimeSys)
+	}
+
+	return nil
 
 }
 

--- a/glry_db/glry_nft.go
+++ b/glry_db/glry_nft.go
@@ -141,7 +141,7 @@ func NFTgetByID(pIDstr string, pCtx context.Context, pRuntime *glry_core.Runtime
 
 	col := pRuntime.RuntimeSys.Mongo_db.Collection("glry_nfts")
 
-	cur, gErr := gfcore.Mongo__find(bson.M{"_id": pIDstr},
+	cur, gErr := gfcore.Mongo__find(bson.M{"_id": pIDstr, "deleted": false},
 		opts,
 		map[string]interface{}{},
 		col,

--- a/glry_db/glry_nft.go
+++ b/glry_db/glry_nft.go
@@ -167,10 +167,11 @@ func NFTgetByID(pIDstr string, pCtx context.Context, pRuntime *glry_core.Runtime
 // NOTE: there is no gfcore mongo func for update... using default mongo lib for now
 func NFTupdateById(pIDstr string, updatedNft *GLRYnft, pCtx context.Context, pRuntime *glry_core.Runtime) *gfcore.Gf_error {
 
-	opts := &options.FindOptions{}
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.MaxTime = &dur
+	//------------------
+	// VALIDATE
+	gErr := glry_core.Validate(updatedNft, pRuntime)
+	if gErr != nil {
+		return gErr
 	}
 
 	col := pRuntime.RuntimeSys.Mongo_db.Collection("glry_nfts")

--- a/glry_db/t__nft_test.go
+++ b/glry_db/t__nft_test.go
@@ -58,6 +58,30 @@ func TestCreateAndGetNFT(pTest *testing.T) {
 		pTest.Fail()
 	}
 
+	singleNft := results[0]
+
+	singleNft.DescriptionStr = "Testing this out"
+
+	gErr = NFTupdateById(string(id), singleNft, ctx, runtime)
+
+	if gErr != nil {
+		pTest.Fail()
+	}
+
+	newResults, gErr := NFTgetByID(string(id), ctx, runtime)
+	if gErr != nil {
+		pTest.Fail()
+	}
+	if len(newResults) == 0 {
+		pTest.Fail()
+	}
+
+	updatedNft := newResults[0]
+
+	if updatedNft.DescriptionStr != "Testing this out" {
+		pTest.Fail()
+	}
+
 	res, err := runtime.DB.MongoDB.Collection("glry_nfts").DeleteOne(ctx, bson.M{"_id": id})
 	if err != nil {
 		pTest.Fail()

--- a/glry_lib/glry_auth.go
+++ b/glry_lib/glry_auth.go
@@ -3,9 +3,11 @@ package glry_lib
 import (
 	"context"
 	"fmt"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"math/rand"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
 	// log "github.com/sirupsen/logrus"
 	gf_core "github.com/gloflow/gloflow/go/gf_core"
 	"github.com/mikeydub/go-gallery/glry_core"

--- a/glry_lib/glry_http_handlers.go
+++ b/glry_lib/glry_http_handlers.go
@@ -1,10 +1,7 @@
 package glry_lib
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 
 	// "time"
 	"context"
@@ -225,29 +222,14 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 						}, nil, "glry_lib", pRuntime.RuntimeSys)
 				}
 
-				buf := &bytes.Buffer{}
-
-				_, err := io.Copy(buf, pReq.Body)
-				if err != nil {
-					return nil, gf_core.Error__create("unable to read bytes of body",
-						"io_reader_error",
-						map[string]interface{}{
-							"uri": "/glry/v1/nfts/update",
-						}, err, "glry_lib", pRuntime.RuntimeSys)
-				}
-
 				nft := &glry_db.GLRYnft{}
 
-				err = json.Unmarshal(buf.Bytes(), nft)
-				if err != nil {
-					return nil, gf_core.Error__create("unable to unmarshal body; expecting nft",
-						"io_reader_error",
-						map[string]interface{}{
-							"uri": "/glry/v1/nfts/update",
-						}, err, "glry_lib", pRuntime.RuntimeSys)
+				gErr := glry_core.UnmarshalBody(nft, pReq.Body, pRuntime)
+				if gErr != nil {
+					return nil, gErr
 				}
 
-				gErr := glry_db.NFTupdateById(nftIDstr, nft, pCtx, pRuntime)
+				gErr = glry_db.NFTupdateById(nftIDstr, nft, pCtx, pRuntime)
 				if gErr != nil {
 					return nil, gErr
 				}

--- a/glry_lib/glry_http_handlers.go
+++ b/glry_lib/glry_http_handlers.go
@@ -168,12 +168,20 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 						"http_client_req_error",
 						map[string]interface{}{
 							"uri": "/glry/v1/nfts/get",
-						}, nil, "glry_core", pRuntime.RuntimeSys)
+						}, nil, "glry_lib", pRuntime.RuntimeSys)
 				}
 
 				nfts, gErr := glry_db.NFTgetByID(nftIDstr, pCtx, pRuntime)
 				if gErr != nil {
 					return nil, gErr
+				}
+
+				if len(nfts) == 0 {
+					return nil, gf_core.Error__create(fmt.Sprintf("no nfts found with id: %s", nftIDstr),
+						"http_client_req_error",
+						map[string]interface{}{
+							"uri": "/glry/v1/nfts/get",
+						}, nil, "glry_lib", pRuntime.RuntimeSys)
 				}
 
 				//------------------

--- a/glry_lib/glry_http_handlers.go
+++ b/glry_lib/glry_http_handlers.go
@@ -151,7 +151,7 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 	gf_rpc_lib.Create_handler__http("/glry/v1/nfts/get",
 		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
 
-			if pReq.Method == "GET" {
+			if pReq.Method == http.MethodGet {
 
 				//------------------
 				// INPUT
@@ -189,6 +189,67 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 				dataMap := map[string]interface{}{
 					"nfts": nfts,
 				}
+
+				//------------------
+				return dataMap, nil
+			}
+
+			return nil, nil
+		},
+		pRuntime.RuntimeSys)
+
+	// SINGLE UPDATE
+	gf_rpc_lib.Create_handler__http("/glry/v1/nfts/update",
+		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+
+			if pReq.Method == http.MethodPatch {
+
+				//------------------
+				// INPUT
+
+				//------------------
+
+				pReq.ParseForm()
+
+				nftIDstr := pReq.FormValue("id")
+
+				// TODO any other values that could be potentially changed here
+
+				nftCollectorsNote := pReq.FormValue("collectors_note")
+
+				if nftIDstr == "" {
+					// is this the right way to create an error for gf_core?
+					return nil, gf_core.Error__create("no id found in form values",
+						"http_client_req_error",
+						map[string]interface{}{
+							"uri": "/glry/v1/nfts/get",
+						}, nil, "glry_lib", pRuntime.RuntimeSys)
+				}
+
+				nfts, gErr := glry_db.NFTgetByID(nftIDstr, pCtx, pRuntime)
+				if gErr != nil {
+					return nil, gErr
+				}
+
+				if len(nfts) == 0 {
+					return nil, gf_core.Error__create(fmt.Sprintf("no nfts found with id: %s", nftIDstr),
+						"http_client_req_error",
+						map[string]interface{}{
+							"uri": "/glry/v1/nfts/get",
+						}, nil, "glry_lib", pRuntime.RuntimeSys)
+				}
+
+				for _, nft := range nfts {
+					nft.DescriptionStr = nftCollectorsNote
+					gErr := glry_db.NFTupdateById(nftIDstr, nft, pCtx, pRuntime)
+					if gErr != nil {
+						return nil, gErr
+					}
+				}
+
+				//------------------
+				// OUTPUT
+				dataMap := map[string]interface{}{}
 
 				//------------------
 				return dataMap, nil


### PR DESCRIPTION
Changes:

- **Added** error handle for single nft get empty result possibility
- **Added** endpoint for updating nft by id
- **Added** mongo function for updating nft by id
- **Changed** nft mongo test function to also run an update after creation

Considerations:

- In the update http handler, I chose to loop over the results of find nft and update each nft rather than grabbing the first nft from the find results (assuming there should only ever be one nft per id anyway) and just updating that one. Either way it will only update one nft and that loop should only ever run once but is it a better idea to instead grab `nfts[0]` and just update that one? We could also add a check to ensure that the length of `nfts` is always one. 
- Is `http.MethodPatch` the right method we would like to use for updates? Or is `http.MethodPost` better and the endpoint itself ending in update will be what differentiates it from e.g. a create nft request. 
- The mongo function for updating an nft by id utilizes the mongo go library instead of `gfcore` because `gfcore` did not have a function that I could find for updating. I did see a function for upserting, however, and I was wondering if it would be worth it to use `gfcore.Mongo__upsert()`, use the mongo lib like is currently implemented, wait for a possible update to `gfcore` to add an update func, or another reason why we are not using a mongo update altogether?