### PR TITLE
multiple addresses for opensea request

### DIFF
--- a/persist/nft.go
+++ b/persist/nft.go
@@ -3,6 +3,7 @@ package persist
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -265,66 +266,32 @@ func NftBulkUpsert(pCtx context.Context, pNfts []*NftDB, pRuntime *runtime.Runti
 
 }
 
-// NftRemoveDifference will update all nfts that are not in the given slice of nfts with having an
-// empty owner id and address
-func NftRemoveDifference(pCtx context.Context, pNfts []*NftDB, pWalletAddress string, pRuntime *runtime.Runtime) (int, error) {
-
-	mp := newStorage(0, nftColName, pRuntime)
-	// FIND DIFFERENCE AND DELETE OUTLIERS
-	// -------------------------------------------------------
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
-	dbNfts := []*NftDB{}
-	if err := mp.find(pCtx, bson.M{"owner_address": strings.ToLower(pWalletAddress)}, &dbNfts, opts); err != nil {
-		return 0, err
-	}
-
-	if len(dbNfts) > len(pNfts) {
-		diff, err := findDifference(pNfts, dbNfts)
-		if err != nil {
-			return 0, err
-		}
-
-		updateModels := make([]mongo.WriteModel, len(diff))
-
-		for i, v := range diff {
-			updateModels[i] = &mongo.UpdateOneModel{Filter: bson.M{"_id": v}, Update: bson.M{"$set": bson.M{"owner_user_id": "", "owner_address": ""}}}
-		}
-
-		res, err := mp.collection.BulkWrite(pCtx, updateModels)
-		if err != nil {
-			return 0, err
-		}
-		return int(res.ModifiedCount), nil
-	}
-
-	return 0, nil
-}
-
 // NftOpenseaCacheSet adds a set of nfts to the opensea cache under a given wallet address
