### PR TITLE
Benny/jwt middleware

### DIFF
--- a/glry_db/glry_auth.go
+++ b/glry_db/glry_auth.go
@@ -52,17 +52,6 @@ type GLRYuserNonce struct {
 	AddressStr GLRYuserAddress `bson:"address" mapstructure:"address"`
 }
 
-// USER_JWT_KEY - is unique per user, and stored in the DB for now.
-type GLRYuserJWTkey struct {
-	VersionInt    int64            `bson:"version"       mapstructure:"version"`
-	ID            GLRYuserJWTkeyID `bson:"_id"           mapstructure:"_id"`
-	CreationTimeF float64          `bson:"creation_time" mapstructure:"creation_time"`
-	DeletedBool   bool             `bson:"deleted"       mapstructure:"deleted"`
-
-	ValueStr   string          `bson:"value"   mapstructure:"value"`
-	AddressStr GLRYuserAddress `bson:"address" mapstructure:"address"`
-}
-
 // USER_LOGIN_ATTEMPT
 type GLRYuserLoginAttempt struct {
 	VersionInt    int64              `bson:"version"`
@@ -85,70 +74,6 @@ type GLRYuserLoginAttempt struct {
 type GLRYuserUpdate struct {
 	CreationTimeF float64 `bson:"creation_time"`
 	NameNewStr    string  `bson:"name_new"`
-}
-
-//-------------------------------------------------------------
-// JWT
-//-------------------------------------------------------------
-// GET
-func AuthUserJWTkeyGet(pUserAddressStr GLRYuserAddress,
-	pCtx context.Context,
-	pRuntime *glry_core.Runtime) (*GLRYuserJWTkey, *gf_core.Gf_error) {
-
-	record, gErr := gf_core.MongoFindLatest(bson.M{
-		"address": pUserAddressStr,
-		"deleted": false,
-	},
-		"creation_time", // p_time_field_name_str
-		map[string]interface{}{
-			"address":            pUserAddressStr,
-			"caller_err_msg_str": "failed to get JWT key from DB",
-		},
-		pRuntime.DB.MongoDB.Collection("glry_users_jwt_keys"),
-		pCtx,
-		pRuntime.RuntimeSys)
-	if gErr != nil {
-		return nil, gErr
-	}
-
-	var JWTkey GLRYuserJWTkey
-	err := mapstructure.Decode(record, &JWTkey)
-	if err != nil {
-		gErr := gf_core.Error__create("failed to load DB result of GLRYuserJWTkey into its struct",
-			"mapstruct__decode",
-			map[string]interface{}{
-				"address": pUserAddressStr,
-			},
-			err, "glry_db", pRuntime.RuntimeSys)
-		return nil, gErr
-	}
-
-	// spew.Dump(JWTkey)
-
-	return &JWTkey, nil
-}
-
-//-------------------------------------------------------------
-// CREATE
-
-func AuthUserJWTkeyCreate(pJWTkey *GLRYuserJWTkey,
-	pCtx context.Context,
-	pRuntime *glry_core.Runtime) *gf_core.Gf_error {
-
-	collNameStr := "glry_users_jwt_keys"
-	gErr := gf_core.Mongo__insert(pJWTkey,
-		collNameStr,
-		map[string]interface{}{
-			"address":        pJWTkey.AddressStr,
-			"caller_err_msg": "failed to insert a new GLRYuserJWTkey into the DB",
-		},
-		pCtx,
-		pRuntime.RuntimeSys)
-	if gErr != nil {
-		return gErr
-	}
-
-	return nil
 }
 
 //-------------------------------------------------------------

--- a/glry_lib/glry_http_handlers.go
+++ b/glry_lib/glry_http_handlers.go
@@ -2,8 +2,6 @@ package glry_lib
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	// "time"
 	"context"
@@ -330,50 +328,4 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 		pRuntime.RuntimeSys)
 
 	//-------------------------------------------------------------
-}
-
-// information to be added to context with middlewares
-type contextKey string
-
-type authContextValue struct {
-	AuthenticatedBool bool
-	UserAddressStr    string
-}
-
-// jwt middleware
-// parameter hell because gf_core http_handler is private :(
-// both funcs (param and return funcs) are of type gf_core.http_handler implicitly
-func precheckJwt(midd func(pCtx context.Context, pResp http.ResponseWriter,
-	pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error), pRuntime *glry_core.Runtime) func(context.Context, http.ResponseWriter,
-	*http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-	return func(pCtx context.Context, pResp http.ResponseWriter,
-		pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-
-		authHeaders := strings.Split(pReq.Header.Get("Authorization"), " ")
-		if len(authHeaders) > 0 {
-			// get string after "Bearer"
-			jwt := authHeaders[1]
-			// use an env variable as jwt secret as upposed to using a stateful secret stored in
-			// database that is unique to every user and session
-			valid, userAddr, gErr := AuthJWTverify(jwt, os.Getenv("JWT_SECRET"), pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			// using a struct for storing values with a kard
-			pCtx = context.WithValue(pCtx, contextKey("auth"), authContextValue{
-				AuthenticatedBool: valid,
-				UserAddressStr:    userAddr,
-			})
-		}
-		return midd(pCtx, pResp, pReq)
-	}
-}
-
-func getAuthFromCtx(pCtx context.Context) bool {
-	if value, ok := pCtx.Value("auth").(authContextValue); ok {
-		return value.AuthenticatedBool
-	} else {
-		return false
-	}
 }

--- a/glry_lib/glry_http_middlewares.go
+++ b/glry_lib/glry_http_middlewares.go
@@ -1,0 +1,58 @@
+package glry_lib
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+
+	gf_core "github.com/gloflow/gloflow/go/gf_core"
+	"github.com/mikeydub/go-gallery/glry_core"
+)
+
+// information to be added to context with middlewares
+type contextKey string
+
+type authContextValue struct {
+	AuthenticatedBool bool
+	UserAddressStr    string
+}
+
+// jwt middleware
+// parameter hell because gf_core http_handler is private :(
+// both funcs (param and return funcs) are of type gf_core.http_handler implicitly
+func precheckJwt(midd func(pCtx context.Context, pResp http.ResponseWriter,
+	pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error), pRuntime *glry_core.Runtime) func(context.Context, http.ResponseWriter,
+	*http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	return func(pCtx context.Context, pResp http.ResponseWriter,
+		pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+
+		authHeaders := strings.Split(pReq.Header.Get("Authorization"), " ")
+		if len(authHeaders) > 0 {
+			// get string after "Bearer"
+			jwt := authHeaders[1]
+			// use an env variable as jwt secret as upposed to using a stateful secret stored in
+			// database that is unique to every user and session
+			valid, userAddr, gErr := AuthJWTverify(jwt, os.Getenv("JWT_SECRET"), pRuntime)
+			if gErr != nil {
+				return nil, gErr
+			}
+
+			// using a struct for storing values with a kard
+			pCtx = context.WithValue(pCtx, contextKey("auth"), authContextValue{
+				AuthenticatedBool: valid,
+				UserAddressStr:    userAddr,
+			})
+		}
+		return midd(pCtx, pResp, pReq)
+	}
+}
+
+// helper func to get the current auth bool from the context
+func getAuthFromCtx(pCtx context.Context) bool {
+	if value, ok := pCtx.Value("auth").(authContextValue); ok {
+		return value.AuthenticatedBool
+	} else {
+		return false
+	}
+}

