### PR TITLE
aggregate owner username for nft get

### DIFF
--- a/server/nft.go
+++ b/server/nft.go
@@ -63,7 +63,11 @@ func getNftByID(pRuntime *runtime.Runtime) gin.HandlerFunc {
 		}
 
 		nfts, err := persist.NftGetByID(c, input.NftID, pRuntime)
-		if len(nfts) == 0 || err != nil {
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, errorResponse{Error: err.Error()})
+			return
+		}
+		if len(nfts) == 0 {
 			c.JSON(http.StatusNotFound, errorResponse{
 				Error: fmt.Sprintf("no nfts found with id: %s", input.NftID),
 			})

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -20,21 +20,21 @@ func TestFetchAssertsForAcc(t *testing.T) {
 	giannaUserID, err := persist.UserCreate(ctx, gianna, tc.r)
 	assert.Nil(t, err)
 
-	nft := &persist.Nft{
+	nft := &persist.NftDB{
 		OwnerUserID:  giannaUserID,
 		OwnerAddress: "0xdd33e6fd03983c970ae5e647df07314435d69f6b",
 		Name:         "kks",
 		OpenSeaID:    34147626,
 	}
 
-	nft2 := &persist.Nft{
+	nft2 := &persist.NftDB{
 		OwnerUserID:  robinUserID,
 		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
 		Name:         "malsjdlaksjd",
 		OpenSeaID:    46062326,
 	}
 
-	_, err = persist.NftCreateBulk(ctx, []*persist.Nft{nft, nft2}, tc.r)
+	_, err = persist.NftCreateBulk(ctx, []*persist.NftDB{nft, nft2}, tc.r)
 	assert.Nil(t, err)
 
 	now, err := persist.NftGetByUserID(ctx, giannaUserID, tc.r)

--- a/server/t__routes_collection_test.go
+++ b/server/t__routes_collection_test.go
@@ -50,7 +50,7 @@ func TestCreateCollection_Success(t *testing.T) {
 	setupTest(t)
 	assert := assert.New(t)
 
-	nfts := []*persist.Nft{
+	nfts := []*persist.NftDB{
 		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
@@ -100,7 +100,7 @@ func TestGetUnassignedCollection_Success(t *testing.T) {
 	setupTest(t)
 	assert := assert.New(t)
 
-	nfts := []*persist.Nft{
+	nfts := []*persist.NftDB{
 		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
@@ -118,8 +118,8 @@ func TestGetUnassignedCollection_Success(t *testing.T) {
 	assertValidResponse(assert, resp)
 
 	type NftsResponse struct {
-		Nfts  []*persist.Nft `json:"nfts"`
-		Error string         `json:"error"`
+		Nfts  []*persist.NftDB `json:"nfts"`
+		Error string           `json:"error"`
 	}
 	// ensure nft was updated
 	body := NftsResponse{}
@@ -173,7 +173,7 @@ func TestGetHiddenCollections_Success(t *testing.T) {
 	setupTest(t)
 	assert := assert.New(t)
 
-	nfts := []*persist.Nft{
+	nfts := []*persist.NftDB{
 		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
@@ -205,7 +205,7 @@ func TestGetNoHiddenCollections_Success(t *testing.T) {
 	setupTest(t)
 	assert := assert.New(t)
 
-	nfts := []*persist.Nft{
+	nfts := []*persist.NftDB{
 		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
@@ -243,7 +243,7 @@ func TestCreateCollectionWithUsedNFT_Success(t *testing.T) {
 	setupTest(t)
 	assert := assert.New(t)
 
-	nfts := []*persist.Nft{
+	nfts := []*persist.NftDB{
 		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
@@ -278,7 +278,7 @@ func TestUpdateCollectionNftsOrder_Success(t *testing.T) {
 	setupTest(t)
 	assert := assert.New(t)
 
-	nfts := []*persist.Nft{
+	nfts := []*persist.NftDB{
 		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},

--- a/server/t__routes_nft_test.go
+++ b/server/t__routes_nft_test.go
@@ -20,8 +20,9 @@ func TestGetNftByID_Success(t *testing.T) {
 
 	// seed DB with nft
 	name := "very cool nft"
-	nftID, err := persist.NftCreate(context.Background(), &persist.Nft{
-		Name: name,
+	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
+		Name:        name,
+		OwnerUserID: tc.user1.id,
 	}, tc.r)
 	assert.Nil(err)
 
@@ -32,6 +33,7 @@ func TestGetNftByID_Success(t *testing.T) {
 	body := persist.Nft{}
 	util.UnmarshallBody(&body, resp.Body)
 	assert.Equal(name, body.Name)
+	assert.NotEmpty(body.OwnerUsername)
 }
 
 func TestGetNftByID_NoParamError(t *testing.T) {
@@ -67,7 +69,7 @@ func TestUpdateNftByID_Success(t *testing.T) {
 	assert := assert.New(t)
 
 	// seed DB with nft
-	nftID, err := persist.NftCreate(context.Background(), &persist.Nft{
+	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
 		Name:           "very cool nft",
 		CollectorsNote: "silly note",
 		OwnerUserID:    tc.user1.id,
@@ -94,7 +96,7 @@ func TestUpdateNftByID_UnauthedError(t *testing.T) {
 	assert := assert.New(t)
 
 	// seed DB with nft
-	nftID, err := persist.NftCreate(context.Background(), &persist.Nft{
+	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
 		Name:           "very cool nft",
 		CollectorsNote: "this is a bad note",
 		OwnerUserID:    tc.user1.id,
@@ -142,7 +144,7 @@ func TestUpdateNftByID_UpdatingAsUserWithoutToken_CantDo(t *testing.T) {
 	assert := assert.New(t)
 
 	// seed DB with nft
-	nftID, err := persist.NftCreate(context.Background(), &persist.Nft{
+	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
 		Name:        "very cool nft",
 		OwnerUserID: tc.user1.id,
 	}, tc.r)


### PR DESCRIPTION
Changes:

- **Added** steps to aggregation pipeline for NFTs to go get username from user collection
- **Added** `NftDB` struct and `Nft` struct that represent Nfts with or without aggregation additions
- **Added** check in nft get by ID test to make sure username is filled