### PR TITLE
ensure user owns nfts for coll update

### DIFF
--- a/persist/gallery.go
+++ b/persist/gallery.go
@@ -2,6 +2,7 @@ package persist
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/mikeydub/go-gallery/runtime"
@@ -66,12 +67,22 @@ func GalleryCreate(pCtx context.Context, pGallery *GalleryDB,
 // pUpdate is a struct that contains bson tags representing the fields to be updated
 func GalleryUpdate(pCtx context.Context, pIDstr DBID,
 	pOwnerUserID DBID,
-	pUpdate interface{},
+	pUpdate *GalleryUpdateInput,
 	pRuntime *runtime.Runtime) error {
 
 	mp := newStorage(0, galleryColName, pRuntime)
 
-	return mp.update(pCtx, bson.M{"_id": pIDstr, "owner_user_id": pOwnerUserID}, pUpdate)
+	npm := newStorage(0, collectionColName, pRuntime)
+	ct, err := npm.count(pCtx, bson.M{"_id": bson.M{"$in": pUpdate.Collections}, "owner_user_id": pOwnerUserID})
+	if err != nil {
+		return err
+	}
+
+	if int(ct) != len(pUpdate.Collections) {
+		return errors.New("user does not own all collections to be inserted")
+	}
+
+	return mp.update(pCtx, bson.M{"_id": pIDstr}, pUpdate)
 }
 
 // GalleryAddCollections adds collections to the specified gallery

--- a/server/collection.go
+++ b/server/collection.go
@@ -220,7 +220,10 @@ func updateCollectionNfts(pRuntime *runtime.Runtime) gin.HandlerFunc {
 			return
 		}
 
-		update := &persist.CollectionUpdateNftsInput{Nfts: input.Nfts}
+		// ensure that there are no repeat NFTs
+		withNoRepeats := uniqueDBID(input.Nfts)
+
+		update := &persist.CollectionUpdateNftsInput{Nfts: withNoRepeats}
 
 		err := persist.CollUpdateNFTs(c, input.ID, userID, update, pRuntime)
 		if err != nil {
@@ -293,4 +296,19 @@ func collectionCreateDb(pCtx context.Context, pInput *collectionCreateInput,
 
 	return collID, nil
 
+}
+
+// uniqueDBID ensures that an array of DBIDs has no repeat items
+func uniqueDBID(a []persist.DBID) []persist.DBID {
+	result := make([]persist.DBID, 0)
+	m := make(map[persist.DBID]bool)
+
+	for _, val := range a {
+		if _, ok := m[val]; !ok {
+			m[val] = true
+			result = append(result, val)
+		}
+	}
+
+	return result
 }

--- a/server/collection.go
+++ b/server/collection.go
@@ -300,8 +300,8 @@ func collectionCreateDb(pCtx context.Context, pInput *collectionCreateInput,
 
 // uniqueDBID ensures that an array of DBIDs has no repeat items
 func uniqueDBID(a []persist.DBID) []persist.DBID {
-	result := make([]persist.DBID, 0)
-	m := make(map[persist.DBID]bool)
+	result := []persist.DBID{}
+	m := map[persist.DBID]bool{}
 
 	for _, val := range a {
 		if _, ok := m[val]; !ok {


### PR DESCRIPTION
Changes:

- **Added** a check to ensure that the NFTs that a user is adding to their collection are their own
- **Added** a function to remove repeat NFTs from the list of NFTs being updated