### PR TITLE
add get by username and get by wallet addr

### DIFF
--- a/persist/user.go
+++ b/persist/user.go
@@ -104,8 +104,11 @@ func UserGetById(userId DbId,
 		return nil, err
 	}
 
-	if len(result) == 0 || len(result) > 1 {
-		return nil, fmt.Errorf("invalid amount of returned users: %d", len(result))
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no users found")
+	}
+	if len(result) > 1 {
+		return nil, fmt.Errorf("more than one user found when expecting a single result")
 	}
 
 	return result[0], nil
@@ -132,8 +135,11 @@ func UserGetByAddress(pAddress string,
 		return nil, err
 	}
 
-	if len(result) == 0 || len(result) > 1 {
-		return nil, fmt.Errorf("invalid amount of returned users: %d", len(result))
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no users found")
+	}
+	if len(result) > 1 {
+		return nil, fmt.Errorf("more than one user found when expecting a single result")
 	}
 
 	return result[0], nil
@@ -160,8 +166,11 @@ func UserGetByUsername(pUsername string,
 		return nil, err
 	}
 
-	if len(result) == 0 || len(result) > 1 {
-		return nil, fmt.Errorf("invalid amount of returned users: %d", len(result))
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no users found")
+	}
+	if len(result) > 1 {
+		return nil, fmt.Errorf("more than one user found when expecting a single result")
 	}
 
 	return result[0], nil

--- a/server/auth.go
+++ b/server/auth.go
@@ -18,6 +18,31 @@ import (
 	// "github.com/davecgh/go-spew/spew"
 )
 
+// INPUT - USER_LOGIN
+type authUserLoginInput struct {
+	SignatureStr string `json:"signature" validate:"required,min=4,max=50"`
+	Address      string `json:"address"   validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
+}
+
+// OUTPUT - USER_LOGIN
+type authUserLoginOutput struct {
+	SignatureValidBool bool         `json:"signature_valid"`
+	JWTtokenStr        string       `json:"jwt_token"`
+	UserIDstr          persist.DbId `json:"user_id"`
+	AddressStr         string       `json:"address"`
+}
+
+// INPUT - USER_GET_PREFLIGHT
+type authUserGetPreflightInput struct {
+	AddressStr string `json:"address" validate:"required,eth_addr"` // len=42"` // standard ETH "0x"-prefixed address
+}
+
+// OUTPUT - USER_GET_PREFLIGHT
+type authUserGetPreflightOutput struct {
+	NonceStr       string `json:"nonce"`
+	UserExistsBool bool   `json:"user_exists"`
+}
+
 //-------------------------------------------------------------
 // HANDLERS
 


### PR DESCRIPTION
Changes:

- **Added** parts of get func to handle getting by address or username
- **Changed** get user input to reflect possible query values
- **Added** db func for getting by username

Considerations:

- Currently there is no validation to ensure that the query only contained one of: username, wallet, user_id -- and instead will only handle once based on their priority. This priority is user_id, username, address (in order of least to most complex/time consuming query). That means the query could be something like /glry/v1/users/get?username=:username&addr=:walletAddress&user_id=:userId and it would still work. Do we want it to function this way, or do we want to ensure that only one query param is given?
