### PR TITLE
Support ledger-produced signature

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -268,7 +268,12 @@ func authVerifySignature(pSignatureStr string,
 	if err != nil {
 		return false, err
 	}
-	if sig[64] != 27 && sig[64] != 28 {
+	v := sig[64]
+	// Ledger-produced signatures have v = 0 or 1
+	if v == 0 || v == 1 {
+		v = v + 27
+	}
+	if v != 27 && v != 28 {
 		return false, errors.New("invalid signature (V is not 27 or 28)")
 	}
 	sig[64] -= 27

--- a/server/auth.go
+++ b/server/auth.go
@@ -268,11 +268,11 @@ func authVerifySignature(pSignatureStr string,
 	if err != nil {
 		return false, err
 	}
-	v := sig[64]
 	// Ledger-produced signatures have v = 0 or 1
-	if v == 0 || v == 1 {
-		v = v + 27
+	if sig[64] == 0 || sig[64] == 1 {
+		sig[64] += 27
 	}
+	v := sig[64]
 	if v != 27 && v != 28 {
 		return false, errors.New("invalid signature (V is not 27 or 28)")
 	}


### PR DESCRIPTION
Ledger-produced signatures have v = 0 or 1, meaning they fail the existing signature validation which expects v to be 27 or 28.
Manually making an exception to allow v to be 0 or 1 seems to be an accepted solution for now.
The issue is documented in [this Github Issue](https://github.com/MetaMask/metamask-extension/issues/10240)

More info: https://ethereum.stackexchange.com/questions/103307/cannot-verifiy-a-signature-produced-by-ledger-in-solidity-using-ecrecover