-func NftOpenseaCacheSet(pCtx context.Context, pWalletAddress string, pNfts []*Nft, pRuntime *runtime.Runtime) error {
+func NftOpenseaCacheSet(pCtx context.Context, pWalletAddresses []string, pNfts []*Nft, pRuntime *runtime.Runtime) error {
 
 	mp := newStorage(0, nftColName, pRuntime).withRedis(OpenseaAssetsRDB, pRuntime)
 	defer mp.cacheClose()
+	for i, v := range pWalletAddresses {
+		pWalletAddresses[i] = strings.ToLower(v)
+	}
 
 	toCache, err := json.Marshal(pNfts)
 	if err != nil {
 		return err
 	}
-	return mp.cacheSet(pCtx, strings.ToLower(pWalletAddress), toCache, openseaAssetsTTL)
+	return mp.cacheSet(pCtx, fmt.Sprint(pWalletAddresses), toCache, openseaAssetsTTL)
 }
 
 // NftOpenseaCacheGet gets a set of nfts from the opensea cache under a given wallet address
-func NftOpenseaCacheGet(pCtx context.Context, pWalletAddress string, pRuntime *runtime.Runtime) ([]*Nft, error) {
+func NftOpenseaCacheGet(pCtx context.Context, pWalletAddresses []string, pRuntime *runtime.Runtime) ([]*Nft, error) {
 
 	mp := newStorage(0, nftColName, pRuntime).withRedis(OpenseaAssetsRDB, pRuntime)
 	defer mp.cacheClose()
+	for i, v := range pWalletAddresses {
+		pWalletAddresses[i] = strings.ToLower(v)
+	}
 
-	result, err := mp.cacheGet(pCtx, strings.ToLower(pWalletAddress))
+	result, err := mp.cacheGet(pCtx, fmt.Sprint(pWalletAddresses))
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -19,6 +19,8 @@ const (
 	mongoUseTLS        = "GLRY_MONGO_USE_TLS"
 	mongoDBname        = "GLRY_MONGO_DB_NAME"
 
+	openseaAPIKey = "OPENSEA_API_KEY"
+
 	redisURL            = "GLRY_REDIS_URL"
 	redisPassSecretName = "REDIS_PASS_SECRET_NAME"
 
@@ -37,6 +39,8 @@ type Config struct {
 	MongoURL    string
 	MongoDBName string
 	MongoUseTLS bool
+
+	OpenseaAPIKey string
 
 	RedisURL      string
 	RedisPassword string
@@ -58,14 +62,9 @@ func ConfigLoad() *Config {
 	viper.SetDefault(allowedOrigins, "http://localhost:3000")
 
 	viper.SetDefault(mongoDBname, "gallery")
-	viper.SetDefault(mongoUseTLS, false)
-	viper.SetDefault(mongoURLSecretName, "")
-	viper.SetDefault(mongoTLSSecretName, "")
 
 	viper.SetDefault(redisURL, "localhost:6379")
-	viper.SetDefault(redisPassSecretName, "")
 
-	viper.SetDefault(sentryEndpoint, "")
 	viper.SetDefault(jwtTokenTTLsecInt, 60*60*24*3)
 
 	//------------------
@@ -92,8 +91,9 @@ func ConfigLoad() *Config {
 		PortMetrics:    viper.GetInt(portMetrics),
 		AllowedOrigins: viper.GetString(allowedOrigins),
 
-		MongoUseTLS: viper.GetBool(mongoUseTLS),
-		MongoDBName: viper.GetString(mongoDBname),
+		MongoUseTLS:   viper.GetBool(mongoUseTLS),
+		MongoDBName:   viper.GetString(mongoDBname),
+		OpenseaAPIKey: viper.GetString(openseaAPIKey),
 
 		RedisURL: viper.GetString(redisURL),
 

--- a/server/opensea.go
+++ b/server/opensea.go
@@ -34,6 +34,7 @@ type openseaAsset struct {
 	ExternalURL      string           `json:"external_link"`
 	TokenMetadataURL string           `json:"token_metadata_url"`
 	Creator          openseaAccount   `json:"creator"`
+	Owner            openseaAccount   `json:"owner"`
 	Contract         persist.Contract `json:"asset_contract"`
 
 	// OPEN_SEA_TOKEN_ID
@@ -70,22 +71,30 @@ type openseaUser struct {
 	Username string `json:"username"`
 }
 
-func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOwnerWalletAddress string, skipCache bool,
+func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOwnerWalletAddresses []string, skipCache bool,
 	pRuntime *runtime.Runtime) ([]*persist.Nft, error) {
 
 	if !skipCache {
-		nfts, err := persist.NftOpenseaCacheGet(pCtx, pOwnerWalletAddress, pRuntime)
+		nfts, err := persist.NftOpenseaCacheGet(pCtx, pOwnerWalletAddresses, pRuntime)
 		if err == nil && len(nfts) > 0 {
 			return nfts, nil
 		}
 	}
 
-	openSeaAssetsForAccLst, err := openSeaFetchAssetsForAcc(pOwnerWalletAddress)
+	user, err := persist.UserGetByID(pCtx, pUserID, pRuntime)
+	if err != nil {
+		return nil, err
+	}
+	if len(pOwnerWalletAddresses) == 0 {
+		pOwnerWalletAddresses = user.Addresses
+	}
+
+	openSeaAssetsForAccLst, err := openseaFetchAssetsForWallets(pOwnerWalletAddresses)
 	if err != nil {
 		return nil, err
 	}
 
-	asDBNfts, err := openseaToDBNfts(pCtx, openSeaAssetsForAccLst, pOwnerWalletAddress, pRuntime)
+	asDBNfts, err := openseaToDBNfts(pCtx, openSeaAssetsForAccLst, user, pRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -97,16 +106,10 @@ func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOw
 
 	// update other user's collections and this user's collection so that they and ONLY they can display these
 	// specific NFTs while also ensuring that NFTs they don't own don't list them as the owner
-	// TODO we don't necessarily need to NftRemoveDifference seeing as if someone owns that NFT it will
-	// sync with them when they claim it for their own collection
 	go func() {
-		err = persist.CollClaimNFTs(pCtx, pUserID, &persist.CollectionUpdateNftsInput{Nfts: ids}, pRuntime)
+		err = persist.CollClaimNFTs(pCtx, pUserID, pOwnerWalletAddresses, &persist.CollectionUpdateNftsInput{Nfts: ids}, pRuntime)
 		if err != nil {
 			logrus.WithFields(logrus.Fields{"method": "openSeaPipelineAssetsForAcc"}).Errorf("failed to claim nfts: %v", err)
-		}
-		_, err := persist.NftRemoveDifference(pCtx, asDBNfts, pOwnerWalletAddress, pRuntime)
-		if err != nil {
-			logrus.WithFields(logrus.Fields{"method": "openSeaPipelineAssetsForAcc"}).Errorf("failed to remove difference: %v", err)
 		}
 	}()
 
@@ -115,12 +118,12 @@ func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOw
 		return nil, err
 	}
 
-	result, err := dbToGalleryNFTs(pCtx, updatedNfts, pOwnerWalletAddress, pRuntime)
+	result, err := dbToGalleryNFTs(pCtx, updatedNfts, user, pRuntime)
 	if err != nil {
 		return nil, err
 	}
 
-	err = persist.NftOpenseaCacheSet(pCtx, pOwnerWalletAddress, result, pRuntime)
+	err = persist.NftOpenseaCacheSet(pCtx, pOwnerWalletAddresses, result, pRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -203,167 +206,28 @@ func openseaSyncHistory(pCtx context.Context, pTokenID string, pTokenContractAdd
 	return events, nil
 }
 
-func openSeaFetchAssetsForAcc(pOwnerWalletAddressStr string) ([]*openseaAsset, error) {
-
-	/*{
-	*	"id": 21976544,
-	*	"token_id": "1137",
-	*	"num_sales": 0,
-		"background_color": null,
-	*	"image_url": "https://lh3.googleusercontent.com/8S2uhc_74_JijJwYnNOEQvlnHs6dI4lU86k8Zj2WcelVG9Gp4hx62UDzf2B_R4cTMdd_03SLOV_rFZFF8_5vwFSEz76OX61of4ZPaA",
-	*	"image_preview_url": "https://lh3.googleusercontent.com/8S2uhc_74_JijJwYnNOEQvlnHs6dI4lU86k8Zj2WcelVG9Gp4hx62UDzf2B_R4cTMdd_03SLOV_rFZFF8_5vwFSEz76OX61of4ZPaA=s250",
-	*	"image_thumbnail_url": "https://lh3.googleusercontent.com/8S2uhc_74_JijJwYnNOEQvlnHs6dI4lU86k8Zj2WcelVG9Gp4hx62UDzf2B_R4cTMdd_03SLOV_rFZFF8_5vwFSEz76OX61of4ZPaA=s128",
-	*	"image_original_url": "https://coin-nfts.s3.us-east-2.amazonaws.com/coin-500px.gif",
-	*	"animation_url": null,
-		"animation_original_url": null,
-	*	"name": "April 14 2021",
-	*	"description": "A special thank you for all of the hard work you put in to usher in an open financial system and bring Coinbase public.",
-	*	"external_link": "https://www.coinbase.com/",
-		"asset_contract": {
-	*		"address": "0x6966ac85200cadd8c66d14d6c1a5431353edc8c9",
-			"asset_contract_type": "non-fungible",
-	*		"created_date": "2021-04-14T19:18:41.926804",
-	*		"name": "Coinbase Direct Public Offering",
-			"nft_version": "3.0",
-			"opensea_version": null,
-	*		"owner": 833403,
-			"schema_name": "ERC721",
-	*		"symbol": "$COIN",
-			"total_supply": "0",
-	*		"description": "We did it! This commemorative NFT is a special thank you to all of the people who worked tirelessly to bring Coinbase public.",
-			"external_link": "https://www.coinbase.com/",
-			"image_url": "https://lh3.googleusercontent.com/cudWSCgwfsRLdmHrZ7wBx74pk5xBLDOcAvxYMgQicyZ1wG3VeASwL5WXoJbR1P70CjGTCE-wc6mPpvV-AMGVhVZ9QTPzzcHGpal1=s120",
-			"default_to_fiat": false,
-			"dev_buyer_fee_basis_points": 0,
-			"dev_seller_fee_basis_points": 0,
-			"only_proxied_transfers": false,
-			"opensea_buyer_fee_basis_points": 0,
-			"opensea_seller_fee_basis_points": 250,
-			"buyer_fee_basis_points": 0,
-			"seller_fee_basis_points": 250,
-			"payout_address": null
-		},
-		"owner": {
-			"user": null,
-	*		"profile_img_url": "https://storage.googleapis.com/opensea-static/opensea-profile/25.png",
-	*		"address": "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-			"config": "",
-			"discord_id": ""
-		},
-		"permalink": "https://opensea.io/assets/0x6966ac85200cadd8c66d14d6c1a5431353edc8c9/1137",
-		"collection": {
-			"banner_image_url": null,
-			"chat_url": null,
-	*		"created_date": "2021-04-14T19:22:29.035968",
-			"default_to_fiat": false,
-	*		"description": "We did it! This commemorative NFT is a special thank you to all of the people who worked tirelessly to bring Coinbase public.",
-			"dev_buyer_fee_basis_points": "0",
-			"dev_seller_fee_basis_points": "0",
-			"discord_url": null,
-			"display_data": {
-				"card_display_style": "contain",
-				"images": []
-			},
-	*		"external_url": "https://www.coinbase.com/",
-			"featured": false,
-			"featured_image_url": null,
-			"hidden": true,
-			"safelist_request_status": "not_requested",
-	*		"image_url": "https://lh3.googleusercontent.com/cudWSCgwfsRLdmHrZ7wBx74pk5xBLDOcAvxYMgQicyZ1wG3VeASwL5WXoJbR1P70CjGTCE-wc6mPpvV-AMGVhVZ9QTPzzcHGpal1=s120",
-			"is_subject_to_whitelist": false,
-			"large_image_url": "https://lh3.googleusercontent.com/cudWSCgwfsRLdmHrZ7wBx74pk5xBLDOcAvxYMgQicyZ1wG3VeASwL5WXoJbR1P70CjGTCE-wc6mPpvV-AMGVhVZ9QTPzzcHGpal1",
-			"medium_username": null,
-	*		"name": "Coinbase Direct Public Offering",
-			"only_proxied_transfers": false,
-			"opensea_buyer_fee_basis_points": "0",
-			"opensea_seller_fee_basis_points": "250",
-	*		"payout_address": null,
-			"require_email": false,
-			"short_description": null,
-			"slug": "coinbase-direct-public-offering",
-			"telegram_url": null,
-	*		"twitter_username": null,
-	*		"instagram_username": null,
-			"wiki_url": null
-		},
-		"decimals": 0,
-		"sell_orders": null,
-		"creator": {
-	*		"user": null,
-	*		"profile_img_url": "https://storage.googleapis.com/opensea-static/opensea-profile/25.png",
-	*		"address": "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-			"config": "",
-			"discord_id": ""
-		},
-		"traits": [],
-	*	"last_sale": null,
-		"top_bid": null,
-	*	"listing_date": null,
-		"is_presale": false,
-		"transfer_fee_payment_token": null,
-		"transfer_fee": null
+func openseaFetchAssetsForWallets(pWalletAddresses []string) ([]*openseaAsset, error) {
+	result := []*openseaAsset{}
+	for _, walletAddress := range pWalletAddresses {
+		assets, err := openseaFetchAssetsForWallet(walletAddress, 0)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, assets...)
 	}
 
+	return result, nil
+}
 
-	LAST_SALE:
-	map[
-		asset:map[
-			decimals: <nil>
-	*		token_id: 98168371784320387514732815439041609751844866237332060982262479279862392553473
-		]
-		asset_bundle:    <nil>
-		auction_type:    <nil>
-	*	created_date:    2021-03-18T17:22:56.965029
-	*	event_timestamp: 2021-03-18T17:22:37
-	*	event_type:      successful
-		payment_token: map[
-			address:   0x0000000000000000000000000000000000000000
-			decimals:  18
-	*		eth_price: 1.000000000000000
-			id:        1
-			image_url: https://lh3.googleusercontent.com/7hQyiGtBt8vmUTq4T0aIUhIhT00dPhnav87TuFQ5cLtjlk724JgXdjQjoH_CzYz-z37JpPuMFbRRQuyC7I9abyZRKA
-			name:      Ether
-	*		symbol:    ETH
-	*		usd_price: 3446.929999999999836000
-		]
-	*	quantity:    1
-		total_price: 250000000000000000
-		transaction: map[
-	*		block_hash:   0x16b63828a3ee23184949ed0ddbf6f24a1718cea610c59e83497d4db0a4ed6d50
-	*		block_number: 12063985
-	*		from_account: map[
-	*			address: 0xbb3f043290841b97b9c92f6bc001a020d4b33255
-				config:
-				discord_id:
-	*			profile_img_url: https://storage.googleapis.com/opensea-static/opensea-profile/8.png
-				user: map[
-	*				username:mikeybitcoin
-				]
-			]
-	*		id:         9.1561879e+07
-	*		timestamp:  2021-03-18T17:22:37
-	*		to_account: map[
-	*			address: 0x7be8076f4ea4a4ad08075c2508e481d6c946d12b
-				config:  verified
-				discord_id:
-	*			profile_img_url: https://storage.googleapis.com/opensea-static/opensea-profile/22.png
-				user: map[
-	*				username:OpenSea-Orders
-				]
-			]
-	*		transaction_hash:  0xb49f436bf95b22c6ddd35494e393d41eae728045045cf4cefbb2df599933adbd
-	*		transaction_index: 68
-		]
-	]
-	*/
+// recursively fetches all assets for a wallet
+func openseaFetchAssetsForWallet(pWalletAddress string, offset int) ([]*openseaAsset, error) {
 
-	offsetInt := 0
-	limitInt := 50
+	result := []*openseaAsset{}
 	qsArgsMap := map[string]string{
-		"owner":           pOwnerWalletAddressStr,
+		"owner":           pWalletAddress,
 		"order_direction": "desc",
-		"offset":          fmt.Sprintf("%d", offsetInt),
-		"limit":           fmt.Sprintf("%d", limitInt),
+		"offset":          fmt.Sprintf("%d", offset),
+		"limit":           fmt.Sprintf("%d", 50),
 	}
 
 	qsLst := []string{}
@@ -380,20 +244,27 @@ func openSeaFetchAssetsForAcc(pOwnerWalletAddressStr string) ([]*openseaAsset, e
 	defer resp.Body.Close()
 	response := &openSeaAssets{}
 	err = util.UnmarshallBody(response, resp.Body)
-
-	return response.Assets, nil
-}
-
-func openseaToDBNfts(pCtx context.Context, openseaNfts []*openseaAsset, pWalletAddress string, pRuntime *runtime.Runtime) ([]*persist.NftDB, error) {
-	ownerUser, err := persist.UserGetByAddress(pCtx, pWalletAddress, pRuntime)
 	if err != nil {
 		return nil, err
 	}
+	result = append(result, response.Assets...)
+	if len(response.Assets) == 50 {
+		next, err := openseaFetchAssetsForWallet(pWalletAddress, offset+50)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, next...)
+	}
+	return result, nil
+}
+
+func openseaToDBNfts(pCtx context.Context, openseaNfts []*openseaAsset, pUser *persist.User, pRuntime *runtime.Runtime) ([]*persist.NftDB, error) {
+
 	nfts := make([]*persist.NftDB, len(openseaNfts))
 	nftChan := make(chan *persist.NftDB)
 	for _, openseaNft := range openseaNfts {
 		go func(openseaNft *openseaAsset) {
-			nftChan <- openseaToDBNft(pCtx, openseaNft, pWalletAddress, ownerUser.ID, pRuntime)
+			nftChan <- openseaToDBNft(pCtx, openseaNft, pUser.ID, pRuntime)
 		}(openseaNft)
 	}
 	for i := 0; i < len(openseaNfts); i++ {
@@ -405,11 +276,8 @@ func openseaToDBNfts(pCtx context.Context, openseaNfts []*openseaAsset, pWalletA
 	return nfts, nil
 }
 
-func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NftDB, pWalletAddress string, pRuntime *runtime.Runtime) ([]*persist.Nft, error) {
-	user, err := persist.UserGetByAddress(pCtx, pWalletAddress, pRuntime)
-	if err != nil {
-		return nil, err
-	}
+func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NftDB, pUser *persist.User, pRuntime *runtime.Runtime) ([]*persist.Nft, error) {
+
 	nfts := make([]*persist.Nft, len(pNfts))
 	for i, nft := range pNfts {
 		nfts[i] = &persist.Nft{
@@ -420,15 +288,15 @@ func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NftDB, pWalletAddres
 			CreationTime:         nft.CreationTime,
 			Deleted:              nft.Deleted,
 			CollectorsNote:       nft.CollectorsNote,
-			OwnerUserID:          user.ID,
-			OwnerUsername:        user.UserName,
+			OwnerUserID:          pUser.ID,
+			OwnerUsername:        pUser.UserName,
 			OwnershipHistory:     nft.OwnershipHistory,
 			ExternalURL:          nft.ExternalURL,
 			TokenMetadataURL:     nft.TokenMetadataURL,
 			ImageURL:             nft.ImageURL,
 			CreatorAddress:       nft.CreatorAddress,
 			CreatorName:          nft.CreatorName,
-			OwnerAddress:         pWalletAddress,
+			OwnerAddress:         nft.OwnerAddress,
 			Contract:             nft.Contract,
 			OpenSeaID:            nft.OpenSeaID,
 			OpenSeaTokenID:       nft.OpenSeaTokenID,
@@ -444,12 +312,11 @@ func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NftDB, pWalletAddres
 	return nfts, nil
 }
 
-func openseaToDBNft(pCtx context.Context, nft *openseaAsset, pWalletAddress string, ownerUserID persist.DBID, pRuntime *runtime.Runtime) *persist.NftDB {
+func openseaToDBNft(pCtx context.Context, nft *openseaAsset, ownerUserID persist.DBID, pRuntime *runtime.Runtime) *persist.NftDB {
 
 	result := &persist.NftDB{
-		OwnerUserID:  ownerUserID,
-		OwnerAddress: strings.ToLower(pWalletAddress),
-
+		OwnerUserID:          ownerUserID,
+		OwnerAddress:         strings.ToLower(nft.Owner.Address),
 		Name:                 nft.Name,
 		Description:          nft.Description,
 		ExternalURL:          nft.ExternalURL,

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -41,7 +41,7 @@ func TestFetchAssertsForAcc(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, now, 1)
 
-	nfts, err := openSeaPipelineAssetsForAcc(ctx, robinUserID, "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15", true, tc.r)
+	nfts, err := openSeaPipelineAssetsForAcc(ctx, robinUserID, []string{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"}, true, tc.r)
 	assert.Nil(t, err)
 
 	nftsByUser, err := persist.NftGetByUserID(ctx, robinUserID, tc.r)


### PR DESCRIPTION
Changes:

- **Changed** opensea sync input to take a list of comma separated addresses
- **Changed** funcs that are involved in opensea sync to take multiple addresses such as getting all opensea assets for each address and pulling every nft from your account with the specified addresses that was not a part of the synced nfts
- **Removed** `NftRemoveDifference` because it does the same thing as in `CollClaimNFTs` but with more work
