### PR TITLE
field adjustments to collection struct

### DIFF
--- a/glry_db/glry_collection.go
+++ b/glry_db/glry_collection.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/gloflow/gloflow/go/gf_core"
 	"github.com/mikeydub/go-gallery/glry_core"
 	"go.mongodb.org/mongo-driver/bson"
@@ -19,13 +20,13 @@ type GLRYcollection struct {
 	CreationTimeF float64    `bson:"creation_time" json:"creation_time"`
 	DeletedBool   bool       `bson:"deleted"`
 
-	NameStr        string   `bson:"name"          json:"name"`
-	DescriptionStr string   `bson:"description"   json:"description"`
-	OwnerUserIDstr string   `bson:"owner_user_id" json:"owner_user_id"`
-	NFTsLst        []string `bson:"nfts"          json:"nfts"`
+	NameStr           string   `bson:"name"          json:"name"`
+	CollectorsNoteStr string   `bson:"collectors_note"   json:"collectors_note"`
+	OwnerUserIDstr    string   `bson:"owner_user_id" json:"owner_user_id"`
+	NFTsLst           []string `bson:"nfts"          json:"nfts"`
 
 	// collections can be hidden from public-viewing
-	HiddeBool bool `bson:"hidden"`
+	HiddenBool bool `bson:"hidden" json:"hidden"`
 }
 
 //-------------------------------------------------------------


### PR DESCRIPTION
Changes:

- Small changes to collection struct as mentioned in https://github.com/gallery-so/go-gallery/issues/38

Considerations:

- bson tags can have an optional `,omitempty` such as `bson:"contract_name,omitempty"` that will make sure that empty falsy fields are not put into mongo when a struct field is it's 0 value. Which fields do we want to have omitempty? My vote is that most fields should have omitempty and only the required ones don't
