### PR TITLE
Ensure a gallery's collections are returned in the correct order

### DIFF
--- a/persist/collection.go
+++ b/persist/collection.go
@@ -311,17 +311,3 @@ func newCollectionPipeline(matchFilter bson.M) mongo.Pipeline {
 		}}},
 	}
 }
-
-func newSortedCollectionPipeline(matchFilter bson.M) mongo.Pipeline {
-	collectionPipeline := newCollectionPipeline(matchFilter)
-	return append(
-		collectionPipeline,
-		bson.D{{Key: "$addFields", Value: bson.M{
-			"sort": bson.M{
-				"$indexOfArray": []string{"$$childArray", "$_id"},
-			}},
-		}},
-		bson.D{{Key: "$sort", Value: bson.M{"sort": 1}}},
-		bson.D{{Key: "$addFields", Value: bson.M{"sort": "$$REMOVE"}}},
-	)
-}

--- a/persist/collection.go
+++ b/persist/collection.go
@@ -324,29 +324,4 @@ func newSortedCollectionPipeline(matchFilter bson.M) mongo.Pipeline {
 		bson.D{{Key: "$sort", Value: bson.M{"sort": 1}}},
 		bson.D{{Key: "$addFields", Value: bson.M{"sort": "$$REMOVE"}}},
 	)
-	// return mongo.Pipeline{
-	// 	{{Key: "$match", Value: matchFilter}},
-	// 	{{Key: "$lookup", Value: bson.M{
-	// 		"from": "nfts",
-	// 		"let":  bson.M{"array": "$nfts"},
-	// 		"pipeline": mongo.Pipeline{
-	// 			{{Key: "$match", Value: bson.M{
-	// 				"$expr": bson.M{
-	// 					"$and": []bson.M{
-	// 						{"$in": []string{"$_id", "$$array"}},
-	// 						{"$eq": []interface{}{"$deleted", false}},
-	// 					},
-	// 				},
-	// 			}}},
-	// 		},
-	// 		"as": "nfts",
-	// 	}}},
-	// 	{{Key: "$addFields", Value: bson.M{
-	// 		"sort": bson.M{
-	// 			"$indexOfArray": []string{"$$childArray", "$_id"},
-	// 		}},
-	// 	}},
-	// 	{{Key: "$sort", Value: bson.M{"sort": 1}}},
-	// 	{{Key: "$addFields", Value: bson.M{"sort": "$$REMOVE"}}},
-	// }
 }

--- a/persist/collection.go
+++ b/persist/collection.go
@@ -311,3 +311,42 @@ func newCollectionPipeline(matchFilter bson.M) mongo.Pipeline {
 		}}},
 	}
 }
+
+func newSortedCollectionPipeline(matchFilter bson.M) mongo.Pipeline {
+	collectionPipeline := newCollectionPipeline(matchFilter)
+	return append(
+		collectionPipeline,
+		bson.D{{Key: "$addFields", Value: bson.M{
+			"sort": bson.M{
+				"$indexOfArray": []string{"$$childArray", "$_id"},
+			}},
+		}},
+		bson.D{{Key: "$sort", Value: bson.M{"sort": 1}}},
+		bson.D{{Key: "$addFields", Value: bson.M{"sort": "$$REMOVE"}}},
+	)
+	// return mongo.Pipeline{
+	// 	{{Key: "$match", Value: matchFilter}},
+	// 	{{Key: "$lookup", Value: bson.M{
+	// 		"from": "nfts",
+	// 		"let":  bson.M{"array": "$nfts"},
+	// 		"pipeline": mongo.Pipeline{
+	// 			{{Key: "$match", Value: bson.M{
+	// 				"$expr": bson.M{
+	// 					"$and": []bson.M{
+	// 						{"$in": []string{"$_id", "$$array"}},
+	// 						{"$eq": []interface{}{"$deleted", false}},
+	// 					},
+	// 				},
+	// 			}}},
+	// 		},
+	// 		"as": "nfts",
+	// 	}}},
+	// 	{{Key: "$addFields", Value: bson.M{
+	// 		"sort": bson.M{
+	// 			"$indexOfArray": []string{"$$childArray", "$_id"},
+	// 		}},
+	// 	}},
+	// 	{{Key: "$sort", Value: bson.M{"sort": 1}}},
+	// 	{{Key: "$addFields", Value: bson.M{"sort": "$$REMOVE"}}},
+	// }
+}

--- a/persist/gallery.go
+++ b/persist/gallery.go
@@ -93,6 +93,8 @@ func GalleryGetByUserID(pCtx context.Context, pUserID DBID, pAuth bool,
 
 	result := []*Gallery{}
 
+	// pipeline := newGalleryPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth)
+
 	if err := mp.aggregate(pCtx, newGalleryPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result, opts); err != nil {
 		return nil, err
 	}
@@ -141,7 +143,7 @@ func newGalleryPipeline(matchFilter bson.M, pAuth bool) mongo.Pipeline {
 		{{Key: "$lookup", Value: bson.M{
 			"from":     "collections",
 			"let":      bson.M{"childArray": "$collections"},
-			"pipeline": newCollectionPipeline(innerMatch),
+			"pipeline": newSortedCollectionPipeline(innerMatch),
 			"as":       "collections",
 		}}},
 	}

--- a/persist/gallery.go
+++ b/persist/gallery.go
@@ -136,12 +136,24 @@ func newGalleryPipeline(matchFilter bson.M, pAuth bool) mongo.Pipeline {
 			"$and": andExpr,
 		},
 	}
