### PR TITLE
create with collections

### DIFF
--- a/server/gallery.go
+++ b/server/gallery.go
@@ -18,7 +18,7 @@ type galleryGetByIDInput struct {
 }
 
 type galleryCreateInput struct {
-	OwnerUserID persist.DBID `form:"owner_user_id" json:"owner_user_id" binding:"required"`
+	Collections []persist.DBID `form:"collections" json:"collections" binding:"required"`
 }
 
 type galleryUpdateInput struct {


### PR DESCRIPTION
Changes:

- **Changed** gallery create to take in a list of collections instead of user id

Considerations:

- UserID is already given by context which is why it was not necessary in post, it is also possible that collections are not necessary for create either but in this case it would be an empty post. It could also save a round trip just creating the gallery at the first time they set up their collections. 