### PR TITLE
refresh opensea endpoint

### DIFF
--- a/persist/mongodb/nft.go
+++ b/persist/mongodb/nft.go
@@ -205,7 +205,7 @@ func (n *NFTMongoRepository) BulkUpsert(pCtx context.Context, pNfts []*persist.N
 
 }
 
-// OpenseaCacheSet adds a set of nfts to the opensea cache under a given wallet address
+// OpenseaCacheSet adds a set of nfts to the opensea cache under a given set of wallet addresses
 func (n *NFTMongoRepository) OpenseaCacheSet(pCtx context.Context, pWalletAddresses []string, pNfts []*persist.NFT) error {
 
 	for i, v := range pWalletAddresses {
@@ -220,7 +220,17 @@ func (n *NFTMongoRepository) OpenseaCacheSet(pCtx context.Context, pWalletAddres
 	return n.redisClients.Set(pCtx, memstore.OpenseaRDB, fmt.Sprint(pWalletAddresses), toCache, openseaAssetsTTL)
 }
 
-// OpenseaCacheGet gets a set of nfts from the opensea cache under a given wallet address
+// OpenseaCacheDelete deletes a set of nfts from the opensea cache under a given set of wallet addresses
+func (n *NFTMongoRepository) OpenseaCacheDelete(pCtx context.Context, pWalletAddresses []string) error {
+
+	for i, v := range pWalletAddresses {
+		pWalletAddresses[i] = strings.ToLower(v)
+	}
+
+	return n.redisClients.Delete(pCtx, memstore.OpenseaRDB, fmt.Sprint(pWalletAddresses))
+}
+
+// OpenseaCacheGet gets a set of nfts from the opensea cache under a given set of wallet addresses
 func (n *NFTMongoRepository) OpenseaCacheGet(pCtx context.Context, pWalletAddresses []string) ([]*persist.NFT, error) {
 
 	for i, v := range pWalletAddresses {

--- a/persist/nft.go
+++ b/persist/nft.go
@@ -146,4 +146,5 @@ type NFTRepository interface {
 	BulkUpsert(context.Context, []*NFTDB) ([]DBID, error)
 	OpenseaCacheGet(context.Context, []string) ([]*NFT, error)
 	OpenseaCacheSet(context.Context, []string, []*NFT) error
+	OpenseaCacheDelete(context.Context, []string) error
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -130,7 +130,8 @@ func nftHandlersInit(parent *gin.RouterGroup, repos *repositories, ethClient *et
 
 	nftsGroup.GET("/get", jwtOptional(), getNftByID(repos.nftRepository))
 	nftsGroup.GET("/user_get", jwtOptional(), getNftsForUser(repos.nftRepository))
-	nftsGroup.GET("/opensea_get", rateLimited(), jwtRequired(), getNftsFromOpensea(repos.nftRepository, repos.userRepository, repos.collectionRepository, repos.historyRepository))
+	nftsGroup.GET("/opensea/get", rateLimited(), jwtRequired(), getNftsFromOpensea(repos.nftRepository, repos.userRepository, repos.collectionRepository, repos.historyRepository))
+	nftsGroup.GET("/opensea/refresh", jwtRequired(), refreshOpenseaNFTs(repos.nftRepository, repos.userRepository))
 	nftsGroup.POST("/update", jwtRequired(), updateNftByID(repos.nftRepository))
 	nftsGroup.GET("/unassigned/get", jwtRequired(), getUnassignedNftsForUser(repos.collectionRepository))
 	nftsGroup.POST("/unassigned/refresh", jwtRequired(), refreshUnassignedNftsForUser(repos.collectionRepository))

--- a/server/nft.go
+++ b/server/nft.go
@@ -22,7 +22,10 @@ type getNftsByUserIDInput struct {
 type getOpenseaNftsInput struct {
 	// Comma separated list of wallet addresses
 	WalletAddresses string `json:"addresses" form:"addresses"`
-	SkipCache       bool   `json:"skip_cache" form:"skip_cache"`
+}
+type refreshOpenseaNftsInput struct {
+	// Comma separated list of wallet addresses
+	WalletAddresses string `json:"addresses" form:"addresses"`
 }
 
 type getNftsOutput struct {
@@ -205,12 +208,51 @@ func getNftsFromOpensea(nftRepo persist.NFTRepository, userRepo persist.UserRepo
 			}
 		}
 
-		nfts, err := openSeaPipelineAssetsForAcc(c, userID, addresses, input.SkipCache, nftRepo, userRepo, collRepo, historyRepo)
+		nfts, err := openSeaPipelineAssetsForAcc(c, userID, addresses, nftRepo, userRepo, collRepo, historyRepo)
 		if len(nfts) == 0 || err != nil {
 			nfts = []*persist.NFT{}
 		}
 
 		c.JSON(http.StatusOK, getNftsOutput{Nfts: nfts})
+	}
+}
+func refreshOpenseaNFTs(nftRepo persist.NFTRepository, userRepo persist.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		input := &refreshOpenseaNftsInput{}
+		if err := c.ShouldBindQuery(input); err != nil {
+			c.JSON(http.StatusBadRequest, util.ErrorResponse{Error: err.Error()})
+			return
+		}
+
+		userID := getUserIDfromCtx(c)
+		if userID == "" {
+			c.JSON(http.StatusBadRequest, util.ErrorResponse{Error: errUserIDNotInCtx.Error()})
+			return
+		}
+
+		addresses := []string{}
+		if input.WalletAddresses != "" {
+			addresses = []string{input.WalletAddresses}
+			if strings.Contains(input.WalletAddresses, ",") {
+				addresses = strings.Split(input.WalletAddresses, ",")
+			}
+			ownsWallet, err := doesUserOwnWallets(c, userID, addresses, userRepo)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, util.ErrorResponse{Error: err.Error()})
+				return
+			}
+			if !ownsWallet {
+				c.JSON(http.StatusBadRequest, util.ErrorResponse{Error: errDoesNotOwnWallets{userID, addresses}.Error()})
+				return
+			}
+		}
+
+		if err := nftRepo.OpenseaCacheDelete(c, addresses); err != nil {
+			c.JSON(http.StatusInternalServerError, util.ErrorResponse{Error: err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
 	}
 }
 

--- a/server/opensea.go
+++ b/server/opensea.go
@@ -83,14 +83,12 @@ type errNoSingleNFTForOpenseaID struct {
 	openseaID int
 }
 
-func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOwnerWalletAddresses []string, skipCache bool,
+func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOwnerWalletAddresses []string,
 	nftRepo persist.NFTRepository, userRepo persist.UserRepository, collRepo persist.CollectionRepository, historyRepo persist.OwnershipHistoryRepository) ([]*persist.NFT, error) {
 
-	if !skipCache {
-		nfts, err := nftRepo.OpenseaCacheGet(pCtx, pOwnerWalletAddresses)
-		if err == nil && len(nfts) > 0 {
-			return nfts, nil
-		}
+	nfts, err := nftRepo.OpenseaCacheGet(pCtx, pOwnerWalletAddresses)
+	if err == nil && len(nfts) > 0 {
+		return nfts, nil
 	}
 
 	user, err := userRepo.GetByID(pCtx, pUserID)

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -63,10 +63,10 @@ func TestOpenseaSync_Success(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(now, 1)
 
-	robinOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, robinUserID, []string{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"}, true, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
+	robinOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, robinUserID, []string{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
 	assert.Nil(err)
 
-	mikeOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, mikeUserID, []string{strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")}, true, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
+	mikeOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, mikeUserID, []string{strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
 	assert.Nil(err)
 
 	mikeColl, err := tc.repos.collectionRepository.GetByID(ctx, collID, true)
@@ -136,7 +136,7 @@ func TestOpenseaRateLimit_Failure(t *testing.T) {
 
 func openseaSyncRequest(assert *assert.Assertions, address string, jwt string) *http.Response {
 	req, err := http.NewRequest("GET",
-		fmt.Sprintf("%s/nfts/opensea_get?addresses=%s&skip_cache=true", tc.serverURL, address),
+		fmt.Sprintf("%s/nfts/opensea/get?addresses=%s&skip_cache=true", tc.serverURL, address),
 		nil)
 	assert.Nil(err)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", jwt))

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -112,8 +112,6 @@ func TestOpenseaSync_Success(t *testing.T) {
 
 	assert.Greater(len(nftsByUserThree), 0)
 
-	assert.NotNil(nftsByUser[0].OwnershipHistory)
-
 }
 
 func TestOpenseaRateLimit_Failure(t *testing.T) {


### PR DESCRIPTION
Changes:

- **Added** separate endpoint for refreshing opensea cache
- **Changed** opensea endpoints to be `/nfts/opensea/get` and `/nfts/opensea/refresh`