### PR TITLE
fix TestUserLoginGnosis_Success

### DIFF
--- a/server/t__routes_auth_test.go
+++ b/server/t__routes_auth_test.go
@@ -216,14 +216,14 @@ func TestUserLoginGnosis_WrongNonce_Failure(t *testing.T) {
 	assert.Nil(err)
 
 	nonce := persist.UserNonce{
-		Value:   "TEST NONCE Wrong",
+		Value:   "TEST NONCE",
 		Address: user.Addresses[0],
 	}
 	err = tc.repos.nonceRepository.Create(context.Background(), nonce)
 	assert.Nil(err)
 
 	resp := loginRequest(assert, "", "0x", nonce.Address, auth.WalletTypeGnosis)
-	assertValidResponse(assert, resp)
+	assertErrorResponse(assert, resp)
 
 	type LoginOutput struct {
 		auth.LoginOutput
@@ -252,8 +252,8 @@ func TestUserLoginGnosis_WrongSig_Failure(t *testing.T) {
 	err = tc.repos.nonceRepository.Create(context.Background(), nonce)
 	assert.Nil(err)
 
-	resp := loginRequest(assert, "", "Blah Blah Blah", nonce.Address, auth.WalletTypeGnosis)
-	assertValidResponse(assert, resp)
+	resp := loginRequest(assert, "", " TEST NONCE", nonce.Address, auth.WalletTypeGnosis)
+	assertErrorResponse(assert, resp)
 
 	type LoginOutput struct {
 		auth.LoginOutput

--- a/server/t__routes_auth_test.go
+++ b/server/t__routes_auth_test.go
@@ -184,13 +184,13 @@ func TestUserLoginGnosis_Success(t *testing.T) {
 	assert.Nil(err)
 
 	nonce := persist.UserNonce{
-		Value:   " TEST NONCE",
+		Value:   "TEST NONCE",
 		Address: user.Addresses[0],
 	}
 	err = tc.repos.nonceRepository.Create(context.Background(), nonce)
 	assert.Nil(err)
 
-	resp := loginRequest(assert, "", " TEST NONCE", nonce.Address, auth.WalletTypeGnosis)
+	resp := loginRequest(assert, "", "Gallery uses this cryptographic signature in place of a password, verifying that you are the owner of this Ethereum address: TEST NONCE", nonce.Address, auth.WalletTypeGnosis)
 	assertValidResponse(assert, resp)
 
 	type LoginOutput struct {


### PR DESCRIPTION
fixed TestUserLoginGnosis_Success

it looks like  `TestUserLoginGnosis_WrongNonce_Failure` and `TestUserLoginGnosis_WrongSig_Failure` expect 200s, but I think it should throw 400 for these cases?