### PR TITLE
add caching for user nfts

### DIFF
--- a/server/opensea.go
+++ b/server/opensea.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/sirupsen/logrus"
 )
 
 // mongodb.GLRYnft struct tags reflect the json data of an open sea response and therefore
@@ -107,26 +106,21 @@ func openSeaPipelineAssetsForAcc(pCtx context.Context, pUserID persist.DBID, pOw
 		pOwnerWalletAddresses = user.Addresses
 	}
 
-	logrus.WithField("owner_wallet_addresses", pOwnerWalletAddresses).Info("getting opensea assets for user")
-
 	asDBNfts, err := openseaFetchAssetsForWallets(pCtx, pOwnerWalletAddresses, nftRepo)
 	if err != nil {
 		return nil, err
 	}
 
-	ids, err := nftRepo.BulkUpsert(pCtx, asDBNfts)
+	ids, err := nftRepo.BulkUpsert(pCtx, pUserID, asDBNfts)
 	if err != nil {
 		return nil, err
 	}
 
 	// update other user's collections and this user's collection so that they and ONLY they can display these
 	// specific NFTs while also ensuring that NFTs they don't own don't list them as the owner
-	go func() {
-		if err := collRepo.ClaimNFTs(pCtx, pUserID, pOwnerWalletAddresses, persist.CollectionUpdateNftsInput{Nfts: ids}); err != nil {
-			logrus.WithFields(logrus.Fields{"method": "openSeaPipelineAssetsForAcc"}).Errorf("failed to claim nfts: %v", err)
-			return
-		}
-	}()
+	if err := collRepo.ClaimNFTs(pCtx, pUserID, pOwnerWalletAddresses, persist.CollectionUpdateNftsInput{Nfts: ids}); err != nil {
+		return nil, err
+	}
 
 	result, err := dbToGalleryNFTs(pCtx, asDBNfts, user, nftRepo)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -108,18 +108,20 @@ func newRepos() *repositories {
 	mgoClient := newMongoClient()
 	openseaCache, unassignedCache, galleriesCache := redis.NewCache(0), redis.NewCache(1), redis.NewCache(2)
 	galleriesCacheToken, unassignedCacheToken := redis.NewCache(3), redis.NewCache(4)
+	nftsCache := redis.NewCache(5)
 	galleryTokenRepo := mongodb.NewGalleryTokenMongoRepository(mgoClient, galleriesCacheToken)
 	galleryRepo := mongodb.NewGalleryMongoRepository(mgoClient, galleriesCache)
+	nftRepo := mongodb.NewNFTMongoRepository(mgoClient, nftsCache, openseaCache, galleryRepo)
 	return &repositories{
 		nonceRepository:           mongodb.NewNonceMongoRepository(mgoClient),
 		loginRepository:           mongodb.NewLoginMongoRepository(mgoClient),
-		collectionRepository:      mongodb.NewCollectionMongoRepository(mgoClient, unassignedCache, galleryRepo),
+		collectionRepository:      mongodb.NewCollectionMongoRepository(mgoClient, unassignedCache, galleryRepo, nftRepo),
 		tokenRepository:           mongodb.NewTokenMongoRepository(mgoClient, galleryTokenRepo),
 		collectionTokenRepository: mongodb.NewCollectionTokenMongoRepository(mgoClient, unassignedCacheToken, galleryTokenRepo),
 		galleryTokenRepository:    galleryTokenRepo,
 		galleryRepository:         galleryRepo,
 		historyRepository:         mongodb.NewHistoryMongoRepository(mgoClient),
-		nftRepository:             mongodb.NewNFTMongoRepository(mgoClient, openseaCache, galleryRepo),
+		nftRepository:             nftRepo,
 		userRepository:            mongodb.NewUserMongoRepository(mgoClient),
 		accountRepository:         mongodb.NewAccountMongoRepository(mgoClient),
 		contractRepository:        mongodb.NewContractMongoRepository(mgoClient),

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
@@ -19,48 +20,36 @@ func TestOpenseaSync_Success(t *testing.T) {
 
 	mike := persist.User{UserNameIdempotent: "mikey", UserName: "mikey", Addresses: []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}}
 	robin := persist.User{UserName: "robin", UserNameIdempotent: "robin", Addresses: []persist.Address{persist.Address(strings.ToLower("0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"))}}
-	gianna := persist.User{UserName: "gianna", UserNameIdempotent: "gianna", Addresses: []persist.Address{persist.Address(strings.ToLower("0xdd33e6fd03983c970ae5e647df07314435d69f6b"))}}
 
 	robinUserID, err := tc.repos.userRepository.Create(ctx, robin)
 	assert.Nil(err)
-	giannaUserID, err := tc.repos.userRepository.Create(ctx, gianna)
-	assert.Nil(err)
+
 	mikeUserID, err := tc.repos.userRepository.Create(ctx, mike)
 	assert.Nil(err)
 
-	nft := persist.NFTDB{
-		OwnerAddress: "0xdd33e6fd03983c970ae5e647df07314435d69f6b",
-		Name:         "kks",
-		OpenseaID:    34147626,
-	}
-
-	nft2 := persist.NFTDB{
+	nft1 := persist.NFTDB{
 		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
 		Name:         "malsjdlaksjd",
 		OpenseaID:    46062326,
 	}
-	nft3 := persist.NFTDB{
+	nft2 := persist.NFTDB{
 		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
 		Name:         "asdjasdasd",
 		OpenseaID:    46062320,
 	}
 
-	nft4 := persist.NFTDB{
+	nft3 := persist.NFTDB{
 		OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
 		Name:         "asdasdasd",
 		OpenseaID:    46062322,
 	}
 
-	ids, err := tc.repos.nftRepository.CreateBulk(ctx, []persist.NFTDB{nft, nft2, nft3, nft4})
+	ids, err := tc.repos.nftRepository.CreateBulk(ctx, []persist.NFTDB{nft1, nft2, nft3})
 	assert.Nil(err)
 
-	coll := persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", Nfts: []persist.DBID{ids[3]}}
+	coll := persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", Nfts: []persist.DBID{ids[1]}}
 	collID, err := tc.repos.collectionRepository.Create(ctx, coll)
 	assert.Nil(err)
-
-	now, err := tc.repos.nftRepository.GetByUserID(ctx, giannaUserID)
-	assert.Nil(err)
-	assert.Len(now, 1)
 
 	robinOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, robinUserID, []persist.Address{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
 	assert.Nil(err)
@@ -68,22 +57,24 @@ func TestOpenseaSync_Success(t *testing.T) {
 	mikeOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, mikeUserID, []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
 	assert.Nil(err)
 
+	time.Sleep(time.Second * 3)
+
 	mikeColl, err := tc.repos.collectionRepository.GetByID(ctx, collID, true)
 	assert.Nil(err)
 	assert.Len(mikeColl.Nfts, 0)
 
-	nftsByUser, err := tc.repos.nftRepository.GetByUserID(ctx, robinUserID)
+	robinNFTs, err := tc.repos.nftRepository.GetByUserID(ctx, robinUserID)
 	assert.Nil(err)
 
-	nftsByUserThree, err := tc.repos.nftRepository.GetByUserID(ctx, mikeUserID)
+	mikeNFTs, err := tc.repos.nftRepository.GetByUserID(ctx, mikeUserID)
 	assert.Nil(err)
 
 	ids1 := make([]int, len(robinOpenseaNFTs))
-	ids2 := make([]int, len(nftsByUser))
+	ids2 := make([]int, len(robinNFTs))
 	for i, nft := range robinOpenseaNFTs {
 		ids1[i] = nft.OpenSeaID
 	}
-	for i, nft := range nftsByUser {
+	for i, nft := range robinNFTs {
 		ids2[i] = nft.OpenSeaID
 	}
 
@@ -104,11 +95,11 @@ func TestOpenseaSync_Success(t *testing.T) {
 
 	log.Println("DIF", arrayDiff(ids1, ids2))
 
-	assert.Len(robinOpenseaNFTs, len(nftsByUser))
+	assert.Len(robinOpenseaNFTs, len(robinNFTs))
 
-	assert.Len(mikeOpenseaNFTs, len(nftsByUserThree))
+	assert.Len(mikeOpenseaNFTs, len(mikeNFTs))
 
-	assert.Greater(len(nftsByUserThree), 0)
+	assert.Greater(len(mikeNFTs), 0)
 
 }
 

--- a/service/memstore/tasks.go
+++ b/service/memstore/tasks.go
@@ -104,6 +104,11 @@ func (uq *UpdateQueue) start() {
 func (uq *UpdateQueue) Stop() {
 	close(uq.updates)
 	uq.wg.Wait()
+	uq.poolMu.Lock()
+	defer uq.poolMu.Unlock()
+	for _, pool := range uq.pools {
+		pool.StopWait()
+	}
 }
 
 // QueueUpdate queues an update to be run

--- a/service/persist/mongodb/gallery_nft.go
+++ b/service/persist/mongodb/gallery_nft.go
@@ -141,9 +141,6 @@ func (g *GalleryMongoRepository) GetByID(pCtx context.Context, pID persist.DBID)
 }
 
 func (g *GalleryMongoRepository) resetCache(pCtx context.Context, ownerUserID persist.DBID) error {
-	if ownerUserID == "" {
-		return errNoUserIDProvided
-	}
 	_, err := g.getByUserIDSkipCache(pCtx, ownerUserID)
 	if err != nil {
 		return err

--- a/service/persist/mongodb/gallery_token.go
+++ b/service/persist/mongodb/gallery_token.go
@@ -152,9 +152,6 @@ func (g *GalleryTokenMongoRepository) GetByID(pCtx context.Context, pID persist.
 }
 
 func (g *GalleryTokenMongoRepository) resetCache(pCtx context.Context, ownerUserID persist.DBID) error {
-	if ownerUserID == "" {
-		return errNoUserIDProvided
-	}
 	_, err := g.getByUserIDSkipCache(pCtx, ownerUserID)
 	if err != nil {
 		return err

--- a/service/persist/mongodb/nft.go
+++ b/service/persist/mongodb/nft.go
@@ -60,24 +60,24 @@ func (n *NFTMongoRepository) CreateBulk(pCtx context.Context, pNfts []persist.NF
 		return nil, err
 	}
 
-	// go func() {
-	// 	usersFound := map[persist.DBID]bool{}
-	// 	for _, v := range pNfts {
-	// 		if v.OwnerAddress != "" {
-	// 			users := []persist.User{}
-	// 			err := n.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": v.OwnerAddress}}, &users)
-	// 			if err != nil {
-	// 				continue
-	// 			}
-	// 			for _, u := range users {
-	// 				if u.ID != "" && !usersFound[u.ID] {
-	// 					usersFound[u.ID] = true
-	// 					n.resetCache(pCtx, u.ID)
-	// 				}
-	// 			}
-	// 		}
-	// 	}
-	// }()
+	go func() {
+		usersFound := map[persist.DBID]bool{}
+		for _, v := range pNfts {
+			if v.OwnerAddress != "" {
+				users := []persist.User{}
+				err := n.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": v.OwnerAddress}}, &users)
+				if err != nil {
+					continue
+				}
+				for _, u := range users {
+					if u.ID != "" && !usersFound[u.ID] {
+						usersFound[u.ID] = true
+						n.resetCache(pCtx, u.ID)
+					}
+				}
+			}
+		}
+	}()
 	return ids, nil
 }
 

--- a/service/persist/mongodb/nft.go
+++ b/service/persist/mongodb/nft.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/mikeydub/go-gallery/service/memstore"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -16,23 +18,29 @@ const (
 	nftColName = "nfts"
 )
 
+var nftsTTL = time.Hour * 24
+
 var errOwnerAddressRequired = errors.New("owner address required")
 
 // NFTMongoRepository is a repository that stores collections in a MongoDB database
 type NFTMongoRepository struct {
-	nftsStorage  *storage
-	usersStorage *storage
-	openseaCache memstore.Cache
-	galleryRepo  *GalleryMongoRepository
+	nftsStorage          *storage
+	usersStorage         *storage
+	openseaCache         memstore.Cache
+	nftsCache            memstore.Cache
+	nftsCacheUpdateQueue *memstore.UpdateQueue
+	galleryRepo          *GalleryMongoRepository
 }
 
 // NewNFTMongoRepository creates a new instance of the collection mongo repository
-func NewNFTMongoRepository(mgoClient *mongo.Client, openseaCache memstore.Cache, galleryRepo *GalleryMongoRepository) *NFTMongoRepository {
+func NewNFTMongoRepository(mgoClient *mongo.Client, nftscache, openseaCache memstore.Cache, galleryRepo *GalleryMongoRepository) *NFTMongoRepository {
 	return &NFTMongoRepository{
-		nftsStorage:  newStorage(mgoClient, 0, galleryDBName, nftColName),
-		usersStorage: newStorage(mgoClient, 0, galleryDBName, usersCollName),
-		openseaCache: openseaCache,
-		galleryRepo:  galleryRepo,
+		nftsStorage:          newStorage(mgoClient, 0, galleryDBName, nftColName),
+		usersStorage:         newStorage(mgoClient, 0, galleryDBName, usersCollName),
+		nftsCache:            nftscache,
+		nftsCacheUpdateQueue: memstore.NewUpdateQueue(nftscache),
+		openseaCache:         openseaCache,
+		galleryRepo:          galleryRepo,
 	}
 }
 
@@ -51,16 +59,72 @@ func (n *NFTMongoRepository) CreateBulk(pCtx context.Context, pNfts []persist.NF
 	if err != nil {
 		return nil, err
 	}
+
+	// go func() {
+	// 	usersFound := map[persist.DBID]bool{}
+	// 	for _, v := range pNfts {
+	// 		if v.OwnerAddress != "" {
+	// 			users := []persist.User{}
+	// 			err := n.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": v.OwnerAddress}}, &users)
+	// 			if err != nil {
+	// 				continue
+	// 			}
+	// 			for _, u := range users {
+	// 				if u.ID != "" && !usersFound[u.ID] {
+	// 					usersFound[u.ID] = true
+	// 					n.resetCache(pCtx, u.ID)
+	// 				}
+	// 			}
+	// 		}
+	// 	}
+	// }()
 	return ids, nil
 }
 
 // Create inserts an NFT into the database
 func (n *NFTMongoRepository) Create(pCtx context.Context, pNFT persist.NFTDB) (persist.DBID, error) {
-	return n.nftsStorage.insert(pCtx, pNFT)
+	id, err := n.nftsStorage.insert(pCtx, pNFT)
+	if err != nil {
+		return "", err
+	}
+	go func() {
+		if pNFT.OwnerAddress != "" {
+			users := []persist.User{}
+			err := n.usersStorage.find(pCtx, bson.M{"addresses": bson.M{"$in": pNFT.OwnerAddress}}, &users)
+			if err != nil {
+				return
+			}
+			for _, u := range users {
+				if u.ID != "" {
+					n.resetCache(pCtx, u.ID)
+				}
+			}
+		}
+	}()
+	return id, nil
 }
 
 // GetByUserID finds an nft by its owner user id
 func (n *NFTMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.DBID) ([]persist.NFT, error) {
+
+	nftsJSON, err := n.nftsCache.Get(pCtx, pUserID.String())
+	if err == nil && len(nftsJSON) > 0 {
+		nfts := []persist.NFT{}
+		err = json.Unmarshal(nftsJSON, &nfts)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(nfts) > 0 {
+			return nfts, nil
+		}
+	}
+
+	return n.getByUserIDSkipCache(pCtx, pUserID)
+}
+
+// GetByUserID finds an nft by its owner user id
+func (n *NFTMongoRepository) getByUserIDSkipCache(pCtx context.Context, pUserID persist.DBID) ([]persist.NFT, error) {
 
 	users := []persist.User{}
 	err := n.usersStorage.find(pCtx, bson.M{"_id": pUserID}, &users)
@@ -71,7 +135,19 @@ func (n *NFTMongoRepository) GetByUserID(pCtx context.Context, pUserID persist.D
 		return nil, persist.ErrUserNotFoundByID{ID: pUserID}
 	}
 
-	return n.GetByAddresses(pCtx, users[0].Addresses)
+	nfts, err := n.GetByAddresses(pCtx, users[0].Addresses)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		asJSON, err := json.Marshal(nfts)
+		if err != nil {
+			logrus.WithError(err).Error("failed to marshal nfts")
+			return
+		}
+		n.nftsCacheUpdateQueue.QueueUpdate(pUserID.String(), asJSON, nftsTTL)
+	}()
+	return nfts, nil
 }
 
 // GetByAddresses finds an nft by its owner user id
@@ -147,12 +223,13 @@ func (n *NFTMongoRepository) UpdateByID(pCtx context.Context, pID persist.DBID, 
 		return err
 	}
 	go n.galleryRepo.resetCache(pCtx, pUserID)
+	go n.resetCache(pCtx, pUserID)
 	return nil
 }
 
 // BulkUpsert will create a bulk operation on the database to upsert many nfts for a given wallet address
 // This function's primary purpose is to be used when syncing a user's NFTs from an external provider
-func (n *NFTMongoRepository) BulkUpsert(pCtx context.Context, pNfts []persist.NFTDB) ([]persist.DBID, error) {
+func (n *NFTMongoRepository) BulkUpsert(pCtx context.Context, pUserID persist.DBID, pNfts []persist.NFTDB) ([]persist.DBID, error) {
 
 	ids := make(chan persist.DBID)
 	errs := make(chan error)
@@ -181,11 +258,14 @@ func (n *NFTMongoRepository) BulkUpsert(pCtx context.Context, pNfts []persist.NF
 		}
 	}
 
+	go n.resetCache(pCtx, pUserID)
+
 	return result, nil
 
 }
 
-// OpenseaCacheSet adds a set of nfts to the opensea cache under a given set of wallet addresses
+// OpenseaCacheSet adds a set of nfts to the opensea cache under a given set of wallet addresses as well as ensures
+// that the nfts for user cache is most up to date
 func (n *NFTMongoRepository) OpenseaCacheSet(pCtx context.Context, pWalletAddresses []persist.Address, pNfts []persist.NFT) error {
 	for i, v := range pWalletAddresses {
 		pWalletAddresses[i] = v
@@ -226,6 +306,14 @@ func (n *NFTMongoRepository) OpenseaCacheGet(pCtx context.Context, pWalletAddres
 		return nil, err
 	}
 	return nfts, nil
+}
+
+func (n *NFTMongoRepository) resetCache(pCtx context.Context, pUserID persist.DBID) error {
+	_, err := n.getByUserIDSkipCache(pCtx, pUserID)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func newNFTPipeline(matchFilter bson.M) mongo.Pipeline {

--- a/service/persist/nft.go
+++ b/service/persist/nft.go
@@ -143,7 +143,7 @@ type NFTRepository interface {
 	GetByContractData(context.Context, TokenID, Address) ([]NFT, error)
 	GetByOpenseaID(context.Context, int, Address) ([]NFT, error)
 	UpdateByID(context.Context, DBID, DBID, interface{}) error
-	BulkUpsert(context.Context, []NFTDB) ([]DBID, error)
+	BulkUpsert(context.Context, DBID, []NFTDB) ([]DBID, error)
 	OpenseaCacheGet(context.Context, []Address) ([]NFT, error)
 	OpenseaCacheSet(context.Context, []Address, []NFT) error
 	OpenseaCacheDelete(context.Context, []Address) error


### PR DESCRIPTION
Changes:

- **Added** caching for getting nfts by user ID
- **Change** memory store task queue to ensure synchronous updates by key. This means that although many updates can be running asynchronously for different keys, no more than one update can be run at a time per key. This is to ensure that when updates come in for a given key, the most recent update will be the one that will be reflected in the cache.
 