### PR TITLE
remove sync nfts from other collections

### DIFF
--- a/server/nft.go
+++ b/server/nft.go
@@ -172,7 +172,7 @@ func getNftsFromOpensea(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			return
 		}
 
-		nfts, err := openSeaPipelineAssetsForAcc(c, input.WalletAddress, input.SkipCache, pRuntime)
+		nfts, err := openSeaPipelineAssetsForAcc(c, userID, input.WalletAddress, input.SkipCache, pRuntime)
 		if len(nfts) == 0 || err != nil {
 			nfts = []*persist.Nft{}
 		}

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -13,36 +13,46 @@ func TestFetchAssertsForAcc(t *testing.T) {
 	setupTest(t)
 	ctx := context.Background()
 
-	user := &persist.User{Addresses: []string{"0x485b8ac36535fae56b2910780245dd69dda270bc"}}
-
-	userID, err := persist.UserCreate(ctx, user, tc.r)
+	robin := &persist.User{Addresses: []string{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"}}
+	gianna := &persist.User{Addresses: []string{"0xdd33e6fd03983c970ae5e647df07314435d69f6b"}}
+	robinUserID, err := persist.UserCreate(ctx, robin, tc.r)
+	assert.Nil(t, err)
+	giannaUserID, err := persist.UserCreate(ctx, gianna, tc.r)
 	assert.Nil(t, err)
 
 	nft := &persist.Nft{
-		OwnerUserID:  userID,
-		OwnerAddress: "0x485b8ac36535fae56b2910780245dd69dda270bc",
+		OwnerUserID:  giannaUserID,
+		OwnerAddress: "0xdd33e6fd03983c970ae5e647df07314435d69f6b",
 		Name:         "kks",
-		OpenSeaID:    0,
+		OpenSeaID:    34147626,
 	}
 
 	nft2 := &persist.Nft{
-		OwnerUserID:  userID,
-		OwnerAddress: "0x485b8ac36535fae56b2910780245dd69dda270bc",
+		OwnerUserID:  robinUserID,
+		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
 		Name:         "malsjdlaksjd",
-		OpenSeaID:    32087758,
+		OpenSeaID:    46062326,
 	}
 
 	_, err = persist.NftCreateBulk(ctx, []*persist.Nft{nft, nft2}, tc.r)
 	assert.Nil(t, err)
 
-	nfts, err := openSeaPipelineAssetsForAcc(ctx, "0x485b8ac36535fae56b2910780245dd69dda270bc", true, tc.r)
+	now, err := persist.NftGetByUserID(ctx, giannaUserID, tc.r)
+	assert.Nil(t, err)
+	assert.Len(t, now, 1)
 
+	nfts, err := openSeaPipelineAssetsForAcc(ctx, robinUserID, "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15", true, tc.r)
 	assert.Nil(t, err)
 
-	nftsByUser, err := persist.NftGetByUserID(ctx, userID, tc.r)
+	nftsByUser, err := persist.NftGetByUserID(ctx, robinUserID, tc.r)
 	assert.Nil(t, err)
 
-	assert.Equal(t, len(nfts), len(nftsByUser))
+	nftsByUserTwo, err := persist.NftGetByUserID(ctx, giannaUserID, tc.r)
+	assert.Nil(t, err)
+
+	assert.Len(t, nftsByUserTwo, 0)
+
+	assert.Len(t, nfts, len(nftsByUser))
 
 	// process is async so this may not work
 	assert.NotNil(t, nftsByUser[0].OwnershipHistory)


### PR DESCRIPTION
Changes:

- **Added** a func that will remove a set of NFTs from all other user's collections and remove any of your NFTs that are not a part of that set. In other words, ensure that only you and ONLY you can display only the NFTs passed into that function
- **Changed** opensea sync to use this func