### PR TITLE
collections in gallery push, nft with username, possible preflight fix

### DIFF
--- a/persist/collection.go
+++ b/persist/collection.go
@@ -76,6 +76,10 @@ func CollCreate(pCtx context.Context, pColl *CollectionDB,
 
 	mp := newStorage(0, collectionColName, pRuntime)
 
+	if pColl.Nfts == nil {
+		pColl.Nfts = []DBID{}
+	}
+
 	return mp.insert(pCtx, pColl)
 
 }

--- a/persist/gallery.go
+++ b/persist/gallery.go
@@ -51,6 +51,10 @@ func GalleryCreate(pCtx context.Context, pGallery *GalleryDB,
 
 	mp := newStorage(0, galleryColName, pRuntime)
 
+	if pGallery.Collections == nil {
+		pGallery.Collections = []DBID{}
+	}
+
 	return mp.insert(pCtx, pGallery)
 }
 

--- a/persist/nft.go
+++ b/persist/nft.go
@@ -27,7 +27,6 @@ type Nft struct {
 	Description    string `bson:"description"          json:"description"`
 	CollectorsNote string `bson:"collectors_note" json:"collectors_note"`
 	OwnerUserID    DBID   `bson:"owner_user_id" json:"user_id"`
-	OwnerUsername  string `json:"owner_username"`
 
 	ExternalURL      string   `bson:"external_url"         json:"external_url"`
 	TokenMetadataURL string   `bson:"token_metadata_url" json:"token_metadata_url"`
@@ -108,13 +107,6 @@ func NftGetByUserID(pCtx context.Context, pUserID DBID,
 	if err := mp.find(pCtx, bson.M{"owner_user_id": pUserID}, &result, opts); err != nil {
 		return nil, err
 	}
-	ownerUser, err := UserGetByID(pCtx, pUserID, pRuntime)
-	if err != nil {
-		return nil, err
-	}
-	for _, v := range result {
-		v.OwnerUsername = ownerUser.UserName
-	}
 
 	return result, nil
 }
@@ -133,14 +125,6 @@ func NftGetByID(pCtx context.Context, pID DBID, pRuntime *runtime.Runtime) ([]*N
 
 	if err := mp.find(pCtx, bson.M{"_id": pID}, &result, opts); err != nil {
 		return nil, err
-	}
-
-	for _, v := range result {
-		ownerUser, err := UserGetByID(pCtx, v.OwnerUserID, pRuntime)
-		if err != nil {
-			return nil, err
-		}
-		v.OwnerUsername = ownerUser.UserName
 	}
 
 	return result, nil

--- a/persist/nft.go
+++ b/persist/nft.go
@@ -27,6 +27,7 @@ type Nft struct {
 	Description    string `bson:"description"          json:"description"`
 	CollectorsNote string `bson:"collectors_note" json:"collectors_note"`
 	OwnerUserID    DBID   `bson:"owner_user_id" json:"user_id"`
+	OwnerUsername  string `json:"owner_username"`
 
 	ExternalURL      string   `bson:"external_url"         json:"external_url"`
 	TokenMetadataURL string   `bson:"token_metadata_url" json:"token_metadata_url"`
@@ -107,6 +108,13 @@ func NftGetByUserID(pCtx context.Context, pUserID DBID,
 	if err := mp.find(pCtx, bson.M{"owner_user_id": pUserID}, &result, opts); err != nil {
 		return nil, err
 	}
+	ownerUser, err := UserGetByID(pCtx, pUserID, pRuntime)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range result {
+		v.OwnerUsername = ownerUser.UserName
+	}
 
 	return result, nil
 }
@@ -125,6 +133,14 @@ func NftGetByID(pCtx context.Context, pID DBID, pRuntime *runtime.Runtime) ([]*N
 
 	if err := mp.find(pCtx, bson.M{"_id": pID}, &result, opts); err != nil {
 		return nil, err
+	}
+
+	for _, v := range result {
+		ownerUser, err := UserGetByID(pCtx, v.OwnerUserID, pRuntime)
+		if err != nil {
+			return nil, err
+		}
+		v.OwnerUsername = ownerUser.UserName
 	}
 
 	return result, nil

--- a/persist/storage.go
+++ b/persist/storage.go
@@ -136,7 +136,8 @@ func (m *storage) update(ctx context.Context, query bson.M, update interface{}, 
 }
 
 // Push pushes items into an array field for a given queried document
-func (m *storage) Push(ctx context.Context, query bson.M, field string, value ...interface{}) error {
+// value must be an array
+func (m *storage) Push(ctx context.Context, query bson.M, field string, value interface{}) error {
 
 	result, err := m.collection.UpdateOne(ctx, query, bson.D{{Key: "$push", Value: bson.M{field: bson.M{"$each": value}}}})
 	if err != nil {

--- a/server/auth.go
+++ b/server/auth.go
@@ -360,13 +360,13 @@ func authUserGetPreflightDb(pCtx context.Context, pInput *authUserGetPreflightIn
 
 	user, err := persist.UserGetByAddress(pCtx, pInput.Address, pRuntime)
 
-	userExistsBool := user != nil
+	userExistsBool := user != nil && err == nil
 
 	output := &authUserGetPreflightOutput{
 		UserExists: userExistsBool,
 	}
 	var nonce *persist.UserNonce
-	if err != nil || !userExistsBool {
+	if !userExistsBool {
 
 		nonce = &persist.UserNonce{
 			Address: pInput.Address,

--- a/server/handler.go
+++ b/server/handler.go
@@ -59,8 +59,8 @@ func authHandlersInit(pRuntime *runtime.Runtime, parent *gin.RouterGroup) {
 
 	// called before login/sugnup calls, mostly to get nonce and also discover if user exists.
 
-	// [GET] /glry/v1/auth/get_preflight?addr=:walletAddress
-	authGroup.GET("/get_preflight", jwtOptional(pRuntime), getAuthPreflight(pRuntime))
+	// [GET] /glry/v1/auth/get_preflight?address=:walletAddress
+	authGroup.GET("/get_preflight", getAuthPreflight(pRuntime))
 
 	// AUTH VALIDATE_JWT
 

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"time"
 
@@ -41,7 +42,7 @@ func validateJwt(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		auth := c.GetBool(authContextKey)
 		userID, _ := getUserIDfromCtx(c)
 
-		c.JSON(200, jwtValidateResponse{
+		c.JSON(http.StatusOK, jwtValidateResponse{
 			IsValid: auth,
 			UserID:  userID,
 		})

--- a/server/t__routes_auth_test.go
+++ b/server/t__routes_auth_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/mikeydub/go-gallery/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthPreflightUserExists_Success(t *testing.T) {
+	assert := assert.New(t)
+
+	// send update request
+	req, err := http.NewRequest("GET",
+		fmt.Sprintf("%s/auth/get_preflight?address=%s", tc.serverURL, tc.user1.address),
+		nil)
+	assert.Nil(err)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tc.user1.jwt))
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.Nil(err)
+	assertValidResponse(assert, resp)
+
+	type PreflightResp struct {
+		authUserGetPreflightOutput
+		Error string `json:"error"`
+	}
+	output := &PreflightResp{}
+	err = runtime.UnmarshallBody(output, resp.Body, tc.r)
+	assert.Nil(err)
+	assert.Empty(output.Error)
+	assert.True(output.UserExists)
+}

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -27,12 +27,13 @@ func generateTestUser(r *runtime.Runtime) *TestUser {
 	username := util.RandStringBytes(8)
 	address := fmt.Sprintf("0x%s", util.RandStringBytes(40))
 	user := &persist.User{
-		UserName: username,
+		UserName:           username,
 		UserNameIdempotent: strings.ToLower(username),
-		Addresses: []string{address},
+		Addresses:          []string{address},
 	}
 	id, _ := persist.UserCreate(ctx, user, r)
 	jwt, _ := jwtGeneratePipeline(ctx, id, r)
+	authNonceRotateDb(ctx, address, id, r)
 
 	return &TestUser{id, address, jwt, username}
 }


### PR DESCRIPTION
Changes:

- **Changed** push function to take in an array rather than an array of arrays so that it pushes collections into galleries correctly
- **Added** tests for preflight and collection creation
- **Added** owner username field to nft with just json tag and fills field upon retrieval
- **Changed** test user creation to create a nonce

Consirations:

- Made some minor adjustments to preflight func and test passes but not sure why @Robinnnnn 's issue with preflight showing no user existing is happening yet