### PR TITLE
Rename ID field on auth schema to IDstr

### DIFF
--- a/persist/auth.go
+++ b/persist/auth.go
@@ -23,7 +23,7 @@ type UserNonce struct {
 
 	// nonces are shortlived, and not something to be persisted across DB's
 	// other than mongo. so use mongo-native ID generation
-	ID            DbId    `bson:"_id"           json:"id"`
+	IDstr         DbId    `bson:"_id"           json:"id"`
 	CreationTimeF float64 `bson:"creation_time" json:"creation_time"`
 	DeletedBool   bool    `bson:"deleted"       json:"deleted"`
 
@@ -35,7 +35,7 @@ type UserNonce struct {
 // USER_LOGIN_ATTEMPT
 type UserLoginAttempt struct {
 	VersionInt    int64   `bson:"version"`
-	ID            DbId    `bson:"_id"`
+	IDstr         DbId    `bson:"_id"`
 	CreationTimeF float64 `bson:"creation_time"`
 
 	AddressStr         string `bson:"address"     json:"address"`

--- a/persist/mongo.go
+++ b/persist/mongo.go
@@ -33,8 +33,9 @@ func (m *MongoStorage) Insert(ctx context.Context, insert interface{}, opts ...*
 	elem := reflect.TypeOf(insert).Elem()
 	val := reflect.ValueOf(insert).Elem()
 	now := float64(time.Now().UnixNano()) / 1000000000.0
-	if _, ok := elem.FieldByName("IDstr"); ok {
-		idField := val.FieldByName("IDstr")
+
+	if _, ok := elem.FieldByName("ID"); ok {
+		idField := val.FieldByName("ID")
 		if !idField.CanSet() {
 			// panic because this literally cannot happen in prod
 			panic("unable to set id field on struct")

--- a/persist/mongo.go
+++ b/persist/mongo.go
@@ -34,8 +34,8 @@ func (m *MongoStorage) Insert(ctx context.Context, insert interface{}, opts ...*
 	val := reflect.ValueOf(insert).Elem()
 	now := float64(time.Now().UnixNano()) / 1000000000.0
 
-	if _, ok := elem.FieldByName("ID"); ok {
-		idField := val.FieldByName("ID")
+	if _, ok := elem.FieldByName("IDstr"); ok {
+		idField := val.FieldByName("IDstr")
 		if !idField.CanSet() {
 			// panic because this literally cannot happen in prod
 			panic("unable to set id field on struct")

--- a/server/auth.go
+++ b/server/auth.go
@@ -59,6 +59,7 @@ func getAuthPreflight(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		// GET_PUBLIC_INFO
 		output, err := authUserGetPreflightDb(input, c, pRuntime)
 		if err != nil {
+			// TODO: log specific error and return user friendly error message instead
 			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: err.Error()})
 
 			return


### PR DESCRIPTION
We get a duplicate key error when inserting a record into the db (and 1 record already exists in the db), because the `_id` field is getting set as an empty string. I encountered this when trying to generate a nonce more than once.

It looks like it's just an issue setting the ID field using an incorrect field name. We're using `IDstr` instead of `ID` which is what is set in the schema.

This PR changes `IDstr` to `ID` in our mongo Insert function so that the id gets persisted.

Empty ID before fix:
![Screen Shot 2021-07-24 at 10 51 38 AM](https://user-images.githubusercontent.com/80802871/126854886-26e86287-fb9b-439c-9290-a0bb60ef29bb.png)

 ID after fix:
![Screen Shot 2021-07-24 at 11 28 24 AM](https://user-images.githubusercontent.com/80802871/126854983-de2907fc-e98b-4cfb-93ea-f3a04324fa06.png)



@bennycio @fbrcsftnr  Do we prefer `ID` or `IDstr` ?  we can use `IDstr` if we want to be consistent with our other fields. But I don't feel strongly since this field has the type `DbId`, which is also a `string` so both are correct

