### PR TITLE
pull operation to ensure no duplicate nfts

### DIFF
--- a/persist/gallery.go
+++ b/persist/gallery.go
@@ -75,7 +75,7 @@ func GalleryUpdate(pCtx context.Context, pIDstr DBID,
 func GalleryAddCollections(pCtx context.Context, pID DBID, pUserID DBID, pCollectionIDs []DBID, pRuntime *runtime.Runtime) error {
 	mp := newStorage(0, galleryColName, pRuntime)
 
-	return mp.Push(pCtx, bson.M{"_id": pID, "owner_user_id": pUserID}, "collections", pCollectionIDs)
+	return mp.push(pCtx, bson.M{"_id": pID, "owner_user_id": pUserID}, "collections", pCollectionIDs)
 }
 
 // GalleryGetByUserID gets a gallery by its owner user ID and will variably return

--- a/persist/storage.go
+++ b/persist/storage.go
@@ -135,11 +135,27 @@ func (m *storage) update(ctx context.Context, query bson.M, update interface{}, 
 	return nil
 }
 
-// Push pushes items into an array field for a given queried document
+// push pushes items into an array field for a given queried document(s)
 // value must be an array
-func (m *storage) Push(ctx context.Context, query bson.M, field string, value interface{}) error {
+func (m *storage) push(ctx context.Context, query bson.M, field string, value interface{}) error {
 
 	result, err := m.collection.UpdateOne(ctx, query, bson.D{{Key: "$push", Value: bson.M{field: bson.M{"$each": value}}}})
+	if err != nil {
+		return err
+	}
+	if result.MatchedCount == 0 {
+		// TODO this should return a 404 or 204
+		return errors.New(copy.CouldNotFindDocument)
+	}
+
+	return nil
+}
+
+// pull puls items from an array field for a given queried document(s)
+// value must be an array
+func (m *storage) pull(ctx context.Context, query bson.M, field string, value interface{}) error {
+
+	result, err := m.collection.UpdateOne(ctx, query, bson.D{{Key: "$pull", Value: bson.M{field: bson.M{"$in": value}}}})
 	if err != nil {
 		return err
 	}

--- a/persist/storage.go
+++ b/persist/storage.go
@@ -157,8 +157,7 @@ func (m *storage) pull(ctx context.Context, query bson.M, field string, value in
 		return err
 	}
 	if result.MatchedCount == 0 {
-		// TODO this should return a 404 or 204
-		return errors.New(copy.CouldNotFindDocument)
+		return &DocumentNotFoundError{}
 	}
 
 	return nil

--- a/persist/user.go
+++ b/persist/user.go
@@ -180,5 +180,5 @@ func UserGetByUsername(pCtx context.Context, pUsername string,
 func UserAddAddresses(pCtx context.Context, pUserID DBID, pAddresses []string, pRuntime *runtime.Runtime) error {
 	mp := newStorage(0, usersCollName, pRuntime)
 
-	return mp.Push(pCtx, bson.M{"_id": pUserID}, "addresses", pAddresses)
+	return mp.push(pCtx, bson.M{"_id": pUserID}, "addresses", pAddresses)
 }

--- a/server/collection.go
+++ b/server/collection.go
@@ -208,9 +208,9 @@ func updateCollectionNfts(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			return
 		}
 
-		coll := &persist.CollectionUpdateNftsInput{Nfts: input.Nfts}
+		update := &persist.CollectionUpdateNftsInput{Nfts: input.Nfts}
 
-		err := persist.CollUpdate(c, input.ID, userID, coll, pRuntime)
+		err := persist.CollUpdateNFTs(c, input.ID, userID, update, pRuntime)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, errorResponse{Error: err.Error()})
 			return


### PR DESCRIPTION
Changes

- **Added** a pull operation to remove an array of items from an array field of queried documents
- **Added** an update nfts func that will first pull nfts from all other documents before adding it to the new one.
- **Changed** create coll func to also remove nfts from other colls that have the nfts it is being created with

Considerations:

- Needs tests still...