### PR TITLE
columns with token layout in updates and creation of collections

### DIFF
--- a/persist/collection_nft.go
+++ b/persist/collection_nft.go
@@ -15,6 +15,8 @@ type CollectionDB struct {
 	Deleted      bool            `bson:"deleted" json:"-"`
 	LastUpdated  LastUpdatedTime `bson:"last_updated,update_time" json:"last_updated"`
 
+	Layout TokenLayout `bson:"layout" json:"layout"`
+
 	Name           string `bson:"name"          json:"name"`
 	CollectorsNote string `bson:"collectors_note"   json:"collectors_note"`
 	OwnerUserID    DBID   `bson:"owner_user_id" json:"owner_user_id"`
@@ -35,6 +37,8 @@ type Collection struct {
 	Deleted      bool            `bson:"deleted" json:"-"`
 	LastUpdated  LastUpdatedTime `bson:"last_updated,update_time" json:"last_updated"`
 
+	Layout TokenLayout `bson:"layout" json:"layout"`
+
 	Name           string           `bson:"name"          json:"name"`
 	CollectorsNote string           `bson:"collectors_note"   json:"collectors_note"`
 	OwnerUserID    string           `bson:"owner_user_id" json:"owner_user_id"`
@@ -52,7 +56,8 @@ type CollectionUpdateInfoInput struct {
 
 // CollectionUpdateNftsInput represents the data that will be changed when updating a collection's NFTs
 type CollectionUpdateNftsInput struct {
-	Nfts []DBID `bson:"nfts" json:"nfts"`
+	Nfts   []DBID      `bson:"nfts" json:"nfts"`
+	Layout TokenLayout `bson:"layout" json:"layout"`
 }
 
 // CollectionUpdateHiddenInput represents the data that will be changed when updating a collection's hidden status


### PR DESCRIPTION
Changes:

- **Added** a token layout object that for the time being just holds a column field representing the number of columns in a collection
- **Added** a function to validate layouts ensuring the column constraints are met as well as defaults are set
- **Changed** update and create collection functions to optionally take in a layout object that will have its defaults set if not included in the request