### PR TITLE
only use pointers where they are necessary

### DIFF
--- a/features/access.go
+++ b/features/access.go
@@ -24,7 +24,7 @@ type getUserFeaturesInput struct {
 }
 
 type getUserFeaturesOutput struct {
-	Features []*persist.FeatureFlag `json:"features"`
+	Features []persist.FeatureFlag `json:"features"`
 }
 
 func getUserFeatures(userRepo persist.UserRepository, featureRepo persist.FeatureFlagRepository, accessRepo persist.AccessRepository, ethClient *ethclient.Client) gin.HandlerFunc {

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -546,12 +546,12 @@ func receiveOwners(wg *sync.WaitGroup, ownersChan <-chan ownerAtBlock, owners ma
 	}
 }
 
-func (i *Indexer) storedDataToTokens(owners map[tokenIdentifiers]ownerAtBlock, previousOwners map[tokenIdentifiers][]ownerAtBlock, balances map[tokenIdentifiers]map[persist.Address]balanceAtBlock, metadatas map[tokenIdentifiers]tokenMetadata, uris map[tokenIdentifiers]tokenURI) []*persist.Token {
+func (i *Indexer) storedDataToTokens(owners map[tokenIdentifiers]ownerAtBlock, previousOwners map[tokenIdentifiers][]ownerAtBlock, balances map[tokenIdentifiers]map[persist.Address]balanceAtBlock, metadatas map[tokenIdentifiers]tokenMetadata, uris map[tokenIdentifiers]tokenURI) []persist.Token {
 	totalBalances := 0
 	for _, v := range balances {
 		totalBalances += len(v)
 	}
-	result := make([]*persist.Token, len(owners)+totalBalances, len(owners)+totalBalances+len(metadatas)+len(uris))
+	result := make([]persist.Token, len(owners)+totalBalances, len(owners)+totalBalances+len(metadatas)+len(uris))
 	j := 0
 
 	for k, v := range owners {
@@ -574,7 +574,7 @@ func (i *Indexer) storedDataToTokens(owners map[tokenIdentifiers]ownerAtBlock, p
 		}
 
 		uri := uris[k]
-		result[j] = &persist.Token{
+		result[j] = persist.Token{
 			TokenID:          tokenID,
 			ContractAddress:  contractAddress,
 			OwnerAddress:     v.owner,
@@ -614,7 +614,7 @@ func (i *Indexer) storedDataToTokens(owners map[tokenIdentifiers]ownerAtBlock, p
 
 		uri := uris[k]
 		for addr, balance := range v {
-			result[j] = &persist.Token{
+			result[j] = persist.Token{
 				TokenID:         tokenID,
 				ContractAddress: contractAddress,
 				OwnerAddress:    addr,
@@ -643,7 +643,7 @@ func (i *Indexer) storedDataToTokens(owners map[tokenIdentifiers]ownerAtBlock, p
 			panic(err)
 		}
 		if v.uri != "" {
-			result = append(result, &persist.Token{
+			result = append(result, persist.Token{
 				TokenID:         tokenID,
 				ContractAddress: contractAddress,
 				TokenURI:        v.uri,
@@ -659,7 +659,7 @@ func (i *Indexer) storedDataToTokens(owners map[tokenIdentifiers]ownerAtBlock, p
 			panic(err)
 		}
 		if v.md != nil && len(v.md) > 0 {
-			result = append(result, &persist.Token{
+			result = append(result, persist.Token{
 				TokenID:         tokenID,
 				ContractAddress: contractAddress,
 				TokenMetadata:   v.md,
@@ -671,7 +671,7 @@ func (i *Indexer) storedDataToTokens(owners map[tokenIdentifiers]ownerAtBlock, p
 	return result
 }
 
-func upsertTokensAndContracts(ctx context.Context, t []*persist.Token, tokenRepo persist.TokenRepository, contractRepo persist.ContractRepository, ethClient *ethclient.Client) error {
+func upsertTokensAndContracts(ctx context.Context, t []persist.Token, tokenRepo persist.TokenRepository, contractRepo persist.ContractRepository, ethClient *ethclient.Client) error {
 
 	now := time.Now()
 	logrus.Infof("Upserting %d tokens", len(t))
@@ -684,7 +684,7 @@ func upsertTokensAndContracts(ctx context.Context, t []*persist.Token, tokenRepo
 
 	nextNow := time.Now()
 
-	toUpsert := make([]*persist.Contract, 0, len(t))
+	toUpsert := make([]persist.Contract, 0, len(t))
 	for _, token := range t {
 		if contracts[token.ContractAddress] {
 			continue
@@ -707,8 +707,8 @@ func upsertTokensAndContracts(ctx context.Context, t []*persist.Token, tokenRepo
 	return nil
 }
 
-func handleContract(ethClient *ethclient.Client, contractAddress persist.Address, lastSyncedBlock persist.BlockNumber) *persist.Contract {
-	c := &persist.Contract{
+func handleContract(ethClient *ethclient.Client, contractAddress persist.Address, lastSyncedBlock persist.BlockNumber) persist.Contract {
+	c := persist.Contract{
 		Address:     contractAddress,
 		LatestBlock: lastSyncedBlock,
 	}

--- a/persist/access.go
+++ b/persist/access.go
@@ -29,7 +29,7 @@ type ErrAccessNotFoundByUserID struct {
 
 // AccessRepository represents a repository for interacting with persisted access states
 type AccessRepository interface {
-	GetByUserID(context.Context, DBID) (*Access, error)
+	GetByUserID(context.Context, DBID) (Access, error)
 	HasRequiredTokens(context.Context, DBID, []TokenIdentifiers) (bool, error)
 	UpsertRequiredTokensByUserID(context.Context, DBID, map[TokenIdentifiers]uint64, BlockNumber) error
 }

--- a/persist/accounts.go
+++ b/persist/accounts.go
@@ -31,8 +31,8 @@ type Account struct {
 
 // AccountRepository is the interface for interacting with the account persistence layer
 type AccountRepository interface {
-	GetByAddress(context.Context, Address) (*Account, error)
-	UpsertByAddress(context.Context, Address, *Account) error
+	GetByAddress(context.Context, Address) (Account, error)
+	UpsertByAddress(context.Context, Address, Account) error
 }
 
 // ErrAccountNotFoundByAddress is an error that occurs when an account is not found by an address

--- a/persist/auth.go
+++ b/persist/auth.go
@@ -40,13 +40,13 @@ type UserLoginAttempt struct {
 
 // NonceRepository is the interface for interacting with the auth nonce persistence layer
 type NonceRepository interface {
-	Get(context.Context, Address) (*UserNonce, error)
-	Create(context.Context, *UserNonce) error
+	Get(context.Context, Address) (UserNonce, error)
+	Create(context.Context, UserNonce) error
 }
 
 // LoginAttemptRepository is the interface for interacting with the auth login attempt persistence layer
 type LoginAttemptRepository interface {
-	Create(context.Context, *UserLoginAttempt) (DBID, error)
+	Create(context.Context, UserLoginAttempt) (DBID, error)
 }
 
 // ErrNonceNotFoundForAddress is returned when no nonce is found for a given address

--- a/persist/backups.go
+++ b/persist/backups.go
@@ -12,11 +12,11 @@ type Backup struct {
 	Deleted      bool            `bson:"deleted" json:"-"`
 	LastUpdated  LastUpdatedTime `bson:"last_updated,update_time" json:"last_updated"`
 
-	GalleryID DBID     `bson:"gallery_id" json:"gallery_id" `
-	Gallery   *Gallery `bson:"gallery" json:"gallery"`
+	GalleryID DBID    `bson:"gallery_id" json:"gallery_id" `
+	Gallery   Gallery `bson:"gallery" json:"gallery"`
 }
 
 // BackupRepository is the interface for interacting with backed up versions of galleries
 type BackupRepository interface {
-	Insert(context.Context, *Gallery) error
+	Insert(context.Context, Gallery) error
 }

--- a/persist/collection_nft.go
+++ b/persist/collection_nft.go
@@ -39,10 +39,10 @@ type Collection struct {
 
 	Layout TokenLayout `bson:"layout" json:"layout"`
 
-	Name           string           `bson:"name"          json:"name"`
-	CollectorsNote string           `bson:"collectors_note"   json:"collectors_note"`
-	OwnerUserID    DBID             `bson:"owner_user_id" json:"owner_user_id"`
-	Nfts           []*CollectionNFT `bson:"nfts"          json:"nfts"`
+	Name           string          `bson:"name"          json:"name"`
+	CollectorsNote string          `bson:"collectors_note"   json:"collectors_note"`
+	OwnerUserID    DBID            `bson:"owner_user_id" json:"owner_user_id"`
+	Nfts           []CollectionNFT `bson:"nfts"          json:"nfts"`
 
 	// collections can be hidden from public-viewing
 	Hidden bool `bson:"hidden" json:"hidden"`
@@ -72,14 +72,14 @@ type CollectionUpdateDeletedInput struct {
 
 // CollectionRepository represents the interface for interacting with the collection persistence layer
 type CollectionRepository interface {
-	Create(context.Context, *CollectionDB) (DBID, error)
-	GetByUserID(context.Context, DBID, bool) ([]*Collection, error)
-	GetByID(context.Context, DBID, bool) (*Collection, error)
+	Create(context.Context, CollectionDB) (DBID, error)
+	GetByUserID(context.Context, DBID, bool) ([]Collection, error)
+	GetByID(context.Context, DBID, bool) (Collection, error)
 	Update(context.Context, DBID, DBID, interface{}) error
-	UpdateNFTs(context.Context, DBID, DBID, *CollectionUpdateNftsInput) error
-	ClaimNFTs(context.Context, DBID, []Address, *CollectionUpdateNftsInput) error
+	UpdateNFTs(context.Context, DBID, DBID, CollectionUpdateNftsInput) error
+	ClaimNFTs(context.Context, DBID, []Address, CollectionUpdateNftsInput) error
 	RemoveNFTsOfAddresses(context.Context, DBID, []Address) error
 	Delete(context.Context, DBID, DBID) error
-	GetUnassigned(context.Context, DBID) (*Collection, error)
+	GetUnassigned(context.Context, DBID) (Collection, error)
 	RefreshUnassigned(context.Context, DBID) error
 }

--- a/persist/collection_token.go
+++ b/persist/collection_token.go
@@ -40,10 +40,10 @@ type CollectionToken struct {
 
 	Layout TokenLayout `bson:"layout" json:"layout"`
 
-	Name           string               `bson:"name"          json:"name"`
-	CollectorsNote string               `bson:"collectors_note"   json:"collectors_note"`
-	OwnerUserID    DBID                 `bson:"owner_user_id" json:"owner_user_id"`
-	Nfts           []*TokenInCollection `bson:"nfts"          json:"nfts"`
+	Name           string              `bson:"name"          json:"name"`
+	CollectorsNote string              `bson:"collectors_note"   json:"collectors_note"`
+	OwnerUserID    DBID                `bson:"owner_user_id" json:"owner_user_id"`
+	Nfts           []TokenInCollection `bson:"nfts"          json:"nfts"`
 
 	// collections can be hidden from public-viewing
 	Hidden bool `bson:"hidden" json:"hidden"`
@@ -80,17 +80,17 @@ type CollectionTokenUpdateDeletedInput struct {
 
 // CollectionTokenRepository represents the interface for interacting with the collection persistence layer
 type CollectionTokenRepository interface {
-	Create(context.Context, *CollectionTokenDB) (DBID, error)
-	GetByUserID(context.Context, DBID, bool) ([]*CollectionToken, error)
-	GetByID(context.Context, DBID, bool) (*CollectionToken, error)
+	Create(context.Context, CollectionTokenDB) (DBID, error)
+	GetByUserID(context.Context, DBID, bool) ([]CollectionToken, error)
+	GetByID(context.Context, DBID, bool) (CollectionToken, error)
 	Update(context.Context, DBID, DBID, interface{}) error
-	UpdateNFTs(context.Context, DBID, DBID, *CollectionTokenUpdateNftsInput) error
+	UpdateNFTs(context.Context, DBID, DBID, CollectionTokenUpdateNftsInput) error
 	UpdateUnsafe(context.Context, DBID, interface{}) error
-	UpdateNFTsUnsafe(context.Context, DBID, *CollectionTokenUpdateNftsInput) error
-	ClaimNFTs(context.Context, DBID, []Address, *CollectionTokenUpdateNftsInput) error
+	UpdateNFTsUnsafe(context.Context, DBID, CollectionTokenUpdateNftsInput) error
+	ClaimNFTs(context.Context, DBID, []Address, CollectionTokenUpdateNftsInput) error
 	RemoveNFTsOfAddresses(context.Context, DBID, []Address) error
 	Delete(context.Context, DBID, DBID) error
-	GetUnassigned(context.Context, DBID) (*CollectionToken, error)
+	GetUnassigned(context.Context, DBID) (CollectionToken, error)
 	RefreshUnassigned(context.Context, DBID) error
 }
 

--- a/persist/contracts.go
+++ b/persist/contracts.go
@@ -24,9 +24,9 @@ type Contract struct {
 
 // ContractRepository represents a repository for interacting with persisted contracts
 type ContractRepository interface {
-	GetByAddress(context.Context, Address) (*Contract, error)
-	UpsertByAddress(context.Context, Address, *Contract) error
-	BulkUpsert(context.Context, []*Contract) error
+	GetByAddress(context.Context, Address) (Contract, error)
+	UpsertByAddress(context.Context, Address, Contract) error
+	BulkUpsert(context.Context, []Contract) error
 }
 
 // ErrContractNotFoundByAddress is an error type for when a contract is not found by address

--- a/persist/features.go
+++ b/persist/features.go
@@ -40,9 +40,9 @@ type ErrFeatureNotFoundByName struct {
 
 // FeatureFlagRepository represents a repository for interacting with persisted feature flags
 type FeatureFlagRepository interface {
-	GetByRequiredTokens(context.Context, map[TokenIdentifiers]uint64) ([]*FeatureFlag, error)
-	GetByName(context.Context, string) (*FeatureFlag, error)
-	GetAll(context.Context) ([]*FeatureFlag, error)
+	GetByRequiredTokens(context.Context, map[TokenIdentifiers]uint64) ([]FeatureFlag, error)
+	GetByName(context.Context, string) (FeatureFlag, error)
+	GetAll(context.Context) ([]FeatureFlag, error)
 }
 
 // NewTokenIdentifiers creates a new token identifiers

--- a/persist/gallery_nft.go
+++ b/persist/gallery_nft.go
@@ -30,8 +30,8 @@ type Gallery struct {
 	Deleted      bool            `bson:"deleted" json:"-"`
 	LastUpdated  LastUpdatedTime `bson:"last_updated,update_time" json:"last_updated"`
 
-	OwnerUserID DBID          `bson:"owner_user_id" json:"owner_user_id"`
-	Collections []*Collection `bson:"collections"          json:"collections"`
+	OwnerUserID DBID         `bson:"owner_user_id" json:"owner_user_id"`
+	Collections []Collection `bson:"collections"          json:"collections"`
 }
 
 // GalleryUpdateInput represents a struct that is used to update a gallery's list of collections in the databse
@@ -41,9 +41,9 @@ type GalleryUpdateInput struct {
 
 // GalleryRepository is an interface for interacting with the gallery persistence layer
 type GalleryRepository interface {
-	Create(context.Context, *GalleryDB) (DBID, error)
-	Update(context.Context, DBID, DBID, *GalleryUpdateInput) error
+	Create(context.Context, GalleryDB) (DBID, error)
+	Update(context.Context, DBID, DBID, GalleryUpdateInput) error
 	AddCollections(context.Context, DBID, DBID, []DBID) error
-	GetByUserID(context.Context, DBID, bool) ([]*Gallery, error)
-	GetByID(context.Context, DBID, bool) (*Gallery, error)
+	GetByUserID(context.Context, DBID, bool) ([]Gallery, error)
+	GetByID(context.Context, DBID, bool) (Gallery, error)
 }

--- a/persist/gallery_token.go
+++ b/persist/gallery_token.go
@@ -31,8 +31,8 @@ type GalleryToken struct {
 	Deleted      bool            `bson:"deleted" json:"-"`
 	LastUpdated  LastUpdatedTime `bson:"last_updated,update_time" json:"last_updated"`
 
-	OwnerUserID DBID               `bson:"owner_user_id" json:"owner_user_id"`
-	Collections []*CollectionToken `bson:"collections"          json:"collections"`
+	OwnerUserID DBID              `bson:"owner_user_id" json:"owner_user_id"`
+	Collections []CollectionToken `bson:"collections"          json:"collections"`
 }
 
 // GalleryTokenUpdateInput represents a struct that is used to update a gallery's list of collections in the databse
@@ -42,12 +42,12 @@ type GalleryTokenUpdateInput struct {
 
 // GalleryTokenRepository is an interface for interacting with the gallery persistence layer
 type GalleryTokenRepository interface {
-	Create(context.Context, *GalleryTokenDB) (DBID, error)
-	Update(context.Context, DBID, DBID, *GalleryTokenUpdateInput) error
-	UpdateUnsafe(context.Context, DBID, *GalleryTokenUpdateInput) error
+	Create(context.Context, GalleryTokenDB) (DBID, error)
+	Update(context.Context, DBID, DBID, GalleryTokenUpdateInput) error
+	UpdateUnsafe(context.Context, DBID, GalleryTokenUpdateInput) error
 	AddCollections(context.Context, DBID, DBID, []DBID) error
-	GetByUserID(context.Context, DBID, bool) ([]*GalleryToken, error)
-	GetByID(context.Context, DBID, bool) (*GalleryToken, error)
+	GetByUserID(context.Context, DBID, bool) ([]GalleryToken, error)
+	GetByID(context.Context, DBID, bool) (GalleryToken, error)
 }
 
 // ErrGalleryNotFoundByID is returned when a gallery is not found by its ID

--- a/persist/history.go
+++ b/persist/history.go
@@ -13,8 +13,8 @@ type OwnershipHistory struct {
 	Deleted      bool            `bson:"deleted" json:"-"`
 	LastUpdated  LastUpdatedTime `bson:"last_updated,update_time" json:"last_updated"`
 
-	NFTID  DBID     `bson:"nft_id" json:"nft_id"`
-	Owners []*Owner `bson:"owners" json:"owners"`
+	NFTID  DBID    `bson:"nft_id" json:"nft_id"`
+	Owners []Owner `bson:"owners" json:"owners"`
 }
 
 // Owner represents a single owner of an NFT.
@@ -27,5 +27,5 @@ type Owner struct {
 
 // OwnershipHistoryRepository is the interface for the OwnershipHistory persistence layer
 type OwnershipHistoryRepository interface {
-	Upsert(context.Context, DBID, *OwnershipHistory) error
+	Upsert(context.Context, DBID, OwnershipHistory) error
 }

--- a/persist/membership.go
+++ b/persist/membership.go
@@ -18,9 +18,9 @@ type MembershipTier struct {
 
 // MembershipRepository represents the interface for interacting with the persisted state of users
 type MembershipRepository interface {
-	UpsertByTokenID(context.Context, TokenID, *MembershipTier) error
-	GetByTokenID(context.Context, TokenID) (*MembershipTier, error)
-	GetAll(context.Context) ([]*MembershipTier, error)
+	UpsertByTokenID(context.Context, TokenID, MembershipTier) error
+	GetByTokenID(context.Context, TokenID) (MembershipTier, error)
+	GetAll(context.Context) ([]MembershipTier, error)
 }
 
 // ErrMembershipNotFoundByTokenID represents an error when a membership is not found by token id

--- a/persist/mongodb/access.go
+++ b/persist/mongodb/access.go
@@ -38,20 +38,20 @@ func NewAccessMongoRepository(mgoClient *mongo.Client) *AccessMongoRepository {
 }
 
 // GetByUserID returns an feature by a given token identifiers
-func (c *AccessMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID) (*persist.Access, error) {
+func (c *AccessMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID) (persist.Access, error) {
 
 	opts := options.Find()
 	opts.SetLimit(1)
 
-	result := []*persist.Access{}
+	result := []persist.Access{}
 	err := c.accessStorage.find(pCtx, bson.M{"user_id": pUserID}, &result, opts)
 
 	if err != nil {
-		return nil, err
+		return persist.Access{}, err
 	}
 
 	if len(result) == 0 {
-		return nil, persist.ErrAccessNotFoundByUserID{UserID: pUserID}
+		return persist.Access{}, persist.ErrAccessNotFoundByUserID{UserID: pUserID}
 	}
 
 	return result[0], nil

--- a/persist/mongodb/accounts.go
+++ b/persist/mongodb/accounts.go
@@ -26,7 +26,7 @@ func NewAccountMongoRepository(mgoClient *mongo.Client) *AccountMongoRepository 
 
 // UpsertByAddress upserts an account by a given address
 // pUpdate represents a struct with bson tags to specify which fields to update
-func (a *AccountMongoRepository) UpsertByAddress(pCtx context.Context, pAddress persist.Address, pUpsert *persist.Account) error {
+func (a *AccountMongoRepository) UpsertByAddress(pCtx context.Context, pAddress persist.Address, pUpsert persist.Account) error {
 
 	_, err := a.accountStorage.upsert(pCtx, bson.M{
 		"address": strings.ToLower(pAddress.String()),
@@ -39,16 +39,16 @@ func (a *AccountMongoRepository) UpsertByAddress(pCtx context.Context, pAddress 
 }
 
 // GetByAddress returns an account by a given address
-func (a *AccountMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (*persist.Account, error) {
+func (a *AccountMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (persist.Account, error) {
 
-	result := []*persist.Account{}
+	result := []persist.Account{}
 	err := a.accountStorage.find(pCtx, bson.M{"address": strings.ToLower(pAddress.String())}, &result)
 	if err != nil {
-		return nil, err
+		return persist.Account{}, err
 	}
 
 	if len(result) < 1 {
-		return nil, persist.ErrAccountNotFoundByAddress{Address: pAddress}
+		return persist.Account{}, persist.ErrAccountNotFoundByAddress{Address: pAddress}
 	}
 
 	if len(result) > 1 {

--- a/persist/mongodb/auth.go
+++ b/persist/mongodb/auth.go
@@ -40,34 +40,33 @@ func NewNonceMongoRepository(mgoClient *mongo.Client) *NonceMongoRepository {
 }
 
 // Create inserts a single login attempt into the database and will return the ID of the inserted attempt
-func (l *LoginMongoRepository) Create(pCtx context.Context, pLoginAttempt *persist.UserLoginAttempt,
-) (persist.DBID, error) {
+func (l *LoginMongoRepository) Create(pCtx context.Context, pLoginAttempt persist.UserLoginAttempt) (persist.DBID, error) {
 	return l.loginsStorage.insert(pCtx, pLoginAttempt)
 }
 
 // Get returns the most recent nonce for a given address
-func (n *NonceMongoRepository) Get(pCtx context.Context, pAddress persist.Address) (*persist.UserNonce, error) {
+func (n *NonceMongoRepository) Get(pCtx context.Context, pAddress persist.Address) (persist.UserNonce, error) {
 
 	opts := options.Find()
 	opts.SetSort(bson.M{"created_at": -1})
 	opts.SetLimit(1)
 
-	result := []*persist.UserNonce{}
+	result := []persist.UserNonce{}
 	err := n.mp.find(pCtx, bson.M{"address": pAddress}, &result, opts)
 
 	if err != nil {
-		return nil, err
+		return persist.UserNonce{}, err
 	}
 
 	if len(result) != 1 {
-		return nil, persist.ErrNonceNotFoundForAddress{Address: pAddress}
+		return persist.UserNonce{}, persist.ErrNonceNotFoundForAddress{Address: pAddress}
 	}
 
 	return result[0], nil
 }
 
 // Create inserts a new nonce into the database and will return the ID of the inserted nonce
-func (n *NonceMongoRepository) Create(pCtx context.Context, pNonce *persist.UserNonce) error {
+func (n *NonceMongoRepository) Create(pCtx context.Context, pNonce persist.UserNonce) error {
 	_, err := n.mp.insert(pCtx, pNonce)
 	return err
 }

--- a/persist/mongodb/backups.go
+++ b/persist/mongodb/backups.go
@@ -25,7 +25,7 @@ func NewBackupMongoRepository(mgoClient *mongo.Client) *BackupMongoRepository {
 
 // Insert inserts a backed up gallery into the mongo db while also ensuring there are
 // no more than three backups per gallery at any given time
-func (b *BackupMongoRepository) Insert(pCtx context.Context, pGallery *persist.Gallery) error {
+func (b *BackupMongoRepository) Insert(pCtx context.Context, pGallery persist.Gallery) error {
 
 	currentlyBackedUp := []*persist.Backup{}
 	err := b.backupsStorage.find(pCtx, bson.M{"gallery_id": pGallery.ID}, &currentlyBackedUp, options.Find().SetSort(bson.M{"last_updated": -1}))

--- a/persist/mongodb/collection_token.go
+++ b/persist/mongodb/collection_token.go
@@ -45,8 +45,7 @@ func NewCollectionTokenMongoRepository(mgoClient *mongo.Client, unassignedCache 
 }
 
 // Create inserts a single CollectionDB into the database and will return the ID of the inserted document
-func (c *CollectionTokenMongoRepository) Create(pCtx context.Context, pColl *persist.CollectionTokenDB,
-) (persist.DBID, error) {
+func (c *CollectionTokenMongoRepository) Create(pCtx context.Context, pColl persist.CollectionTokenDB) (persist.DBID, error) {
 
 	if pColl.OwnerUserID == "" {
 		return "", errUserIDRequired
@@ -78,9 +77,9 @@ func (c *CollectionTokenMongoRepository) Create(pCtx context.Context, pColl *per
 
 // GetByUserID will form an aggregation pipeline to get all collections owned by a user
 // and variably show hidden collections depending on the auth status of the caller
-func (c *CollectionTokenMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID, pShowHidden bool) ([]*persist.CollectionToken, error) {
+func (c *CollectionTokenMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID, pShowHidden bool) ([]persist.CollectionToken, error) {
 
-	result := []*persist.CollectionToken{}
+	result := []persist.CollectionToken{}
 
 	fil := bson.M{"owner_user_id": pUserID, "deleted": false}
 	if !pShowHidden {
@@ -96,20 +95,20 @@ func (c *CollectionTokenMongoRepository) GetByUserID(pCtx context.Context, pUser
 
 // GetByID will form an aggregation pipeline to get a single collection by ID and
 // variably show hidden collections depending on the auth status of the caller
-func (c *CollectionTokenMongoRepository) GetByID(pCtx context.Context, pID persist.DBID, pShowHidden bool) (*persist.CollectionToken, error) {
+func (c *CollectionTokenMongoRepository) GetByID(pCtx context.Context, pID persist.DBID, pShowHidden bool) (persist.CollectionToken, error) {
 
-	result := []*persist.CollectionToken{}
+	result := []persist.CollectionToken{}
 
 	fil := bson.M{"_id": pID, "deleted": false}
 	if !pShowHidden {
 		fil["hidden"] = false
 	}
 	if err := c.collectionsStorage.aggregate(pCtx, newCollectionTokenPipeline(fil), &result); err != nil {
-		return nil, err
+		return persist.CollectionToken{}, err
 	}
 
 	if len(result) != 1 {
-		return nil, persist.ErrCollectionNotFoundByID{ID: pID}
+		return persist.CollectionToken{}, persist.ErrCollectionNotFoundByID{ID: pID}
 	}
 
 	return result[0], nil
@@ -118,10 +117,7 @@ func (c *CollectionTokenMongoRepository) GetByID(pCtx context.Context, pID persi
 // Update will update a single collection by ID, also ensuring that the collection is owned
 // by a given authorized user.
 // pUpdate will be a struct with bson tags that represent the fields to be updated
-func (c *CollectionTokenMongoRepository) Update(pCtx context.Context, pIDstr persist.DBID,
-	pUserID persist.DBID,
-	pUpdate interface{},
-) error {
+func (c *CollectionTokenMongoRepository) Update(pCtx context.Context, pIDstr persist.DBID, pUserID persist.DBID, pUpdate interface{}) error {
 	if err := c.collectionsStorage.update(pCtx, bson.M{"_id": pIDstr, "owner_user_id": pUserID}, pUpdate); err != nil {
 		return err
 	}
@@ -135,10 +131,7 @@ func (c *CollectionTokenMongoRepository) Update(pCtx context.Context, pIDstr per
 // by a given authorized user as well as that no other collection contains the NFTs
 // being included in the updated collection. This is to ensure that the NFTs are not
 // being shared between collections.
-func (c *CollectionTokenMongoRepository) UpdateNFTs(pCtx context.Context, pID persist.DBID,
-	pUserID persist.DBID,
-	pUpdate *persist.CollectionTokenUpdateNftsInput,
-) error {
+func (c *CollectionTokenMongoRepository) UpdateNFTs(pCtx context.Context, pID persist.DBID, pUserID persist.DBID, pUpdate persist.CollectionTokenUpdateNftsInput) error {
 
 	users := []*persist.User{}
 	err := c.usersStorage.find(pCtx, bson.M{"_id": pUserID}, &users)
@@ -191,9 +184,7 @@ func (c *CollectionTokenMongoRepository) UpdateUnsafe(pCtx context.Context, pIDs
 // no other collection contains the NFTs being included in the updated collection.
 // This is to ensure that the NFTs are not
 // being shared between collections.
-func (c *CollectionTokenMongoRepository) UpdateNFTsUnsafe(pCtx context.Context, pID persist.DBID,
-	pUpdate *persist.CollectionTokenUpdateNftsInput,
-) error {
+func (c *CollectionTokenMongoRepository) UpdateNFTsUnsafe(pCtx context.Context, pID persist.DBID, pUpdate persist.CollectionTokenUpdateNftsInput) error {
 
 	// TODO this is to ensure that the NFTs are not being shared between collections
 	// if err := c.mp.pullAll(pCtx, bson.M{}, "nfts", pUpdate.Nfts); err != nil {
@@ -210,11 +201,7 @@ func (c *CollectionTokenMongoRepository) UpdateNFTsUnsafe(pCtx context.Context, 
 }
 
 // ClaimNFTs will remove all NFTs from anyone's collections EXCEPT the user who is claiming them
-func (c *CollectionTokenMongoRepository) ClaimNFTs(pCtx context.Context,
-	pUserID persist.DBID,
-	pWalletAddresses []persist.Address,
-	pUpdate *persist.CollectionTokenUpdateNftsInput,
-) error {
+func (c *CollectionTokenMongoRepository) ClaimNFTs(pCtx context.Context, pUserID persist.DBID, pWalletAddresses []persist.Address, pUpdate persist.CollectionTokenUpdateNftsInput) error {
 
 	nftsToBeRemoved := []*persist.Token{}
 
@@ -247,10 +234,7 @@ func (c *CollectionTokenMongoRepository) ClaimNFTs(pCtx context.Context,
 
 // RemoveNFTsOfAddresses will remove all NFTs from a user's collections that are associated with
 // an array of addresses
-func (c *CollectionTokenMongoRepository) RemoveNFTsOfAddresses(pCtx context.Context,
-	pUserID persist.DBID,
-	pAddresses []persist.Address,
-) error {
+func (c *CollectionTokenMongoRepository) RemoveNFTsOfAddresses(pCtx context.Context, pUserID persist.DBID, pAddresses []persist.Address) error {
 
 	for i, address := range pAddresses {
 		pAddresses[i] = address
@@ -283,9 +267,7 @@ func (c *CollectionTokenMongoRepository) RemoveNFTsOfAddresses(pCtx context.Cont
 
 // Delete will delete a single collection by ID, also ensuring that the collection is owned
 // by a given authorized user.
-func (c *CollectionTokenMongoRepository) Delete(pCtx context.Context, pIDstr persist.DBID,
-	pUserID persist.DBID,
-) error {
+func (c *CollectionTokenMongoRepository) Delete(pCtx context.Context, pIDstr persist.DBID, pUserID persist.DBID) error {
 
 	update := &persist.CollectionTokenUpdateDeletedInput{Deleted: true}
 
@@ -300,53 +282,53 @@ func (c *CollectionTokenMongoRepository) Delete(pCtx context.Context, pIDstr per
 
 // GetUnassigned returns a collection that is empty except for a list of nfts that are not
 // assigned to any collection
-func (c *CollectionTokenMongoRepository) GetUnassigned(pCtx context.Context, pUserID persist.DBID) (*persist.CollectionToken, error) {
+func (c *CollectionTokenMongoRepository) GetUnassigned(pCtx context.Context, pUserID persist.DBID) (persist.CollectionToken, error) {
 
-	result := []*persist.CollectionToken{}
+	result := []persist.CollectionToken{}
 
 	if cachedResult, err := c.unassignedCache.Get(pCtx, pUserID.String()); err == nil && string(cachedResult) != "" {
 		err = json.Unmarshal([]byte(cachedResult), &result)
 		if err != nil {
-			return nil, err
+			return persist.CollectionToken{}, err
 		}
 		return result[0], nil
 	}
 
 	countColls, err := c.collectionsStorage.count(pCtx, bson.M{"owner_user_id": pUserID})
 	if err != nil {
-		return nil, err
+		return persist.CollectionToken{}, err
 	}
 
 	users := []*persist.User{}
 	err = c.usersStorage.find(pCtx, bson.M{"_id": pUserID}, &users)
 	if err != nil {
-		return nil, err
+		return persist.CollectionToken{}, err
 	}
 	if len(users) != 1 {
-		return nil, persist.ErrUserNotFoundByID{ID: pUserID}
+		return persist.CollectionToken{}, persist.ErrUserNotFoundByID{ID: pUserID}
 	}
 
 	if countColls == 0 {
-		nfts := []*persist.Token{}
+		nfts := []persist.Token{}
 		err = c.tokensStorage.find(pCtx, bson.M{"owner_address": bson.M{"$in": users[0].Addresses}}, &nfts)
 		if err != nil {
-			return nil, err
+			return persist.CollectionToken{}, err
 		}
-		collNfts := []*persist.TokenInCollection{}
+		collNfts := []persist.TokenInCollection{}
 		for _, nft := range nfts {
 			collNfts = append(collNfts, tokenToCollectionToken(nft))
 		}
 
-		result = []*persist.CollectionToken{{Nfts: collNfts}}
+		result = []persist.CollectionToken{{Nfts: collNfts}}
 	} else {
 		if err := c.collectionsStorage.aggregate(pCtx, newUnassignedCollectionTokenPipeline(pUserID, users[0].Addresses), &result); err != nil {
-			return nil, err
+			return persist.CollectionToken{}, err
 		}
 	}
 
 	toCache, err := json.Marshal(result)
 	if err != nil {
-		return nil, err
+		return persist.CollectionToken{}, err
 	}
 
 	c.cacheUpdateQueue.QueueUpdate(pUserID.String(), toCache, collectionUnassignedTTL)
@@ -430,8 +412,8 @@ func newCollectionTokenPipeline(matchFilter bson.M) mongo.Pipeline {
 	}
 }
 
-func tokenToCollectionToken(nft *persist.Token) *persist.TokenInCollection {
-	return &persist.TokenInCollection{
+func tokenToCollectionToken(nft persist.Token) persist.TokenInCollection {
+	return persist.TokenInCollection{
 		ID:              nft.ID,
 		Name:            nft.Name,
 		CreationTime:    nft.CreationTime,

--- a/persist/mongodb/contracts.go
+++ b/persist/mongodb/contracts.go
@@ -26,7 +26,7 @@ func NewContractMongoRepository(mgoClient *mongo.Client) *ContractMongoRepositor
 
 // UpsertByAddress upserts an contract by a given address
 // pUpdate represents a struct with bson tags to specify which fields to update
-func (c *ContractMongoRepository) UpsertByAddress(pCtx context.Context, pAddress persist.Address, pUpsert *persist.Contract) error {
+func (c *ContractMongoRepository) UpsertByAddress(pCtx context.Context, pAddress persist.Address, pUpsert persist.Contract) error {
 
 	_, err := c.contractsStorage.upsert(pCtx, bson.M{
 		"address": pAddress,
@@ -39,7 +39,7 @@ func (c *ContractMongoRepository) UpsertByAddress(pCtx context.Context, pAddress
 }
 
 // BulkUpsert upserts many contracts by their address field
-func (c *ContractMongoRepository) BulkUpsert(pCtx context.Context, contracts []*persist.Contract) error {
+func (c *ContractMongoRepository) BulkUpsert(pCtx context.Context, contracts []persist.Contract) error {
 
 	upserts := make([]updateModel, len(contracts))
 	for i, contract := range contracts {
@@ -86,17 +86,17 @@ func (c *ContractMongoRepository) BulkUpsert(pCtx context.Context, contracts []*
 }
 
 // GetByAddress returns an contract by a given address
-func (c *ContractMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (*persist.Contract, error) {
+func (c *ContractMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (persist.Contract, error) {
 
-	result := []*persist.Contract{}
+	result := []persist.Contract{}
 	err := c.contractsStorage.find(pCtx, bson.M{"address": pAddress}, &result)
 
 	if err != nil {
-		return nil, err
+		return persist.Contract{}, err
 	}
 
 	if len(result) < 1 {
-		return nil, persist.ErrContractNotFoundByAddress{Address: pAddress}
+		return persist.Contract{}, persist.ErrContractNotFoundByAddress{Address: pAddress}
 	}
 
 	if len(result) > 1 {

--- a/persist/mongodb/features.go
+++ b/persist/mongodb/features.go
@@ -38,9 +38,9 @@ func NewFeaturesMongoRepository(mgoClient *mongo.Client) *FeaturesMongoRepositor
 }
 
 // GetByRequiredTokens returns an feature by given token identifiers
-func (c *FeaturesMongoRepository) GetByRequiredTokens(pCtx context.Context, pRequiredtokens map[persist.TokenIdentifiers]uint64) ([]*persist.FeatureFlag, error) {
+func (c *FeaturesMongoRepository) GetByRequiredTokens(pCtx context.Context, pRequiredtokens map[persist.TokenIdentifiers]uint64) ([]persist.FeatureFlag, error) {
 
-	result := []*persist.FeatureFlag{}
+	result := []persist.FeatureFlag{}
 	keys := make([]persist.TokenIdentifiers, len(pRequiredtokens))
 	i := 0
 	for k := range pRequiredtokens {
@@ -66,37 +66,31 @@ func (c *FeaturesMongoRepository) GetByRequiredTokens(pCtx context.Context, pReq
 }
 
 // GetByName returns an feature by a given name
-func (c *FeaturesMongoRepository) GetByName(pCtx context.Context, pName string) (*persist.FeatureFlag, error) {
+func (c *FeaturesMongoRepository) GetByName(pCtx context.Context, pName string) (persist.FeatureFlag, error) {
 
 	opts := options.Find()
 	opts.SetSort(bson.M{"created_at": -1})
 	opts.SetLimit(1)
 
-	result := []*persist.FeatureFlag{}
+	result := []persist.FeatureFlag{}
 	err := c.featuresStorage.find(pCtx, bson.M{"name": pName}, &result, opts)
 
 	if err != nil {
-		return nil, err
+		return persist.FeatureFlag{}, err
 	}
 
 	if len(result) == 0 {
-		return nil, persist.ErrFeatureNotFoundByName{Name: pName}
+		return persist.FeatureFlag{}, persist.ErrFeatureNotFoundByName{Name: pName}
 	}
 
 	return result[0], nil
 }
 
 // GetAll returns all features
-func (c *FeaturesMongoRepository) GetAll(pCtx context.Context) ([]*persist.FeatureFlag, error) {
+func (c *FeaturesMongoRepository) GetAll(pCtx context.Context) ([]persist.FeatureFlag, error) {
 
-	opts := options.Find()
-	if deadline, ok := pCtx.Deadline(); ok {
-		dur := time.Until(deadline)
-		opts.SetMaxTime(dur)
-	}
-
-	result := []*persist.FeatureFlag{}
-	err := c.featuresStorage.find(pCtx, bson.M{}, &result, opts)
+	result := []persist.FeatureFlag{}
+	err := c.featuresStorage.find(pCtx, bson.M{}, &result)
 
 	if err != nil {
 		return nil, err

--- a/persist/mongodb/history.go
+++ b/persist/mongodb/history.go
@@ -23,7 +23,7 @@ func NewHistoryMongoRepository(mgoClient *mongo.Client) *HistoryMongoRepository 
 }
 
 // Upsert caches a transfer in the memory storage
-func (h *HistoryMongoRepository) Upsert(pCtx context.Context, pNFTID persist.DBID, pHistory *persist.OwnershipHistory) error {
+func (h *HistoryMongoRepository) Upsert(pCtx context.Context, pNFTID persist.DBID, pHistory persist.OwnershipHistory) error {
 
 	pHistory.NFTID = pNFTID
 

--- a/persist/mongodb/membership.go
+++ b/persist/mongodb/membership.go
@@ -24,7 +24,7 @@ func NewMembershipMongoRepository(mgoClient *mongo.Client) *MembershipRepository
 }
 
 // UpsertByTokenID upserts an membership tier by a given token ID
-func (c *MembershipRepository) UpsertByTokenID(pCtx context.Context, pTokenID persist.TokenID, pUpsert *persist.MembershipTier) error {
+func (c *MembershipRepository) UpsertByTokenID(pCtx context.Context, pTokenID persist.TokenID, pUpsert persist.MembershipTier) error {
 
 	_, err := c.membershipsStorage.upsert(pCtx, bson.M{
 		"token_id": pTokenID,
@@ -37,17 +37,17 @@ func (c *MembershipRepository) UpsertByTokenID(pCtx context.Context, pTokenID pe
 }
 
 // GetByTokenID returns a membership tier by token ID
-func (c *MembershipRepository) GetByTokenID(pCtx context.Context, pTokenID persist.TokenID) (*persist.MembershipTier, error) {
+func (c *MembershipRepository) GetByTokenID(pCtx context.Context, pTokenID persist.TokenID) (persist.MembershipTier, error) {
 
-	result := []*persist.MembershipTier{}
+	result := []persist.MembershipTier{}
 	err := c.membershipsStorage.find(pCtx, bson.M{"token_id": pTokenID}, &result)
 
 	if err != nil {
-		return nil, err
+		return persist.MembershipTier{}, err
 	}
 
 	if len(result) < 1 {
-		return nil, persist.ErrMembershipNotFoundByTokenID{TokenID: pTokenID}
+		return persist.MembershipTier{}, persist.ErrMembershipNotFoundByTokenID{TokenID: pTokenID}
 	}
 
 	if len(result) > 1 {
@@ -58,9 +58,9 @@ func (c *MembershipRepository) GetByTokenID(pCtx context.Context, pTokenID persi
 }
 
 // GetAll returns all membership tiers
-func (c *MembershipRepository) GetAll(pCtx context.Context) ([]*persist.MembershipTier, error) {
+func (c *MembershipRepository) GetAll(pCtx context.Context) ([]persist.MembershipTier, error) {
 
-	result := []*persist.MembershipTier{}
+	result := []persist.MembershipTier{}
 	err := c.membershipsStorage.find(pCtx, bson.M{}, &result)
 
 	if err != nil {

--- a/persist/mongodb/user.go
+++ b/persist/mongodb/user.go
@@ -36,8 +36,7 @@ func NewUserMongoRepository(mgoClient *mongo.Client) *UserMongoRepository {
 
 // UpdateByID updates a user by ID
 // pUpdate represents a struct with bson tags to specify which fields to update
-func (u *UserMongoRepository) UpdateByID(pCtx context.Context, pID persist.DBID, pUpdate interface{},
-) error {
+func (u *UserMongoRepository) UpdateByID(pCtx context.Context, pID persist.DBID, pUpdate interface{}) error {
 
 	err := u.usersStorage.update(pCtx, bson.M{"_id": pID}, pUpdate)
 	if err != nil {
@@ -63,7 +62,7 @@ func (u *UserMongoRepository) ExistsByAddress(pCtx context.Context, pAddress per
 }
 
 // Create inserts a user into the database
-func (u *UserMongoRepository) Create(pCtx context.Context, pUser *persist.User) (persist.DBID, error) {
+func (u *UserMongoRepository) Create(pCtx context.Context, pUser persist.User) (persist.DBID, error) {
 	return u.usersStorage.insert(pCtx, pUser)
 }
 
@@ -74,34 +73,34 @@ func (u *UserMongoRepository) Delete(pCtx context.Context, pUserID persist.DBID,
 }
 
 // GetByID returns a user by a given ID
-func (u *UserMongoRepository) GetByID(pCtx context.Context, userID persist.DBID) (*persist.User, error) {
+func (u *UserMongoRepository) GetByID(pCtx context.Context, userID persist.DBID) (persist.User, error) {
 
-	result := []*persist.User{}
+	result := []persist.User{}
 	err := u.usersStorage.find(pCtx, bson.M{"_id": userID}, &result)
 
 	if err != nil {
-		return nil, err
+		return persist.User{}, err
 	}
 
 	if len(result) != 1 {
-		return nil, persist.ErrUserNotFoundByID{ID: userID}
+		return persist.User{}, persist.ErrUserNotFoundByID{ID: userID}
 	}
 
 	return result[0], nil
 }
 
 // GetByAddress returns a user by a given wallet address
-func (u *UserMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (*persist.User, error) {
+func (u *UserMongoRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (persist.User, error) {
 
-	result := []*persist.User{}
+	result := []persist.User{}
 	err := u.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": []persist.Address{pAddress}}}, &result)
 
 	if err != nil {
-		return nil, err
+		return persist.User{}, err
 	}
 
 	if len(result) != 1 {
-		return nil, persist.ErrUserNotFoundByAddress{Address: pAddress}
+		return persist.User{}, persist.ErrUserNotFoundByAddress{Address: pAddress}
 	}
 
 	if len(result) > 1 {
@@ -112,17 +111,17 @@ func (u *UserMongoRepository) GetByAddress(pCtx context.Context, pAddress persis
 }
 
 // GetByUsername returns a user by a given username (case insensitive)
-func (u *UserMongoRepository) GetByUsername(pCtx context.Context, pUsername string) (*persist.User, error) {
+func (u *UserMongoRepository) GetByUsername(pCtx context.Context, pUsername string) (persist.User, error) {
 
-	result := []*persist.User{}
+	result := []persist.User{}
 	err := u.usersStorage.find(pCtx, bson.M{"username_idempotent": strings.ToLower(pUsername)}, &result)
 
 	if err != nil {
-		return nil, err
+		return persist.User{}, err
 	}
 
 	if len(result) < 1 {
-		return nil, persist.ErrUserNotFoundByUsername{Username: pUsername}
+		return persist.User{}, persist.ErrUserNotFoundByUsername{Username: pUsername}
 	}
 
 	if len(result) > 1 {

--- a/persist/nft.go
+++ b/persist/nft.go
@@ -17,7 +17,7 @@ type NFTDB struct {
 
 	MultipleOwners bool `bson:"multiple_owners" json:"multiple_owners"`
 
-	OwnershipHistory *OwnershipHistory `bson:"ownership_history,only_get" json:"ownership_history"`
+	OwnershipHistory OwnershipHistory `bson:"ownership_history,only_get" json:"ownership_history"`
 
 	Name                string      `bson:"name"                 json:"name"`
 	Description         string      `bson:"description"          json:"description"`
@@ -59,7 +59,7 @@ type NFT struct {
 
 	MultipleOwners bool `bson:"multiple_owners" json:"multiple_owners"`
 
-	OwnershipHistory *OwnershipHistory `bson:"ownership_history" json:"ownership_history"`
+	OwnershipHistory OwnershipHistory `bson:"ownership_history" json:"ownership_history"`
 
 	Name                string      `bson:"name"                 json:"name"`
 	Description         string      `bson:"description"          json:"description"`
@@ -135,17 +135,17 @@ type UpdateNFTInfoInput struct {
 
 // NFTRepository represents the interface for interacting with persisted NFTs
 type NFTRepository interface {
-	CreateBulk(context.Context, []*NFTDB) ([]DBID, error)
-	Create(context.Context, *NFTDB) (DBID, error)
-	GetByUserID(context.Context, DBID) ([]*NFT, error)
-	GetByAddresses(context.Context, []Address) ([]*NFT, error)
-	GetByID(context.Context, DBID) (*NFT, error)
-	GetByContractData(context.Context, TokenID, Address) ([]*NFT, error)
-	GetByOpenseaID(context.Context, int, Address) ([]*NFT, error)
+	CreateBulk(context.Context, []NFTDB) ([]DBID, error)
+	Create(context.Context, NFTDB) (DBID, error)
+	GetByUserID(context.Context, DBID) ([]NFT, error)
+	GetByAddresses(context.Context, []Address) ([]NFT, error)
+	GetByID(context.Context, DBID) (NFT, error)
+	GetByContractData(context.Context, TokenID, Address) ([]NFT, error)
+	GetByOpenseaID(context.Context, int, Address) ([]NFT, error)
 	UpdateByID(context.Context, DBID, DBID, interface{}) error
-	BulkUpsert(context.Context, []*NFTDB) ([]DBID, error)
-	OpenseaCacheGet(context.Context, []Address) ([]*NFT, error)
-	OpenseaCacheSet(context.Context, []Address, []*NFT) error
+	BulkUpsert(context.Context, []NFTDB) ([]DBID, error)
+	OpenseaCacheGet(context.Context, []Address) ([]NFT, error)
+	OpenseaCacheSet(context.Context, []Address, []NFT) error
 	OpenseaCacheDelete(context.Context, []Address) error
 }
 

--- a/persist/tokens.go
+++ b/persist/tokens.go
@@ -196,15 +196,15 @@ type TokenUpdateMediaInput struct {
 
 // TokenRepository represents a repository for interacting with persisted tokens
 type TokenRepository interface {
-	CreateBulk(context.Context, []*Token) ([]DBID, error)
-	Create(context.Context, *Token) (DBID, error)
-	GetByWallet(context.Context, Address, int64, int64) ([]*Token, error)
-	GetByUserID(context.Context, DBID, int64, int64) ([]*Token, error)
-	GetByContract(context.Context, Address, int64, int64) ([]*Token, error)
-	GetByTokenIdentifiers(context.Context, TokenID, Address, int64, int64) ([]*Token, error)
-	GetByID(context.Context, DBID) (*Token, error)
-	BulkUpsert(context.Context, []*Token) error
-	Upsert(context.Context, *Token) error
+	CreateBulk(context.Context, []Token) ([]DBID, error)
+	Create(context.Context, Token) (DBID, error)
+	GetByWallet(context.Context, Address, int64, int64) ([]Token, error)
+	GetByUserID(context.Context, DBID, int64, int64) ([]Token, error)
+	GetByContract(context.Context, Address, int64, int64) ([]Token, error)
+	GetByTokenIdentifiers(context.Context, TokenID, Address, int64, int64) ([]Token, error)
+	GetByID(context.Context, DBID) (Token, error)
+	BulkUpsert(context.Context, []Token) error
+	Upsert(context.Context, Token) error
 	UpdateByIDUnsafe(context.Context, DBID, interface{}) error
 	UpdateByID(context.Context, DBID, DBID, interface{}) error
 	MostRecentBlock(context.Context) (BlockNumber, error)

--- a/persist/user.go
+++ b/persist/user.go
@@ -30,10 +30,10 @@ type UserUpdateInfoInput struct {
 type UserRepository interface {
 	UpdateByID(context.Context, DBID, interface{}) error
 	ExistsByAddress(context.Context, Address) (bool, error)
-	Create(context.Context, *User) (DBID, error)
-	GetByID(context.Context, DBID) (*User, error)
-	GetByAddress(context.Context, Address) (*User, error)
-	GetByUsername(context.Context, string) (*User, error)
+	Create(context.Context, User) (DBID, error)
+	GetByID(context.Context, DBID) (User, error)
+	GetByAddress(context.Context, Address) (User, error)
+	GetByUsername(context.Context, string) (User, error)
 	Delete(context.Context, DBID) error
 	AddAddresses(context.Context, DBID, []Address) error
 	RemoveAddresses(context.Context, DBID, []Address) error

--- a/server/auth.go
+++ b/server/auth.go
@@ -160,7 +160,7 @@ func authUserLoginAndMemorizeAttemptDb(pCtx context.Context, pInput *authUserLog
 		return nil, err
 	}
 
-	loginAttempt := &persist.UserLoginAttempt{
+	loginAttempt := persist.UserLoginAttempt{
 
 		Address:        pInput.Address,
 		Signature:      pInput.Signature,
@@ -335,7 +335,7 @@ func authUserGetPreflightDb(pCtx context.Context, pInput *authUserGetPreflightIn
 
 	logrus.WithError(err).Error("error retrieving user by address for auth preflight")
 
-	userExistsBool := user != nil
+	userExistsBool := user.ID != ""
 
 	output := &authUserGetPreflightOutput{
 		UserExists: userExistsBool,
@@ -354,7 +354,7 @@ func authUserGetPreflightDb(pCtx context.Context, pInput *authUserGetPreflightIn
 
 		}
 
-		nonce := &persist.UserNonce{
+		nonce := persist.UserNonce{
 			Address: pInput.Address,
 			Value:   generateNonce(),
 		}
@@ -378,7 +378,7 @@ func authUserGetPreflightDb(pCtx context.Context, pInput *authUserGetPreflightIn
 
 func authNonceRotateDb(pCtx context.Context, pAddress persist.Address, pUserID persist.DBID, nonceRepo persist.NonceRepository) error {
 
-	newNonce := &persist.UserNonce{
+	newNonce := persist.UserNonce{
 		Value:   generateNonce(),
 		Address: pAddress,
 	}

--- a/server/collection_nft.go
+++ b/server/collection_nft.go
@@ -21,11 +21,11 @@ type collectionGetByIDInput struct {
 	ID persist.DBID `form:"id" json:"id" binding:"required"`
 }
 type collectionGetByIDOutput struct {
-	Collection *persist.Collection `json:"collection"`
+	Collection persist.Collection `json:"collection"`
 }
 
 type collectionGetOutput struct {
-	Collections []*persist.Collection `json:"collections"`
+	Collections []persist.Collection `json:"collections"`
 }
 
 type collectionCreateInput struct {
@@ -77,7 +77,7 @@ func getCollectionsByUserID(collectionsRepository persist.CollectionRepository) 
 		auth := userID == input.UserID
 		colls, err := collectionsRepository.GetByUserID(c, input.UserID, auth)
 		if len(colls) == 0 || err != nil {
-			colls = []*persist.Collection{}
+			colls = []persist.Collection{}
 		}
 
 		c.JSON(http.StatusOK, collectionGetOutput{Collections: colls})
@@ -120,8 +120,8 @@ func getCollectionByID(collectionsRepository persist.CollectionRepository) gin.H
 func createCollection(collectionsRepository persist.CollectionRepository, galleryRepository persist.GalleryRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
-		input := &collectionCreateInput{}
-		if err := c.ShouldBindJSON(input); err != nil {
+		input := collectionCreateInput{}
+		if err := c.ShouldBindJSON(&input); err != nil {
 			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
@@ -227,7 +227,7 @@ func updateCollectionNfts(collectionsRepository persist.CollectionRepository, ga
 			return
 		}
 
-		update := &persist.CollectionUpdateNftsInput{Nfts: withNoRepeats, Layout: layout}
+		update := persist.CollectionUpdateNftsInput{Nfts: withNoRepeats, Layout: layout}
 
 		err = collectionsRepository.UpdateNFTs(c, input.ID, userID, update)
 		if err != nil {
@@ -275,7 +275,7 @@ func deleteCollection(collectionsRepository persist.CollectionRepository) gin.Ha
 }
 
 // CREATE
-func collectionCreateDb(pCtx context.Context, pInput *collectionCreateInput,
+func collectionCreateDb(pCtx context.Context, pInput collectionCreateInput,
 	pUserID persist.DBID,
 	collectionsRepo persist.CollectionRepository, galleryRepo persist.GalleryRepository) (persist.DBID, error) {
 
@@ -283,7 +283,7 @@ func collectionCreateDb(pCtx context.Context, pInput *collectionCreateInput,
 	if err != nil {
 		return "", err
 	}
-	coll := &persist.CollectionDB{
+	coll := persist.CollectionDB{
 		OwnerUserID:    pUserID,
 		Nfts:           pInput.Nfts,
 		Layout:         layout,

--- a/server/collection_token.go
+++ b/server/collection_token.go
@@ -25,11 +25,11 @@ type collectionGetByIDInputToken struct {
 	ID persist.DBID `form:"id" json:"id" binding:"required"`
 }
 type collectionGetByIDOutputToken struct {
-	Collection *persist.CollectionToken `json:"collection"`
+	Collection persist.CollectionToken `json:"collection"`
 }
 
 type collectionGetOutputtoken struct {
-	Collections []*persist.CollectionToken `json:"collections"`
+	Collections []persist.CollectionToken `json:"collections"`
 }
 
 type collectionCreateInputToken struct {
@@ -85,7 +85,7 @@ func getCollectionsByUserIDToken(collectionsRepository persist.CollectionTokenRe
 		auth := userID == input.UserID
 		colls, err := collectionsRepository.GetByUserID(c, input.UserID, auth)
 		if len(colls) == 0 || err != nil {
-			colls = []*persist.CollectionToken{}
+			colls = []persist.CollectionToken{}
 		}
 
 		aeCtx := appengine.NewContext(c.Request)
@@ -133,8 +133,8 @@ func getCollectionByIDToken(collectionsRepository persist.CollectionTokenReposit
 func createCollectionToken(collectionsRepository persist.CollectionTokenRepository, galleryRepository persist.GalleryTokenRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
-		input := &collectionCreateInputToken{}
-		if err := c.ShouldBindJSON(input); err != nil {
+		input := collectionCreateInputToken{}
+		if err := c.ShouldBindJSON(&input); err != nil {
 			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
@@ -241,7 +241,7 @@ func updateCollectionTokensToken(collectionsRepository persist.CollectionTokenRe
 			return
 		}
 
-		update := &persist.CollectionTokenUpdateNftsInput{Nfts: withNoRepeats, Layout: layout}
+		update := persist.CollectionTokenUpdateNftsInput{Nfts: withNoRepeats, Layout: layout}
 
 		err = collectionsRepository.UpdateNFTs(c, input.ID, userID, update)
 		if err != nil {
@@ -280,15 +280,13 @@ func deleteCollectionToken(collectionsRepository persist.CollectionTokenReposito
 }
 
 // CREATE
-func collectionCreateDbToken(pCtx context.Context, pInput *collectionCreateInputToken,
-	pUserID persist.DBID,
-	collectionsRepo persist.CollectionTokenRepository, galleryRepo persist.GalleryTokenRepository) (persist.DBID, error) {
+func collectionCreateDbToken(pCtx context.Context, pInput collectionCreateInputToken, pUserID persist.DBID, collectionsRepo persist.CollectionTokenRepository, galleryRepo persist.GalleryTokenRepository) (persist.DBID, error) {
 
 	layout, err := persist.ValidateLayout(pInput.Layout)
 	if err != nil {
 		return "", err
 	}
-	coll := &persist.CollectionTokenDB{
+	coll := persist.CollectionTokenDB{
 		OwnerUserID:    pUserID,
 		Nfts:           pInput.Nfts,
 		Name:           sanitizationPolicy.Sanitize(pInput.Name),

--- a/server/gallery_nft.go
+++ b/server/gallery_nft.go
@@ -46,7 +46,7 @@ func getGalleriesByUserID(galleryRepository persist.GalleryRepository) gin.Handl
 
 		auth := c.GetBool(middleware.AuthContextKey)
 		galleries, err := galleryRepository.GetByUserID(c, input.UserID, auth)
-		if len(galleries) == 0 || err != nil {
+		if galleries == nil || err != nil {
 			galleries = []persist.Gallery{}
 		}
 

--- a/server/gallery_nft.go
+++ b/server/gallery_nft.go
@@ -19,7 +19,7 @@ type galleryGetByIDInput struct {
 }
 
 type galleryGetByIDOutput struct {
-	Gallery *persist.Gallery `json:"gallery"`
+	Gallery persist.Gallery `json:"gallery"`
 }
 
 type galleryUpdateInput struct {
@@ -28,7 +28,7 @@ type galleryUpdateInput struct {
 }
 
 type galleryGetOutput struct {
-	Galleries []*persist.Gallery `json:"galleries"`
+	Galleries []persist.Gallery `json:"galleries"`
 }
 
 // HANDLERS
@@ -47,7 +47,7 @@ func getGalleriesByUserID(galleryRepository persist.GalleryRepository) gin.Handl
 		auth := c.GetBool(middleware.AuthContextKey)
 		galleries, err := galleryRepository.GetByUserID(c, input.UserID, auth)
 		if len(galleries) == 0 || err != nil {
-			galleries = []*persist.Gallery{}
+			galleries = []persist.Gallery{}
 		}
 
 		c.JSON(http.StatusOK, galleryGetOutput{Galleries: galleries})
@@ -99,7 +99,7 @@ func updateGallery(galleryRepository persist.GalleryRepository, backupRepository
 			return
 		}
 
-		update := &persist.GalleryUpdateInput{Collections: input.Collections}
+		update := persist.GalleryUpdateInput{Collections: input.Collections}
 
 		err := galleryRepository.Update(c, input.ID, userID, update)
 		if err != nil {

--- a/server/gallery_token.go
+++ b/server/gallery_token.go
@@ -22,7 +22,7 @@ type galleryTokenGetByIDInput struct {
 }
 
 type galleryTokenGetByIDOutput struct {
-	Gallery *persist.GalleryToken `json:"gallery"`
+	Gallery persist.GalleryToken `json:"gallery"`
 }
 
 type galleryTokenUpdateInput struct {
@@ -31,7 +31,7 @@ type galleryTokenUpdateInput struct {
 }
 
 type galleryTokenGetOutput struct {
-	Galleries []*persist.GalleryToken `json:"galleries"`
+	Galleries []persist.GalleryToken `json:"galleries"`
 }
 
 type errNoGalleriesFoundWithID struct {
@@ -54,7 +54,7 @@ func getGalleriesByUserIDToken(galleryRepository persist.GalleryTokenRepository,
 		auth := c.GetBool(middleware.AuthContextKey)
 		galleries, err := galleryRepository.GetByUserID(c, input.UserID, auth)
 		if len(galleries) == 0 || err != nil {
-			galleries = []*persist.GalleryToken{}
+			galleries = []persist.GalleryToken{}
 		}
 		aeCtx := appengine.NewContext(c.Request)
 		for _, gallery := range galleries {
@@ -117,7 +117,7 @@ func updateGalleryToken(galleryRepository persist.GalleryTokenRepository) gin.Ha
 			return
 		}
 
-		update := &persist.GalleryTokenUpdateInput{Collections: input.Collections}
+		update := persist.GalleryTokenUpdateInput{Collections: input.Collections}
 
 		err := galleryRepository.Update(c, input.ID, userID, update)
 		if err != nil {

--- a/server/membership.go
+++ b/server/membership.go
@@ -15,7 +15,7 @@ import (
 )
 
 type getMembershipTiersResponse struct {
-	Tiers []*persist.MembershipTier `json:"tiers"`
+	Tiers []persist.MembershipTier `json:"tiers"`
 }
 
 func getMembershipTiers(membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, ethClient *eth.Client) gin.HandlerFunc {
@@ -49,12 +49,12 @@ func getMembershipTiers(membershipRepository persist.MembershipRepository, userR
 	}
 }
 
-func updateMembershipTiers(pCtx context.Context, membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, ethClient *eth.Client) ([]*persist.MembershipTier, error) {
-	membershipTiers := make([]*persist.MembershipTier, len(middleware.RequiredNFTs))
-	tierChan := make(chan *persist.MembershipTier)
+func updateMembershipTiers(pCtx context.Context, membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, ethClient *eth.Client) ([]persist.MembershipTier, error) {
+	membershipTiers := make([]persist.MembershipTier, len(middleware.RequiredNFTs))
+	tierChan := make(chan persist.MembershipTier)
 	for _, v := range middleware.RequiredNFTs {
 		go func(id persist.TokenID) {
-			tier := &persist.MembershipTier{
+			tier := persist.MembershipTier{
 				TokenID: id,
 			}
 
@@ -74,7 +74,7 @@ func updateMembershipTiers(pCtx context.Context, membershipRepository persist.Me
 					owners := []string{}
 					hasNFT, _ := ethClient.HasNFT(pCtx, id, event.FromAccount.Address)
 					if hasNFT {
-						if glryUser, err := userRepository.GetByAddress(pCtx, event.FromAccount.Address); err == nil && glryUser != nil && glryUser.UserName != "" {
+						if glryUser, err := userRepository.GetByAddress(pCtx, event.FromAccount.Address); err == nil && glryUser.UserName != "" {
 							owners = append(owners, glryUser.UserName)
 						} else {
 							owners = append(owners, event.FromAccount.Address.String())
@@ -82,7 +82,7 @@ func updateMembershipTiers(pCtx context.Context, membershipRepository persist.Me
 					}
 					hasNFT, _ = ethClient.HasNFT(pCtx, id, event.ToAccount.Address)
 					if hasNFT {
-						if glryUser, err := userRepository.GetByAddress(pCtx, event.ToAccount.Address); err == nil && glryUser != nil && glryUser.UserName != "" {
+						if glryUser, err := userRepository.GetByAddress(pCtx, event.ToAccount.Address); err == nil && glryUser.UserName != "" {
 							owners = append(owners, glryUser.UserName)
 						} else {
 							owners = append(owners, event.ToAccount.Address.String())

--- a/server/nft.go
+++ b/server/nft.go
@@ -30,15 +30,15 @@ type refreshOpenseaNftsInput struct {
 }
 
 type getNftsOutput struct {
-	Nfts []*persist.NFT `json:"nfts"`
+	Nfts []persist.NFT `json:"nfts"`
 }
 
 type getNftByIDOutput struct {
-	Nft *persist.NFT `json:"nft"`
+	Nft persist.NFT `json:"nft"`
 }
 
 type getUnassignedNftsOutput struct {
-	Nfts []*persist.CollectionNFT `json:"nfts"`
+	Nfts []persist.CollectionNFT `json:"nfts"`
 }
 
 type updateNftByIDInput struct {
@@ -52,7 +52,7 @@ type getOwnershipHistoryInput struct {
 }
 
 type getOwnershipHistoryOutput struct {
-	OwnershipHistory *persist.OwnershipHistory `json:"ownership_history"`
+	OwnershipHistory persist.OwnershipHistory `json:"ownership_history"`
 }
 
 type errDoesNotOwnWallets struct {
@@ -122,8 +122,8 @@ func getNftsForUser(nftRepository persist.NFTRepository) gin.HandlerFunc {
 			return
 		}
 		nfts, err := nftRepository.GetByUserID(c, input.UserID)
-		if len(nfts) == 0 || err != nil {
-			nfts = []*persist.NFT{}
+		if nfts == nil || err != nil {
+			nfts = []persist.NFT{}
 		}
 
 		c.JSON(http.StatusOK, getNftsOutput{Nfts: nfts})
@@ -139,8 +139,8 @@ func getUnassignedNftsForUser(collectionRepository persist.CollectionRepository)
 			return
 		}
 		coll, err := collectionRepository.GetUnassigned(c, userID)
-		if coll == nil || err != nil {
-			coll = &persist.Collection{Nfts: []*persist.CollectionNFT{}}
+		if err != nil {
+			coll = persist.Collection{Nfts: []persist.CollectionNFT{}}
 		}
 
 		c.JSON(http.StatusOK, getUnassignedNftsOutput{Nfts: coll.Nfts})
@@ -199,8 +199,8 @@ func getNftsFromOpensea(nftRepo persist.NFTRepository, userRepo persist.UserRepo
 		}
 
 		nfts, err := openSeaPipelineAssetsForAcc(c, userID, addresses, nftRepo, userRepo, collRepo, historyRepo)
-		if len(nfts) == 0 || err != nil {
-			nfts = []*persist.NFT{}
+		if nfts == nil || err != nil {
+			nfts = []persist.NFT{}
 		}
 
 		c.JSON(http.StatusOK, getNftsOutput{Nfts: nfts})

--- a/server/opensea.go
+++ b/server/opensea.go
@@ -286,7 +286,7 @@ func openseaFetchAssetsForWallet(pWalletAddress persist.Address, pOffset int) ([
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 	response := openseaAssets{}
-	err = util.UnmarshallBody(response, resp.Body)
+	err = util.UnmarshallBody(&response, resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/server/opensea.go
+++ b/server/opensea.go
@@ -19,7 +19,7 @@ import (
 // mongodb.GLRYnft struct tags reflect the json data of an open sea response and therefore
 // can be unmarshalled from the api response
 type openseaAssets struct {
-	Assets []*openseaAsset `json:"assets"`
+	Assets []openseaAsset `json:"assets"`
 }
 
 type openseaAsset struct {
@@ -92,7 +92,7 @@ type errNoSingleNFTForOpenseaID struct {
 }
 
 func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOwnerWalletAddresses []persist.Address,
-	nftRepo persist.NFTRepository, userRepo persist.UserRepository, collRepo persist.CollectionRepository, historyRepo persist.OwnershipHistoryRepository) ([]*persist.NFT, error) {
+	nftRepo persist.NFTRepository, userRepo persist.UserRepository, collRepo persist.CollectionRepository, historyRepo persist.OwnershipHistoryRepository) ([]persist.NFT, error) {
 
 	nfts, err := nftRepo.OpenseaCacheGet(pCtx, pOwnerWalletAddresses)
 	if err == nil && len(nfts) > 0 {
@@ -122,7 +122,7 @@ func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOw
 	// update other user's collections and this user's collection so that they and ONLY they can display these
 	// specific NFTs while also ensuring that NFTs they don't own don't list them as the owner
 	go func() {
-		if err := collRepo.ClaimNFTs(pCtx, pUserID, pOwnerWalletAddresses, &persist.CollectionUpdateNftsInput{Nfts: ids}); err != nil {
+		if err := collRepo.ClaimNFTs(pCtx, pUserID, pOwnerWalletAddresses, persist.CollectionUpdateNftsInput{Nfts: ids}); err != nil {
 			logrus.WithFields(logrus.Fields{"method": "openSeaPipelineAssetsForAcc"}).Errorf("failed to claim nfts: %v", err)
 			return
 		}
@@ -176,47 +176,47 @@ func openseaSyncHistories(pCtx context.Context, pNfts []*persist.NFTDB, userRepo
 	return updatedNfts, nil
 }
 
-func openseaSyncHistory(pCtx context.Context, pTokenID persist.TokenID, pTokenContractAddress, pWalletAddress persist.Address, userRepo persist.UserRepository, nftRepo persist.NFTRepository, historyRepo persist.OwnershipHistoryRepository) (*persist.OwnershipHistory, error) {
+func openseaSyncHistory(pCtx context.Context, pTokenID persist.TokenID, pTokenContractAddress, pWalletAddress persist.Address, userRepo persist.UserRepository, nftRepo persist.NFTRepository, historyRepo persist.OwnershipHistoryRepository) (persist.OwnershipHistory, error) {
 	getURL := fmt.Sprintf("https://api.opensea.io/api/v1/events?token_id=%s&asset_contract_address=%s&event_type=transfer&only_opensea=false&limit=50&offset=0", pTokenID, pTokenContractAddress)
-	events := &persist.OwnershipHistory{}
+	events := persist.OwnershipHistory{}
 	resp, err := http.Get(getURL)
 	if err != nil {
-		return nil, err
+		return persist.OwnershipHistory{}, err
 	}
 	defer resp.Body.Close()
 	buf := &bytes.Buffer{}
 	if _, err := io.Copy(buf, resp.Body); err != nil {
-		return nil, err
+		return persist.OwnershipHistory{}, err
 	}
 	openseaEvents := &openseaEvents{}
 	if err := json.Unmarshal(buf.Bytes(), openseaEvents); err != nil {
-		return nil, err
+		return persist.OwnershipHistory{}, err
 	}
 
 	events, err = openseaToGalleryEvents(pCtx, openseaEvents, userRepo)
 	if err != nil {
-		return nil, err
+		return persist.OwnershipHistory{}, err
 	}
 
 	nfts, err := nftRepo.GetByContractData(pCtx, pTokenID, pTokenContractAddress)
 	if err != nil {
-		return nil, err
+		return persist.OwnershipHistory{}, err
 	}
 	if len(nfts) < 1 {
-		return nil, fmt.Errorf("no nfts found for token id: %s, contract address: %s", pTokenID, pTokenContractAddress)
+		return persist.OwnershipHistory{}, fmt.Errorf("no nfts found for token id: %s, contract address: %s", pTokenID, pTokenContractAddress)
 	}
 
 	err = historyRepo.Upsert(pCtx, nfts[0].ID, events)
 	if err != nil {
-		return nil, err
+		return persist.OwnershipHistory{}, err
 	}
 
 	return events, nil
 }
 
-func openseaFetchAssetsForWallets(pCtx context.Context, pWalletAddresses []persist.Address, nftRepo persist.NFTRepository) ([]*persist.NFTDB, error) {
-	result := []*persist.NFTDB{}
-	nftsChan := make(chan []*persist.NFTDB)
+func openseaFetchAssetsForWallets(pCtx context.Context, pWalletAddresses []persist.Address, nftRepo persist.NFTRepository) ([]persist.NFTDB, error) {
+	result := []persist.NFTDB{}
+	nftsChan := make(chan []persist.NFTDB)
 	errChan := make(chan error)
 	for _, walletAddress := range pWalletAddresses {
 		go func(wa persist.Address) {
@@ -255,9 +255,9 @@ func openseaFetchAssetsForWallets(pCtx context.Context, pWalletAddresses []persi
 }
 
 // recursively fetches all assets for a wallet
-func openseaFetchAssetsForWallet(pWalletAddress persist.Address, pOffset int) ([]*openseaAsset, error) {
+func openseaFetchAssetsForWallet(pWalletAddress persist.Address, pOffset int) ([]openseaAsset, error) {
 
-	result := []*openseaAsset{}
+	result := []openseaAsset{}
 	qsArgsMap := map[string]interface{}{
 		"owner":           pWalletAddress,
 		"order_direction": "desc",
@@ -285,7 +285,7 @@ func openseaFetchAssetsForWallet(pWalletAddress persist.Address, pOffset int) ([
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
-	response := &openseaAssets{}
+	response := openseaAssets{}
 	err = util.UnmarshallBody(response, resp.Body)
 	if err != nil {
 		return nil, err
@@ -301,12 +301,12 @@ func openseaFetchAssetsForWallet(pWalletAddress persist.Address, pOffset int) ([
 	return result, nil
 }
 
-func openseaToDBNfts(pCtx context.Context, pWalletAddress persist.Address, openseaNfts []*openseaAsset, nftRepo persist.NFTRepository) ([]*persist.NFTDB, error) {
+func openseaToDBNfts(pCtx context.Context, pWalletAddress persist.Address, openseaNfts []openseaAsset, nftRepo persist.NFTRepository) ([]persist.NFTDB, error) {
 
-	nfts := make([]*persist.NFTDB, len(openseaNfts))
-	nftChan := make(chan *persist.NFTDB)
+	nfts := make([]persist.NFTDB, len(openseaNfts))
+	nftChan := make(chan persist.NFTDB)
 	for _, openseaNft := range openseaNfts {
-		go func(nft *openseaAsset) {
+		go func(nft openseaAsset) {
 			nftChan <- openseaToDBNft(pCtx, pWalletAddress, nft, nftRepo)
 		}(openseaNft)
 	}
@@ -316,14 +316,14 @@ func openseaToDBNfts(pCtx context.Context, pWalletAddress persist.Address, opens
 	return nfts, nil
 }
 
-func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NFTDB, pUser *persist.User, nftRepo persist.NFTRepository) ([]*persist.NFT, error) {
+func dbToGalleryNFTs(pCtx context.Context, pNfts []persist.NFTDB, pUser persist.User, nftRepo persist.NFTRepository) ([]persist.NFT, error) {
 
-	nfts := make([]*persist.NFT, len(pNfts))
-	nftChan := make(chan *persist.NFT)
+	nfts := make([]persist.NFT, len(pNfts))
+	nftChan := make(chan persist.NFT)
 	errChan := make(chan error)
 	for _, nft := range pNfts {
-		go func(n *persist.NFTDB) {
-			result := &persist.NFT{
+		go func(n persist.NFTDB) {
+			result := persist.NFT{
 				ID:                   n.ID,
 				Name:                 n.Name,
 				MultipleOwners:       n.MultipleOwners,
@@ -377,9 +377,9 @@ func dbToGalleryNFTs(pCtx context.Context, pNfts []*persist.NFTDB, pUser *persis
 	return nfts, nil
 }
 
-func openseaToDBNft(pCtx context.Context, pWalletAddress persist.Address, nft *openseaAsset, nftRepo persist.NFTRepository) *persist.NFTDB {
+func openseaToDBNft(pCtx context.Context, pWalletAddress persist.Address, nft openseaAsset, nftRepo persist.NFTRepository) persist.NFTDB {
 
-	result := &persist.NFTDB{
+	result := persist.NFTDB{
 		OwnerAddress:         pWalletAddress,
 		MultipleOwners:       nft.Owner.Address == "0x0000000000000000000000000000000000000000",
 		Name:                 nft.Name,
@@ -410,14 +410,14 @@ func openseaToDBNft(pCtx context.Context, pWalletAddress persist.Address, nft *o
 
 }
 
-func openseaToGalleryEvents(pCtx context.Context, pEvents *openseaEvents, userRepo persist.UserRepository) (*persist.OwnershipHistory, error) {
+func openseaToGalleryEvents(pCtx context.Context, pEvents *openseaEvents, userRepo persist.UserRepository) (persist.OwnershipHistory, error) {
 	timeLayout := "2006-01-02T15:04:05"
-	ownershipHistory := &persist.OwnershipHistory{Owners: []*persist.Owner{}}
+	ownershipHistory := persist.OwnershipHistory{Owners: []persist.Owner{}}
 	for _, event := range pEvents.Events {
-		owner := &persist.Owner{}
+		owner := persist.Owner{}
 		time, err := time.Parse(timeLayout, event.CreatedDate)
 		if err != nil {
-			return nil, err
+			return persist.OwnershipHistory{}, err
 		}
 		owner.TimeObtained = time
 		owner.Address = event.ToAccount.Address

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -17,9 +17,9 @@ func TestOpenseaSync_Success(t *testing.T) {
 	assert := setupTest(t)
 	ctx := context.Background()
 
-	mike := &persist.User{UserNameIdempotent: "mikey", UserName: "mikey", Addresses: []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}}
-	robin := &persist.User{UserName: "robin", UserNameIdempotent: "robin", Addresses: []persist.Address{persist.Address(strings.ToLower("0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"))}}
-	gianna := &persist.User{UserName: "gianna", UserNameIdempotent: "gianna", Addresses: []persist.Address{persist.Address(strings.ToLower("0xdd33e6fd03983c970ae5e647df07314435d69f6b"))}}
+	mike := persist.User{UserNameIdempotent: "mikey", UserName: "mikey", Addresses: []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}}
+	robin := persist.User{UserName: "robin", UserNameIdempotent: "robin", Addresses: []persist.Address{persist.Address(strings.ToLower("0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"))}}
+	gianna := persist.User{UserName: "gianna", UserNameIdempotent: "gianna", Addresses: []persist.Address{persist.Address(strings.ToLower("0xdd33e6fd03983c970ae5e647df07314435d69f6b"))}}
 
 	robinUserID, err := tc.repos.userRepository.Create(ctx, robin)
 	assert.Nil(err)
@@ -28,33 +28,33 @@ func TestOpenseaSync_Success(t *testing.T) {
 	mikeUserID, err := tc.repos.userRepository.Create(ctx, mike)
 	assert.Nil(err)
 
-	nft := &persist.NFTDB{
+	nft := persist.NFTDB{
 		OwnerAddress: "0xdd33e6fd03983c970ae5e647df07314435d69f6b",
 		Name:         "kks",
 		OpenseaID:    34147626,
 	}
 
-	nft2 := &persist.NFTDB{
+	nft2 := persist.NFTDB{
 		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
 		Name:         "malsjdlaksjd",
 		OpenseaID:    46062326,
 	}
-	nft3 := &persist.NFTDB{
+	nft3 := persist.NFTDB{
 		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
 		Name:         "asdjasdasd",
 		OpenseaID:    46062320,
 	}
 
-	nft4 := &persist.NFTDB{
+	nft4 := persist.NFTDB{
 		OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
 		Name:         "asdasdasd",
 		OpenseaID:    46062322,
 	}
 
-	ids, err := tc.repos.nftRepository.CreateBulk(ctx, []*persist.NFTDB{nft, nft2, nft3, nft4})
+	ids, err := tc.repos.nftRepository.CreateBulk(ctx, []persist.NFTDB{nft, nft2, nft3, nft4})
 	assert.Nil(err)
 
-	coll := &persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", Nfts: []persist.DBID{ids[3]}}
+	coll := persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", Nfts: []persist.DBID{ids[3]}}
 	collID, err := tc.repos.collectionRepository.Create(ctx, coll)
 	assert.Nil(err)
 

--- a/server/t__routes_auth_test.go
+++ b/server/t__routes_auth_test.go
@@ -68,7 +68,7 @@ func TestAuthPreflightUserNotExistWithJWT_Success(t *testing.T) {
 func TestUserCreate_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 	}
@@ -92,7 +92,7 @@ func TestUserCreate_Success(t *testing.T) {
 func TestUserCreate_WrongNonce_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "Wrong Nonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 	}
@@ -106,7 +106,7 @@ func TestUserCreate_WrongNonce_Failure(t *testing.T) {
 func TestUserCreate_WrongSig_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 	}
@@ -120,7 +120,7 @@ func TestUserCreate_WrongSig_Failure(t *testing.T) {
 func TestUserCreate_WrongAddress_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3349a3F8AC5")),
 	}
@@ -141,14 +141,14 @@ func TestUserCreate_NoNonce_Failure(t *testing.T) {
 func TestUserLogin_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
 	}
 
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: user.Addresses[0],
 	}
@@ -173,14 +173,14 @@ func TestUserLogin_Success(t *testing.T) {
 func TestUserLoginGnosis_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
 	}
 
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   " TEST NONCE",
 		Address: user.Addresses[0],
 	}
@@ -205,14 +205,14 @@ func TestUserLoginGnosis_Success(t *testing.T) {
 func TestUserLoginGnosis_WrongNonce_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
 	}
 
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TEST NONCE Wrong",
 		Address: user.Addresses[0],
 	}
@@ -235,14 +235,14 @@ func TestUserLoginGnosis_WrongNonce_Failure(t *testing.T) {
 func TestUserLoginGnosis_WrongSig_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
 	}
 
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   " TEST NONCE",
 		Address: user.Addresses[0],
 	}
@@ -264,14 +264,14 @@ func TestUserLoginGnosis_WrongSig_Failure(t *testing.T) {
 func TestUserLogin_WrongNonce_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
 	}
 
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "Wrong Nonce",
 		Address: user.Addresses[0],
 	}
@@ -285,14 +285,14 @@ func TestUserLogin_WrongNonce_Failure(t *testing.T) {
 func TestUserLogin_WrongSig_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
 	}
 
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: user.Addresses[0],
 	}
@@ -306,14 +306,14 @@ func TestUserLogin_WrongSig_Failure(t *testing.T) {
 func TestUserLogin_WrongAddr_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
 	}
 
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: user.Addresses[0],
 	}
@@ -327,7 +327,7 @@ func TestUserLogin_WrongAddr_Failure(t *testing.T) {
 func TestUserLogin_NoNonce_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
 	}
 
@@ -341,7 +341,7 @@ func TestUserLogin_NoNonce_Failure(t *testing.T) {
 func TestUserLogin_UserNotExist_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 	}
@@ -355,7 +355,7 @@ func TestUserLogin_UserNotExist_Failure(t *testing.T) {
 func TestUserLogin_UserNotOwnAddress_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5",
 	}

--- a/server/t__routes_collection_test.go
+++ b/server/t__routes_collection_test.go
@@ -48,14 +48,14 @@ import (
 func TestCreateCollection_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nfts := []*persist.NFTDB{
+	nfts := []persist.NFTDB{
 		{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
 	}
 	nftIDs, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 	assert.Nil(err)
-	gid, err := tc.repos.galleryRepository.Create(context.Background(), &persist.GalleryDB{OwnerUserID: tc.user1.id})
+	gid, err := tc.repos.galleryRepository.Create(context.Background(), persist.GalleryDB{OwnerUserID: tc.user1.id})
 	assert.Nil(err)
 
 	input := collectionCreateInput{GalleryID: gid, Nfts: nftIDs}
@@ -96,14 +96,14 @@ func TestCreateCollection_Success(t *testing.T) {
 func TestGetUnassignedCollection_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nfts := []*persist.NFTDB{
+	nfts := []persist.NFTDB{
 		{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
 	}
 	nftIDs, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 	// seed DB with collection
-	_, err = tc.repos.collectionRepository.Create(context.Background(), &persist.CollectionDB{
+	_, err = tc.repos.collectionRepository.Create(context.Background(), persist.CollectionDB{
 		Name:        "very cool collection",
 		OwnerUserID: tc.user1.id,
 		Nfts:        nftIDs[:2],
@@ -164,14 +164,14 @@ func TestDeleteCollection_Failure_DifferentUsersCollection(t *testing.T) {
 func TestGetHiddenCollections_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nfts := []*persist.NFTDB{
+	nfts := []persist.NFTDB{
 		{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
 	}
 	nftIDs, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 
-	_, err = tc.repos.collectionRepository.Create(context.Background(), &persist.CollectionDB{
+	_, err = tc.repos.collectionRepository.Create(context.Background(), persist.CollectionDB{
 		Name:        "very cool collection",
 		OwnerUserID: tc.user1.id,
 		Nfts:        nftIDs,
@@ -195,20 +195,20 @@ func TestGetHiddenCollections_Success(t *testing.T) {
 func TestGetNoHiddenCollections_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nfts := []*persist.NFTDB{
+	nfts := []persist.NFTDB{
 		{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
 	}
 	nftIDs, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 
-	_, err = tc.repos.collectionRepository.Create(context.Background(), &persist.CollectionDB{
+	_, err = tc.repos.collectionRepository.Create(context.Background(), persist.CollectionDB{
 		Name:        "very cool collection",
 		OwnerUserID: tc.user1.id,
 		Nfts:        nftIDs[0:1],
 		Hidden:      false,
 	})
-	_, err = tc.repos.collectionRepository.Create(context.Background(), &persist.CollectionDB{
+	_, err = tc.repos.collectionRepository.Create(context.Background(), persist.CollectionDB{
 		Name:        "very cool collection",
 		OwnerUserID: tc.user1.id,
 		Nfts:        nftIDs[1:],
@@ -232,15 +232,15 @@ func TestGetNoHiddenCollections_Success(t *testing.T) {
 func TestCreateCollectionWithUsedNFT_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nfts := []*persist.NFTDB{
+	nfts := []persist.NFTDB{
 		{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
 	}
 	nftIDs, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 
-	preCollID, err := tc.repos.collectionRepository.Create(context.Background(), &persist.CollectionDB{Name: "test", Nfts: nftIDs, OwnerUserID: tc.user1.id})
-	gid, err := tc.repos.galleryRepository.Create(context.Background(), &persist.GalleryDB{Collections: []persist.DBID{preCollID}, OwnerUserID: tc.user1.id})
+	preCollID, err := tc.repos.collectionRepository.Create(context.Background(), persist.CollectionDB{Name: "test", Nfts: nftIDs, OwnerUserID: tc.user1.id})
+	gid, err := tc.repos.galleryRepository.Create(context.Background(), persist.GalleryDB{Collections: []persist.DBID{preCollID}, OwnerUserID: tc.user1.id})
 
 	input := collectionCreateInput{GalleryID: gid, Nfts: nftIDs[0:2]}
 	resp := createCollectionRequest(assert, input, tc.user1.jwt)
@@ -266,7 +266,7 @@ func TestCreateCollectionWithUsedNFT_Success(t *testing.T) {
 func TestUpdateCollectionNftsOrder_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nfts := []*persist.NFTDB{
+	nfts := []persist.NFTDB{
 		{Description: "asd", CollectorsNote: "asd", OwnerAddress: tc.user1.address},
 		{Description: "bbb", CollectorsNote: "bbb", OwnerAddress: tc.user1.address},
 		{Description: "wowowowow", CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address},
@@ -274,7 +274,7 @@ func TestUpdateCollectionNftsOrder_Success(t *testing.T) {
 	nftIDs, err := tc.repos.nftRepository.CreateBulk(context.Background(), nfts)
 	assert.Nil(err)
 
-	collID, err := tc.repos.collectionRepository.Create(context.Background(), &persist.CollectionDB{
+	collID, err := tc.repos.collectionRepository.Create(context.Background(), persist.CollectionDB{
 		Name:        "very cool collection",
 		OwnerUserID: tc.user1.id,
 		Nfts:        nftIDs,
@@ -415,7 +415,7 @@ func updateCollectionNftsRequest(assert *assert.Assertions, input collectionUpda
 }
 
 func createCollectionInDbForUserID(assert *assert.Assertions, collectionName string, userID persist.DBID) persist.DBID {
-	collID, err := tc.repos.collectionRepository.Create(context.Background(), &persist.CollectionDB{
+	collID, err := tc.repos.collectionRepository.Create(context.Background(), persist.CollectionDB{
 		Name:        collectionName,
 		OwnerUserID: userID,
 	})

--- a/server/t__routes_gallery_test.go
+++ b/server/t__routes_gallery_test.go
@@ -26,7 +26,7 @@ func TestUpdateGalleryById_ReorderCollections_Success(t *testing.T) {
 		initialCollectionOrder = append(initialCollectionOrder, collID)
 	}
 	// Seed DB with gallery
-	id, err := tc.repos.galleryRepository.Create(context.Background(), &persist.GalleryDB{
+	id, err := tc.repos.galleryRepository.Create(context.Background(), persist.GalleryDB{
 		OwnerUserID: tc.user1.id,
 		Collections: initialCollectionOrder,
 	})

--- a/server/t__routes_nft_test.go
+++ b/server/t__routes_nft_test.go
@@ -19,7 +19,7 @@ func TestGetNftByID_Success(t *testing.T) {
 
 	// seed DB with nft
 	name := "very cool nft"
-	nftID, err := tc.repos.nftRepository.Create(context.Background(), &persist.NFTDB{
+	nftID, err := tc.repos.nftRepository.Create(context.Background(), persist.NFTDB{
 		Name:         name,
 		OwnerAddress: tc.user1.address,
 	})
@@ -69,7 +69,7 @@ func TestUpdateNftByID_Success(t *testing.T) {
 	assert := setupTest(t)
 
 	// seed DB with nft
-	nftID, err := tc.repos.nftRepository.Create(context.Background(), &persist.NFTDB{
+	nftID, err := tc.repos.nftRepository.Create(context.Background(), persist.NFTDB{
 		Name:           "very cool nft",
 		CollectorsNote: "silly note",
 		OwnerAddress:   tc.user1.address,
@@ -101,7 +101,7 @@ func TestUpdateNftByID_UnauthedError(t *testing.T) {
 	assert := setupTest(t)
 
 	// seed DB with nft
-	nftID, err := tc.repos.nftRepository.Create(context.Background(), &persist.NFTDB{
+	nftID, err := tc.repos.nftRepository.Create(context.Background(), persist.NFTDB{
 		Name:           "very cool nft",
 		CollectorsNote: "this is a bad note",
 		OwnerAddress:   tc.user1.address,
@@ -146,7 +146,7 @@ func TestUpdateNftByID_UpdatingAsUserWithoutToken_CantDo(t *testing.T) {
 	assert := setupTest(t)
 
 	// seed DB with nft
-	nftID, err := tc.repos.nftRepository.Create(context.Background(), &persist.NFTDB{
+	nftID, err := tc.repos.nftRepository.Create(context.Background(), persist.NFTDB{
 		Name: "very cool nft",
 	})
 	assert.Nil(err)

--- a/server/t__routes_user_test.go
+++ b/server/t__routes_user_test.go
@@ -146,7 +146,7 @@ func TestUpdateUserAuthenticated_UsernameInvalid_Failure(t *testing.T) {
 func TestUserAddAddresses_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 	}
@@ -173,7 +173,7 @@ func TestUserAddAddresses_Success(t *testing.T) {
 func TestUserAddAddresses_WrongNonce_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "Wrong Nonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 	}
@@ -191,12 +191,12 @@ func TestUserAddAddresses_WrongNonce_Failure(t *testing.T) {
 func TestUserAddAddresses_OtherUserOwnsAddress_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
 	}
 	_, err := tc.repos.userRepository.Create(context.Background(), user)
 
-	nonce := &persist.UserNonce{
+	nonce := persist.UserNonce{
 		Value:   "TestNonce",
 		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 	}
@@ -214,7 +214,7 @@ func TestUserAddAddresses_OtherUserOwnsAddress_Failure(t *testing.T) {
 func TestUserRemoveAddresses_Success(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses:          []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9", persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
 		UserName:           "TestUser",
 		UserNameIdempotent: "testuser",
@@ -222,13 +222,13 @@ func TestUserRemoveAddresses_Success(t *testing.T) {
 	userID, err := tc.repos.userRepository.Create(context.Background(), user)
 	assert.Nil(err)
 
-	nft := &persist.NFTDB{
+	nft := persist.NFTDB{
 		OwnerAddress: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
 		Name:         "test",
 	}
 	nftID, err := tc.repos.nftRepository.Create(context.Background(), nft)
 
-	coll := &persist.CollectionDB{
+	coll := persist.CollectionDB{
 		Nfts:        []persist.DBID{nftID},
 		Name:        "test-coll",
 		OwnerUserID: userID,
@@ -261,7 +261,7 @@ func TestUserRemoveAddresses_Success(t *testing.T) {
 func TestUserRemoveAddresses_NotOwnAddress_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")), "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
 	}
 	userID, err := tc.repos.userRepository.Create(context.Background(), user)
@@ -282,7 +282,7 @@ func TestUserRemoveAddresses_NotOwnAddress_Failure(t *testing.T) {
 func TestUserRemoveAddresses_AllAddresses_Failure(t *testing.T) {
 	assert := setupTest(t)
 
-	user := &persist.User{
+	user := persist.User{
 		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")), "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
 	}
 	userID, err := tc.repos.userRepository.Create(context.Background(), user)

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -39,7 +39,7 @@ func generateTestUser(repos *repositories, username string) *TestUser {
 	ctx := context.Background()
 
 	address := persist.Address(strings.ToLower(fmt.Sprintf("0x%s", util.RandStringBytes(40))))
-	user := &persist.User{
+	user := persist.User{
 		UserName:           username,
 		UserNameIdempotent: strings.ToLower(username),
 		Addresses:          []persist.Address{address},


### PR DESCRIPTION
Changes:

- **Changed** most uses of pointers to not use pointers because pointers should only be used only when one of the following conditions is met:

1. Another function needs to update the value pointed to by the pointer and the calling function needs to reflect that update
2. The pointer is pointing to a very large struct that would be cheaper to copy a pointer than copy the entire struct
3. When emptiness or null-ness needs to be represented and can't be with the zero value of the value's type

At first I thought that because some of our structs can get quite large that we should be using pointer for most of them but after learning more about how pointers work, it will be cheaper to not use them because they will consistently go to another part of memory every time they are copied (heap memory) where as without pointers the copies stay on the stack. The go compiler also optimizes for copies and often ends up not copying whole structs anyway. Finally, our structs are mostly large because of large arrays or maps and maps and arrays are always reference values so when a struct is copied with an array field or map field the struct copies the pointer to the array or map and not every value stored in the array or map. This means most of our structs are actually quite small.