### PR TITLE
http-framework

### DIFF
--- a/glry_core/glry_runtime.go
+++ b/glry_core/glry_runtime.go
@@ -4,14 +4,17 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
 	"github.com/gloflow/gloflow/go/gf_core"
 	"github.com/go-playground/validator"
 	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/mongo"
-	"io/ioutil"
-	"os"
-	"os/exec"
+
 	// "github.com/davecgh/go-spew/spew"
+	"github.com/gin-gonic/gin"
 )
 
 //-------------------------------------------------------------
@@ -20,6 +23,7 @@ type Runtime struct {
 	DB         *DB
 	Validator  *validator.Validate
 	RuntimeSys *gf_core.Runtime_sys
+	Router     *gin.Engine
 }
 
 type DB struct {

--- a/glry_lib/glry_auth_http_handlers.go
+++ b/glry_lib/glry_auth_http_handlers.go
@@ -47,7 +47,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 
 	usersGroup.POST("/login", func(c *gin.Context) {
 		input := &GLRYauthUserLoginInput{}
-		if err := c.BindJSON(input); err != nil {
+		if err := c.ShouldBindJSON(input); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -85,14 +85,14 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 
 	usersGroup.POST("/update", func(c *gin.Context) {
 
-		if auth, ok := getAuthFromCtx(c); !ok || !auth.AuthenticatedBool {
+		if auth := c.GetBool("authenticated"); !auth {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization required"})
 			return
 		}
 
 		up := &GLRYauthUserUpdateInput{}
 
-		if err := c.BindJSON(up); err != nil {
+		if err := c.ShouldBindJSON(up); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -115,7 +115,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 
 	usersGroup.GET("/get", func(c *gin.Context) {
 
-		auth, _ := getAuthFromCtx(c)
+		auth := c.GetBool("authenticated")
 
 		userAddrStr := c.Query("addr")
 		input := &GLRYauthUserGetInput{
@@ -123,7 +123,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 		}
 
 		output, gErr := AuthUserGetPipeline(input,
-			auth.AuthenticatedBool,
+			auth,
 			c, pRuntime)
 		if gErr != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
@@ -145,7 +145,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 
 		input := &GLRYauthUserCreateInput{}
 
-		if err := c.BindJSON(input); err != nil {
+		if err := c.ShouldBindJSON(input); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}

--- a/glry_lib/glry_auth_http_handlers.go
+++ b/glry_lib/glry_auth_http_handlers.go
@@ -2,21 +2,20 @@ package glry_lib
 
 import (
 	// "fmt"
-	"context"
+
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	gf_core "github.com/gloflow/gloflow/go/gf_core"
-	gf_rpc_lib "github.com/gloflow/gloflow/go/gf_rpc_lib"
 	"github.com/mikeydub/go-gallery/glry_core"
 	"github.com/mikeydub/go-gallery/glry_db"
-	"github.com/mitchellh/mapstructure"
-	log "github.com/sirupsen/logrus"
 	// "github.com/davecgh/go-spew/spew"
 )
 
 //-------------------------------------------------------------
-func AuthHandlersInit(pRuntime *glry_core.Runtime) {
+func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
+
+	usersGroup := parent.Group("/users")
+	usersGroup.Use(jwtMiddleware(pRuntime))
 
 	//-------------------------------------------------------------
 	// AUTH_GET_PREFLIGHT
@@ -25,292 +24,162 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime) {
 	// called before login/sugnup calls, mostly to get nonce and also discover if user exists.
 
 	// [GET] /glry/v1/auth/get_preflight?addr=:walletAddress
-	gf_rpc_lib.Create_handler__http("/glry/v1/auth/get_preflight",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	usersGroup.GET("/auth/get_preflight", func(c *gin.Context) {
+		userAddrStr := c.Query("addr")
+		input := &GLRYauthUserGetPreflightInput{
+			AddressStr: glry_db.GLRYuserAddress(userAddrStr),
+		}
+		// GET_PUBLIC_INFO
+		output, gErr := AuthUserGetPreflightPipeline(input, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-			log.WithFields(log.Fields{}).Debug("/glry/v1/auth/get_preflight")
-
-			//------------------
-			// INPUT
-
-			qMap := pReq.URL.Query()
-			userAddrStr := qMap["addr"][0]
-
-			input := &GLRYauthUserGetPreflightInput{
-				AddressStr: glry_db.GLRYuserAddress(userAddrStr),
-			}
-
-			//------------------
-
-			// GET_PUBLIC_INFO
-			output, gErr := AuthUserGetPreflightPipeline(input, pCtx, pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{
-				"nonce":       output.NonceStr,
-				"user_exists": output.UserExistsBool,
-			}
-
-			//------------------
-
-			return dataMap, nil
-		},
-		pRuntime.RuntimeSys)
+		//------------------
+		// OUTPUT
+		c.JSON(http.StatusOK, gin.H{
+			"nonce":       output.NonceStr,
+			"user_exists": output.UserExistsBool,
+		})
+	})
 
 	//-------------------------------------------------------------
 	// AUTH_USER_LOGIN
 	// UN-AUTHENTICATED
 
-	gf_rpc_lib.Create_handler__http("/glry/v1/users/login",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	usersGroup.POST("/login", func(c *gin.Context) {
+		input := &GLRYauthUserLoginInput{}
+		if err := c.BindJSON(input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 
-			//------------------
-			// INPUT
+		//------------------
 
-			inputMap, gErr := gf_rpc_lib.Get_http_input(pResp, pReq, pRuntime.RuntimeSys)
-			if gErr != nil {
-				return nil, gErr
-			}
+		// USER_LOGIN__PIPELINE
+		output, gErr := AuthUserLoginAndMemorizeAttemptPipeline(input,
+			c.Request,
+			c,
+			pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-			var input GLRYauthUserLoginInput
-			err := mapstructure.Decode(inputMap, &input)
-			if err != nil {
-				gf_err := gf_core.Error__create("failed to load input map into GLRYauthUserLoginInput struct",
-					"mapstruct__decode",
-					map[string]interface{}{},
-					err, "glry_lib", pRuntime.RuntimeSys)
-				return nil, gf_err
-			}
+		// FAILED - INVALID_SIGNATURE
+		if !output.SignatureValidBool {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"sig_valid": false,
+			})
+			return
+		}
 
-			//------------------
+		/*
+			// ADD!! - going forward we should follow this approach, after v1
+			// SET_JWT_COOKIE
+			expirationTime := time.Now().Add(time.Duration(pRuntime.Config.JWTtokenTTLsecInt/60) * time.Minute)
+			http.SetCookie(pResp, &http.Cookie{
+				Name:    "glry_token",
+				Value:   userJWTtokenStr,
+				Expires: expirationTime,
+			})*/
 
-			// USER_LOGIN__PIPELINE
-			output, gErr := AuthUserLoginAndMemorizeAttemptPipeline(&input,
-				pReq,
-				pCtx,
-				pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			// FAILED - INVALID_SIGNATURE
-			if !output.SignatureValidBool {
-				dataMap := map[string]interface{}{
-					"sig_valid": false,
-				}
-				return dataMap, nil
-			}
-
-			/*
-				// ADD!! - going forward we should follow this approach, after v1
-				// SET_JWT_COOKIE
-				expirationTime := time.Now().Add(time.Duration(pRuntime.Config.JWTtokenTTLsecInt/60) * time.Minute)
-				http.SetCookie(pResp, &http.Cookie{
-					Name:    "glry_token",
-					Value:   userJWTtokenStr,
-					Expires: expirationTime,
-				})*/
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{
-				"jwt_token": output.JWTtokenStr,
-				"user_id":   output.UserIDstr,
-			}
-
-			//------------------
-
-			return dataMap, nil
-		},
-		pRuntime.RuntimeSys)
+		//------------------
+		// OUTPUT
+		c.JSON(http.StatusOK, gin.H{
+			"jwt_token": output.JWTtokenStr,
+			"user_id":   output.UserIDstr,
+		})
+	})
 
 	//-------------------------------------------------------------
 	// USER_UPDATE
 	// AUTHENTICATED
 
-	pRuntime.Router.POST("/glry/v1/users/update", jwtMiddleware(), func(c *gin.Context) {
+	usersGroup.POST("/update", func(c *gin.Context) {
 
-		if !getAuthFromGinCtx(c) {
+		if auth, ok := getAuthFromCtx(c); !ok || !auth.AuthenticatedBool {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization required"})
 			return
 		}
-		// blah blah more code
+
+		up := &GLRYauthUserUpdateInput{}
+
+		if err := c.BindJSON(up); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		//------------------
+		// UPDATE
+		gErr := AuthUserUpdatePipeline(up, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
+		//------------------
+		// OUTPUT
+		c.Status(http.StatusOK)
 	})
-
-	gf_rpc_lib.Create_handler__http("/glry/v1/users/update",
-		precheckJwt(func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-
-			if !getAuthFromCtx(pCtx) {
-				return nil, gf_core.Error__create("jwt authentication required",
-					"http_client_req_error",
-					map[string]interface{}{}, nil,
-					"glry_lib", pRuntime.RuntimeSys)
-			}
-			//------------------
-			// INPUT
-			qMap := pReq.URL.Query()
-			userAddrStr := qMap["addr"][0]
-
-			inputMap, gErr := gf_rpc_lib.Get_http_input(pResp, pReq, pRuntime.RuntimeSys)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			var input GLRYauthUserUpdateInput
-			err := mapstructure.Decode(inputMap, &input)
-			if err != nil {
-				gf_err := gf_core.Error__create("failed to load input map into GLRYauthUserUpdateInput struct",
-					"mapstruct__decode",
-					map[string]interface{}{},
-					err, "glry_lib", pRuntime.RuntimeSys)
-				return nil, gf_err
-			}
-
-			input.AddressStr = glry_db.GLRYuserAddress(userAddrStr)
-
-			//------------------
-			// UPDATE
-			gErr = AuthUserUpdatePipeline(&input, pCtx, pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{}
-
-			//------------------
-
-			return dataMap, nil
-		}, pRuntime),
-		pRuntime.RuntimeSys)
 
 	//-------------------------------------------------------------
 	// USER_GET
 	// AUTHENTICATED/UN-AUTHENTICATED
 
-	gf_rpc_lib.Create_handler__http("/glry/v1/users/get",
-		precheckJwt(func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	usersGroup.GET("/get", func(c *gin.Context) {
 
-			authenticated := getAuthFromCtx(pCtx)
+		auth, _ := getAuthFromCtx(c)
 
-			//------------------
-			// INPUT
+		userAddrStr := c.Query("addr")
+		input := &GLRYauthUserGetInput{
+			AddressStr: glry_db.GLRYuserAddress(userAddrStr),
+		}
 
-			qMap := pReq.URL.Query()
-			userAddrStr := qMap["addr"][0]
+		output, gErr := AuthUserGetPipeline(input,
+			auth.AuthenticatedBool,
+			c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-			input := &GLRYauthUserGetInput{
-				AddressStr: glry_db.GLRYuserAddress(userAddrStr),
-			}
+		//------------------
+		// OUTPUT
 
-			//------------------
-			// USER_GET
+		c.JSON(http.StatusOK, output)
 
-			var output *GLRYauthUserGetOutput
-
-			// AUTHENTICATED
-			if authenticated {
-				o, gErr := AuthUserGetPipeline(input,
-					authenticated,
-					pCtx, pRuntime)
-				if gErr != nil {
-					return nil, gErr
-				}
-				output = o
-			} else {
-				// UN_AUTHENTICATED - different set of results for user not-authenticated
-				o, gErr := AuthUserGetPipeline(input,
-					authenticated, // pAuthenticatedBool
-					pCtx, pRuntime)
-				if gErr != nil {
-					return nil, gErr
-				}
-				output = o
-
-			}
-
-			//------------------
-			// OUTPUT
-
-			var dataMap map[string]interface{}
-			err := mapstructure.Decode(output, &dataMap)
-			if err != nil {
-				gf_err := gf_core.Error__create("failed to load user_get pipeline output into a map",
-					"mapstruct__decode",
-					map[string]interface{}{},
-					err, "glry_lib", pRuntime.RuntimeSys)
-				return nil, gf_err
-			}
-
-			// dataMap := map[string]interface{}{
-			// 	"username":    output.UserNameStr,
-			// 	"description": output.DescriptionStr,
-			// }
-
-			//------------------
-
-			return dataMap, nil
-		}, pRuntime),
-		pRuntime.RuntimeSys)
+	})
 
 	//-------------------------------------------------------------
 	// USER_CREATE
 	// UN-AUTHENTICATED
 
-	gf_rpc_lib.Create_handler__http("/glry/v1/users/create",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	usersGroup.POST("/create", func(c *gin.Context) {
 
-			if pReq.Method == "POST" {
+		input := &GLRYauthUserCreateInput{}
 
-				log.WithFields(log.Fields{}).Debug("/glry/v1/users/create")
+		if err := c.BindJSON(input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 
-				//------------------
-				// INPUT
+		//------------------
+		// USER_CREATE
+		output, gErr := AuthUserCreatePipeline(input, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-				inputMap, gErr := gf_rpc_lib.Get_http_input(pResp, pReq, pRuntime.RuntimeSys)
-				if gErr != nil {
-					return nil, gErr
-				}
+		//------------------
+		// OUTPUT
 
-				var input GLRYauthUserCreateInput
-				err := mapstructure.Decode(inputMap, &input)
-				if err != nil {
-					gf_err := gf_core.Error__create("failed to load input map into GLRYauthUserCreateInput struct",
-						"mapstruct__decode",
-						map[string]interface{}{},
-						err, "glry_lib", pRuntime.RuntimeSys)
-					return nil, gf_err
-				}
+		c.JSON(http.StatusOK, gin.H{
+			"sig_valid": output.SignatureValidBool,
+			"jwt_token": output.JWTtokenStr,
+			"user_id":   output.UserIDstr,
+		})
 
-				//------------------
-				// USER_CREATE
-				output, gErr := AuthUserCreatePipeline(&input, pCtx, pRuntime)
-				if gErr != nil {
-					return nil, gErr
-				}
+	})
 
-				//------------------
-				// OUTPUT
-
-				dataMap := map[string]interface{}{
-					"sig_valid": output.SignatureValidBool,
-					"jwt_token": output.JWTtokenStr,
-					"user_id":   output.UserIDstr,
-				}
-
-				//------------------
-
-				return dataMap, nil
-			}
-
-			return nil, nil
-		},
-		pRuntime.RuntimeSys)
-
-	//-------------------------------------------------------------
 }

--- a/glry_lib/glry_auth_http_handlers.go
+++ b/glry_lib/glry_auth_http_handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/gin-gonic/gin"
 	gf_core "github.com/gloflow/gloflow/go/gf_core"
 	gf_rpc_lib "github.com/gloflow/gloflow/go/gf_rpc_lib"
 	"github.com/mikeydub/go-gallery/glry_core"
@@ -130,6 +131,15 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime) {
 	//-------------------------------------------------------------
 	// USER_UPDATE
 	// AUTHENTICATED
+
+	pRuntime.Router.POST("/glry/v1/users/update", jwtMiddleware(), func(c *gin.Context) {
+
+		if !getAuthFromGinCtx(c) {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization required"})
+			return
+		}
+		// blah blah more code
+	})
 
 	gf_rpc_lib.Create_handler__http("/glry/v1/users/update",
 		precheckJwt(func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {

--- a/glry_lib/glry_auth_http_handlers.go
+++ b/glry_lib/glry_auth_http_handlers.go
@@ -161,6 +161,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 
 		if err := c.BindJSON(input); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
 		}
 
 		//------------------

--- a/glry_lib/glry_auth_http_handlers.go
+++ b/glry_lib/glry_auth_http_handlers.go
@@ -38,10 +38,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 
 		//------------------
 		// OUTPUT
-		c.JSON(http.StatusOK, gin.H{
-			"nonce":       output.NonceStr,
-			"user_exists": output.UserExistsBool,
-		})
+		c.JSON(http.StatusOK, output)
 	})
 
 	//-------------------------------------------------------------
@@ -67,14 +64,6 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 			return
 		}
 
-		// FAILED - INVALID_SIGNATURE
-		if !output.SignatureValidBool {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"sig_valid": false,
-			})
-			return
-		}
-
 		/*
 			// ADD!! - going forward we should follow this approach, after v1
 			// SET_JWT_COOKIE
@@ -87,10 +76,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 
 		//------------------
 		// OUTPUT
-		c.JSON(http.StatusOK, gin.H{
-			"jwt_token": output.JWTtokenStr,
-			"user_id":   output.UserIDstr,
-		})
+		c.JSON(http.StatusOK, output)
 	})
 
 	//-------------------------------------------------------------
@@ -175,11 +161,7 @@ func AuthHandlersInit(pRuntime *glry_core.Runtime, parent *gin.RouterGroup) {
 		//------------------
 		// OUTPUT
 
-		c.JSON(http.StatusOK, gin.H{
-			"sig_valid": output.SignatureValidBool,
-			"jwt_token": output.JWTtokenStr,
-			"user_id":   output.UserIDstr,
-		})
+		c.JSON(http.StatusOK, output)
 
 	})
 

--- a/glry_lib/glry_auth_user.go
+++ b/glry_lib/glry_auth_user.go
@@ -3,59 +3,60 @@ package glry_lib
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gloflow/gloflow/go/gf_core"
 	"github.com/mikeydub/go-gallery/glry_core"
 	"github.com/mikeydub/go-gallery/glry_db"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-	"time"
 	// "github.com/davecgh/go-spew/spew"
 )
 
 //-------------------------------------------------------------
 // INPUT - USER_UPDATE
 type GLRYauthUserUpdateInput struct {
-	AddressStr        glry_db.GLRYuserAddress `mapstructure:"address" validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
-	UserNameNewStr    string                  `mapstructure:"username"`
-	DescriptionNewStr string                  `mapstructure:"description"`
+	AddressStr        glry_db.GLRYuserAddress `json:"address" validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
+	UserNameNewStr    string                  `json:"username"`
+	DescriptionNewStr string                  `json:"description"`
 }
 
 // INPUT - USER_GET
 type GLRYauthUserGetInput struct {
-	AddressStr glry_db.GLRYuserAddress `validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
+	AddressStr glry_db.GLRYuserAddress `json:"address" validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
 }
 
 // OUTPUT - USER_GET
 type GLRYauthUserGetOutput struct {
-	UserNameStr    string   `mapstructure:"username"`
-	DescriptionStr string   `mapstructure:"description"`
-	AddressesLst   []string `mapstructure:"addresses`
+	UserNameStr  string   ` json:"username"`
+	BioStr       string   ` json:"bio"`
+	AddressesLst []string ` json:"addresses"`
 }
 
 // INPUT - USER_LOGIN
 type GLRYauthUserLoginInput struct {
-	SignatureStr string                  `mapstructure:"signature" validate:"required,min=4,max=50"`
-	AddressStr   glry_db.GLRYuserAddress `mapstructure:"address"   validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
+	SignatureStr string                  `json:"signature" validate:"required,min=4,max=50"`
+	AddressStr   glry_db.GLRYuserAddress `json:"address"   validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
 }
 
 // OUTPUT - USER_LOGIN
 type GLRYauthUserLoginOutput struct {
-	SignatureValidBool bool
-	JWTtokenStr        string
-	UserIDstr          glry_db.GLRYuserID
+	SignatureValidBool bool               `json:"signature_valid"`
+	JWTtokenStr        string             `json:"jwt_token"`
+	UserIDstr          glry_db.GLRYuserID `json:"user_id"`
 }
 
 // INPUT - USER_GET_PREFLIGHT
 type GLRYauthUserGetPreflightInput struct {
-	AddressStr glry_db.GLRYuserAddress `mapstructure:"address" validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
+	AddressStr glry_db.GLRYuserAddress `json:"address" validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
 }
 
 // OUTPUT - USER_GET_PREFLIGHT
 type GLRYauthUserGetPreflightOutput struct {
-	NonceStr       string
-	UserExistsBool bool
+	NonceStr       string `json:"nonce"`
+	UserExistsBool bool   `json:"user_exists"`
 }
 
 // INPUT - USER_CREATE - initial user creation is just an empty user, to store it in the DB.
@@ -66,16 +67,16 @@ type GLRYauthUserCreateInput struct {
 
 	// needed because this is a new user that cant be logged into, and the client creating
 	// the user still needs to prove ownership of their address.
-	SignatureStr  string                  `mapstructure:"signature" validate:"required,min=80,max=200"`
-	AddressStr    glry_db.GLRYuserAddress `mapstructure:"address"   validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
-	NonceValueStr string                  `mapstructure:"nonce"     validate:"required,min=10,max=150"`
+	SignatureStr  string                  `json:"signature" validate:"required,min=80,max=200"`
+	AddressStr    glry_db.GLRYuserAddress `json:"address"   validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
+	NonceValueStr string                  `json:"nonce"     validate:"required,min=10,max=150"`
 }
 
 // OUTPUT - USER_CREATE
 type GLRYauthUserCreateOutput struct {
-	SignatureValidBool bool
-	JWTtokenStr        string // JWT token is sent back to user to use to continue onboarding
-	UserIDstr          glry_db.GLRYuserID
+	SignatureValidBool bool               `json:"signature_valid"`
+	JWTtokenStr        string             `json:"jwt_token"` // JWT token is sent back to user to use to continue onboarding
+	UserIDstr          glry_db.GLRYuserID `json:"user_id"`
 }
 
 //-------------------------------------------------------------
@@ -185,8 +186,8 @@ func AuthUserGetPipeline(pInput *GLRYauthUserGetInput,
 	var output *GLRYauthUserGetOutput
 	if pAuthenticatedBool {
 		output = &GLRYauthUserGetOutput{
-			UserNameStr:    user.UserNameStr,
-			DescriptionStr: user.DescriptionStr,
+			UserNameStr: user.UserNameStr,
+			BioStr:      user.BioStr,
 		}
 	} else {
 

--- a/glry_lib/glry_collections.go
+++ b/glry_lib/glry_collections.go
@@ -22,6 +22,7 @@ type GLRYcollGetOutput struct {
 
 // INPUT
 type GLRYcollCreateInput struct {
+	OwnerUserIdStr    string `json:"user_id" validate:"required"`
 	NameStr           string `json:"name"        validate:"required,min=4,max=50"`
 	CollectorsNoteStr string `json:"collectors_note" validate:"required,min=0,max=500"`
 }

--- a/glry_lib/glry_http_handlers.go
+++ b/glry_lib/glry_http_handlers.go
@@ -9,26 +9,25 @@ import (
 
 	// log "github.com/sirupsen/logrus"
 	"github.com/gin-gonic/gin"
-	gf_core "github.com/gloflow/gloflow/go/gf_core"
-	gf_rpc_lib "github.com/gloflow/gloflow/go/gf_rpc_lib"
 	"github.com/mikeydub/go-gallery/glry_core"
 	"github.com/mikeydub/go-gallery/glry_db"
 	"github.com/mikeydub/go-gallery/glry_extern_services"
-	"github.com/mitchellh/mapstructure"
 )
 
 //-------------------------------------------------------------
 func HandlersInit(pRuntime *glry_core.Runtime) {
 
+	apiGroupV1 := pRuntime.Router.Group("/glry/v1")
+
 	// AUTH_HANDLERS
-	AuthHandlersInit(pRuntime)
+	AuthHandlersInit(pRuntime, apiGroupV1)
 
 	//-------------------------------------------------------------
 	// COLLECTION
 	//-------------------------------------------------------------
 	// COLLECTION_GET
 
-	pRuntime.Router.GET("/glry/v1/collections/get", func(c *gin.Context) {
+	apiGroupV1.GET("/collections/get", func(c *gin.Context) {
 		//------------------
 		// INPUT
 
@@ -52,305 +51,150 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 		c.JSON(http.StatusOK, gin.H{"colls": output.CollsOutputsLst})
 	})
 
-	gf_rpc_lib.Create_handler__http("/glry/v1/collections/get",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-
-			//------------------
-			// INPUT
-
-			qMap := pReq.URL.Query()
-			userIDstr := qMap["userid"][0]
-
-			input := &GLRYcollGetInput{
-				UserIDstr: glry_db.GLRYuserID(userIDstr),
-			}
-
-			//------------------
-			// CREATE
-			output, gErr := CollGetPipeline(input, pCtx, pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{
-				"colls": output.CollsOutputsLst,
-			}
-
-			//------------------
-
-			return dataMap, nil
-		},
-		pRuntime.RuntimeSys)
-
 	//-------------------------------------------------------------
 	// COLLECTION_CREATE
 
-	gf_rpc_lib.Create_handler__http("/glry/v1/collections/create",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	apiGroupV1.POST("/collections/create", func(c *gin.Context) {
+		input := &GLRYcollCreateInput{}
+		if err := c.BindJSON(input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 
-			//------------------
-			// INPUT
+		//------------------
+		// CREATE
+		output, gErr := CollCreatePipeline(input, input.OwnerUserIdStr, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-			inputMap, gErr := gf_rpc_lib.Get_http_input(pResp, pReq, pRuntime.RuntimeSys)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			// FINISH!! - get user_id mechanism
-			userIDstr := ""
-
-			var input GLRYcollCreateInput
-			err := mapstructure.Decode(inputMap, &input)
-			if err != nil {
-				gf_err := gf_core.Error__create("failed to load input map into GLRYcollCreateInput struct",
-					"mapstruct__decode",
-					map[string]interface{}{},
-					err, "glry_lib", pRuntime.RuntimeSys)
-				return nil, gf_err
-			}
-
-			//------------------
-			// CREATE
-			output, gErr := CollCreatePipeline(&input, userIDstr, pCtx, pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			fmt.Println(output)
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{}
-
-			//------------------
-
-			return dataMap, nil
-		},
-		pRuntime.RuntimeSys)
+		//------------------
+		// OUTPUT
+		c.JSON(http.StatusOK, output)
+	})
 
 	//-------------------------------------------------------------
 	// COLLECTION_DELETE
-	gf_rpc_lib.Create_handler__http("/glry/v1/collections/delete",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
 
-			//------------------
-			// INPUT
+	apiGroupV1.POST("/collections/delete", func(c *gin.Context) {
+		input := &GLRYcollDeleteInput{}
+		if err := c.BindJSON(input); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 
-			inputMap, gErr := gf_rpc_lib.Get_http_input(pResp, pReq, pRuntime.RuntimeSys)
-			if gErr != nil {
-				return nil, gErr
-			}
+		output, gErr := CollDeletePipeline(input, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-			var input GLRYcollDeleteInput
-			err := mapstructure.Decode(inputMap, &input)
-			if err != nil {
-				gf_err := gf_core.Error__create("failed to load input map into GLRYcollDeleteInput struct",
-					"mapstruct__decode",
-					map[string]interface{}{},
-					err, "glry_lib", pRuntime.RuntimeSys)
-				return nil, gf_err
-			}
-
-			//------------------
-
-			_, gErr = CollDeletePipeline(&input, pCtx, pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{}
-
-			//------------------
-
-			return dataMap, nil
-		},
-		pRuntime.RuntimeSys)
+		//------------------
+		// OUTPUT
+		c.JSON(http.StatusOK, output)
+	})
 
 	//-------------------------------------------------------------
 	// NFTS
 	//-------------------------------------------------------------
 	// SINGLE GET
-	gf_rpc_lib.Create_handler__http("/glry/v1/nfts/get",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
 
-			if pReq.Method == http.MethodGet {
+	apiGroupV1.GET("/nfts/get", func(c *gin.Context) {
+		nftIDstr := c.Query("id")
+		if nftIDstr == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "nft id not found in query values"})
+			return
+		}
+		nfts, gErr := glry_db.NFTgetByID(nftIDstr, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-				//------------------
-				// INPUT
+		if len(nfts) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("no nfts found with id: %s", nftIDstr)})
+			return
+		}
 
-				//------------------
+		//------------------
+		// OUTPUT
+		c.JSON(http.StatusOK, gin.H{
+			"nfts": nfts,
+		})
 
-				qMap := pReq.URL.Query()
-
-				nftIDstr := qMap.Get("id")
-
-				if nftIDstr == "" {
-					// is this the right way to create an error for gf_core?
-					return nil, gf_core.Error__create("nft id not found in query values",
-						"http_client_req_error",
-						map[string]interface{}{
-							"uri": "/glry/v1/nfts/get",
-						}, nil, "glry_lib", pRuntime.RuntimeSys)
-				}
-
-				nfts, gErr := glry_db.NFTgetByID(nftIDstr, pCtx, pRuntime)
-				if gErr != nil {
-					return nil, gErr
-				}
-
-				if len(nfts) == 0 {
-					return nil, gf_core.Error__create(fmt.Sprintf("no nfts found with id: %s", nftIDstr),
-						"http_client_req_error",
-						map[string]interface{}{
-							"uri": "/glry/v1/nfts/get",
-						}, nil, "glry_lib", pRuntime.RuntimeSys)
-				}
-
-				//------------------
-				// OUTPUT
-				dataMap := map[string]interface{}{
-					"nfts": nfts,
-				}
-
-				//------------------
-				return dataMap, nil
-			}
-
-			return nil, nil
-		},
-		pRuntime.RuntimeSys)
+	})
 
 	// SINGLE UPDATE
-	gf_rpc_lib.Create_handler__http("/glry/v1/nfts/update",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	// must specify nft id in json input
+	apiGroupV1.POST("/nfts/update", func(c *gin.Context) {
+		nft := &glry_db.GLRYnft{}
+		if err := c.BindJSON(nft); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
 
-			if pReq.Method == http.MethodPut {
+		gErr := glry_db.NFTupdateById(string(nft.IDstr), nft, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-				//------------------
-				// INPUT
-
-				//------------------
-
-				pReq.ParseForm()
-
-				nftIDstr := pReq.FormValue("id")
-
-				if nftIDstr == "" {
-					return nil, gf_core.Error__create("no id found in form values",
-						"http_client_req_error",
-						map[string]interface{}{
-							"uri": "/glry/v1/nfts/update",
-						}, nil, "glry_lib", pRuntime.RuntimeSys)
-				}
-
-				nft := &glry_db.GLRYnft{}
-
-				gErr := glry_core.UnmarshalBody(nft, pReq.Body, pRuntime)
-				if gErr != nil {
-					return nil, gErr
-				}
-
-				gErr = glry_db.NFTupdateById(nftIDstr, nft, pCtx, pRuntime)
-				if gErr != nil {
-					return nil, gErr
-				}
-
-				//------------------
-				// OUTPUT
-				dataMap := map[string]interface{}{}
-
-				//------------------
-				return dataMap, nil
-			}
-
-			return nil, nil
-		},
-		pRuntime.RuntimeSys)
+		c.Status(http.StatusOK)
+	})
 
 	// USER_GET
-	gf_rpc_lib.Create_handler__http("/glry/v1/nfts/user_get",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
+	apiGroupV1.GET("/nfts/user_get", func(c *gin.Context) {
+		userId := c.Query("user_id")
+		if userId == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "user id not found in query values"})
+			return
+		}
+		nfts, gErr := glry_db.NFTgetByUserID(userId, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-			if pReq.Method == "GET" {
+		//------------------
+		// OUTPUT
+		c.JSON(http.StatusOK, gin.H{"nfts": nfts})
 
-				//------------------
-				// INPUT
-
-				//------------------
-
-				userIDstr := "7bfaafcc-722e-4dce-986f-fe0d9bee2047"
-				nfts, gErr := glry_db.NFTgetByUserID(userIDstr, pCtx, pRuntime)
-				if gErr != nil {
-					return nil, gErr
-				}
-
-				//------------------
-				// OUTPUT
-				dataMap := map[string]interface{}{
-					"nfts": nfts,
-				}
-
-				//------------------
-				return dataMap, nil
-			}
-
-			return nil, nil
-		},
-		pRuntime.RuntimeSys)
+	})
 
 	//-------------------------------------------------------------
 	// OPENSEA_GET
-	gf_rpc_lib.Create_handler__http("/glry/v1/nfts/opensea_get",
-		func(pCtx context.Context, pResp http.ResponseWriter,
-			pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
 
-			//------------------
-			// INPUT
+	// USER_GET
+	apiGroupV1.GET("/nfts/opensea_get", func(c *gin.Context) {
+		ownerWalletAddr := c.Query("user_id")
+		if ownerWalletAddr == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "owner wallet address not found in query values"})
+			return
+		}
+		_, gErr := glry_extern_services.OpenSeaPipelineAssetsForAcc(ownerWalletAddr, c, pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
 
-			//------------------
+		//------------------
+		// OUTPUT
+		c.Status(http.StatusOK)
 
-			ownerWalletAddressStr := "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"
-			_, gErr := glry_extern_services.OpenSeaPipelineAssetsForAcc(ownerWalletAddressStr, pCtx, pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{}
-
-			//------------------
-
-			return dataMap, nil
-		},
-		pRuntime.RuntimeSys)
+	})
 
 	//-------------------------------------------------------------
 	// VAR
 	//-------------------------------------------------------------
 	// HEALTH
 
-	gf_rpc_lib.Create_handler__http("/glry/v1/health",
-		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-
-			// log.WithFields(log.Fields{}).Debug("/health")
-
-			//------------------
-			// OUTPUT
-			dataMap := map[string]interface{}{
-				"msg": "gallery operational",
-				"env": pRuntime.Config.EnvStr,
-			}
-
-			//------------------
-
-			return dataMap, nil
-		},
-		pRuntime.RuntimeSys)
+	apiGroupV1.GET("/health", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"msg": "gallery operational",
+			"env": pRuntime.Config.EnvStr,
+		})
+	})
 
 	//-------------------------------------------------------------
 }

--- a/glry_lib/glry_http_handlers.go
+++ b/glry_lib/glry_http_handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	// log "github.com/sirupsen/logrus"
+	"github.com/gin-gonic/gin"
 	gf_core "github.com/gloflow/gloflow/go/gf_core"
 	gf_rpc_lib "github.com/gloflow/gloflow/go/gf_rpc_lib"
 	"github.com/mikeydub/go-gallery/glry_core"
@@ -26,6 +27,30 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 	// COLLECTION
 	//-------------------------------------------------------------
 	// COLLECTION_GET
+
+	pRuntime.Router.GET("/glry/v1/collections/get", func(c *gin.Context) {
+		//------------------
+		// INPUT
+
+		userIDstr := c.Query("userid")
+
+		input := &GLRYcollGetInput{
+			UserIDstr: glry_db.GLRYuserID(userIDstr),
+		}
+
+		//------------------
+		// CREATE
+		output, gErr := CollGetPipeline(input, context.TODO(), pRuntime)
+		if gErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": gErr})
+			return
+		}
+
+		//------------------
+		// OUTPUT
+
+		c.JSON(http.StatusOK, gin.H{"colls": output.CollsOutputsLst})
+	})
 
 	gf_rpc_lib.Create_handler__http("/glry/v1/collections/get",
 		func(pCtx context.Context, pResp http.ResponseWriter, pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {

--- a/glry_lib/glry_http_handlers.go
+++ b/glry_lib/glry_http_handlers.go
@@ -56,7 +56,7 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 
 	apiGroupV1.POST("/collections/create", func(c *gin.Context) {
 		input := &GLRYcollCreateInput{}
-		if err := c.BindJSON(input); err != nil {
+		if err := c.ShouldBindJSON(input); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -79,7 +79,7 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 
 	apiGroupV1.POST("/collections/delete", func(c *gin.Context) {
 		input := &GLRYcollDeleteInput{}
-		if err := c.BindJSON(input); err != nil {
+		if err := c.ShouldBindJSON(input); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
@@ -129,7 +129,7 @@ func HandlersInit(pRuntime *glry_core.Runtime) {
 	// must specify nft id in json input
 	apiGroupV1.POST("/nfts/update", func(c *gin.Context) {
 		nft := &glry_db.GLRYnft{}
-		if err := c.BindJSON(nft); err != nil {
+		if err := c.ShouldBindJSON(nft); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}

--- a/glry_lib/glry_http_middlewares.go
+++ b/glry_lib/glry_http_middlewares.go
@@ -1,87 +1,33 @@
 package glry_lib
 
 import (
-	"context"
 	"net/http"
 	"os"
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	gf_core "github.com/gloflow/gloflow/go/gf_core"
 	"github.com/mikeydub/go-gallery/glry_core"
 )
-
-// information to be added to context with middlewares
-type contextKey string
 
 type authContextValue struct {
 	AuthenticatedBool bool
 	UserAddressStr    string
 }
 
-// jwt middleware
-// parameter hell because gf_core http_handler is private :(
-// both funcs (parameter and return funcs) are of type gf_core.http_handler implicitly
-func precheckJwt(midd func(pCtx context.Context,
-	pResp http.ResponseWriter,
-	pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error),
-	pRuntime *glry_core.Runtime) func(context.Context,
-	http.ResponseWriter,
-	*http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-	return func(pCtx context.Context,
-		pResp http.ResponseWriter,
-		pReq *http.Request) (map[string]interface{}, *gf_core.Gf_error) {
-
-		authHeaders := strings.Split(pReq.Header.Get("Authorization"), " ")
-		if len(authHeaders) > 0 && len(authHeaders) < 2 {
-			if authHeaders[0] != "Bearer" {
-				return nil, gf_core.Error__create("incorrect authorization header format",
-					"http_client_req_error",
-					map[string]interface{}{},
-					nil, "glry_lib", pRuntime.RuntimeSys)
-			}
-			// get string after "Bearer"
-			jwt := authHeaders[1]
-			// use an env variable as jwt secret as upposed to using a stateful secret stored in
-			// database that is unique to every user and session
-			valid, userAddr, gErr := AuthJWTverify(jwt, os.Getenv("JWT_SECRET"), pRuntime)
-			if gErr != nil {
-				return nil, gErr
-			}
-
-			// using a struct for storing values with a kard
-			pCtx = context.WithValue(pCtx, contextKey("auth"), authContextValue{
-				AuthenticatedBool: valid,
-				UserAddressStr:    userAddr,
-			})
-		}
-		return midd(pCtx, pResp, pReq)
-	}
-}
-
-// helper func to get the current auth bool from the context
-func getAuthFromCtx(pCtx context.Context) bool {
-	if value, ok := pCtx.Value("auth").(authContextValue); ok {
-		return value.AuthenticatedBool
-	} else {
-		return false
-	}
-}
-
-func getAuthFromGinCtx(c *gin.Context) bool {
+func getAuthFromCtx(c *gin.Context) (authContextValue, bool) {
 	auth, ok := c.Get("auth")
 	if !ok {
-		return false
+		return authContextValue{}, false
 	}
 	if authStruct, ok := auth.(authContextValue); ok {
-		return authStruct.AuthenticatedBool
+		return authStruct, true
 	} else {
-		return false
+		return authContextValue{}, false
 	}
 
 }
 
-func jwtMiddleware() gin.HandlerFunc {
+func jwtMiddleware(runtime *glry_core.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeaders := strings.Split(c.GetHeader("Authorization"), " ")
 		if len(authHeaders) > 0 && len(authHeaders) < 2 {
@@ -93,7 +39,7 @@ func jwtMiddleware() gin.HandlerFunc {
 			jwt := authHeaders[1]
 			// use an env variable as jwt secret as upposed to using a stateful secret stored in
 			// database that is unique to every user and session
-			valid, userAddr, gErr := AuthJWTverify(jwt, os.Getenv("JWT_SECRET"), pRuntime)
+			valid, userAddr, gErr := AuthJWTverify(jwt, os.Getenv("JWT_SECRET"), runtime)
 			if gErr != nil {
 				c.JSON(http.StatusUnauthorized, gin.H{"error": gErr})
 				return

--- a/glry_lib/glry_http_middlewares.go
+++ b/glry_lib/glry_http_middlewares.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gin-gonic/gin"
 	gf_core "github.com/gloflow/gloflow/go/gf_core"
 	"github.com/mikeydub/go-gallery/glry_core"
 )
@@ -64,5 +65,45 @@ func getAuthFromCtx(pCtx context.Context) bool {
 		return value.AuthenticatedBool
 	} else {
 		return false
+	}
+}
+
+func getAuthFromGinCtx(c *gin.Context) bool {
+	auth, ok := c.Get("auth")
+	if !ok {
+		return false
+	}
+	if authStruct, ok := auth.(authContextValue); ok {
+		return authStruct.AuthenticatedBool
+	} else {
+		return false
+	}
+
+}
+
+func jwtMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		authHeaders := strings.Split(c.GetHeader("Authorization"), " ")
+		if len(authHeaders) > 0 && len(authHeaders) < 2 {
+			if authHeaders[0] != "Bearer" {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid authorization header format"})
+				return
+			}
+			// get string after "Bearer"
+			jwt := authHeaders[1]
+			// use an env variable as jwt secret as upposed to using a stateful secret stored in
+			// database that is unique to every user and session
+			valid, userAddr, gErr := AuthJWTverify(jwt, os.Getenv("JWT_SECRET"), pRuntime)
+			if gErr != nil {
+				c.JSON(http.StatusUnauthorized, gin.H{"error": gErr})
+				return
+			}
+
+			c.Set("auth", authContextValue{
+				AuthenticatedBool: valid,
+				UserAddressStr:    userAddr,
+			})
+		}
+		c.Next()
 	}
 }

--- a/glry_lib/glry_http_middlewares.go
+++ b/glry_lib/glry_http_middlewares.go
@@ -9,24 +9,6 @@ import (
 	"github.com/mikeydub/go-gallery/glry_core"
 )
 
-type authContextValue struct {
-	AuthenticatedBool bool
-	UserAddressStr    string
-}
-
-func getAuthFromCtx(c *gin.Context) (authContextValue, bool) {
-	auth, ok := c.Get("auth")
-	if !ok {
-		return authContextValue{}, false
-	}
-	if authStruct, ok := auth.(authContextValue); ok {
-		return authStruct, true
-	} else {
-		return authContextValue{}, false
-	}
-
-}
-
 func jwtMiddleware(runtime *glry_core.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeaders := strings.Split(c.GetHeader("Authorization"), " ")
@@ -45,10 +27,8 @@ func jwtMiddleware(runtime *glry_core.Runtime) gin.HandlerFunc {
 				return
 			}
 
-			c.Set("auth", authContextValue{
-				AuthenticatedBool: valid,
-				UserAddressStr:    userAddr,
-			})
+			c.Set("authenticated", valid)
+			c.Set("user_addr", userAddr)
 		}
 		c.Next()
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,11 @@ require (
 	github.com/fatih/color v1.12.0
 	github.com/fortytw2/leaktest v1.3.0 // indirect
 	github.com/getsentry/sentry-go v0.11.0
+	github.com/gin-gonic/gin v1.7.2 // indirect
 	github.com/gloflow/gloflow v0.0.0-20210619031649-35015e10a1ff
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator v9.31.0+incompatible
+	github.com/go-playground/validator/v10 v10.6.1 // indirect
 	github.com/klauspost/compress v1.13.1 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
@@ -25,8 +27,10 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.8.0
 	github.com/stretchr/testify v1.7.0
+	github.com/ugorji/go v1.2.6 // indirect
 	go.mongodb.org/mongo-driver v1.5.3
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
-	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/fatih/color v1.12.0
 	github.com/fortytw2/leaktest v1.3.0 // indirect
 	github.com/getsentry/sentry-go v0.11.0
-	github.com/gin-gonic/gin v1.7.2 // indirect
+	github.com/gin-gonic/autotls v0.0.3 // indirect
+	github.com/gin-gonic/gin v1.7.2
 	github.com/gloflow/gloflow v0.0.0-20210619031649-35015e10a1ff
-	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/go-playground/validator/v10 v10.6.1 // indirect
 	github.com/klauspost/compress v1.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -198,7 +198,10 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
+github.com/gin-gonic/autotls v0.0.3 h1:/kVAtMOz7qmohg93VMTb0SqB0g7wQm6ujPS8BsNeDC8=
+github.com/gin-gonic/autotls v0.0.3/go.mod h1:GThKJ63OxN5tZl+YkxOVVaqm9qYiwi8kk9z0dbSCe5M=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
+github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.2 h1:Tg03T9yM2xa8j6I3Z3oqLaQRSmKvxPd6g/2HJ6zICFA=
 github.com/gin-gonic/gin v1.7.2/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
@@ -218,6 +221,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
@@ -225,6 +229,7 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp4Mit+3FDh548oRqwVgNsHA=
 github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
+github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-playground/validator/v10 v10.6.1 h1:W6TRDXt4WcWp4c4nf/G+6BkGdhiIo0k417gfr+V6u4I=
 github.com/go-playground/validator/v10 v10.6.1/go.mod h1:xm76BBt941f7yWdGnI2DVPFFg1UK3YY04qifoXU3lOk=
@@ -732,6 +737,7 @@ golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -914,8 +920,6 @@ golang.org/x/sys v0.0.0-20210420205809-ac73e9fd8988/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go.sum
+++ b/go.sum
@@ -196,7 +196,11 @@ github.com/getsentry/sentry-go v0.11.0 h1:qro8uttJGvNAMr5CLcFI9CHR0aDzXl0Vs3Pmw/
 github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaUCn30Q3bCvANo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
+github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
+github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
+github.com/gin-gonic/gin v1.7.2 h1:Tg03T9yM2xa8j6I3Z3oqLaQRSmKvxPd6g/2HJ6zICFA=
+github.com/gin-gonic/gin v1.7.2/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/gloflow/gloflow v0.0.0-20210619031649-35015e10a1ff h1:KACYv8MogA3jthDxv5JqK5clKgapA6YOv/vBL4atGKI=
@@ -214,12 +218,16 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator v9.31.0+incompatible h1:UA72EPEogEnq76ehGdEDp4Mit+3FDh548oRqwVgNsHA=
 github.com/go-playground/validator v9.31.0+incompatible/go.mod h1:yrEkQXlcI+PugkyDjY2bRrL/UBU4f3rvrgkN3V8JEig=
+github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-playground/validator/v10 v10.6.1 h1:W6TRDXt4WcWp4c4nf/G+6BkGdhiIo0k417gfr+V6u4I=
+github.com/go-playground/validator/v10 v10.6.1/go.mod h1:xm76BBt941f7yWdGnI2DVPFFg1UK3YY04qifoXU3lOk=
 github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -289,6 +297,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -402,6 +411,7 @@ github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFF
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -450,6 +460,7 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/labstack/echo/v4 v4.1.11/go.mod h1:i541M3Fj6f76NZtHSj7TXnyM8n2gaodfvfxNnFqi74g=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
+github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -497,8 +508,10 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -641,8 +654,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go v1.2.6 h1:tGiWC9HENWE2tqYycIqFTNorMmFRVhNwCpDOpWqnk8E=
+github.com/ugorji/go v1.2.6/go.mod h1:anCg0y61KIhDlPZmnH+so+RQbysYVyDko0IMgJv0Nn0=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
+github.com/ugorji/go/codec v1.2.6 h1:7kbGefxLoDBuYXOms4yD7223OpNMMPNPZxXk5TvFcyQ=
+github.com/ugorji/go/codec v1.2.6/go.mod h1:V6TCNZ4PHqoHGFZuSG1W8nrCzzdgA2DozYxWFFpvxTw=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
@@ -899,6 +916,8 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1090,6 +1109,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/server/glry_server.go
+++ b/server/glry_server.go
@@ -4,7 +4,9 @@ import (
 	// "fmt"
 	// log "github.com/sirupsen/logrus"
 	// gfcore "github.com/gloflow/gloflow/go/gf_core"
-	gf_rpc_lib "github.com/gloflow/gloflow/go/gf_rpc_lib"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/glry_core"
 	"github.com/mikeydub/go-gallery/glry_lib"
 )
@@ -13,10 +15,13 @@ import (
 func Init(pPortInt int,
 	pRuntime *glry_core.Runtime) {
 
+	pRuntime.Router = gin.Default()
+
 	// HANDLERS
 	glry_lib.HandlersInit(pRuntime)
 
-	// SERVER_INIT
-	gf_rpc_lib.Server__init(pPortInt)
+	if err := pRuntime.Router.Run(fmt.Sprintf(":%d", pPortInt)); err != nil {
+		panic(err)
+	}
 
 }


### PR DESCRIPTION
We have been talking about looking at different ways of handling http that give us more control over things like middlewares and return values. In the most recent commit I have experimented with gin, a very popular go web framework that is very clear and is especially easy to use with regards to middlewares and keeping our routes organized and clear in code. I wrote out some examples using our current code but using the gin web framework. You can check out gin at https://github.com/gin-gonic/gin.

It would take some adjustments to switch over to gin, nothing major, but I believe it will save us headaches and roadblocks in the future. If we believe it will be too much to change now or anyone has any other suggestions I would love to hear! The standard library also has a lot of the versatility as gin just with less of the built in optimization, API features, logging, error handling, etc. so we could also take a look at how that would look.

If we believe gin is the right way to go, I will get going on converting our current handlers to gin handlers.