### PR TITLE
support nfts having multiple owners

### DIFF
--- a/persist/nft.go
+++ b/persist/nft.go
@@ -42,7 +42,7 @@ type NftDB struct {
 	Contract            Contract `bson:"contract"     json:"asset_contract"`
 	TokenCollectionName string   `bson:"token_collection_name" json:"token_collection_name"`
 
-	OpenSeaID int `bson:"opensea_id"       json:"opensea_id"`
+	OpenseaID int `bson:"opensea_id"       json:"opensea_id"`
 	// OPEN_SEA_TOKEN_ID
 	// https://api.opensea.io/api/v1/asset/0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270/26000331
 	// (/asset/:contract_address/:token_id)
@@ -322,7 +322,7 @@ func NftBulkUpsert(pCtx context.Context, pNfts []*NftDB, pRuntime *runtime.Runti
 					addresses := it["owner_addresses"]
 					delete(it, "owner_addresses")
 					delete(it, "_id")
-					_, err := mp.collection.UpdateOne(pCtx, bson.M{"_id": returnID}, bson.M{"$addToSet": bson.M{"owner_addresses": addresses}, "$set": it})
+					_, err := mp.collection.UpdateOne(pCtx, bson.M{"_id": returnID}, bson.M{"$addToSet": bson.M{"owner_addresses": bson.M{"$each": addresses}}, "$set": it})
 					if err != nil {
 						errs <- err
 						return
@@ -330,7 +330,7 @@ func NftBulkUpsert(pCtx context.Context, pNfts []*NftDB, pRuntime *runtime.Runti
 				}
 				ids <- returnID
 			} else {
-				id, err := mp.upsert(pCtx, bson.M{"opensea_id": nft.OpenSeaID}, nft)
+				id, err := mp.upsert(pCtx, bson.M{"opensea_id": nft.OpenseaID}, nft)
 				if err != nil {
 					errs <- err
 				}
@@ -394,12 +394,12 @@ func findDifference(nfts []*NftDB, dbNfts []*NftDB) ([]DBID, error) {
 	currOpenseaIds := map[int]bool{}
 
 	for _, v := range nfts {
-		currOpenseaIds[v.OpenSeaID] = true
+		currOpenseaIds[v.OpenseaID] = true
 	}
 
 	diff := []DBID{}
 	for _, v := range dbNfts {
-		if !currOpenseaIds[v.OpenSeaID] {
+		if !currOpenseaIds[v.OpenseaID] {
 			diff = append(diff, v.ID)
 		}
 	}

--- a/persist/storage.go
+++ b/persist/storage.go
@@ -50,7 +50,7 @@ func (m *storage) insert(ctx context.Context, insert interface{}, opts ...*optio
 	}
 	asMap["created_at"] = now
 	asMap["last_updated"] = now
-	asMap["_id"] = generateID(asMap)
+	asMap["_id"] = generateID()
 
 	res, err := m.collection.InsertOne(ctx, asMap, opts...)
 	if err != nil {
@@ -72,7 +72,7 @@ func (m *storage) insertMany(ctx context.Context, insert []interface{}, opts ...
 		}
 		asMap["created_at"] = now
 		asMap["last_updated"] = now
-		asMap["_id"] = generateID(asMap)
+		asMap["_id"] = generateID()
 		mapsToInsert[i] = asMap
 	}
 
@@ -191,7 +191,7 @@ func (m *storage) upsert(ctx context.Context, query bson.M, upsert interface{}, 
 		delete(asMap, k)
 	}
 
-	res, err := m.collection.UpdateOne(ctx, query, bson.M{"$setOnInsert": bson.M{"_id": generateID(asMap)}, "$set": asMap}, opts...)
+	res, err := m.collection.UpdateOne(ctx, query, bson.M{"$setOnInsert": bson.M{"_id": generateID()}, "$set": asMap}, opts...)
 	if err != nil {
 		return "", err
 	}
@@ -291,7 +291,7 @@ func (m *storage) cacheDelete(r runtime.RedisDB, key string) error {
 	}
 }
 
-func generateID(it interface{}) DBID {
+func generateID() DBID {
 	id, err := ksuid.NewRandom()
 	if err != nil {
 		panic(err)

--- a/server/opensea.go
+++ b/server/opensea.go
@@ -323,7 +323,7 @@ func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NftDB, pUser *persis
 				CreatorName:          n.CreatorName,
 				OwnerAddresses:       n.OwnerAddresses,
 				Contract:             n.Contract,
-				OpenSeaID:            n.OpenSeaID,
+				OpenSeaID:            n.OpenseaID,
 				OpenSeaTokenID:       n.OpenSeaTokenID,
 				ImageThumbnailURL:    n.ImageThumbnailURL,
 				ImagePreviewURL:      n.ImagePreviewURL,
@@ -333,13 +333,13 @@ func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NftDB, pUser *persis
 				AcquisitionDateStr:   n.AcquisitionDateStr,
 			}
 			if n.ID == "" {
-				dbNFT, err := persist.NftGetByOpenseaID(pCtx, n.OpenSeaID, pRuntime)
+				dbNFT, err := persist.NftGetByOpenseaID(pCtx, n.OpenseaID, pRuntime)
 				if err != nil {
 					errChan <- err
 					return
 				}
 				if len(dbNFT) != 1 {
-					errChan <- fmt.Errorf("unable to find a single nft with opensea id %d", n.OpenSeaID)
+					errChan <- fmt.Errorf("unable to find a single nft with opensea id %d", n.OpenseaID)
 					return
 				}
 				result.ID = dbNFT[0].ID
@@ -371,7 +371,7 @@ func openseaToDBNft(pCtx context.Context, pWalletAddress string, nft *openseaAss
 		CreatorAddress:       strings.ToLower(nft.Creator.Address),
 		AnimationURL:         nft.AnimationURL,
 		OpenSeaTokenID:       nft.TokenID,
-		OpenSeaID:            nft.ID,
+		OpenseaID:            nft.ID,
 		TokenCollectionName:  nft.Collection.Name,
 		ImageThumbnailURL:    nft.ImageThumbnailURL,
 		ImagePreviewURL:      nft.ImagePreviewURL,

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -28,30 +28,26 @@ func TestOpenseaSync_Success(t *testing.T) {
 	mikeUserID, err := persist.UserCreate(ctx, mike, tc.r)
 
 	nft := &persist.NftDB{
-		OwnerUserID:  giannaUserID,
-		OwnerAddress: "0xdd33e6fd03983c970ae5e647df07314435d69f6b",
-		Name:         "kks",
-		OpenSeaID:    34147626,
+		OwnerAddresses: []string{"0xdd33e6fd03983c970ae5e647df07314435d69f6b"},
+		Name:           "kks",
+		OpenSeaID:      34147626,
 	}
 
 	nft2 := &persist.NftDB{
-		OwnerUserID:  robinUserID,
-		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-		Name:         "malsjdlaksjd",
-		OpenSeaID:    46062326,
+		OwnerAddresses: []string{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"},
+		Name:           "malsjdlaksjd",
+		OpenSeaID:      46062326,
 	}
 	nft3 := &persist.NftDB{
-		OwnerUserID:  robinUserID,
-		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-		Name:         "asdjasdasd",
-		OpenSeaID:    46062320,
+		OwnerAddresses: []string{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"},
+		Name:           "asdjasdasd",
+		OpenSeaID:      46062320,
 	}
 
 	nft4 := &persist.NftDB{
-		OwnerUserID:  mikeUserID,
-		OwnerAddress: strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"),
-		Name:         "asdasdasd",
-		OpenSeaID:    46062322,
+		OwnerAddresses: []string{strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")},
+		Name:           "asdasdasd",
+		OpenSeaID:      46062322,
 	}
 
 	ids, err := persist.NftCreateBulk(ctx, []*persist.NftDB{nft, nft2, nft3, nft4}, tc.r)
@@ -111,7 +107,7 @@ func TestOpenseaSync_Success(t *testing.T) {
 		return ab
 	}
 
-	log.Println(arrayDiff(ids1, ids2))
+	log.Println("DIF", arrayDiff(ids1, ids2))
 
 	assert.Len(t, robinOpenseaNFTs, len(nftsByUser))
 

--- a/server/t__routes_collection_test.go
+++ b/server/t__routes_collection_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/mikeydub/go-gallery/persist"
@@ -49,9 +50,9 @@ func TestCreateCollection_Success(t *testing.T) {
 	assert := setupTest(t)
 
 	nfts := []*persist.NftDB{
-		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
-		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
-		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
+		{Description: "asd", CollectorsNote: "asd", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "bbb", CollectorsNote: "bbb", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
 	}
 	nftIDs, err := persist.NftCreateBulk(context.Background(), nfts, tc.r)
 	assert.Nil(err)
@@ -98,9 +99,9 @@ func TestGetUnassignedCollection_Success(t *testing.T) {
 	assert := setupTest(t)
 
 	nfts := []*persist.NftDB{
-		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
-		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
-		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
+		{Description: "asd", CollectorsNote: "asd", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "bbb", CollectorsNote: "bbb", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
 	}
 	nftIDs, err := persist.NftCreateBulk(context.Background(), nfts, tc.r)
 	// seed DB with collection
@@ -167,9 +168,9 @@ func TestGetHiddenCollections_Success(t *testing.T) {
 	assert := setupTest(t)
 
 	nfts := []*persist.NftDB{
-		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
-		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
-		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
+		{Description: "asd", CollectorsNote: "asd", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "bbb", CollectorsNote: "bbb", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
 	}
 	nftIDs, err := persist.NftCreateBulk(context.Background(), nfts, tc.r)
 
@@ -198,9 +199,9 @@ func TestGetNoHiddenCollections_Success(t *testing.T) {
 	assert := setupTest(t)
 
 	nfts := []*persist.NftDB{
-		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
-		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
-		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
+		{Description: "asd", CollectorsNote: "asd", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "bbb", CollectorsNote: "bbb", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
 	}
 	nftIDs, err := persist.NftCreateBulk(context.Background(), nfts, tc.r)
 
@@ -235,14 +236,14 @@ func TestCreateCollectionWithUsedNFT_Success(t *testing.T) {
 	assert := setupTest(t)
 
 	nfts := []*persist.NftDB{
-		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
-		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
-		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
+		{Description: "asd", CollectorsNote: "asd", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "bbb", CollectorsNote: "bbb", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
 	}
 	nftIDs, err := persist.NftCreateBulk(context.Background(), nfts, tc.r)
 
 	preCollID, err := persist.CollCreate(context.Background(), &persist.CollectionDB{Name: "test", Nfts: nftIDs, OwnerUserID: tc.user1.id}, tc.r)
-	gid, err := persist.GalleryCreate(context.Background(), &persist.GalleryDB{OwnerUserID: tc.user1.id, Collections: []persist.DBID{preCollID}}, tc.r)
+	gid, err := persist.GalleryCreate(context.Background(), &persist.GalleryDB{Collections: []persist.DBID{preCollID}, OwnerUserID: tc.user1.id}, tc.r)
 
 	input := collectionCreateInput{GalleryID: gid, Nfts: nftIDs[0:2]}
 	resp := createCollectionRequest(assert, input, tc.user1.jwt)
@@ -269,9 +270,9 @@ func TestUpdateCollectionNftsOrder_Success(t *testing.T) {
 	assert := setupTest(t)
 
 	nfts := []*persist.NftDB{
-		{Description: "asd", OwnerUserID: tc.user1.id, CollectorsNote: "asd", OwnerAddress: tc.user1.address},
-		{Description: "bbb", OwnerUserID: tc.user1.id, CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
-		{Description: "wowowowow", OwnerUserID: tc.user1.id, CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
+		{Description: "asd", CollectorsNote: "asd", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "bbb", CollectorsNote: "bbb", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
+		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddresses: []string{strings.ToLower(tc.user1.address)}},
 	}
 	nftIDs, err := persist.NftCreateBulk(context.Background(), nfts, tc.r)
 	assert.Nil(err)
@@ -290,6 +291,10 @@ func TestUpdateCollectionNftsOrder_Success(t *testing.T) {
 	update := collectionUpdateNftsByIDinput{ID: collID, Nfts: nftIDs}
 	resp := updateCollectionNftsRequest(assert, update, tc.user1.jwt)
 	assertValidResponse(assert, resp)
+
+	errResp := errorResponse{}
+	util.UnmarshallBody(&errResp, resp.Body)
+	assert.Empty(errResp.Error)
 
 	// retrieve updated nft
 	resp, err = http.Get(fmt.Sprintf("%s/collections/get?id=%s", tc.serverURL, collID))

--- a/server/t__routes_nft_test.go
+++ b/server/t__routes_nft_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/mikeydub/go-gallery/copy"
@@ -20,8 +21,8 @@ func TestGetNftByID_Success(t *testing.T) {
 	// seed DB with nft
 	name := "very cool nft"
 	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
-		Name:        name,
-		OwnerUserID: tc.user1.id,
+		Name:           name,
+		OwnerAddresses: []string{strings.ToLower(tc.user1.address)},
 	}, tc.r)
 	assert.Nil(err)
 
@@ -72,7 +73,7 @@ func TestUpdateNftByID_Success(t *testing.T) {
 	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
 		Name:           "very cool nft",
 		CollectorsNote: "silly note",
-		OwnerUserID:    tc.user1.id,
+		OwnerAddresses: []string{strings.ToLower(tc.user1.address)},
 	}, tc.r)
 	assert.Nil(err)
 
@@ -104,7 +105,7 @@ func TestUpdateNftByID_UnauthedError(t *testing.T) {
 	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
 		Name:           "very cool nft",
 		CollectorsNote: "this is a bad note",
-		OwnerUserID:    tc.user1.id,
+		OwnerAddresses: []string{strings.ToLower(tc.user1.address)},
 	}, tc.r)
 	assert.Nil(err)
 
@@ -147,8 +148,7 @@ func TestUpdateNftByID_UpdatingAsUserWithoutToken_CantDo(t *testing.T) {
 
 	// seed DB with nft
 	nftID, err := persist.NftCreate(context.Background(), &persist.NftDB{
-		Name:        "very cool nft",
-		OwnerUserID: tc.user1.id,
+		Name: "very cool nft",
 	}, tc.r)
 	assert.Nil(err)
 

--- a/server/t__routes_user_test.go
+++ b/server/t__routes_user_test.go
@@ -229,9 +229,8 @@ func TestUserRemoveAddresses_Success(t *testing.T) {
 	assert.Nil(err)
 
 	nft := &persist.NftDB{
-		OwnerAddress: strings.ToLower("0x456d569592f15Af845D0dbe984C12BAB8F430e31"),
-		Name:         "test",
-		OwnerUserID:  userID,
+		OwnerAddresses: []string{strings.ToLower("0x456d569592f15Af845D0dbe984C12BAB8F430e31")},
+		Name:           "test",
 	}
 	nftID, err := persist.NftCreate(context.Background(), nft, tc.r)
 

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -36,11 +36,11 @@ type TestUser struct {
 func generateTestUser(r *runtime.Runtime, username string) *TestUser {
 	ctx := context.Background()
 
-	address := fmt.Sprintf("0x%s", util.RandStringBytes(40))
+	address := strings.ToLower(fmt.Sprintf("0x%s", util.RandStringBytes(40)))
 	user := &persist.User{
 		UserName:           username,
 		UserNameIdempotent: strings.ToLower(username),
-		Addresses:          []string{strings.ToLower(address)},
+		Addresses:          []string{address},
 	}
 	id, err := persist.UserCreate(ctx, user, r)
 	if err != nil {


### PR DESCRIPTION
Changes:

- **Changed** NFT struct to have `owner_addresses` instead of `owner_address`, have no `owner_user_id` field (because there isn't just one owner anymore), and have a `multiple_owners` field that will determine if updating a token should add users to the list of owners or replace the list of owners with the new owner
- **Changed** funcs that used to use `owner_user_id` field in queries to instead query for addresses and if the addresses are not available, first get the user and find their addresses
- **Changed** tests to reflect changes
- **Removed** pull from other user's collections when an NFT is being claimed

Considerations:

- Frontend will need to reflect the changes made to nft structs. Specifically, the frontend will have to handle `owner_addresses` and `multiple_owners` and also instead of `owner_username` being populated for NFT get there is an `owner_user` field that is an array of every user that owns the NFT. Each item in the array is a user struct.