### PR TITLE
user id for nft update

### DIFF
--- a/persist/nft.go
+++ b/persist/nft.go
@@ -126,7 +126,7 @@ func NftGetById(pIDstr DbId, pCtx context.Context, pRuntime *runtime.Runtime) ([
 	return result, nil
 }
 
-func NftUpdateById(pIDstr DbId, updatedNft *Nft, pCtx context.Context, pRuntime *runtime.Runtime) error {
+func NftUpdateById(pIDstr DbId, pUserIdstr DbId, updatedNft *Nft, pCtx context.Context, pRuntime *runtime.Runtime) error {
 
 	//------------------
 	// VALIDATE
@@ -136,7 +136,7 @@ func NftUpdateById(pIDstr DbId, updatedNft *Nft, pCtx context.Context, pRuntime 
 
 	mp := NewMongoStorage(0, nftColName, pRuntime)
 
-	return mp.Update(pCtx, bson.M{"_id": pIDstr}, bson.M{"$set": updatedNft})
+	return mp.Update(pCtx, bson.M{"_id": pIDstr, "owner_user_Id": pUserIdstr}, updatedNft)
 }
 
 func NftBulkUpsertOrRemove(walletAddress string, pNfts []*Nft, pCtx context.Context, pRuntime *runtime.Runtime) error {

--- a/persist/t__nft_test.go
+++ b/persist/t__nft_test.go
@@ -33,7 +33,7 @@ func TestCreateAndGetNFT(pTest *testing.T) {
 	id, err := NftCreate(&Nft{OwnerUserIdStr: "poop", DescriptionStr: "cool nft", NameStr: "Big Bobby's Balooga"}, ctx, runtime)
 	assert.Nil(pTest, err)
 
-	err = NftUpdateById(id, &Nft{OwnerUserIdStr: "poop", DescriptionStr: "extremely cool nft", NameStr: "Big Bobby's Balooga"}, ctx, runtime)
+	err = NftUpdateById(id, "poop", &Nft{OwnerUserIdStr: "poop", DescriptionStr: "extremely cool nft", NameStr: "Big Bobby's Balooga"}, ctx, runtime)
 	assert.Nil(pTest, err)
 
 	nfts, err := NftGetById(id, ctx, runtime)

--- a/server/nft.go
+++ b/server/nft.go
@@ -61,7 +61,9 @@ func updateNftById(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			return
 		}
 
-		err := persist.NftUpdateById(nft.IDstr, nft, c, pRuntime)
+		userId := c.GetString(userIdContextKey)
+
+		err := persist.NftUpdateById(nft.IDstr, persist.DbId(userId), nft, c, pRuntime)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
 			return


### PR DESCRIPTION
Changes:

- **Changed** NftUpdate func to take in user id given that a user id must always be present for authenticated endpoints and use the user id in filter to make querying faster