### PR TITLE
minor adjustments to user struct fields

### DIFF
--- a/glry_db/glry_auth.go
+++ b/glry_db/glry_auth.go
@@ -28,13 +28,9 @@ type GLRYuser struct {
 	CreationTimeF float64    `bson:"creation_time" json:"creation_time"`
 	DeletedBool   bool       `bson:"deleted"`
 
-	UserNameStr    string            `bson:"name"         json:"name"`      // mutable
-	AddressesLst   []GLRYuserAddress `bson:"addresses     json:"addresses"` // IMPORTANT!! - users can have multiple addresses associated with their account
-	DescriptionStr string            `bson:"description"  json:"description"`
-
-	// LAST_SEEN - last time user logged or out? or some other metric?
-	// FINISH!!  - nothing is setting this yet.
-	LastSeenTimeF float64
+	UserNameStr  string            `bson:"name"         json:"name"`       // mutable
+	AddressesLst []GLRYuserAddress `bson:"addresses"     json:"addresses"` // IMPORTANT!! - users can have multiple addresses associated with their account
+	BioStr       string            `bson:"bio"  json:"bio"`
 }
 
 // USER_NONCE


### PR DESCRIPTION
Changes:

- Small changes to collection struct as mentioned in https://github.com/gallery-so/go-gallery/issues/38

Considerations:

- bson tags can have an optional `,omitempty` such as `bson:"contract_name,omitempty"` that will make sure that empty falsy fields are not put into mongo when a struct field is it's 0 value. Which fields do we want to have omitempty? My vote is that most fields should have omitempty and only the required ones don't
