### PR TITLE
separate handlers for hidden/name/nfts

### DIFF
--- a/persist/collection.go
+++ b/persist/collection.go
@@ -25,7 +25,7 @@ type CollectionDb struct {
 	NameStr           string `bson:"name"          json:"name"`
 	CollectorsNoteStr string `bson:"collectors_note"   json:"collectors_note"`
 	OwnerUserIDstr    DbId   `bson:"owner_user_id" json:"owner_user_id"`
-	NFTsLst           []DbId `bson:"nfts"          json:"nfts"`
+	NftsLst           []DbId `bson:"nfts"          json:"nfts"`
 
 	// collections can be hidden from public-viewing
 	HiddenBool bool `bson:"hidden" json:"hidden"`
@@ -40,7 +40,7 @@ type Collection struct {
 	NameStr           string `bson:"name"          json:"name"`
 	CollectorsNoteStr string `bson:"collectors_note"   json:"collectors_note"`
 	OwnerUserIDstr    string `bson:"owner_user_id" json:"owner_user_id"`
-	NFTsLst           []*Nft `bson:"nfts"          json:"nfts"`
+	NftsLst           []*Nft `bson:"nfts"          json:"nfts"`
 
 	// collections can be hidden from public-viewing
 	HiddenBool bool `bson:"hidden" json:"hidden"`

--- a/persist/t__unassigned_test.go
+++ b/persist/t__unassigned_test.go
@@ -44,9 +44,9 @@ func TestUnassignedWithAggregation(t *testing.T) {
 	assert.Len(t, nftsInColOne, 10)
 	assert.Len(t, nftsInColTwo, 3)
 
-	_, err = CollCreate(&CollectionDb{NameStr: "Poop", NFTsLst: nftsInColOne, OwnerUserIDstr: userId}, context.Background(), runtime)
+	_, err = CollCreate(&CollectionDb{NameStr: "Poop", NftsLst: nftsInColOne, OwnerUserIDstr: userId}, context.Background(), runtime)
 	assert.Nil(t, err)
-	_, err = CollCreate(&CollectionDb{NameStr: "Baby", NFTsLst: nftsInColTwo, OwnerUserIDstr: userId}, context.Background(), runtime)
+	_, err = CollCreate(&CollectionDb{NameStr: "Baby", NftsLst: nftsInColTwo, OwnerUserIDstr: userId}, context.Background(), runtime)
 	assert.Nil(t, err)
 
 	unassignedCollection, err := CollGetUnassigned(user.IDstr, context.Background(), runtime)
@@ -54,7 +54,7 @@ func TestUnassignedWithAggregation(t *testing.T) {
 
 	unassignedIds := []DbId{}
 
-	for _, k := range unassignedCollection.NFTsLst {
+	for _, k := range unassignedCollection.NftsLst {
 		unassignedIds = append(unassignedIds, k.IDstr)
 	}
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -52,14 +52,14 @@ func getAuthPreflight(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		input := &authUserGetPreflightInput{}
 
 		if err := c.ShouldBindQuery(input); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
 
 		// GET_PUBLIC_INFO
 		output, err := authUserGetPreflightDb(input, c, pRuntime)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
 
 			return
 		}
@@ -74,7 +74,7 @@ func login(pRuntime *runtime.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		input := &authUserLoginInput{}
 		if err := c.ShouldBindJSON(input); err != nil {
-			c.JSON(http.StatusOK, gin.H{"error": err.Error()})
+			c.JSON(http.StatusOK, ErrorResponse{Error: err.Error()})
 			return
 		}
 
@@ -86,7 +86,7 @@ func login(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			c,
 			pRuntime)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
 			return
 		}
 

--- a/server/collection.go
+++ b/server/collection.go
@@ -25,12 +25,18 @@ type collectionCreateInput struct {
 	Nfts []persist.DbId `json:"nfts" binding:"required"`
 }
 
+type collectionUpdateNameByIdInput struct {
+	Id   persist.DbId `json:"id" binding:"required"`
+	Name string       `json:"name" binding:"required"`
+}
 
-type collectionUpdateByIdInput struct {
-	Id     persist.DbId   `json:"id" binding:"required"`
-	Name   string         `json:"name,omitempty"`
-	Nfts   []*persist.Nft `json:"nfts,omitempty"`
-	Hidden bool           `json:"hidden,omitempty"`
+type collectionUpdateHiddenByIdInput struct {
+	Id     persist.DbId `json:"id" binding:"required"`
+	Hidden bool         `json:"hidden" binding:"required"`
+}
+type collectionUpdateNftsByIdInput struct {
+	Id   persist.DbId   `json:"id" binding:"required"`
+	Nfts []*persist.Nft `json:"nfts" binding:"required"`
 }
 
 type collectionCreateOutput struct {
@@ -94,9 +100,31 @@ func createCollection(pRuntime *runtime.Runtime) gin.HandlerFunc {
 	}
 }
 
-func updateCollection(pRuntime *runtime.Runtime) gin.HandlerFunc {
+func updateCollectionName(pRuntime *runtime.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		input := &collectionUpdateByIdInput{}
+		input := &collectionUpdateNameByIdInput{}
+		if err := c.ShouldBindJSON(input); err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
+		}
+
+		userId := c.GetString(userIdContextKey)
+
+		coll := &persist.Collection{NameStr: input.Name}
+
+		err := persist.CollUpdate(input.Id, persist.DbId(userId), coll, c, pRuntime)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+			return
+		}
+
+		c.Status(http.StatusOK)
+	}
+}
+
+func updateCollectionHidden(pRuntime *runtime.Runtime) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		input := &collectionUpdateHiddenByIdInput{}
 		if err := c.ShouldBindJSON(input); err != nil {
 			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
@@ -106,12 +134,27 @@ func updateCollection(pRuntime *runtime.Runtime) gin.HandlerFunc {
 
 		coll := &persist.Collection{HiddenBool: input.Hidden}
 
-		if input.Name != "" {
-			coll.NameStr = input.Name
+		err := persist.CollUpdate(input.Id, persist.DbId(userId), coll, c, pRuntime)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
+			return
 		}
-		if input.Nfts != nil {
-			coll.NFTsLst = input.Nfts
+
+		c.Status(http.StatusOK)
+	}
+}
+
+func updateCollectionNfts(pRuntime *runtime.Runtime) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		input := &collectionUpdateNftsByIdInput{}
+		if err := c.ShouldBindJSON(input); err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
+			return
 		}
+
+		userId := c.GetString(userIdContextKey)
+
+		coll := &persist.Collection{NftsLst: input.Nfts}
 
 		err := persist.CollUpdate(input.Id, persist.DbId(userId), coll, c, pRuntime)
 		if err != nil {
@@ -156,7 +199,7 @@ func collectionCreateDb(pInput *collectionCreateInput,
 
 	coll := &persist.CollectionDb{
 		OwnerUserIDstr: pUserIDstr,
-		NFTsLst:        pInput.Nfts,
+		NftsLst:        pInput.Nfts,
 	}
 
 	return persist.CollCreate(coll, pCtx, pRuntime)

--- a/server/handler.go
+++ b/server/handler.go
@@ -11,8 +11,6 @@ func HandlersInit(pRuntime *runtime.Runtime) *gin.Engine {
 	apiGroupV1 := pRuntime.Router.Group("/glry/v1")
 
 	// AUTH_HANDLERS
-	// TODO: bring these handlers out to this file and format
-	// like the routes below
 	authHandlersInit(pRuntime, apiGroupV1)
 
 	//-------------------------------------------------------------
@@ -24,7 +22,9 @@ func HandlersInit(pRuntime *runtime.Runtime) *gin.Engine {
 	collectionsGroup.GET("/get", jwtOptional(pRuntime), getAllCollectionsForUser(pRuntime))
 	collectionsGroup.POST("/create", jwtRequired(pRuntime), createCollection(pRuntime))
 	collectionsGroup.POST("/delete", jwtRequired(pRuntime), deleteCollection(pRuntime))
-	collectionsGroup.POST("/update", jwtRequired(pRuntime), updateCollection(pRuntime))
+	collectionsGroup.POST("/update/name", jwtRequired(pRuntime), updateCollectionName(pRuntime))
+	collectionsGroup.POST("/update/hidden", jwtRequired(pRuntime), updateCollectionHidden(pRuntime))
+	collectionsGroup.POST("/update/nfts", jwtRequired(pRuntime), updateCollectionNfts(pRuntime))
 
 	//-------------------------------------------------------------
 	// NFTS
@@ -36,7 +36,7 @@ func HandlersInit(pRuntime *runtime.Runtime) *gin.Engine {
 	nftsGroup.GET("/user_get", jwtOptional(pRuntime), getNftsForUser(pRuntime))
 	nftsGroup.GET("/opensea_get", jwtOptional(pRuntime), getNftsFromOpensea(pRuntime))
 	nftsGroup.POST("/update", jwtRequired(pRuntime), updateNftById(pRuntime))
-	apiGroupV1.GET("/nfts/get_unassigned", jwtRequired(pRuntime), getUnassignedNftsForUser(pRuntime))
+	apiGroupV1.GET("/get_unassigned", jwtRequired(pRuntime), getUnassignedNftsForUser(pRuntime))
 
 	// HEALTH
 	apiGroupV1.GET("/health", healthcheck(pRuntime))

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -33,7 +33,7 @@ func jwtRequired(runtime *runtime.Runtime) gin.HandlerFunc {
 			// database that is unique to every user and session
 			valid, userId, err := authJwtVerify(jwt, os.Getenv("JWT_SECRET"), runtime)
 			if err != nil {
-				c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+				c.JSON(http.StatusUnauthorized, ErrorResponse{Error: err.Error()})
 				return
 			}
 

--- a/server/nft.go
+++ b/server/nft.go
@@ -57,13 +57,13 @@ func updateNftById(pRuntime *runtime.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		nft := &persist.Nft{}
 		if err := c.ShouldBindJSON(nft); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
 
 		err := persist.NftUpdateById(nft.IDstr, nft, c, pRuntime)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
 			return
 		}
 
@@ -75,7 +75,7 @@ func getNftsForUser(pRuntime *runtime.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		input := &getNftsByUserIdInput{}
 		if err := c.ShouldBindQuery(input); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
 		nfts, err := persist.NftGetByUserId(input.UserId, c, pRuntime)
@@ -91,15 +91,15 @@ func getUnassignedNftsForUser(pRuntime *runtime.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		input := &getNftsByUserIdInput{}
 		if err := c.ShouldBindQuery(input); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
 		coll, err := persist.CollGetUnassigned(input.UserId, c, pRuntime)
 		if coll == nil || err != nil {
-			coll = &persist.Collection{NFTsLst: []*persist.Nft{}}
+			coll = &persist.Collection{NftsLst: []*persist.Nft{}}
 		}
 
-		c.JSON(http.StatusOK, getNftsOutput{Nfts: coll.NFTsLst})
+		c.JSON(http.StatusOK, getNftsOutput{Nfts: coll.NftsLst})
 	}
 }
 

--- a/server/user.go
+++ b/server/user.go
@@ -63,7 +63,7 @@ func updateUserAuth(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		up := &userUpdateInput{}
 
 		if err := c.ShouldBindJSON(up); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
 
@@ -71,7 +71,7 @@ func updateUserAuth(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		// UPDATE
 		err := userUpdateDb(up, c, pRuntime)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
 			return
 		}
 		//------------------
@@ -88,7 +88,7 @@ func getUserAuth(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		input := &userGetInput{}
 
 		if err := c.ShouldBindQuery(input); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
 
@@ -96,7 +96,7 @@ func getUserAuth(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			auth,
 			c, pRuntime)
 		if err != nil {
-			c.JSON(http.StatusNoContent, gin.H{"error": err.Error()})
+			c.JSON(http.StatusNoContent, ErrorResponse{Error: err.Error()})
 			return
 		}
 
@@ -114,7 +114,7 @@ func createUserAuth(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		input := &userCreateInput{}
 
 		if err := c.ShouldBindJSON(input); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
 


### PR DESCRIPTION
Changes:

- **Added** separate endpoints for different update types
- **Changed** gin.H errors to ErrorResponse

Considerations:

- Currently doing /update/name and /update/hidden etc.. Is there a better way we want to do endpoint naming for these? We could also have one handler and do /update/:type and do a switch statement on the type to determine what they are trying to update. Possibly even a required query param. What do you think?