### PR TITLE
cache galleries

### DIFF
--- a/indexer/handler.go
+++ b/indexer/handler.go
@@ -107,7 +107,7 @@ func newIPFSShell() *shell.Shell {
 
 func newRepos() (persist.TokenRepository, persist.ContractRepository) {
 	mgoClient := newMongoClient()
-	return mongodb.NewTokenMongoRepository(mgoClient), mongodb.NewContractMongoRepository(mgoClient)
+	return mongodb.NewTokenMongoRepository(mgoClient, nil), mongodb.NewContractMongoRepository(mgoClient)
 }
 
 func newMongoClient() *mongo.Client {

--- a/memstore/t__tasks_test.go
+++ b/memstore/t__tasks_test.go
@@ -1,0 +1,62 @@
+package memstore
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mikeydub/go-gallery/memstore/redis"
+	"github.com/mikeydub/go-gallery/persist"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateQueue(t *testing.T) {
+	assert := assert.New(t)
+	viper.Set("REDIS_URL", "localhost:6379")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	redisCache := redis.NewCache(5)
+
+	nft := persist.NFT{
+		CollectorsNote: "bob",
+		Description:    "test",
+	}
+
+	asJSON, err := json.Marshal(nft)
+	assert.Nil(err)
+
+	redisCache.Set(ctx, "test", asJSON, time.Hour)
+
+	bs, err := redisCache.Get(ctx, "test")
+	assert.Nil(err)
+
+	result := persist.NFT{}
+	err = json.Unmarshal(bs, &result)
+	assert.Nil(err)
+	assert.Equal(nft.CollectorsNote, result.CollectorsNote)
+
+	uq := NewUpdateQueue(redisCache)
+
+	result.Description = "updated"
+
+	asJSON, err = json.Marshal(result)
+	uq.QueueUpdate("test", asJSON, -1)
+
+	result.Description = "updated2"
+	asJSON, err = json.Marshal(result)
+	uq.QueueUpdate("test", asJSON, -1)
+
+	uq.Stop()
+
+	bs, err = redisCache.Get(ctx, "test")
+	assert.Nil(err)
+
+	result = persist.NFT{}
+	err = json.Unmarshal(bs, &result)
+	assert.Nil(err)
+	assert.Equal(result.Description, "updated2")
+
+}

--- a/memstore/tasks.go
+++ b/memstore/tasks.go
@@ -14,8 +14,7 @@ type update struct {
 	key string
 	val interface{}
 
-	ttl     time.Duration
-	timeout time.Duration
+	ttl time.Duration
 }
 
 // UpdateQueue is a queue of updates to be run
@@ -55,7 +54,7 @@ func (uq *UpdateQueue) start() {
 			uq.mu.Unlock()
 
 			updateFunc := func() {
-				ctx, cancel := context.WithTimeout(context.Background(), update.timeout)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 				defer cancel()
 				err := uq.cache.Set(ctx, update.key, update.val, update.ttl)
 				if err != nil {
@@ -75,7 +74,12 @@ func (uq *UpdateQueue) start() {
 	}()
 }
 
+// Stop stops the update queue
+func (uq *UpdateQueue) Stop() {
+	uq.wp.StopWait()
+}
+
 // QueueUpdate queues an update to be run
-func (uq *UpdateQueue) QueueUpdate(key string, value interface{}, timeout, ttl time.Duration) {
-	uq.updates <- update{key: key, val: value, timeout: timeout, ttl: ttl}
+func (uq *UpdateQueue) QueueUpdate(key string, value interface{}, ttl time.Duration) {
+	uq.updates <- update{key: key, val: value, ttl: ttl}
 }

--- a/memstore/tasks.go
+++ b/memstore/tasks.go
@@ -1,0 +1,81 @@
+package memstore
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/gammazero/workerpool"
+	"github.com/sirupsen/logrus"
+)
+
+// update represents a key and value pair
+type update struct {
+	key string
+	val interface{}
+
+	ttl     time.Duration
+	timeout time.Duration
+}
+
+// UpdateQueue is a queue of updates to be run
+type UpdateQueue struct {
+	mu *sync.Mutex
+	wp *workerpool.WorkerPool
+
+	cache Cache
+
+	updates        chan update
+	runningUpdates map[string]bool
+}
+
+// NewUpdateQueue creates a new UpdateQueue
+func NewUpdateQueue(cache Cache) *UpdateQueue {
+	queue := &UpdateQueue{
+		mu:             &sync.Mutex{},
+		wp:             workerpool.New(10),
+		cache:          cache,
+		updates:        make(chan update),
+		runningUpdates: make(map[string]bool),
+	}
+	queue.start()
+	return queue
+}
+
+// Start starts the update queue
+func (uq *UpdateQueue) start() {
+	go func() {
+		for update := range uq.updates {
+			uq.mu.Lock()
+			if uq.runningUpdates[update.key] {
+				uq.mu.Unlock()
+				continue
+			}
+			uq.runningUpdates[update.key] = true
+			uq.mu.Unlock()
+
+			updateFunc := func() {
+				ctx, cancel := context.WithTimeout(context.Background(), update.timeout)
+				defer cancel()
+				err := uq.cache.Set(ctx, update.key, update.val, update.timeout)
+				if err != nil {
+					logrus.WithError(err).Error("memstore: failed to update key")
+				}
+
+				uq.mu.Lock()
+				defer uq.mu.Unlock()
+				delete(uq.runningUpdates, update.key)
+			}
+			if uq.wp.WaitingQueueSize() > 25 {
+				uq.wp.SubmitWait(updateFunc)
+			} else {
+				uq.wp.Submit(updateFunc)
+			}
+		}
+	}()
+}
+
+// QueueUpdate queues an update to be run
+func (uq *UpdateQueue) QueueUpdate(key string, value interface{}, timeout, ttl time.Duration) {
+	uq.updates <- update{key: key, val: value}
+}

--- a/memstore/tasks.go
+++ b/memstore/tasks.go
@@ -57,7 +57,7 @@ func (uq *UpdateQueue) start() {
 			updateFunc := func() {
 				ctx, cancel := context.WithTimeout(context.Background(), update.timeout)
 				defer cancel()
-				err := uq.cache.Set(ctx, update.key, update.val, update.timeout)
+				err := uq.cache.Set(ctx, update.key, update.val, update.ttl)
 				if err != nil {
 					logrus.WithError(err).Error("memstore: failed to update key")
 				}
@@ -77,5 +77,5 @@ func (uq *UpdateQueue) start() {
 
 // QueueUpdate queues an update to be run
 func (uq *UpdateQueue) QueueUpdate(key string, value interface{}, timeout, ttl time.Duration) {
-	uq.updates <- update{key: key, val: value}
+	uq.updates <- update{key: key, val: value, timeout: timeout, ttl: ttl}
 }

--- a/persist/collection_token.go
+++ b/persist/collection_token.go
@@ -42,7 +42,7 @@ type CollectionToken struct {
 
 	Name           string               `bson:"name"          json:"name"`
 	CollectorsNote string               `bson:"collectors_note"   json:"collectors_note"`
-	OwnerUserID    string               `bson:"owner_user_id" json:"owner_user_id"`
+	OwnerUserID    DBID                 `bson:"owner_user_id" json:"owner_user_id"`
 	Nfts           []*TokenInCollection `bson:"nfts"          json:"nfts"`
 
 	// collections can be hidden from public-viewing

--- a/persist/mongodb/access.go
+++ b/persist/mongodb/access.go
@@ -41,10 +41,6 @@ func NewAccessMongoRepository(mgoClient *mongo.Client) *AccessMongoRepository {
 func (c *AccessMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID) (*persist.Access, error) {
 
 	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 	opts.SetLimit(1)
 
 	result := []*persist.Access{}
@@ -65,10 +61,7 @@ func (c *AccessMongoRepository) GetByUserID(pCtx context.Context, pUserID persis
 func (c *AccessMongoRepository) HasRequiredTokens(pCtx context.Context, pUserID persist.DBID, pTokenIdentifiers []persist.TokenIdentifiers) (bool, error) {
 
 	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
+
 	opts.SetSort(bson.M{"created_at": -1})
 	opts.SetLimit(1)
 

--- a/persist/mongodb/accounts.go
+++ b/persist/mongodb/accounts.go
@@ -3,13 +3,11 @@ package mongodb
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/mikeydub/go-gallery/persist"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const accountCollName = "accounts"
@@ -43,14 +41,8 @@ func (a *AccountMongoRepository) UpsertByAddress(pCtx context.Context, pAddress 
 // GetByAddress returns an account by a given address
 func (a *AccountMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (*persist.Account, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.Account{}
-	err := a.accountStorage.find(pCtx, bson.M{"address": strings.ToLower(pAddress.String())}, &result, opts)
+	err := a.accountStorage.find(pCtx, bson.M{"address": strings.ToLower(pAddress.String())}, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/persist/mongodb/collection_nft.go
+++ b/persist/mongodb/collection_nft.go
@@ -311,7 +311,7 @@ func (c *CollectionMongoRepository) GetUnassigned(pCtx context.Context, pUserID 
 		return nil, err
 	}
 
-	c.cacheUpdateQueue.QueueUpdate(pUserID.String(), toCache, updateQueueDefaultTimeout, collectionUnassignedTTL)
+	c.cacheUpdateQueue.QueueUpdate(pUserID.String(), toCache, collectionUnassignedTTL)
 
 	if len(result) > 0 {
 		return result[0], nil

--- a/persist/mongodb/collection_token.go
+++ b/persist/mongodb/collection_token.go
@@ -344,7 +344,7 @@ func (c *CollectionTokenMongoRepository) GetUnassigned(pCtx context.Context, pUs
 		return nil, err
 	}
 
-	c.cacheUpdateQueue.QueueUpdate(pUserID.String(), toCache, updateQueueDefaultTimeout, collectionUnassignedTTL)
+	c.cacheUpdateQueue.QueueUpdate(pUserID.String(), toCache, collectionUnassignedTTL)
 
 	return result[0], nil
 

--- a/persist/mongodb/collection_token.go
+++ b/persist/mongodb/collection_token.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mikeydub/go-gallery/memstore"
 	"github.com/mikeydub/go-gallery/persist"
-	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -181,16 +180,6 @@ func (c *CollectionTokenMongoRepository) UpdateUnsafe(pCtx context.Context, pIDs
 		return err
 	}
 
-	go func() {
-		coll, err := c.GetByID(pCtx, pIDstr, true)
-		if err != nil {
-			logrus.WithError(err).Error("failed to get collection for cache reset")
-			return
-		}
-		c.galleryRepo.resetCache(pCtx, coll.OwnerUserID)
-		c.RefreshUnassigned(pCtx, coll.OwnerUserID)
-	}()
-
 	return nil
 }
 
@@ -211,16 +200,6 @@ func (c *CollectionTokenMongoRepository) UpdateNFTsUnsafe(pCtx context.Context, 
 	if err := c.collectionsStorage.update(pCtx, bson.M{"_id": pID}, pUpdate); err != nil {
 		return err
 	}
-
-	go func() {
-		coll, err := c.GetByID(pCtx, pID, true)
-		if err != nil {
-			logrus.WithError(err).Error("failed to get collection for cache reset")
-			return
-		}
-		c.galleryRepo.resetCache(pCtx, coll.OwnerUserID)
-		c.RefreshUnassigned(pCtx, coll.OwnerUserID)
-	}()
 
 	return nil
 }

--- a/persist/mongodb/collection_token.go
+++ b/persist/mongodb/collection_token.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mikeydub/go-gallery/memstore"
 	"github.com/mikeydub/go-gallery/persist"
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -198,6 +199,16 @@ func (c *CollectionTokenMongoRepository) UpdateUnsafe(pCtx context.Context, pIDs
 	if err := c.collectionsStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate); err != nil {
 		return err
 	}
+
+	go func() {
+		coll, err := c.GetByID(pCtx, pIDstr, true)
+		if err != nil {
+			logrus.WithError(err).Error("failed to get collection for cache reset")
+			return
+		}
+		c.galleryRepo.resetCache(pCtx, coll.OwnerUserID)
+	}()
+
 	return nil
 }
 
@@ -218,6 +229,15 @@ func (c *CollectionTokenMongoRepository) UpdateNFTsUnsafe(pCtx context.Context, 
 	if err := c.collectionsStorage.update(pCtx, bson.M{"_id": pID}, pUpdate); err != nil {
 		return err
 	}
+
+	go func() {
+		coll, err := c.GetByID(pCtx, pID, true)
+		if err != nil {
+			logrus.WithError(err).Error("failed to get collection for cache reset")
+			return
+		}
+		c.galleryRepo.resetCache(pCtx, coll.OwnerUserID)
+	}()
 
 	return nil
 }

--- a/persist/mongodb/contracts.go
+++ b/persist/mongodb/contracts.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const contractsCollName = "contracts"
@@ -89,14 +88,8 @@ func (c *ContractMongoRepository) BulkUpsert(pCtx context.Context, contracts []*
 // GetByAddress returns an contract by a given address
 func (c *ContractMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (*persist.Contract, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.Contract{}
-	err := c.contractsStorage.find(pCtx, bson.M{"address": pAddress}, &result, opts)
+	err := c.contractsStorage.find(pCtx, bson.M{"address": pAddress}, &result)
 
 	if err != nil {
 		return nil, err

--- a/persist/mongodb/features.go
+++ b/persist/mongodb/features.go
@@ -40,19 +40,13 @@ func NewFeaturesMongoRepository(mgoClient *mongo.Client) *FeaturesMongoRepositor
 // GetByRequiredTokens returns an feature by given token identifiers
 func (c *FeaturesMongoRepository) GetByRequiredTokens(pCtx context.Context, pRequiredtokens map[persist.TokenIdentifiers]uint64) ([]*persist.FeatureFlag, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.FeatureFlag{}
 	keys := make([]persist.TokenIdentifiers, len(pRequiredtokens))
 	i := 0
 	for k := range pRequiredtokens {
 		keys[i] = k
 	}
-	err := c.featuresStorage.find(pCtx, bson.M{"required_token": bson.M{"$in": keys}}, &result, opts)
+	err := c.featuresStorage.find(pCtx, bson.M{"required_token": bson.M{"$in": keys}}, &result)
 
 	if err != nil {
 		return nil, err
@@ -75,10 +69,6 @@ func (c *FeaturesMongoRepository) GetByRequiredTokens(pCtx context.Context, pReq
 func (c *FeaturesMongoRepository) GetByName(pCtx context.Context, pName string) (*persist.FeatureFlag, error) {
 
 	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 	opts.SetSort(bson.M{"created_at": -1})
 	opts.SetLimit(1)
 

--- a/persist/mongodb/gallery_nft.go
+++ b/persist/mongodb/gallery_nft.go
@@ -2,9 +2,14 @@ package mongodb
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
+	"github.com/mikeydub/go-gallery/memstore"
 	"github.com/mikeydub/go-gallery/persist"
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -14,25 +19,35 @@ import (
 type GalleryMongoRepository struct {
 	galleriesStorage   *storage
 	collectionsStorage *storage
+	galleriesCache     memstore.Cache
 }
 
+var errNoUserIDProvided = errors.New("no user ID provided")
+
 // NewGalleryMongoRepository creates a new instance of the collection mongo repository
-func NewGalleryMongoRepository(mgoClient *mongo.Client) *GalleryMongoRepository {
+func NewGalleryMongoRepository(mgoClient *mongo.Client, galleriesCache memstore.Cache) *GalleryMongoRepository {
 	return &GalleryMongoRepository{
 		galleriesStorage:   newStorage(mgoClient, 0, galleryDBName, galleryColName),
 		collectionsStorage: newStorage(mgoClient, 0, galleryDBName, collectionColName),
+		galleriesCache:     galleriesCache,
 	}
 }
 
 // Create inserts a new gallery into the database and returns the ID of the new gallery
-func (g *GalleryMongoRepository) Create(pCtx context.Context, pGallery *persist.GalleryDB,
-) (persist.DBID, error) {
+func (g *GalleryMongoRepository) Create(pCtx context.Context, pGallery *persist.GalleryDB) (persist.DBID, error) {
 
 	if pGallery.Collections == nil {
 		pGallery.Collections = []persist.DBID{}
 	}
 
-	return g.galleriesStorage.insert(pCtx, pGallery)
+	id, err := g.galleriesStorage.insert(pCtx, pGallery)
+	if err != nil {
+		return "", err
+	}
+
+	go g.resetCache(pCtx, pGallery.OwnerUserID)
+
+	return id, err
 }
 
 // Update updates a gallery in the database by ID, also ensuring the gallery
@@ -52,12 +67,20 @@ func (g *GalleryMongoRepository) Update(pCtx context.Context, pIDstr persist.DBI
 		return errUserDoesNotOwnCollections{pOwnerUserID}
 	}
 
-	return g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate)
+	if err = g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate); err != nil {
+		return err
+	}
+	go g.resetCache(pCtx, pOwnerUserID)
+	return nil
 }
 
 // AddCollections adds collections to the specified gallery
 func (g *GalleryMongoRepository) AddCollections(pCtx context.Context, pID persist.DBID, pUserID persist.DBID, pCollectionIDs []persist.DBID) error {
-	return g.galleriesStorage.push(pCtx, bson.M{"_id": pID, "owner_user_id": pUserID}, "collections", pCollectionIDs)
+	if err := g.galleriesStorage.push(pCtx, bson.M{"_id": pID, "owner_user_id": pUserID}, "collections", pCollectionIDs); err != nil {
+		return err
+	}
+	go g.resetCache(pCtx, pUserID)
+	return nil
 }
 
 // GetByUserID gets a gallery by its owner user ID and will variably return
@@ -65,6 +88,22 @@ func (g *GalleryMongoRepository) AddCollections(pCtx context.Context, pID persis
 func (g *GalleryMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID, pAuth bool,
 ) ([]*persist.Gallery, error) {
 
+	galleries := []*persist.Gallery{}
+
+	fromCache, err := g.galleriesCache.Get(pCtx, fmt.Sprintf("%s-%t", pUserID, pAuth))
+	if err != nil || fromCache == nil || len(fromCache) == 0 {
+		return g.getByUserIDSkipCache(pCtx, pUserID, pAuth)
+	}
+
+	err = json.Unmarshal(fromCache, &galleries)
+	if err != nil {
+		return nil, err
+	}
+
+	return galleries, nil
+}
+
+func (g *GalleryMongoRepository) getByUserIDSkipCache(pCtx context.Context, pUserID persist.DBID, pAuth bool) ([]*persist.Gallery, error) {
 	opts := options.Aggregate()
 	if deadline, ok := pCtx.Deadline(); ok {
 		dur := time.Until(deadline)
@@ -76,6 +115,15 @@ func (g *GalleryMongoRepository) GetByUserID(pCtx context.Context, pUserID persi
 	if err := g.galleriesStorage.aggregate(pCtx, newGalleryPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result, opts); err != nil {
 		return nil, err
 	}
+
+	go func() {
+		asJSON, err := json.Marshal(result)
+		if err != nil {
+			logrus.WithError(err).Error("failed to marshal galleries to json")
+			return
+		}
+		g.galleriesCache.Set(pCtx, fmt.Sprintf("%s-%t", pUserID, pAuth), asJSON, time.Hour)
+	}()
 
 	return result, nil
 }
@@ -100,6 +148,23 @@ func (g *GalleryMongoRepository) GetByID(pCtx context.Context, pID persist.DBID,
 	}
 
 	return result[0], nil
+}
+
+func (g *GalleryMongoRepository) resetCache(pCtx context.Context, ownerUserID persist.DBID) error {
+	if ownerUserID == "" {
+		return errNoUserIDProvided
+	}
+	_, err := g.getByUserIDSkipCache(pCtx, ownerUserID, true)
+	if err != nil {
+		return err
+	}
+
+	_, err = g.getByUserIDSkipCache(pCtx, ownerUserID, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func newGalleryPipeline(matchFilter bson.M, pAuth bool) mongo.Pipeline {

--- a/persist/mongodb/gallery_nft.go
+++ b/persist/mongodb/gallery_nft.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // GalleryMongoRepository is a repository that stores collections in a MongoDB database
@@ -104,15 +103,10 @@ func (g *GalleryMongoRepository) GetByUserID(pCtx context.Context, pUserID persi
 }
 
 func (g *GalleryMongoRepository) getByUserIDSkipCache(pCtx context.Context, pUserID persist.DBID, pAuth bool) ([]*persist.Gallery, error) {
-	opts := options.Aggregate()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 
 	result := []*persist.Gallery{}
 
-	if err := g.galleriesStorage.aggregate(pCtx, newGalleryPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result, opts); err != nil {
+	if err := g.galleriesStorage.aggregate(pCtx, newGalleryPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result); err != nil {
 		return nil, err
 	}
 
@@ -131,15 +125,10 @@ func (g *GalleryMongoRepository) getByUserIDSkipCache(pCtx context.Context, pUse
 // GetByID gets a gallery by its ID and will variably return
 // hidden collections depending on the auth status of the caller
 func (g *GalleryMongoRepository) GetByID(pCtx context.Context, pID persist.DBID, pAuth bool) (*persist.Gallery, error) {
-	opts := options.Aggregate()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 
 	result := []*persist.Gallery{}
 
-	if err := g.galleriesStorage.aggregate(pCtx, newGalleryPipeline(bson.M{"_id": pID, "deleted": false}, pAuth), &result, opts); err != nil {
+	if err := g.galleriesStorage.aggregate(pCtx, newGalleryPipeline(bson.M{"_id": pID, "deleted": false}, pAuth), &result); err != nil {
 		return nil, err
 	}
 

--- a/persist/mongodb/gallery_nft.go
+++ b/persist/mongodb/gallery_nft.go
@@ -117,7 +117,7 @@ func (g *GalleryMongoRepository) getByUserIDSkipCache(pCtx context.Context, pUse
 			logrus.WithError(err).Error("failed to marshal galleries to json")
 			return
 		}
-		g.cacheUpdateQueue.QueueUpdate(fmt.Sprintf("%s-%t", pUserID, pAuth), asJSON, updateQueueDefaultTimeout, galleriesTTL)
+		g.cacheUpdateQueue.QueueUpdate(fmt.Sprintf("%s-%t", pUserID, pAuth), asJSON, galleriesTTL)
 	}()
 
 	return result, nil

--- a/persist/mongodb/gallery_token.go
+++ b/persist/mongodb/gallery_token.go
@@ -2,10 +2,13 @@ package mongodb
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/mikeydub/go-gallery/memstore"
 	"github.com/mikeydub/go-gallery/persist"
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -17,6 +20,7 @@ const galleryColName = "galleries"
 type GalleryTokenMongoRepository struct {
 	galleriesStorage   *storage
 	collectionsStorage *storage
+	galleriesCache     memstore.Cache
 }
 
 type errUserDoesNotOwnCollections struct {
@@ -24,10 +28,11 @@ type errUserDoesNotOwnCollections struct {
 }
 
 // NewGalleryTokenMongoRepository creates a new instance of the collection mongo repository
-func NewGalleryTokenMongoRepository(mgoClient *mongo.Client) *GalleryTokenMongoRepository {
+func NewGalleryTokenMongoRepository(mgoClient *mongo.Client, galleriesCache memstore.Cache) *GalleryTokenMongoRepository {
 	return &GalleryTokenMongoRepository{
 		galleriesStorage:   newStorage(mgoClient, 0, galleryDBName, galleryColName),
 		collectionsStorage: newStorage(mgoClient, 0, galleryDBName, collectionColName),
+		galleriesCache:     galleriesCache,
 	}
 }
 
@@ -38,7 +43,12 @@ func (g *GalleryTokenMongoRepository) Create(pCtx context.Context, pGallery *per
 		pGallery.Collections = []persist.DBID{}
 	}
 
-	return g.galleriesStorage.insert(pCtx, pGallery)
+	id, err := g.galleriesStorage.insert(pCtx, pGallery)
+	if err != nil {
+		return "", err
+	}
+	go g.resetCache(pCtx, pGallery.OwnerUserID)
+	return id, nil
 }
 
 // Update updates a gallery in the database by ID, also ensuring the gallery
@@ -48,7 +58,6 @@ func (g *GalleryTokenMongoRepository) Update(pCtx context.Context, pIDstr persis
 	pOwnerUserID persist.DBID,
 	pUpdate *persist.GalleryTokenUpdateInput,
 ) error {
-
 	ct, err := g.collectionsStorage.count(pCtx, bson.M{"_id": bson.M{"$in": pUpdate.Collections}, "owner_user_id": pOwnerUserID})
 	if err != nil {
 		return err
@@ -58,7 +67,12 @@ func (g *GalleryTokenMongoRepository) Update(pCtx context.Context, pIDstr persis
 		return errUserDoesNotOwnCollections{pOwnerUserID}
 	}
 
-	return g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate)
+	if err := g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate); err != nil {
+		return err
+	}
+
+	go g.resetCache(pCtx, pOwnerUserID)
+	return nil
 }
 
 // UpdateUnsafe updates a gallery in the database by ID
@@ -66,20 +80,41 @@ func (g *GalleryTokenMongoRepository) Update(pCtx context.Context, pIDstr persis
 func (g *GalleryTokenMongoRepository) UpdateUnsafe(pCtx context.Context, pIDstr persist.DBID,
 	pUpdate *persist.GalleryTokenUpdateInput,
 ) error {
-
-	return g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate)
+	if err := g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate); err != nil {
+		return err
+	}
+	return nil
 }
 
 // AddCollections adds collections to the specified gallery
 func (g *GalleryTokenMongoRepository) AddCollections(pCtx context.Context, pID persist.DBID, pUserID persist.DBID, pCollectionIDs []persist.DBID) error {
-	return g.galleriesStorage.push(pCtx, bson.M{"_id": pID, "owner_user_id": pUserID}, "collections", pCollectionIDs)
+	if err := g.galleriesStorage.push(pCtx, bson.M{"_id": pID, "owner_user_id": pUserID}, "collections", pCollectionIDs); err != nil {
+		return err
+	}
+	go g.resetCache(pCtx, pUserID)
+	return nil
 }
 
 // GetByUserID gets a gallery by its owner user ID and will variably return
 // hidden collections depending on the auth status of the caller
-func (g *GalleryTokenMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID, pAuth bool,
-) ([]*persist.GalleryToken, error) {
+func (g *GalleryTokenMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID, pAuth bool) ([]*persist.GalleryToken, error) {
 
+	galleries := []*persist.GalleryToken{}
+
+	fromCache, err := g.galleriesCache.Get(pCtx, fmt.Sprintf("%s-%t", pUserID, pAuth))
+	if err != nil || fromCache == nil || len(fromCache) == 0 {
+		return g.getByUserIDSkipCache(pCtx, pUserID, pAuth)
+	}
+
+	err = json.Unmarshal(fromCache, &galleries)
+	if err != nil {
+		return nil, err
+	}
+
+	return galleries, nil
+}
+
+func (g *GalleryTokenMongoRepository) getByUserIDSkipCache(pCtx context.Context, pUserID persist.DBID, pAuth bool) ([]*persist.GalleryToken, error) {
 	opts := options.Aggregate()
 	if deadline, ok := pCtx.Deadline(); ok {
 		dur := time.Until(deadline)
@@ -91,6 +126,14 @@ func (g *GalleryTokenMongoRepository) GetByUserID(pCtx context.Context, pUserID 
 	if err := g.galleriesStorage.aggregate(pCtx, newGalleryTokenPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result, opts); err != nil {
 		return nil, err
 	}
+	go func() {
+		asJSON, err := json.Marshal(result)
+		if err != nil {
+			logrus.WithError(err).Error("failed to marshal galleries to json")
+			return
+		}
+		g.galleriesCache.Set(pCtx, fmt.Sprintf("%s-%t", pUserID, pAuth), asJSON, time.Hour)
+	}()
 
 	return result, nil
 }
@@ -115,6 +158,21 @@ func (g *GalleryTokenMongoRepository) GetByID(pCtx context.Context, pID persist.
 	}
 
 	return result[0], nil
+}
+
+func (g *GalleryTokenMongoRepository) resetCache(pCtx context.Context, ownerUserID persist.DBID) error {
+	if ownerUserID == "" {
+		return errNoUserIDProvided
+	}
+	_, err := g.getByUserIDSkipCache(pCtx, ownerUserID, true)
+	if err != nil {
+		return err
+	}
+	_, err = g.getByUserIDSkipCache(pCtx, ownerUserID, false)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func newGalleryTokenPipeline(matchFilter bson.M, pAuth bool) mongo.Pipeline {

--- a/persist/mongodb/gallery_token.go
+++ b/persist/mongodb/gallery_token.go
@@ -83,6 +83,14 @@ func (g *GalleryTokenMongoRepository) UpdateUnsafe(pCtx context.Context, pIDstr 
 	if err := g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate); err != nil {
 		return err
 	}
+	go func() {
+		gallery, err := g.GetByID(pCtx, pIDstr, true)
+		if err != nil {
+			logrus.WithError(err).Error("error getting gallery to reset cache")
+			return
+		}
+		g.resetCache(pCtx, gallery.OwnerUserID)
+	}()
 	return nil
 }
 

--- a/persist/mongodb/gallery_token.go
+++ b/persist/mongodb/gallery_token.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const galleryColName = "galleries"
@@ -123,15 +122,10 @@ func (g *GalleryTokenMongoRepository) GetByUserID(pCtx context.Context, pUserID 
 }
 
 func (g *GalleryTokenMongoRepository) getByUserIDSkipCache(pCtx context.Context, pUserID persist.DBID, pAuth bool) ([]*persist.GalleryToken, error) {
-	opts := options.Aggregate()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 
 	result := []*persist.GalleryToken{}
 
-	if err := g.galleriesStorage.aggregate(pCtx, newGalleryTokenPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result, opts); err != nil {
+	if err := g.galleriesStorage.aggregate(pCtx, newGalleryTokenPipeline(bson.M{"owner_user_id": pUserID, "deleted": false}, pAuth), &result); err != nil {
 		return nil, err
 	}
 	go func() {
@@ -149,15 +143,10 @@ func (g *GalleryTokenMongoRepository) getByUserIDSkipCache(pCtx context.Context,
 // GetByID gets a gallery by its ID and will variably return
 // hidden collections depending on the auth status of the caller
 func (g *GalleryTokenMongoRepository) GetByID(pCtx context.Context, pID persist.DBID, pAuth bool) (*persist.GalleryToken, error) {
-	opts := options.Aggregate()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 
 	result := []*persist.GalleryToken{}
 
-	if err := g.galleriesStorage.aggregate(pCtx, newGalleryTokenPipeline(bson.M{"_id": pID, "deleted": false}, pAuth), &result, opts); err != nil {
+	if err := g.galleriesStorage.aggregate(pCtx, newGalleryTokenPipeline(bson.M{"_id": pID, "deleted": false}, pAuth), &result); err != nil {
 		return nil, err
 	}
 

--- a/persist/mongodb/gallery_token.go
+++ b/persist/mongodb/gallery_token.go
@@ -128,7 +128,7 @@ func (g *GalleryTokenMongoRepository) getByUserIDSkipCache(pCtx context.Context,
 			logrus.WithError(err).Error("failed to marshal galleries to json")
 			return
 		}
-		g.updateCacheQueue.QueueUpdate(fmt.Sprintf("%s-%t", pUserID, pAuth), asJSON, updateQueueDefaultTimeout, galleriesTTL)
+		g.updateCacheQueue.QueueUpdate(fmt.Sprintf("%s-%t", pUserID, pAuth), asJSON, galleriesTTL)
 	}()
 
 	return result, nil

--- a/persist/mongodb/gallery_token.go
+++ b/persist/mongodb/gallery_token.go
@@ -83,14 +83,7 @@ func (g *GalleryTokenMongoRepository) UpdateUnsafe(pCtx context.Context, pIDstr 
 	if err := g.galleriesStorage.update(pCtx, bson.M{"_id": pIDstr}, pUpdate); err != nil {
 		return err
 	}
-	go func() {
-		gallery, err := g.GetByID(pCtx, pIDstr, true)
-		if err != nil {
-			logrus.WithError(err).Error("error getting gallery to reset cache")
-			return
-		}
-		g.resetCache(pCtx, gallery.OwnerUserID)
-	}()
+
 	return nil
 }
 

--- a/persist/mongodb/membership.go
+++ b/persist/mongodb/membership.go
@@ -2,13 +2,11 @@ package mongodb
 
 import (
 	"context"
-	"time"
 
 	"github.com/mikeydub/go-gallery/persist"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const membershipColName = "membership"
@@ -41,14 +39,8 @@ func (c *MembershipRepository) UpsertByTokenID(pCtx context.Context, pTokenID pe
 // GetByTokenID returns a membership tier by token ID
 func (c *MembershipRepository) GetByTokenID(pCtx context.Context, pTokenID persist.TokenID) (*persist.MembershipTier, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.MembershipTier{}
-	err := c.membershipsStorage.find(pCtx, bson.M{"token_id": pTokenID}, &result, opts)
+	err := c.membershipsStorage.find(pCtx, bson.M{"token_id": pTokenID}, &result)
 
 	if err != nil {
 		return nil, err
@@ -68,14 +60,8 @@ func (c *MembershipRepository) GetByTokenID(pCtx context.Context, pTokenID persi
 // GetAll returns all membership tiers
 func (c *MembershipRepository) GetAll(pCtx context.Context) ([]*persist.MembershipTier, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.MembershipTier{}
-	err := c.membershipsStorage.find(pCtx, bson.M{}, &result, opts)
+	err := c.membershipsStorage.find(pCtx, bson.M{}, &result)
 
 	if err != nil {
 		return nil, err

--- a/persist/mongodb/mongodb.go
+++ b/persist/mongodb/mongodb.go
@@ -32,12 +32,12 @@ const (
 const bsonDateFormat = "2006-01-02T15:04:05.999Z"
 
 var (
-	collectionUnassignedTTL time.Duration = time.Minute * 15
+	collectionUnassignedTTL time.Duration = time.Hour * 24
 	openseaAssetsTTL        time.Duration = time.Minute * 5
-	galleriesTTL            time.Duration = time.Hour
+	galleriesTTL            time.Duration = time.Hour * 24
 )
 
-var updateQueueDefaultTimeout = time.Second * 5
+var updateQueueDefaultTimeout = time.Second * 10
 
 var errInvalidValue = errors.New("cannot encode invalid element")
 

--- a/persist/mongodb/mongodb.go
+++ b/persist/mongodb/mongodb.go
@@ -32,9 +32,12 @@ const (
 const bsonDateFormat = "2006-01-02T15:04:05.999Z"
 
 var (
-	collectionUnassignedTTL time.Duration = time.Minute * 1
+	collectionUnassignedTTL time.Duration = time.Minute * 15
 	openseaAssetsTTL        time.Duration = time.Minute * 5
+	galleriesTTL            time.Duration = time.Hour
 )
+
+var updateQueueDefaultTimeout = time.Second * 5
 
 var errInvalidValue = errors.New("cannot encode invalid element")
 

--- a/persist/mongodb/mongodb.go
+++ b/persist/mongodb/mongodb.go
@@ -37,8 +37,6 @@ var (
 	galleriesTTL            time.Duration = time.Hour * 24
 )
 
-var updateQueueDefaultTimeout = time.Second * 10
-
 var errInvalidValue = errors.New("cannot encode invalid element")
 
 var addressType = reflect.TypeOf(persist.Address(""))

--- a/persist/mongodb/nft.go
+++ b/persist/mongodb/nft.go
@@ -5,14 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/mikeydub/go-gallery/memstore"
 	"github.com/mikeydub/go-gallery/persist"
 	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 const (
@@ -64,11 +62,6 @@ func (n *NFTMongoRepository) Create(pCtx context.Context, pNFT *persist.NFTDB) (
 
 // GetByUserID finds an nft by its owner user id
 func (n *NFTMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID) ([]*persist.NFT, error) {
-	opts := options.Aggregate()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 
 	users := []*persist.User{}
 	err := n.usersStorage.find(pCtx, bson.M{"_id": pUserID}, &users)
@@ -87,15 +80,10 @@ func (n *NFTMongoRepository) GetByAddresses(pCtx context.Context, pAddresses []p
 	for i, v := range pAddresses {
 		pAddresses[i] = v
 	}
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 
 	result := []*persist.NFT{}
 
-	if err := n.nftsStorage.find(pCtx, bson.M{"owner_address": bson.M{"$in": pAddresses}}, &result, opts); err != nil {
+	if err := n.nftsStorage.find(pCtx, bson.M{"owner_address": bson.M{"$in": pAddresses}}, &result); err != nil {
 		return nil, err
 	}
 
@@ -105,15 +93,9 @@ func (n *NFTMongoRepository) GetByAddresses(pCtx context.Context, pAddresses []p
 // GetByID finds an nft by its id
 func (n *NFTMongoRepository) GetByID(pCtx context.Context, pID persist.DBID) (*persist.NFT, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.NFT{}
 
-	if err := n.nftsStorage.find(pCtx, bson.M{"_id": pID}, &result, opts); err != nil {
+	if err := n.nftsStorage.find(pCtx, bson.M{"_id": pID}, &result); err != nil {
 		return nil, err
 	}
 
@@ -126,14 +108,10 @@ func (n *NFTMongoRepository) GetByID(pCtx context.Context, pID persist.DBID) (*p
 
 // GetByContractData finds an nft by its contract data
 func (n *NFTMongoRepository) GetByContractData(pCtx context.Context, pTokenID persist.TokenID, pContractAddress persist.Address) ([]*persist.NFT, error) {
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
+
 	result := []*persist.NFT{}
 
-	if err := n.nftsStorage.find(pCtx, bson.M{"opensea_token_id": pTokenID, "contract.contract_address": pContractAddress}, &result, opts); err != nil {
+	if err := n.nftsStorage.find(pCtx, bson.M{"opensea_token_id": pTokenID, "contract.contract_address": pContractAddress}, &result); err != nil {
 		return nil, err
 	}
 
@@ -143,14 +121,10 @@ func (n *NFTMongoRepository) GetByContractData(pCtx context.Context, pTokenID pe
 // GetByOpenseaID finds an nft by its opensea ID
 func (n *NFTMongoRepository) GetByOpenseaID(pCtx context.Context, pOpenseaID int, pWalletAddress persist.Address,
 ) ([]*persist.NFT, error) {
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
+
 	result := []*persist.NFT{}
 
-	if err := n.nftsStorage.find(pCtx, bson.M{"opensea_id": pOpenseaID, "owner_address": pWalletAddress}, &result, opts); err != nil {
+	if err := n.nftsStorage.find(pCtx, bson.M{"opensea_id": pOpenseaID, "owner_address": pWalletAddress}, &result); err != nil {
 		return nil, err
 	}
 

--- a/persist/mongodb/nft.go
+++ b/persist/mongodb/nft.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mikeydub/go-gallery/memstore"
 	"github.com/mikeydub/go-gallery/persist"
-	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -182,26 +181,6 @@ func (n *NFTMongoRepository) BulkUpsert(pCtx context.Context, pNfts []*persist.N
 			return nil, err
 		}
 	}
-
-	go func() {
-		processedUsers := make(map[persist.DBID]bool)
-		for _, nft := range pNfts {
-			if nft.OwnerAddress != "" {
-				users := []*persist.User{}
-				err := n.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": nft.OwnerAddress}}, &users)
-				if err != nil {
-					logrus.WithError(err).Error("failed to find users for nft")
-					continue
-				}
-				for _, user := range users {
-					if !processedUsers[user.ID] {
-						n.galleryRepo.resetCache(pCtx, user.ID)
-						processedUsers[user.ID] = true
-					}
-				}
-			}
-		}
-	}()
 
 	return result, nil
 

--- a/persist/mongodb/token.go
+++ b/persist/mongodb/token.go
@@ -86,10 +86,7 @@ func (t *TokenMongoRepository) Create(pCtx context.Context, pERC721 *persist.Tok
 // GetByWallet gets tokens for a given wallet address
 func (t *TokenMongoRepository) GetByWallet(pCtx context.Context, pAddress persist.Address, limit, page int64) ([]*persist.Token, error) {
 	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
+
 	if limit > 0 {
 		opts.SetSkip(limit * page)
 		opts.SetLimit(limit)
@@ -109,10 +106,11 @@ func (t *TokenMongoRepository) GetByWallet(pCtx context.Context, pAddress persis
 // GetByUserID gets ERC721 tokens for a given userID
 func (t *TokenMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID, limit, page int64) ([]*persist.Token, error) {
 	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
+	if limit > 0 {
+		opts.SetSkip(limit * page)
+		opts.SetLimit(limit)
 	}
+	opts.SetSort(bson.M{"block_number": -1})
 
 	result := []*persist.User{}
 	err := t.usersStorage.find(pCtx, bson.M{"_id": pUserID}, &result, opts)
@@ -155,10 +153,6 @@ func (t *TokenMongoRepository) GetByUserID(pCtx context.Context, pUserID persist
 // GetByContract gets ERC721 tokens for a given contract
 func (t *TokenMongoRepository) GetByContract(pCtx context.Context, pAddress persist.Address, limit, page int64) ([]*persist.Token, error) {
 	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 	if limit > 0 {
 		opts.SetSkip(limit * page)
 		opts.SetLimit(limit)
@@ -178,10 +172,7 @@ func (t *TokenMongoRepository) GetByContract(pCtx context.Context, pAddress pers
 // GetByTokenIdentifiers gets tokens for a given contract address and token ID
 func (t *TokenMongoRepository) GetByTokenIdentifiers(pCtx context.Context, pTokenID persist.TokenID, pAddress persist.Address, limit, page int64) ([]*persist.Token, error) {
 	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
+
 	if limit > 0 {
 		opts.SetSkip(limit * page)
 		opts.SetLimit(limit)
@@ -200,15 +191,10 @@ func (t *TokenMongoRepository) GetByTokenIdentifiers(pCtx context.Context, pToke
 
 // GetByID gets tokens for a given DB ID
 func (t *TokenMongoRepository) GetByID(pCtx context.Context, pID persist.DBID) (*persist.Token, error) {
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
 
 	result := []*persist.Token{}
 
-	err := t.tokensStorage.find(pCtx, bson.M{"_id": pID}, &result, opts)
+	err := t.tokensStorage.find(pCtx, bson.M{"_id": pID}, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/persist/mongodb/token.go
+++ b/persist/mongodb/token.go
@@ -293,26 +293,6 @@ func (t *TokenMongoRepository) BulkUpsert(pCtx context.Context, pTokens []*persi
 	}
 	logrus.Infof("Bulk updated %d models in %s", len(updateModels), time.Since(nextNow))
 
-	go func() {
-		processedUsers := make(map[persist.DBID]bool)
-		for _, v := range pTokens {
-			if v.OwnerAddress != "" {
-				users := []*persist.User{}
-				err := t.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": v.OwnerAddress}}, &users)
-				if err != nil {
-					logrus.Errorf("failed to get user by address %s: %s", v.OwnerAddress, err.Error())
-					continue
-				}
-				for _, user := range users {
-					if !processedUsers[user.ID] {
-						t.galleryRepo.resetCache(pCtx, user.ID)
-						processedUsers[user.ID] = true
-					}
-				}
-			}
-		}
-	}()
-
 	return nil
 }
 
@@ -335,29 +315,6 @@ func (t *TokenMongoRepository) UpdateByIDUnsafe(pCtx context.Context, pID persis
 	if err := t.tokensStorage.update(pCtx, bson.M{"_id": pID}, pUpdate); err != nil {
 		return err
 	}
-
-	go func() {
-		token, err := t.GetByID(pCtx, pID)
-		if err != nil {
-			logrus.WithError(err).Errorf("failed to get token by ID %s", pID)
-			return
-		}
-		if token.OwnerAddress != "" {
-			processedUsers := make(map[persist.DBID]bool)
-			users := []*persist.User{}
-			err = t.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": token.OwnerAddress}}, &users)
-			if err != nil {
-				logrus.Errorf("failed to get user by address %s: %s", token.OwnerAddress, err.Error())
-				return
-			}
-			for _, user := range users {
-				if !processedUsers[user.ID] {
-					t.galleryRepo.resetCache(pCtx, user.ID)
-					processedUsers[user.ID] = true
-				}
-			}
-		}
-	}()
 
 	return nil
 

--- a/persist/mongodb/user.go
+++ b/persist/mongodb/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/mikeydub/go-gallery/persist"
 	"github.com/sirupsen/logrus"
@@ -77,14 +76,8 @@ func (u *UserMongoRepository) Delete(pCtx context.Context, pUserID persist.DBID,
 // GetByID returns a user by a given ID
 func (u *UserMongoRepository) GetByID(pCtx context.Context, userID persist.DBID) (*persist.User, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.User{}
-	err := u.usersStorage.find(pCtx, bson.M{"_id": userID}, &result, opts)
+	err := u.usersStorage.find(pCtx, bson.M{"_id": userID}, &result)
 
 	if err != nil {
 		return nil, err
@@ -100,14 +93,8 @@ func (u *UserMongoRepository) GetByID(pCtx context.Context, userID persist.DBID)
 // GetByAddress returns a user by a given wallet address
 func (u *UserMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (*persist.User, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.User{}
-	err := u.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": []persist.Address{pAddress}}}, &result, opts)
+	err := u.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": []persist.Address{pAddress}}}, &result)
 
 	if err != nil {
 		return nil, err
@@ -127,14 +114,8 @@ func (u *UserMongoRepository) GetByAddress(pCtx context.Context, pAddress persis
 // GetByUsername returns a user by a given username (case insensitive)
 func (u *UserMongoRepository) GetByUsername(pCtx context.Context, pUsername string) (*persist.User, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
 	result := []*persist.User{}
-	err := u.usersStorage.find(pCtx, bson.M{"username_idempotent": strings.ToLower(pUsername)}, &result, opts)
+	err := u.usersStorage.find(pCtx, bson.M{"username_idempotent": strings.ToLower(pUsername)}, &result)
 
 	if err != nil {
 		return nil, err

--- a/persist/persist.go
+++ b/persist/persist.go
@@ -23,3 +23,7 @@ func GenerateID() DBID {
 	}
 	return DBID(id.String())
 }
+
+func (d DBID) String() string {
+	return string(d)
+}

--- a/server/t__routes_collection_test.go
+++ b/server/t__routes_collection_test.go
@@ -127,12 +127,6 @@ func TestGetUnassignedCollection_Success(t *testing.T) {
 func TestDeleteCollection_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	// nfts := []*persist.NFTDB{
-	// 	{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
-	// 	{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
-	// 	{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
-	// }
-	// _, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 	collID := createCollectionInDbForUserID(assert, "COLLECTION NAME", tc.user1.id)
 	verifyCollectionExistsInDbForID(assert, collID)
 

--- a/server/t__routes_collection_test.go
+++ b/server/t__routes_collection_test.go
@@ -127,6 +127,12 @@ func TestGetUnassignedCollection_Success(t *testing.T) {
 func TestDeleteCollection_Success(t *testing.T) {
 	assert := setupTest(t)
 
+	// nfts := []*persist.NFTDB{
+	// 	{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
+	// 	{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
+	// 	{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
+	// }
+	// _, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 	collID := createCollectionInDbForUserID(assert, "COLLECTION NAME", tc.user1.id)
 	verifyCollectionExistsInDbForID(assert, collID)
 

--- a/server/t__routes_gallery_test.go
+++ b/server/t__routes_gallery_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/mikeydub/go-gallery/persist"
 	"github.com/mikeydub/go-gallery/util"
@@ -31,6 +32,8 @@ func TestUpdateGalleryById_ReorderCollections_Success(t *testing.T) {
 	})
 	assert.Nil(err)
 
+	time.Sleep(time.Second * 3)
+
 	// Validate the initial order of the gallery's collections
 	validateCollectionsOrderInGallery(assert, initialCollectionOrder)
 
@@ -44,6 +47,8 @@ func TestUpdateGalleryById_ReorderCollections_Success(t *testing.T) {
 	}
 	update := galleryTokenUpdateInput{Collections: updatedCollectionOrder, ID: id}
 	updateTestGallery(assert, update)
+
+	time.Sleep(time.Second * 3)
 
 	// Validate the updated order of the gallery's collections
 	validateCollectionsOrderInGallery(assert, updatedCollectionOrder)

--- a/util/time.go
+++ b/util/time.go
@@ -9,5 +9,5 @@ import (
 // Track the time it takes to execute a function
 func Track(s string, startTime time.Time) {
 	endTime := time.Now()
-	logrus.Infof("%s took %v", s, endTime.Sub(startTime))
+	logrus.Debugf("%s took %v", s, endTime.Sub(startTime))
 }


### PR DESCRIPTION
Changes:

- **Added** caching for galleries. Now galleries are always returned first from the cache and optimistically updated every time an update is made to the gallery or a collection

Considerations:

- The key for cached galleries in the cache is the user ID. Not all functions that update information that would potentially update the result of a `getGalleriesByUserID` call take in a user ID. Those functions have no way of telling the cache that there is something that needs to be updated. Currently I have set an hour long TTL on the cache. Do you have any ideas of how we can ensure the cache stays up to date? We could use what a function does give us to find an owner user ID (such as using the `owner_address` of an NFT) but for functions like `BulkUpsert` there might be a lot of users to find. This still is the best solution I can think of right now.

TODO:
 
- [x] optimistically update unassigned cache
- [x] task queue for updating caches