--- a/glry_lib/glry_http_middlewares.go
+++ b/glry_lib/glry_http_middlewares.go
@@ -21,14 +21,24 @@ type authContextValue struct {
 // jwt middleware
 // parameter hell because gf_core http_handler is private :(
 // both funcs (parameter and return funcs) are of type gf_core.http_handler implicitly
-func precheckJwt(midd func(pCtx context.Context, pResp http.ResponseWriter,
-	pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error), pRuntime *glry_core.Runtime) func(context.Context, http.ResponseWriter,
+func precheckJwt(midd func(pCtx context.Context,
+	pResp http.ResponseWriter,
+	pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error),
+	pRuntime *glry_core.Runtime) func(context.Context,
+	http.ResponseWriter,
 	*http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-	return func(pCtx context.Context, pResp http.ResponseWriter,
+	return func(pCtx context.Context,
+		pResp http.ResponseWriter,
 		pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
 
 		authHeaders := strings.Split(pReq.Header.Get("Authorization"), " ")
-		if len(authHeaders) > 0 {
+		if len(authHeaders) > 0 && len(authHeaders) < 2 {
+			if authHeaders[0] != "Bearer" {
+				return nil, gf_core.Error__create("incorrect authorization header format",
+					"http_client_req_error",
+					map[string]interface{}{},
+					nil, "glry_lib", pRuntime.RuntimeSys)
+			}
 			// get string after "Bearer"
 			jwt := authHeaders[1]
 			// use an env variable as jwt secret as upposed to using a stateful secret stored in

--- a/glry_lib/glry_http_middlewares.go
+++ b/glry_lib/glry_http_middlewares.go
@@ -20,7 +20,7 @@ type authContextValue struct {
 
 // jwt middleware
 // parameter hell because gf_core http_handler is private :(
-// both funcs (param and return funcs) are of type gf_core.http_handler implicitly
+// both funcs (parameter and return funcs) are of type gf_core.http_handler implicitly
 func precheckJwt(midd func(pCtx context.Context, pResp http.ResponseWriter,
 	pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error), pRuntime *glry_core.Runtime) func(context.Context, http.ResponseWriter,
 	*http.Request) (map[string]interface{}, *gf_core.Gf_error) {

--- a/glry_lib/t__auth_jwt_test.go
+++ b/glry_lib/t__auth_jwt_test.go
@@ -3,16 +3,19 @@ package glry_lib
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
 	// gfcore "github.com/gloflow/gloflow/go/gf_core"
 	"github.com/mikeydub/go-gallery/glry_core"
 	"github.com/mikeydub/go-gallery/glry_db"
 	// "github.com/davecgh/go-spew/spew"
 )
 
+// TODO change tests to reflect changes to jwt
 //---------------------------------------------------
 func TestAuthJWT(pTest *testing.T) {
 


### PR DESCRIPTION
Changes:

- **Added** jwt middleware function that will add a value to context including whether the user is authenticated with a jwt and if so their user address (what is this address that is being stored in the jwt claims?)
- **Added** the middleware to the functions that were verifying jwt's and used context to determine the cases where the authentication information was needed
- **Changed** auth db to no longer store jwts and no longer handle anything related to jwts and http
- **Changed** the verify jwt func to also return the address from the claims it parses

Considerations:

- Middlewares currently require a parameter hell to create because `gf_core.http_handler` is private meaning that instead of `func middleware(gf_core.http_handler, pRuntime) gf_core.http_handler` we have `func middleware(midd func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error), pRuntime *glry_core.Runtime) func(context.Context, http.ResponseWriter, *http.Request) (map[string]interface{}, *gf_core.Gf_error)`. Do we want to adjust the way we handle http, possibly write different http wrappers, use another library, etc.?
- Previously, the secret signing key that was being used to sign the jwts was a randomly generated string that was stored with the jwt in the database. Because we are trying to move to stateless jwt, this is harder to do. **Option one** (currently implemented) is using an env variable as a secret for all jwt's. Less secure but as long as we don't accidentally commit the key to the repo we should be find, and if we do mess up, pushing a new key to production would just force everyone to log out which is not the end of the world. **Option two** is store a random key in the redis with the blacklisted jwts seeing as we are going to have to check the redis every time someone uses a jwt anyway. More secure but almost as stateful as the previous solution; only difference being redis instead of mongo. **Option three** is anything else we can come up with. I vote for option one.
- Currently I am attaching a key value pair of string to struct to the context of the middleware which will be accessible to all further funcs using that context. For example, in the currently implemented jwt middleware it will attach a key value pair of `"auth": {Authenticated: bool, UserAddress: string}`. In this implementation the value struct has very explicit fields. We could also, however, store the value as a map and retrieve items with `pCtx.Value("auth").(map[string]interface{})["authenticated"]`. The final solution I can think of is have the key value pair be `"authenticated" => bool` and attach another key, value pair for `"user_address" => string`. This could get really messy in code, though, because a new context has to be created for every key value pair that basically copies the last context and adds a new key value pair, and if there are a lot of fields to be added in a middleware we want down the line it would require a lot more lines of code and way more memory allocations.