### PR TITLE
sync test and fixes

### DIFF
--- a/server/nft.go
+++ b/server/nft.go
@@ -21,6 +21,10 @@ type getNftsByUserIdInput struct {
 	UserId persist.DbId `json:"user_id" form:"user_id" binding:"required"`
 }
 
+type getOpenseaNftsInput struct {
+	WalletAddress string `json:"addr" form:"addr" binding:"required"`
+}
+
 type getNftsOutput struct {
 	Nfts []*persist.Nft `json:"nfts"`
 }
@@ -107,12 +111,12 @@ func getUnassignedNftsForUser(pRuntime *runtime.Runtime) gin.HandlerFunc {
 
 func getNftsFromOpensea(pRuntime *runtime.Runtime) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		ownerWalletAddr := c.Query("addr")
-		if ownerWalletAddr == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "owner wallet address not found in query values"})
+		input := &getOpenseaNftsInput{}
+		if err := c.ShouldBindQuery(input); err != nil {
+			c.JSON(http.StatusBadRequest, ErrorResponse{Error: err.Error()})
 			return
 		}
-		nfts, err := OpenSeaPipelineAssetsForAcc(ownerWalletAddr, c, pRuntime)
+		nfts, err := OpenSeaPipelineAssetsForAcc(input.WalletAddress, c, pRuntime)
 		if len(nfts) == 0 || err != nil {
 			nfts = []*persist.Nft{}
 		}

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -1,36 +1,58 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"testing"
+
+	"github.com/mikeydub/go-gallery/persist"
+	"github.com/stretchr/testify/assert"
 	// gfcore "github.com/gloflow/gloflow/go/gf_core"
 )
 
 //---------------------------------------------------
 func TestFetchAssertsForAcc(pTest *testing.T) {
 
-	fmt.Println("TEST__OPENSEA ==============================================")
+	ctx := context.Background()
 
-	// TODO
-	// ctx := context.Background()
+	user := &persist.User{AddressesLst: []string{"0x485b8ac36535fae56b2910780245dd69dda270bc"}}
 
-	// //--------------------
-	// // RUNTIME_SYS
+	userID, err := persist.UserCreate(user, ctx, r)
+	assert.Nil(pTest, err)
 
-	// runtime, gErr := runtime.RuntimeGet("127.0.0.1:27017", "glry_test")
-	// if gErr != nil {
-	// 	pTest.Fail()
-	// }
+	nft := &persist.Nft{
+		OwnerUserIdStr:  userID,
+		OwnerAddressStr: "0x485b8ac36535fae56b2910780245dd69dda270bc",
+		NameStr:         "test",
+		OpenSeaIDint:    0,
+	}
 
-	// //--------------------
-	// ownerWalletAddressStr := "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"
-	// assetsForAccLst, gErr := OpenSeaPipelineAssetsForAcc(ownerWalletAddressStr, ctx, runtime.RuntimeSys)
-	// if gErr != nil {
-	// 	pTest.Fail()
-	// }
+	nft2 := &persist.Nft{
+		OwnerUserIdStr:  userID,
+		OwnerAddressStr: "0x485b8ac36535fae56b2910780245dd69dda270bc",
+		NameStr:         "test2",
+		OpenSeaIDint:    32087758,
+	}
 
-	// assert.True(pTest, len(assetsForAccLst) > 0, "more then 0 OpenSea assets should be fetched for Account")
+	_, err = persist.NftCreateBulk([]*persist.Nft{nft, nft2}, ctx, r)
+	assert.Nil(pTest, err)
 
-	// spew.Dump(assetsForAccLst)
+	nfts, err := OpenSeaPipelineAssetsForAcc("0x485b8ac36535fae56b2910780245dd69dda270bc", ctx, r)
+	assert.Nil(pTest, err)
+
+	nftsByUser, err := persist.NftGetByUserId(userID, ctx, r)
+	assert.Nil(pTest, err)
+
+	for _, nft := range nfts {
+		fmt.Println(nft.NameStr)
+	}
+
+	fmt.Println("----------------------------------------------- BY USER")
+
+	for _, nft := range nftsByUser {
+		fmt.Println(nft.NameStr)
+	}
+
+	assert.Equal(pTest, len(nfts), len(nftsByUser))
 
 }


### PR DESCRIPTION
Changes:

- **Added** tests for opensea sync
- **Changed** funcs for upserting, checking difference, etc. to ensure all opensea nfts are reflected accurately on gallery

Considerations:

- Should we mark nfts that are not on opensea for a user but on gallery as 1. deleted, 2. remove their `owner_user_id` and `owner_address`, or 3. remove their `owner_user_id` and set their `owner_address` to what it is on opensea. Currently I have implemented 2 because deleting feels odd given that the nft's themselves can't really be deleted and later on someone else could come along with that same nft.
