### PR TITLE
Integration tests for Get NFT by ID route

### DIFF
--- a/persist/auth.go
+++ b/persist/auth.go
@@ -77,7 +77,7 @@ func AuthNonceGet(pAddress string,
 	opts.SetLimit(1)
 
 	result := []*UserNonce{}
-	err := mp.Find(pCtx, bson.M{"addresses": bson.M{"$in": []string{pAddress}}}, result, opts)
+	err := mp.Find(pCtx, bson.M{"addresses": bson.M{"$in": []string{pAddress}}}, &result, opts)
 
 	if err != nil {
 		return nil, err

--- a/persist/nft.go
+++ b/persist/nft.go
@@ -9,10 +9,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	// "github.com/davecgh/go-spew/spew"
 )
-
-//-------------------------------------------------------------
 
 const (
 	nftColName           = "nfts"
@@ -23,7 +20,7 @@ type Nft struct {
 	VersionInt    int64   `bson:"version,omitempty"              json:"version"` // schema version for this model
 	IDstr         DbId    `bson:"_id,omitempty"                  json:"id" binding:"required"`
 	CreationTimeF float64 `bson:"creation_time,omitempty"        json:"creation_time"`
-	DeletedBool   bool    `bson:"deleted,omitempty"`
+	DeletedBool   bool    `bson:"deleted"`
 
 	NameStr           string `bson:"name,omitempty"                 json:"name"`
 	DescriptionStr    string `bson:"description,omitempty"          json:"description"`
@@ -64,7 +61,6 @@ type Contract struct {
 	ContractTotalSupplyInt  int    `bson:"contract_total_supply,omitempty" json:"total_supply"`
 }
 
-//-------------------------------------------------------------
 func NftCreateBulk(pNFTlst []*Nft,
 	pCtx context.Context,
 	pRuntime *runtime.Runtime) ([]DbId, error) {
@@ -83,10 +79,8 @@ func NftCreateBulk(pNFTlst []*Nft,
 		return nil, err
 	}
 	return ids, nil
-
 }
 
-//-------------------------------------------------------------
 func NftCreate(pNFT *Nft,
 	pCtx context.Context,
 	pRuntime *runtime.Runtime) (DbId, error) {
@@ -94,10 +88,8 @@ func NftCreate(pNFT *Nft,
 	mp := NewMongoStorage(0, nftColName, pRuntime)
 
 	return mp.Insert(pCtx, pNFT)
-
 }
 
-//-------------------------------------------------------------
 func NftGetByUserId(pUserIDstr DbId,
 	pCtx context.Context,
 	pRuntime *runtime.Runtime) ([]*Nft, error) {
@@ -109,14 +101,12 @@ func NftGetByUserId(pUserIDstr DbId,
 	mp := NewMongoStorage(0, nftColName, pRuntime)
 	result := []*Nft{}
 
-	if err := mp.Find(pCtx, bson.M{"owner_user_id": pUserIDstr}, result, opts); err != nil {
+	if err := mp.Find(pCtx, bson.M{"owner_user_id": pUserIDstr}, &result, opts); err != nil {
 		return nil, err
 	}
 
 	return result, nil
 }
-
-//-------------------------------------------------------------
 
 func NftGetById(pIDstr DbId, pCtx context.Context, pRuntime *runtime.Runtime) ([]*Nft, error) {
 
@@ -129,15 +119,12 @@ func NftGetById(pIDstr DbId, pCtx context.Context, pRuntime *runtime.Runtime) ([
 	mp := NewMongoStorage(0, nftColName, pRuntime)
 	result := []*Nft{}
 
-	if err := mp.Find(pCtx, bson.M{"_id": pIDstr}, result, opts); err != nil {
+	if err := mp.Find(pCtx, bson.M{"_id": pIDstr}, &result, opts); err != nil {
 		return nil, err
 	}
 
 	return result, nil
-
 }
-
-//-------------------------------------------------------------
 
 func NftUpdateById(pIDstr DbId, updatedNft *Nft, pCtx context.Context, pRuntime *runtime.Runtime) error {
 
@@ -150,10 +137,7 @@ func NftUpdateById(pIDstr DbId, updatedNft *Nft, pCtx context.Context, pRuntime 
 	mp := NewMongoStorage(0, nftColName, pRuntime)
 
 	return mp.Update(pCtx, bson.M{"_id": pIDstr}, updatedNft)
-
 }
-
-//-------------------------------------------------------------
 
 func NftBulkUpsertOrRemove(walletAddress string, pNfts []*Nft, pCtx context.Context, pRuntime *runtime.Runtime) error {
 
@@ -175,7 +159,7 @@ func NftBulkUpsertOrRemove(walletAddress string, pNfts []*Nft, pCtx context.Cont
 
 		// TODO last updated
 
-		upsertModels[i] = mongo.UpdateOneModel{
+		upsertModels[i] = &mongo.UpdateOneModel{
 			Upsert: &weWantToUpsertHere,
 			Filter: bson.M{"owner_address": walletAddress, "opensea_id": v.OpenSeaIDstr},
 			Update: bson.M{
@@ -198,7 +182,7 @@ func NftBulkUpsertOrRemove(walletAddress string, pNfts []*Nft, pCtx context.Cont
 	}
 
 	dbNfts := []*Nft{}
-	if err := mp.Find(pCtx, bson.M{"owner_address": walletAddress}, dbNfts, opts); err != nil {
+	if err := mp.Find(pCtx, bson.M{"owner_address": walletAddress}, &dbNfts, opts); err != nil {
 		return err
 	}
 
@@ -211,7 +195,7 @@ func NftBulkUpsertOrRemove(walletAddress string, pNfts []*Nft, pCtx context.Cont
 		deleteModels := make([]mongo.WriteModel, len(diff))
 
 		for i, v := range diff {
-			deleteModels[i] = mongo.UpdateOneModel{Filter: bson.M{"_id": v}, Update: bson.M{"$set": bson.M{"deleted": true}}}
+			deleteModels[i] = &mongo.UpdateOneModel{Filter: bson.M{"_id": v}, Update: bson.M{"$set": bson.M{"deleted": true}}}
 		}
 
 		if _, err := mp.collection.BulkWrite(pCtx, deleteModels); err != nil {
@@ -223,7 +207,6 @@ func NftBulkUpsertOrRemove(walletAddress string, pNfts []*Nft, pCtx context.Cont
 }
 
 func findDifference(nfts []*Nft, dbNfts []*Nft) ([]DbId, error) {
-
 	currOpenseaIds := map[string]bool{}
 	diff := []DbId{}
 

--- a/persist/user.go
+++ b/persist/user.go
@@ -98,7 +98,7 @@ func UserGetById(userId DbId,
 	mp := NewMongoStorage(0, usersCollName, pRuntime)
 
 	result := []*User{}
-	err := mp.Find(pCtx, bson.M{"_id": userId}, result, opts)
+	err := mp.Find(pCtx, bson.M{"_id": userId}, &result, opts)
 
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ func UserGetByAddress(pAddress string,
 	mp := NewMongoStorage(0, usersCollName, pRuntime)
 
 	result := []*User{}
-	err := mp.Find(pCtx, bson.M{"addresses": bson.M{"$in": []string{pAddress}}}, result, opts)
+	err := mp.Find(pCtx, bson.M{"addresses": bson.M{"$in": []string{pAddress}}}, &result, opts)
 
 	if err != nil {
 		return nil, err
@@ -160,7 +160,7 @@ func UserGetByUsername(pUsername string,
 	mp := NewMongoStorage(0, usersCollName, pRuntime)
 
 	result := []*User{}
-	err := mp.Find(pCtx, bson.M{"username": pUsername}, result, opts)
+	err := mp.Find(pCtx, bson.M{"username": pUsername}, &result, opts)
 
 	if err != nil {
 		return nil, err

--- a/server/nft.go
+++ b/server/nft.go
@@ -9,6 +9,10 @@ import (
 	"github.com/mikeydub/go-gallery/runtime"
 )
 
+const (
+	nftIdQueryNotProvided = "nft id not provided in query values"
+)
+
 type getNftsByIdInput struct {
 	NftId persist.DbId `json:"id" form:"id" binding:"required"`
 }
@@ -26,13 +30,17 @@ func getNftById(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		input := &getNftsByIdInput{}
 
 		if err := c.ShouldBindQuery(input); err != nil {
-			c.JSON(http.StatusOK, gin.H{"error": "nft id not found in query values"})
+			c.JSON(http.StatusBadRequest, ErrorResponse{
+				Error: nftIdQueryNotProvided,
+			})
 			return
 		}
 
 		nfts, err := persist.NftGetById(input.NftId, c, pRuntime)
 		if len(nfts) == 0 || err != nil {
-			c.JSON(http.StatusNoContent, gin.H{"error": fmt.Sprintf("no nfts found with id: %s", input.NftId)})
+			c.JSON(http.StatusNotFound, ErrorResponse{
+				Error: fmt.Sprintf("no nfts found with id: %s", input.NftId),
+			})
 			return
 		}
 
@@ -40,7 +48,7 @@ func getNftById(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			nfts = nfts[:1]
 			// TODO log that this should not be happening
 		}
-		c.JSON(http.StatusOK, getNftsOutput{Nfts: nfts})
+		c.JSON(http.StatusOK, nfts[0])
 	}
 }
 

--- a/server/response.go
+++ b/server/response.go
@@ -1,0 +1,5 @@
+package server
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/server/t__main_test.go
+++ b/server/t__main_test.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/mikeydub/go-gallery/runtime"
+)
+
+var testServer *httptest.Server
+var serverUrl string
+var r *runtime.Runtime
+
+func TestMain(m *testing.M) {
+    testServer, serverUrl, r = setup()
+    code := m.Run() 
+    teardown(testServer)
+    os.Exit(code)
+}

--- a/server/t__routes_health_test.go
+++ b/server/t__routes_health_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/mikeydub/go-gallery/runtime"
+)
+
+func TestHealthcheck(t *testing.T) {
+	assert, testServer, serverUrl, r := setup(t)
+	defer teardown(testServer)
+
+	resp, err := http.Get(fmt.Sprintf("%s/health", serverUrl))
+	assert.Nil(err)
+	assertValidJSONResponse(assert, resp)
+
+	body := HealthcheckResponse{}
+	runtime.UnmarshalBody(&body, resp.Body, r)
+	assert.Equal("gallery operational", body.Message)
+	assert.Equal("local", body.Env)
+}

--- a/server/t__routes_health_test.go
+++ b/server/t__routes_health_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/mikeydub/go-gallery/runtime"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHealthcheck(t *testing.T) {
-	assert, testServer, serverUrl, r := setup(t)
-	defer teardown(testServer)
+	assert := assert.New(t)
 
 	resp, err := http.Get(fmt.Sprintf("%s/health", serverUrl))
 	assert.Nil(err)

--- a/server/t__routes_nft_test.go
+++ b/server/t__routes_nft_test.go
@@ -57,17 +57,3 @@ func TestGetNftById_NotFoundError(t *testing.T) {
 	runtime.UnmarshalBody(&body, resp.Body, r)
 	assert.Equal(fmt.Sprintf("no nfts found with id: %s", nonexistentNftId), body.Error)
 }
-
-func TestHealthcheck(t *testing.T) {
-	assert, testServer, serverUrl, r := setup(t)
-	defer teardown(testServer)
-
-	resp, err := http.Get(fmt.Sprintf("%s/health", serverUrl))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := HealthcheckResponse{}
-	runtime.UnmarshalBody(&body, resp.Body, r)
-	assert.Equal("gallery operational", body.Message)
-	assert.Equal("local", body.Env)
-}

--- a/server/t__routes_nft_test.go
+++ b/server/t__routes_nft_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/mikeydub/go-gallery/persist"
 	"github.com/mikeydub/go-gallery/runtime"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetNftById_Success(t *testing.T) {
-	assert, testServer, serverUrl, r := setup(t)
-	defer teardown(testServer)
+	assert := assert.New(t)
 
 	// seed DB with nft
 	name := "very cool nft"
@@ -31,8 +31,7 @@ func TestGetNftById_Success(t *testing.T) {
 }
 
 func TestGetNftById_NoParamError(t *testing.T) {
-	assert, testServer, serverUrl, r := setup(t)
-	defer teardown(testServer)
+	assert := assert.New(t)
 
 	resp, err := http.Get(fmt.Sprintf("%s/nfts/get", serverUrl))
 	assert.Nil(err)
@@ -44,8 +43,7 @@ func TestGetNftById_NoParamError(t *testing.T) {
 }
 
 func TestGetNftById_NotFoundError(t *testing.T) {
-	assert, testServer, serverUrl, r := setup(t)
-	defer teardown(testServer)
+	assert := assert.New(t)
 
 	nonexistentNftId := "12345"
 

--- a/server/t__routes_test.go
+++ b/server/t__routes_test.go
@@ -1,12 +1,62 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/mikeydub/go-gallery/persist"
 	"github.com/mikeydub/go-gallery/runtime"
 )
+
+func TestGetNftById_Success(t *testing.T) {
+	assert, testServer, serverUrl, r := setup(t)
+	defer teardown(testServer)
+
+	// seed DB with nft
+	name := "very cool nft"
+	nftId, err := persist.NftCreate(&persist.Nft{
+		NameStr: name,
+	}, context.Background(), r)
+	assert.Nil(err)
+
+	resp, err := http.Get(fmt.Sprintf("%s/nfts/get?id=%s", serverUrl, nftId))
+	assert.Nil(err)
+	assertValidJSONResponse(assert, resp)
+
+	body := persist.Nft{}
+	runtime.UnmarshalBody(&body, resp.Body, r)
+	assert.Equal(name, body.NameStr)
+}
+
+func TestGetNftById_NoParamError(t *testing.T) {
+	assert, testServer, serverUrl, r := setup(t)
+	defer teardown(testServer)
+
+	resp, err := http.Get(fmt.Sprintf("%s/nfts/get", serverUrl))
+	assert.Nil(err)
+	assertGalleryErrorResponse(assert, resp)
+
+	body := ErrorResponse{}
+	runtime.UnmarshalBody(&body, resp.Body, r)
+	assert.Equal(nftIdQueryNotProvided, body.Error)
+}
+
+func TestGetNftById_NotFoundError(t *testing.T) {
+	assert, testServer, serverUrl, r := setup(t)
+	defer teardown(testServer)
+
+	nonexistentNftId := "12345"
+
+	resp, err := http.Get(fmt.Sprintf("%s/nfts/get?id=%s", serverUrl, nonexistentNftId))
+	assert.Nil(err)
+	assertGalleryErrorResponse(assert, resp)
+
+	body := ErrorResponse{}
+	runtime.UnmarshalBody(&body, resp.Body, r)
+	assert.Equal(fmt.Sprintf("no nfts found with id: %s", nonexistentNftId), body.Error)
+}
 
 func TestHealthcheck(t *testing.T) {
 	assert, testServer, serverUrl, r := setup(t)
@@ -18,7 +68,6 @@ func TestHealthcheck(t *testing.T) {
 
 	body := HealthcheckResponse{}
 	runtime.UnmarshalBody(&body, resp.Body, r)
-
-	assert.Equal(body.Message, "gallery operational")
-	assert.Equal(body.Env, "local")
+	assert.Equal("gallery operational", body.Message)
+	assert.Equal("local", body.Env)
 }

--- a/server/test_utils.go
+++ b/server/test_utils.go
@@ -41,8 +41,15 @@ func teardown(ts *httptest.Server) {
 }
 
 func assertValidJSONResponse(assert *assert.Assertions, resp *http.Response) {
-	assert.Equal(resp.StatusCode, http.StatusOK, "Status should be 200")
+	assert.Equal(http.StatusOK, resp.StatusCode, "Status should be 200")
 	val, ok := resp.Header["Content-Type"]
 	assert.True(ok, "Content-Type header should be set")
-	assert.Equal(val[0], "application/json; charset=utf-8", "Response should be in JSON")
+	assert.Equal("application/json; charset=utf-8", val[0], "Response should be in JSON")
+}
+
+func assertGalleryErrorResponse(assert *assert.Assertions, resp *http.Response) {
+	assert.NotEqual(http.StatusOK, resp.StatusCode, "Status should not be 200")
+	val, ok := resp.Header["Content-Type"]
+	assert.True(ok, "Content-Type header should be set")
+	assert.Equal("application/json; charset=utf-8", val[0], "Response should be in JSON")
 }

--- a/server/test_utils.go
+++ b/server/test_utils.go
@@ -4,38 +4,31 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/runtime"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
-type serverUrl = string
-
 // Should be called at the beginning of every integration test
 // Initializes the runtime, connects to mongodb, and starts a test server
-func setup(t *testing.T) (*assert.Assertions,
-	*httptest.Server,
-	serverUrl,
-	*runtime.Runtime) {
-	// Initialize assertion handler to be used in actual test downstream
-	assert := assert.New(t)
-
+func setup() (*httptest.Server, string, *runtime.Runtime) {
 	// Initialize runtime
-	runtime, err := runtime.RuntimeGet(runtime.ConfigLoad())
-	assert.Nil(err)
+	runtime, _ := runtime.RuntimeGet(runtime.ConfigLoad())
 
 	// Initialize test server
 	gin.SetMode(gin.ReleaseMode) // Prevent excessive logs
 	runtime.Router = gin.Default()
 	ts := httptest.NewServer(HandlersInit(runtime))
+	log.Info("server connected! ✅")
 
-	return assert, ts, fmt.Sprintf("%s/glry/v1", ts.URL), runtime
+	return ts, fmt.Sprintf("%s/glry/v1", ts.URL), runtime
 }
 
 // Should be called at the end of every integration test
 func teardown(ts *httptest.Server) {
+	log.Info("tearing down test suite...")
 	ts.Close()
 	// TODO: drop mongo database, etc.
 }


### PR DESCRIPTION
**Added**
- `ErrorResponse` struct for standardizing error responses
- `server/t__main_test.go` file for triggering setup/teardown once for all package tests
- integration test utils for detecting server error responses
- integration tests for getNftById

**Changed**
- remove `omitempty` from `DeletedBool` to ensure the field gets set as `false` when saving to DB
- minor bugfixes, cleanup