### PR TITLE
return empty arrays when requests are ambiguous

### DIFF
--- a/server/collection.go
+++ b/server/collection.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -32,14 +31,8 @@ func getAllCollectionsForUser(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		userIDstr := c.Query("userid")
 
 		colls, err := persist.CollGetByUserID(persist.DbId(userIDstr), c, pRuntime)
-
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no collections found with user_id: %s", userIDstr)})
-			return
-		}
-		if len(colls) == 0 {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no collections found with user_id: %s", userIDstr)})
-			return
+		if len(colls) == 0 || err != nil {
+			colls = []*persist.Collection{}
 		}
 
 		c.JSON(http.StatusOK, gin.H{"collections": colls})

--- a/server/nft.go
+++ b/server/nft.go
@@ -65,13 +65,8 @@ func getNftsForUser(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			return
 		}
 		nfts, err := persist.NftGetByUserId(persist.DbId(userId), c, pRuntime)
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no nfts found with user_id: %s", userId)})
-			return
-		}
-		if len(nfts) == 0 {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no nfts found with user_id: %s", userId)})
-			return
+		if len(nfts) == 0 || err != nil {
+			nfts = []*persist.Nft{}
 		}
 
 		c.JSON(http.StatusOK, GetNftsForUserResponse{Nfts: nfts})
@@ -86,13 +81,8 @@ func getUnassignedNftsForUser(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			return
 		}
 		coll, err := persist.CollGetUnassigned(persist.DbId(userId), c, pRuntime)
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no nfts found with user_id: %s", userId)})
-			return
-		}
-		if len(coll.NFTsLst) == 0 {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no nfts found with user_id: %s", userId)})
-			return
+		if coll == nil || err != nil {
+			coll = &persist.Collection{NFTsLst: []*persist.Nft{}}
 		}
 
 		c.JSON(http.StatusOK, GetNftsForUserResponse{Nfts: coll.NFTsLst})
@@ -107,13 +97,8 @@ func getNftsFromOpensea(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			return
 		}
 		nfts, err := OpenSeaPipelineAssetsForAcc(ownerWalletAddr, c, pRuntime)
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no nfts found with wallet: %s", ownerWalletAddr)})
-			return
-		}
-		if len(nfts) == 0 {
-			c.JSON(http.StatusOK, gin.H{"error": fmt.Sprintf("no nfts found with wallet: %s", ownerWalletAddr)})
-			return
+		if len(nfts) == 0 || err != nil {
+			nfts = []*persist.Nft{}
 		}
 
 		c.JSON(http.StatusOK, gin.H{"nfts": nfts})


### PR DESCRIPTION
Changes:

- **Changed** endpoints that have more ambiguous requirements such as get nfts or collections by user_id and return an empty array instead of an error