### PR TITLE
indexer diff script

### DIFF
--- a/persist/mongodb/token.go
+++ b/persist/mongodb/token.go
@@ -107,8 +107,10 @@ func (t *TokenMongoRepository) GetByWallet(pCtx context.Context, pAddress persis
 		dur := time.Until(deadline)
 		opts.SetMaxTime(dur)
 	}
-	opts.SetSkip(limit * page)
-	opts.SetLimit(limit)
+	if limit > 0 {
+		opts.SetSkip(limit * page)
+		opts.SetLimit(limit)
+	}
 	opts.SetSort(bson.M{"block_number": -1})
 
 	result := []*persist.Token{}
@@ -174,8 +176,10 @@ func (t *TokenMongoRepository) GetByContract(pCtx context.Context, pAddress pers
 		dur := time.Until(deadline)
 		opts.SetMaxTime(dur)
 	}
-	opts.SetSkip(limit * page)
-	opts.SetLimit(limit)
+	if limit > 0 {
+		opts.SetSkip(limit * page)
+		opts.SetLimit(limit)
+	}
 	opts.SetSort(bson.M{"block_number": -1})
 
 	result := []*persist.Token{}
@@ -195,8 +199,10 @@ func (t *TokenMongoRepository) GetByTokenIdentifiers(pCtx context.Context, pToke
 		dur := time.Until(deadline)
 		opts.SetMaxTime(dur)
 	}
-	opts.SetSkip(limit * page)
-	opts.SetLimit(limit)
+	if limit > 0 {
+		opts.SetSkip(limit * page)
+		opts.SetLimit(limit)
+	}
 	opts.SetSort(bson.M{"block_number": -1})
 
 	result := []*persist.Token{}

--- a/scripts/get_all_users.py
+++ b/scripts/get_all_users.py
@@ -1,0 +1,36 @@
+import csv
+from pymongo import MongoClient
+
+client = MongoClient()
+db = client.gallery
+
+collection_collection = db.collections
+nft_collection = db.nfts
+gallery_collection = db.galleries
+user_collection = db.users
+
+with open("users.csv", "w", newline="") as csvfile:
+    fieldnames = ["username", "url", "nfts", "collections"]
+    writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+    writer.writeheader()
+    for user in user_collection.find():
+        try:
+            username = user["username"]
+            url = "https://gallery.so/{}".format(user["username_idempotent"])
+            collections = collection_collection.count_documents(
+                {"owner_user_id": user["_id"]}
+            )
+            nfts = 0
+            for address in user["addresses"]:
+                nfts += nft_collection.count_documents({"owner_address": address})
+            row = {
+                "username": username,
+                "url": url,
+                "nfts": nfts,
+                "collections": collections,
+            }
+            print(row)
+            writer.writerow(row)
+        except Exception as e:
+            print(e)

--- a/scripts/post-index-diff.py
+++ b/scripts/post-index-diff.py
@@ -1,0 +1,54 @@
+import requests
+from pymongo import MongoClient
+
+client = MongoClient("")
+db = client.gallery
+
+collection_collection = db.collections
+nft_collection = db.nfts
+gallery_collection = db.galleries
+user_collection = db.users
+
+
+def dif(r1, r2):
+    return set(r1) - set(r2)
+
+
+def identifiersv1(nft):
+    return "{}-{}".format(
+        nft["asset_contract"]["address"].lower(), int(nft["opensea_token_id"].lower())
+    )
+
+
+def identifiersv2(nft):
+    return "{}-{}".format(nft["contract_address"].lower(), int(nft["token_id"].lower()))
+
+
+for user in user_collection.find():
+    try:
+        print(user["username"], ":")
+        urlv1 = "https://api.dev.gallery.so/glry/v1/nfts/user_get?user_id={}".format(
+            user["_id"]
+        )
+        urlv2 = "https://api.dev.gallery.so/glry/v2/nfts/user_get?user_id={}&limit=5000".format(
+            user["_id"]
+        )
+
+        r1 = requests.get(urlv1, timeout=10).json()
+        r2 = requests.get(urlv2, timeout=10).json()
+
+        print("V1 Len", len(r1["nfts"]))
+        print("V2 Len", len(r2["nfts"]))
+
+        print(
+            "Diff V1",
+            dif(map(identifiersv1, r1["nfts"]), map(identifiersv2, r2["nfts"])),
+        )
+        print(
+            "Diff V2",
+            dif(map(identifiersv2, r2["nfts"]), map(identifiersv1, r1["nfts"])),
+        )
+        print("=============================================")
+
+    except Exception as e:
+        print(e)


### PR DESCRIPTION
Changes:

- **Added** script that will print diffs for the post indexer endpoints compared to current endpoints
- **Changed** get token persist funcs to only set limit if the limit is defined. (Learned that Mongo won't return anything if limit is not set for huge collections like we have)
- **Added** get users script for the csv that details users and their nfts/collection counts