### PR TITLE
fix create user

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -373,16 +373,19 @@ func authUserGetPreflightDb(pInput *authUserGetPreflightInput,
 	pRuntime *runtime.Runtime) (*authUserGetPreflightOutput, error) {
 
 	//------------------
-	var nonce *persist.UserNonce
 
 	// DB_GET_USER_BY_ADDRESS
 	user, err := persist.UserGetByAddress(pInput.AddressStr, pCtx, pRuntime)
 
 	userExistsBool := user != nil
 
+	output := &authUserGetPreflightOutput{
+		UserExistsBool: userExistsBool,
+	}
+	var nonce *persist.UserNonce
 	if err != nil || !userExistsBool {
 
-		nonce := &persist.UserNonce{
+		nonce = &persist.UserNonce{
 			AddressStr: pInput.AddressStr,
 			ValueStr:   generateNonce(),
 		}
@@ -393,20 +396,14 @@ func authUserGetPreflightDb(pInput *authUserGetPreflightInput,
 			return nil, err
 		}
 
+	} else {
+		nonce, err = persist.AuthNonceGet(pInput.AddressStr, pCtx, pRuntime)
+		if err != nil {
+			return nil, err
+		}
 	}
+	output.NonceStr = nonce.ValueStr
 
-	// NONCE_GET
-	nonce, err = persist.AuthNonceGet(pInput.AddressStr, pCtx, pRuntime)
-	if err != nil {
-		return nil, err
-	}
-
-	//-------------------------------------------------------------
-
-	output := &authUserGetPreflightOutput{
-		NonceStr:       nonce.ValueStr,
-		UserExistsBool: userExistsBool,
-	}
 	return output, nil
 }
 

--- a/server/t__auth_user_test.go
+++ b/server/t__auth_user_test.go
@@ -2,11 +2,10 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/mikeydub/go-gallery/runtime"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 //---------------------------------------------------
@@ -17,37 +16,19 @@ func TestAuthUser(pTest *testing.T) {
 	ctx := context.Background()
 
 	//--------------------
-	// RUNTIME_SYS
-
-	mongoURLstr := "mongodb://127.0.0.1:27017"
-	mongoDBnameStr := "glry_test"
-	config := &runtime.Config{
-		// Env            string
-		// BaseURL        string
-		// WebBaseURL     string
-		// Port              int
-		MongoURLstr:       mongoURLstr,
-		MongoDBnameStr:    mongoDBnameStr,
-		JWTtokenTTLsecInt: 86400,
-	}
-
-	runtime, gErr := runtime.RuntimeGet(config)
-	if gErr != nil {
-		pTest.Fail()
-	}
-
-	//--------------------
 	// USER_GET_PREFLIGHT
 
 	userGetPublicInfoInput := &authUserGetPreflightInput{
 		AddressStr: addressStr,
 	}
-	output, err := authUserGetPreflightDb(userGetPublicInfoInput, ctx, runtime)
+	output, err := authUserGetPreflightDb(userGetPublicInfoInput, ctx, r)
 	if err != nil {
-		pTest.Fail()
+		pTest.FailNow()
 	}
 
 	nonceStr := output.NonceStr
+
+	assert.NotEmpty(pTest, nonceStr)
 
 	//--------------------
 	// USER_CREATE
@@ -55,7 +36,7 @@ func TestAuthUser(pTest *testing.T) {
 		AddressStr:   addressStr,
 		SignatureStr: "how to make this? can we sign the nonce from go?",
 	}
-	user, err := userCreateDb(userCreateInput, ctx, runtime)
+	user, err := userCreateDb(userCreateInput, ctx, r)
 	if err != nil {
 		pTest.Fail()
 	}
@@ -63,7 +44,7 @@ func TestAuthUser(pTest *testing.T) {
 	//--------------------
 	// USER_DELETE
 
-	err = userDeleteDb(user.UserIDstr, ctx, runtime)
+	err = userDeleteDb(user.UserIDstr, ctx, r)
 	if err != nil {
 		pTest.Fail()
 	}
@@ -71,6 +52,5 @@ func TestAuthUser(pTest *testing.T) {
 	//--------------------
 
 	log.WithFields(log.Fields{"nonce": nonceStr}).Info("signature validity")
-	fmt.Println()
 
 }

--- a/server/user.go
+++ b/server/user.go
@@ -301,12 +301,12 @@ func getUserWithNonce(pAddress string,
 		pCtx,
 		pRuntime)
 	if err != nil {
-		return "", "", err
+		return nonceValueStr, userIdStr, err
 	}
 	if nonce != nil {
 		nonceValueStr = nonce.ValueStr
 	} else {
-		return "", "", errors.New("no nonce found")
+		return nonceValueStr, userIdStr, errors.New("no nonce found")
 	}
 
 	//------------------
@@ -314,12 +314,12 @@ func getUserWithNonce(pAddress string,
 
 	user, err := persist.UserGetByAddress(pAddress, pCtx, pRuntime)
 	if err != nil {
-		return "", "", err
+		return nonceValueStr, userIdStr, err
 	}
 	if user != nil {
 		userIdStr = user.IDstr
 	} else {
-		return "", "", errors.New("no user found")
+		return nonceValueStr, userIdStr, errors.New("no user found")
 	}
 	//------------------
 


### PR DESCRIPTION
Changes:

- **Changed** `getUserWithNonce` to return what it has regardless of errors
- **Changed** auth preflight to not spend time making the extra round trip to the DB to grab nonce immediately after creating it in the case that a user did not exist
- **Changed** test to use global runtime and ensure nonce is not empty