### PR TITLE
Map OS asset's external_link to our NFT model

### DIFF
--- a/scripts/migration.py
+++ b/scripts/migration.py
@@ -98,7 +98,7 @@ def create_nft(nft):
             "deleted": False,
             "name": nft["name"],
             "description": nft["description"],
-            "external_url": nft["external_url"],
+            "external_url": nft["external_link"],
             "creator_address": nft["creator_address"],
             "creator_name": nft["creator_opensea_name"],
             "owner_address": user["addresses"][0].lower(),

--- a/server/opensea.go
+++ b/server/opensea.go
@@ -31,7 +31,7 @@ type openseaAsset struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 
-	ExternalURL      string           `json:"external_url"`
+	ExternalURL      string           `json:"external_link"`
 	TokenMetadataURL string           `json:"token_metadata_url"`
 	Creator          openseaAccount   `json:"creator"`
 	Contract         persist.Contract `json:"asset_contract"`


### PR DESCRIPTION
Changes:
- Change the field that we get the NFT's external link from during the OpenSea -> Gallery NFT mapping