+
+	collectionPipeline := append(
+		newCollectionPipeline(innerMatch),
+		bson.D{{Key: "$addFields", Value: bson.M{
+			"sort": bson.M{
+				"$indexOfArray": []string{"$$childArray", "$_id"},
+			}},
+		}},
+		bson.D{{Key: "$sort", Value: bson.M{"sort": 1}}},
+		bson.D{{Key: "$unset", Value: []string{"sort"}}},
+	)
+
 	return mongo.Pipeline{
 		{{Key: "$match", Value: matchFilter}},
 		{{Key: "$lookup", Value: bson.M{
 			"from":     "collections",
 			"let":      bson.M{"childArray": "$collections"},
-			"pipeline": newSortedCollectionPipeline(innerMatch),
+			"pipeline": collectionPipeline,
 			"as":       "collections",
 		}}},
 	}

--- a/persist/gallery.go
+++ b/persist/gallery.go
@@ -93,8 +93,6 @@ func GalleryGetByUserID(pCtx context.Context, pUserID DBID, pAuth bool,
 
 	result := []*Gallery{}
 
-	// pipeline := newGalleryPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth)
-
 	if err := mp.aggregate(pCtx, newGalleryPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result, opts); err != nil {
 		return nil, err
 	}

--- a/server/t__routes_collection_test.go
+++ b/server/t__routes_collection_test.go
@@ -161,7 +161,7 @@ func TestGetUnassignedCollection_Success(t *testing.T) {
 func TestDeleteCollection_Success(t *testing.T) {
 	assert := assert.New(t)
 
-	collID := createCollectionInDbForUserID(assert, tc.user1.id)
+	collID := createCollectionInDbForUserID(assert, "COLLECTION NAME", tc.user1.id)
 	verifyCollectionExistsInDbForID(assert, collID)
 
 	resp := sendDeleteRequest(assert, collectionDeleteInput{ID: collID}, tc.user1)
@@ -178,7 +178,7 @@ func TestDeleteCollection_Success(t *testing.T) {
 func TestDeleteCollection_Failure_Unauthenticated(t *testing.T) {
 	assert := assert.New(t)
 
-	collID := createCollectionInDbForUserID(assert, tc.user1.id)
+	collID := createCollectionInDbForUserID(assert, "COLLECTION NAME", tc.user1.id)
 	verifyCollectionExistsInDbForID(assert, collID)
 
 	resp := sendDeleteRequest(assert, collectionDeleteInput{ID: collID}, nil)
@@ -189,21 +189,11 @@ func TestDeleteCollection_Failure_Unauthenticated(t *testing.T) {
 func TestDeleteCollection_Failure_DifferentUsersCollection(t *testing.T) {
 	assert := assert.New(t)
 
-	collID := createCollectionInDbForUserID(assert, tc.user1.id)
+	collID := createCollectionInDbForUserID(assert, "COLLECTION NAME", tc.user1.id)
 	verifyCollectionExistsInDbForID(assert, collID)
 
 	resp := sendDeleteRequest(assert, collectionDeleteInput{ID: collID}, tc.user2)
 	assert.Equal(404, resp.StatusCode)
-}
-
-func createCollectionInDbForUserID(assert *assert.Assertions, userID persist.DBID) persist.DBID {
-	collID, err := persist.CollCreate(context.Background(), &persist.CollectionDB{
-		Name:        "very cool collection",
-		OwnerUserID: userID,
-	}, tc.r)
-	assert.Nil(err)
-
-	return collID
 }
 
 func verifyCollectionExistsInDbForID(assert *assert.Assertions, collID persist.DBID) {

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -84,3 +84,13 @@ func assertGalleryErrorResponse(assert *assert.Assertions, resp *http.Response) 
 	assert.True(ok, "Content-Type header should be set")
 	assert.Equal("application/json; charset=utf-8", val[0], "Response should be in JSON")
 }
+
+func createCollectionInDbForUserID(assert *assert.Assertions, collectionName string, userID persist.DBID) persist.DBID {
+	collID, err := persist.CollCreate(context.Background(), &persist.CollectionDB{
+		Name:        collectionName,
+		OwnerUserID: userID,
+	}, tc.r)
+	assert.Nil(err)
+
+	return collID
+}

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -34,7 +34,7 @@ func generateTestUser(r *runtime.Runtime) *TestUser {
 	id, _ := persist.UserCreate(ctx, user, r)
 	jwt, _ := jwtGeneratePipeline(ctx, id, r)
 	authNonceRotateDb(ctx, address, id, r)
-
+	log.Info(id, username)
 	return &TestUser{id, address, jwt, username}
 }
 
@@ -49,7 +49,7 @@ func setup() *TestConfig {
 	runtime.Router = gin.Default()
 	ts := httptest.NewServer(CoreInit(runtime))
 
-	log.Info("server connected! ✅")
+	log.Info("test server connected! ✅")
 
 	return &TestConfig{
 		server:    ts,


### PR DESCRIPTION
When retrieving a user's gallery via `galleries/user_get`, the collections were not populated in the correct order of the collection IDs from the gallery document.
It appears that the issue is that $lookup doesn't guarantee the order of the resulting documents, and uses any order it encounters the matched documents in the db in.

The recommended solution was to add a `indexOfArray` field which is the index of the collection in the gallery.collections array, and use that to sort the populated collection results. After sorting, the `indexOfArray` field is removed.

I also modified the `TestUpdateGalleryById_ReorderCollections_Success` test to validate this case. It looks like the test gave a false positive before because one of the collections was `hidden`, and `galleries/user_get` was called without authenticated, so with one of the collections being omitted from the result, it created an illusion that the updated order was correct. Not 100% sure, but I refactored the test as well to make the updates and validations more explicit and hopefully improve readability.