### PR TITLE
Fix Validation registration and ethValidator

### DIFF
--- a/server/middleware.go
+++ b/server/middleware.go
@@ -71,7 +71,7 @@ func jwtOptional(runtime *runtime.Runtime) gin.HandlerFunc {
 func handleCORS() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// TODO make origin url env specific
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "https://gallery-dev.vercel.app")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE")

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -71,7 +71,7 @@ func jwtOptional(runtime *runtime.Runtime) gin.HandlerFunc {
 func handleCORS() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// TODO make origin url env specific
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "https://gallery-dev.vercel.app")
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT, DELETE")

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-	"github.com/go-playground/validator"
+	"github.com/go-playground/validator/v10"
 	"github.com/mikeydub/go-gallery/runtime"
 	log "github.com/sirupsen/logrus"
 )
@@ -20,6 +20,7 @@ func Init(pPortInt int,
 	pRuntime.Router.Use(handleCORS())
 
 	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
+		log.Info("registering validation")
 		v.RegisterValidation("short_string", shortStringValidator)
 		v.RegisterValidation("medium_string", mediumStringValidator)
 		v.RegisterValidation("eth_addr", ethValidator)

--- a/server/validate.go
+++ b/server/validate.go
@@ -3,12 +3,12 @@ package server
 import (
 	"strings"
 
-	"github.com/go-playground/validator"
+	"github.com/go-playground/validator/v10"
 )
 
 var ethValidator validator.Func = func(fl validator.FieldLevel) bool {
 	addr := fl.Field().String()
-	return len(addr) == 42 && strings.HasSuffix(addr, "0x")
+	return len(addr) == 42 && strings.HasPrefix(addr, "0x")
 }
 
 var signatureValidator validator.Func = func(fl validator.FieldLevel) bool {


### PR DESCRIPTION
The validator functions weren't being registered as expected on init, causing a panic when attempting to save to the user table.

The following code block didn't run because `v` and `ok` were `nil` and `false`, respectively.
```
if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
  v.RegisterValidation("short_string", shortStringValidator)
}
```

Specifying the validator version we use as `v10` solved the issue.

Separately, fixed `ethValidator` by swapping `HasSuffix` for `HasPrefix` to look for "0x" in the expected place.
