### PR TITLE
return more user data if possible for membership tiers

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -37,7 +37,7 @@ func authHandlersInitToken(parent *gin.RouterGroup, repos *repositories, ethClie
 	usersGroup.POST("/update/addresses/add", middleware.JWTRequired(repos.userRepository, ethClient), addUserAddress(repos.userRepository, repos.nonceRepository, ethClient.EthClient))
 	usersGroup.POST("/update/addresses/remove", middleware.JWTRequired(repos.userRepository, ethClient), removeAddressesToken(repos.userRepository, repos.collectionTokenRepository))
 	usersGroup.GET("/get", middleware.JWTOptional(), getUser(repos.userRepository))
-	usersGroup.GET("/membership", getMembershipTiers(repos.membershipRepository, repos.userRepository, ethClient))
+	usersGroup.GET("/membership", getMembershipTiersToken(repos.membershipRepository, repos.userRepository, repos.tokenRepository, ethClient))
 	usersGroup.POST("/create", createUserToken(repos.userRepository, repos.nonceRepository, repos.galleryTokenRepository, psub, ethClient.EthClient))
 
 }
@@ -60,7 +60,7 @@ func authHandlersInitNFT(parent *gin.RouterGroup, repos *repositories, ethClient
 	usersGroup.POST("/update/addresses/add", middleware.JWTRequired(repos.userRepository, ethClient), addUserAddress(repos.userRepository, repos.nonceRepository, ethClient.EthClient))
 	usersGroup.POST("/update/addresses/remove", middleware.JWTRequired(repos.userRepository, ethClient), removeAddresses(repos.userRepository, repos.collectionRepository))
 	usersGroup.GET("/get", middleware.JWTOptional(), getUser(repos.userRepository))
-	usersGroup.GET("/membership", getMembershipTiers(repos.membershipRepository, repos.userRepository, ethClient))
+	usersGroup.GET("/membership", getMembershipTiers(repos.membershipRepository, repos.userRepository, repos.nftRepository, ethClient))
 	usersGroup.POST("/create", createUser(repos.userRepository, repos.nonceRepository, repos.galleryRepository, psub, ethClient.EthClient))
 
 }

--- a/server/handler.go
+++ b/server/handler.go
@@ -138,7 +138,7 @@ func nftHandlersInit(parent *gin.RouterGroup, repos *repositories, ethClient *et
 	nftsGroup.GET("/get", middleware.JWTOptional(), getNftByID(repos.nftRepository))
 	nftsGroup.GET("/user_get", middleware.JWTOptional(), getNftsForUser(repos.nftRepository))
 	nftsGroup.GET("/opensea/get", middleware.JWTRequired(repos.userRepository, ethClient), getNftsFromOpensea(repos.nftRepository, repos.userRepository, repos.collectionRepository, repos.historyRepository))
-	nftsGroup.POST("/opensea/refresh", middleware.RateLimited(), middleware.JWTRequired(repos.userRepository, ethClient), refreshOpenseaNFTs(repos.nftRepository, repos.userRepository))
+	nftsGroup.POST("/opensea/refresh", middleware.JWTRequired(repos.userRepository, ethClient), refreshOpenseaNFTs(repos.nftRepository, repos.userRepository))
 	nftsGroup.POST("/update", middleware.JWTRequired(repos.userRepository, ethClient), updateNftByID(repos.nftRepository))
 	nftsGroup.GET("/unassigned/get", middleware.JWTRequired(repos.userRepository, ethClient), getUnassignedNftsForUser(repos.collectionRepository))
 	nftsGroup.POST("/unassigned/refresh", middleware.JWTRequired(repos.userRepository, ethClient), refreshUnassignedNftsForUser(repos.collectionRepository))

--- a/server/membership.go
+++ b/server/membership.go
@@ -1,24 +1,21 @@
 package server
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/mikeydub/go-gallery/middleware"
 	"github.com/mikeydub/go-gallery/service/eth"
+	"github.com/mikeydub/go-gallery/service/membership"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 type getMembershipTiersResponse struct {
 	Tiers []persist.MembershipTier `json:"tiers"`
 }
 
-func getMembershipTiers(membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, ethClient *eth.Client) gin.HandlerFunc {
+func getMembershipTiers(membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, nftRepository persist.NFTRepository, ethClient *eth.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		allTiers, err := membershipRepository.GetAll(c)
 		if err != nil {
@@ -35,12 +32,12 @@ func getMembershipTiers(membershipRepository persist.MembershipRepository, userR
 				}
 			}
 			if !updatedRecently {
-				go updateMembershipTiers(c.Copy(), membershipRepository, userRepository, ethClient)
+				go membership.UpdateMembershipTiers(c.Copy(), membershipRepository, userRepository, nftRepository, ethClient)
 			}
 			c.JSON(http.StatusOK, getMembershipTiersResponse{Tiers: allTiers})
 			return
 		}
-		membershipTiers, err := updateMembershipTiers(c, membershipRepository, userRepository, ethClient)
+		membershipTiers, err := membership.UpdateMembershipTiers(c, membershipRepository, userRepository, nftRepository, ethClient)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return
@@ -49,101 +46,33 @@ func getMembershipTiers(membershipRepository persist.MembershipRepository, userR
 	}
 }
 
-func updateMembershipTiers(pCtx context.Context, membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, ethClient *eth.Client) ([]persist.MembershipTier, error) {
-	membershipTiers := make([]persist.MembershipTier, len(middleware.RequiredNFTs))
-	tierChan := make(chan persist.MembershipTier)
-	for _, v := range middleware.RequiredNFTs {
-		go func(id persist.TokenID) {
-			tier := persist.MembershipTier{
-				TokenID: id,
-			}
-
-			events, err := openseaFetchMembershipCards(persist.Address(viper.GetString("CONTRACT_ADDRESS")), persist.TokenID(id), 0)
-			if err != nil || len(events) == 0 {
-				tierChan <- tier
-				return
-			}
-			asset := events[0].Asset
-			tier.Name = asset.Name
-			tier.AssetURL = asset.ImageURL
-			tier.Owners = []string{}
-
-			ownersChan := make(chan []string)
-			for _, e := range events {
-				go func(event openseaEvent) {
-					owners := []string{}
-					hasNFT, _ := ethClient.HasNFT(pCtx, id, event.FromAccount.Address)
-					if hasNFT {
-						if glryUser, err := userRepository.GetByAddress(pCtx, event.FromAccount.Address); err == nil && glryUser.UserName != "" {
-							owners = append(owners, glryUser.UserName)
-						} else {
-							owners = append(owners, event.FromAccount.Address.String())
-						}
-					}
-					hasNFT, _ = ethClient.HasNFT(pCtx, id, event.ToAccount.Address)
-					if hasNFT {
-						if glryUser, err := userRepository.GetByAddress(pCtx, event.ToAccount.Address); err == nil && glryUser.UserName != "" {
-							owners = append(owners, glryUser.UserName)
-						} else {
-							owners = append(owners, event.ToAccount.Address.String())
-						}
-					}
-					ownersChan <- owners
-				}(e)
-			}
-			for i := 0; i < len(events); i++ {
-				incomingOwners := <-ownersChan
-				tier.Owners = append(tier.Owners, incomingOwners...)
-			}
-			go membershipRepository.UpsertByTokenID(pCtx, id, tier)
-			tierChan <- tier
-		}(v)
-	}
-
-	for i := 0; i < len(middleware.RequiredNFTs); i++ {
-		membershipTiers[i] = <-tierChan
-	}
-	return membershipTiers, nil
-}
-
-// recursively fetches all membership cards for a token ID
-func openseaFetchMembershipCards(contractAddress persist.Address, tokenID persist.TokenID, pOffset int) ([]openseaEvent, error) {
-
-	client := &http.Client{
-		Timeout: time.Second * 5,
-	}
-
-	result := []openseaEvent{}
-
-	urlStr := fmt.Sprintf("https://api.opensea.io/api/v1/events?asset_contract_address=%s&token_id=%s&only_opensea=false&offset=%d&limit=100", contractAddress, tokenID.Base10String(), pOffset)
-
-	req, err := http.NewRequest("GET", urlStr, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected status code: %d - url: %s", resp.StatusCode, urlStr)
-	}
-
-	response := &openseaEvents{}
-	err = util.UnmarshallBody(response, resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	result = append(result, response.Events...)
-	if len(response.Events) == 100 {
-		next, err := openseaFetchMembershipCards(contractAddress, tokenID, pOffset+100)
+func getMembershipTiersToken(membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, nftRepository persist.TokenRepository, ethClient *eth.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		allTiers, err := membershipRepository.GetAll(c)
 		if err != nil {
-			return nil, err
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
 		}
-		result = append(result, next...)
-	}
+		if len(allTiers) > 0 {
+			updatedRecently := true
+			for _, tier := range allTiers {
 
-	return result, nil
+				if time.Since(time.Time(tier.LastUpdated)) > time.Hour {
+					updatedRecently = false
+					break
+				}
+			}
+			if !updatedRecently {
+				go membership.UpdateMembershipTiersToken(c.Copy(), membershipRepository, userRepository, nftRepository, ethClient)
+			}
+			c.JSON(http.StatusOK, getMembershipTiersResponse{Tiers: allTiers})
+			return
+		}
+		membershipTiers, err := membership.UpdateMembershipTiersToken(c, membershipRepository, userRepository, nftRepository, ethClient)
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+		c.JSON(http.StatusOK, getMembershipTiersResponse{Tiers: membershipTiers})
+	}
 }

--- a/server/nft.go
+++ b/server/nft.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/middleware"
+	"github.com/mikeydub/go-gallery/service/opensea"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/mongodb"
 	"github.com/mikeydub/go-gallery/util"
@@ -199,7 +200,7 @@ func getNftsFromOpensea(nftRepo persist.NFTRepository, userRepo persist.UserRepo
 			}
 		}
 
-		nfts, err := openSeaPipelineAssetsForAcc(c, userID, addresses, nftRepo, userRepo, collRepo, historyRepo)
+		nfts, err := opensea.PipelineAssetsForAcc(c, userID, addresses, nftRepo, userRepo, collRepo, historyRepo)
 		if nfts == nil || err != nil {
 			nfts = []persist.NFT{}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -61,7 +61,7 @@ func CoreInit() *gin.Engine {
 	setDefaults()
 
 	router := gin.Default()
-	router.Use(middleware.HandleCORS(), middleware.ErrLogger(), middleware.RateLimited())
+	router.Use(middleware.HandleCORS(), middleware.ErrLogger())
 
 	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
 		log.Info("registering validation")

--- a/server/server.go
+++ b/server/server.go
@@ -61,7 +61,7 @@ func CoreInit() *gin.Engine {
 	setDefaults()
 
 	router := gin.Default()
-	router.Use(middleware.HandleCORS(), middleware.ErrLogger())
+	router.Use(middleware.HandleCORS(), middleware.ErrLogger(), middleware.RateLimited())
 
 	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
 		log.Info("registering validation")

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mikeydub/go-gallery/service/opensea"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,24 +101,6 @@ func TestOpenseaSync_Success(t *testing.T) {
 
 	assert.Greater(len(mikeNFTs), 0)
 
-}
-
-func TestOpenseaRateLimit_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-	var resp *http.Response
-	for i := 0; i < 100; i++ {
-		resp = openseaSyncRequest(assert, tc.user1.address, tc.user1.jwt)
-	}
-	assertErrorResponse(assert, resp)
-	type OpenseaSyncResp struct {
-		getNftsOutput
-		Error string `json:"error"`
-	}
-	output := &OpenseaSyncResp{}
-	err := util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.NotEmpty(output.Error)
-	assert.Equal(output.Error, "rate limited")
 }
 
 func openseaSyncRequest(assert *assert.Assertions, address persist.Address, jwt string) *http.Response {

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mikeydub/go-gallery/service/opensea"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/stretchr/testify/assert"
@@ -51,10 +52,10 @@ func TestOpenseaSync_Success(t *testing.T) {
 	collID, err := tc.repos.collectionRepository.Create(ctx, coll)
 	assert.Nil(err)
 
-	robinOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, robinUserID, []persist.Address{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
+	robinOpenseaNFTs, err := opensea.PipelineAssetsForAcc(ctx, robinUserID, []persist.Address{"0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15"}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
 	assert.Nil(err)
 
-	mikeOpenseaNFTs, err := openSeaPipelineAssetsForAcc(ctx, mikeUserID, []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
+	mikeOpenseaNFTs, err := opensea.PipelineAssetsForAcc(ctx, mikeUserID, []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}, tc.repos.nftRepository, tc.repos.userRepository, tc.repos.collectionRepository, tc.repos.historyRepository)
 	assert.Nil(err)
 
 	time.Sleep(time.Second * 3)

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -104,8 +104,7 @@ func UpdateMembershipTiers(pCtx context.Context, membershipRepository persist.Me
 				}(e)
 			}
 			for i := 0; i < len(events); i++ {
-				incomingOwners := <-ownersChan
-				tier.Owners = append(tier.Owners, incomingOwners...)
+				tier.Owners = append(tier.Owners, <-ownersChan...)
 			}
 			go membershipRepository.UpsertByTokenID(pCtx, id, tier)
 			tierChan <- tier
@@ -173,8 +172,7 @@ func UpdateMembershipTiersToken(pCtx context.Context, membershipRepository persi
 				}(e)
 			}
 			for i := 0; i < len(tokens); i++ {
-				incomingOwner := <-ownersChan
-				tier.Owners = append(tier.Owners, incomingOwner)
+				tier.Owners = append(tier.Owners, <-ownersChan)
 			}
 			go membershipRepository.UpsertByTokenID(pCtx, id, tier)
 			tierChan <- tier

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -1,0 +1,265 @@
+package membership
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mikeydub/go-gallery/middleware"
+	"github.com/mikeydub/go-gallery/service/eth"
+	"github.com/mikeydub/go-gallery/service/opensea"
+	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/util"
+	"github.com/spf13/viper"
+)
+
+// UpdateMembershipTiers fetches all membership cards for a token ID
+func UpdateMembershipTiers(pCtx context.Context, membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, nftRepository persist.NFTRepository, ethClient *eth.Client) ([]persist.MembershipTier, error) {
+	membershipTiers := make([]persist.MembershipTier, len(middleware.RequiredNFTs))
+	tierChan := make(chan persist.MembershipTier)
+	for _, v := range middleware.RequiredNFTs {
+		go func(id persist.TokenID) {
+			tier := persist.MembershipTier{
+				TokenID: id,
+			}
+
+			events, err := openseaFetchMembershipCards(persist.Address(viper.GetString("CONTRACT_ADDRESS")), persist.TokenID(id), 0)
+			if err != nil || len(events) == 0 {
+				tierChan <- tier
+				return
+			}
+			asset := events[0].Asset
+			tier.Name = asset.Name
+			tier.AssetURL = asset.ImageURL
+			tier.Owners = make([]persist.MembershipOwner, 0, len(events)*2)
+
+			ownersChan := make(chan []persist.MembershipOwner)
+			for _, e := range events {
+				go func(event opensea.Event) {
+					owners := make([]persist.MembershipOwner, 0, 2)
+					hasNFT, _ := ethClient.HasNFT(pCtx, id, event.FromAccount.Address)
+					if hasNFT {
+						membershipOwner := persist.MembershipOwner{}
+						if glryUser, err := userRepository.GetByAddress(pCtx, event.FromAccount.Address); err == nil && glryUser.UserName != "" {
+							membershipOwner.Username = glryUser.UserName
+							membershipOwner.UserID = glryUser.ID
+							membershipOwner.Address = event.FromAccount.Address
+
+							nfts, err := nftRepository.GetByUserID(pCtx, glryUser.ID)
+							if err == nil && len(nfts) > 0 {
+								nftURLs := make([]string, 0, 3)
+								for i, nft := range nfts {
+									if i == 3 {
+										break
+									}
+									if nft.ImagePreviewURL != "" {
+										nftURLs = append(nftURLs, nft.ImagePreviewURL)
+									} else if nft.ImageURL != "" {
+										nftURLs = append(nftURLs, nft.ImageURL)
+									} else {
+										i--
+										continue
+									}
+								}
+								membershipOwner.PreviewNFTs = nftURLs
+							}
+						} else {
+							membershipOwner.Address = event.FromAccount.Address
+						}
+						owners = append(owners, membershipOwner)
+					}
+					hasNFT, _ = ethClient.HasNFT(pCtx, id, event.ToAccount.Address)
+					if hasNFT {
+						membershipOwner := persist.MembershipOwner{}
+						if glryUser, err := userRepository.GetByAddress(pCtx, event.ToAccount.Address); err == nil && glryUser.UserName != "" {
+							membershipOwner.Username = glryUser.UserName
+							membershipOwner.UserID = glryUser.ID
+							membershipOwner.Address = event.FromAccount.Address
+
+							nfts, err := nftRepository.GetByUserID(pCtx, glryUser.ID)
+							if err == nil && len(nfts) > 0 {
+								nftURLs := make([]string, 0, 3)
+								for i, nft := range nfts {
+									if i == 3 {
+										break
+									}
+									if nft.ImagePreviewURL != "" {
+										nftURLs = append(nftURLs, nft.ImagePreviewURL)
+									} else if nft.ImageURL != "" {
+										nftURLs = append(nftURLs, nft.ImageURL)
+									} else {
+										i--
+										continue
+									}
+								}
+								membershipOwner.PreviewNFTs = nftURLs
+							}
+						} else {
+							membershipOwner.Address = event.FromAccount.Address
+						}
+						owners = append(owners, membershipOwner)
+					}
+					ownersChan <- owners
+				}(e)
+			}
+			for i := 0; i < len(events); i++ {
+				incomingOwners := <-ownersChan
+				tier.Owners = append(tier.Owners, incomingOwners...)
+			}
+			go membershipRepository.UpsertByTokenID(pCtx, id, tier)
+			tierChan <- tier
+		}(v)
+	}
+
+	for i := 0; i < len(middleware.RequiredNFTs); i++ {
+		membershipTiers[i] = <-tierChan
+	}
+	return membershipTiers, nil
+}
+
+// UpdateMembershipTiersToken fetches all membership cards for a token ID
+func UpdateMembershipTiersToken(pCtx context.Context, membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, nftRepository persist.TokenRepository, ethClient *eth.Client) ([]persist.MembershipTier, error) {
+	membershipTiers := make([]persist.MembershipTier, len(middleware.RequiredNFTs))
+	tierChan := make(chan persist.MembershipTier)
+	for _, v := range middleware.RequiredNFTs {
+		go func(id persist.TokenID) {
+			tier := persist.MembershipTier{
+				TokenID: id,
+			}
+
+			events, err := openseaFetchMembershipCards(persist.Address(viper.GetString("CONTRACT_ADDRESS")), persist.TokenID(id), 0)
+			if err != nil || len(events) == 0 {
+				tierChan <- tier
+				return
+			}
+			asset := events[0].Asset
+			tier.Name = asset.Name
+			tier.AssetURL = asset.ImageURL
+			tier.Owners = make([]persist.MembershipOwner, 0, len(events)*2)
+
+			ownersChan := make(chan []persist.MembershipOwner)
+			for _, e := range events {
+				go func(event opensea.Event) {
+					owners := make([]persist.MembershipOwner, 0, 2)
+					hasNFT, _ := ethClient.HasNFT(pCtx, id, event.FromAccount.Address)
+					if hasNFT {
+						membershipOwner := persist.MembershipOwner{}
+						if glryUser, err := userRepository.GetByAddress(pCtx, event.FromAccount.Address); err == nil && glryUser.UserName != "" {
+							membershipOwner.Username = glryUser.UserName
+							membershipOwner.UserID = glryUser.ID
+							membershipOwner.Address = event.FromAccount.Address
+
+							nfts, err := nftRepository.GetByUserID(pCtx, glryUser.ID, -1, 0)
+							if err == nil && len(nfts) > 0 {
+								nftURLs := make([]string, 0, 3)
+								for i, nft := range nfts {
+									if i == 3 {
+										break
+									}
+									if nft.Media.PreviewURL != "" {
+										nftURLs = append(nftURLs, nft.Media.PreviewURL)
+									} else if nft.Media.MediaURL != "" {
+										nftURLs = append(nftURLs, nft.Media.MediaURL)
+									} else {
+										i--
+										continue
+									}
+								}
+								membershipOwner.PreviewNFTs = nftURLs
+							}
+						} else {
+							membershipOwner.Address = event.FromAccount.Address
+						}
+						owners = append(owners, membershipOwner)
+					}
+					hasNFT, _ = ethClient.HasNFT(pCtx, id, event.ToAccount.Address)
+					if hasNFT {
+						membershipOwner := persist.MembershipOwner{}
+						if glryUser, err := userRepository.GetByAddress(pCtx, event.ToAccount.Address); err == nil && glryUser.UserName != "" {
+							membershipOwner.Username = glryUser.UserName
+							membershipOwner.UserID = glryUser.ID
+							membershipOwner.Address = event.FromAccount.Address
+
+							nfts, err := nftRepository.GetByUserID(pCtx, glryUser.ID, -1, 0)
+							if err == nil && len(nfts) > 0 {
+								nftURLs := make([]string, 0, 3)
+								for i, nft := range nfts {
+									if i == 3 {
+										break
+									}
+									if nft.Media.PreviewURL != "" {
+										nftURLs = append(nftURLs, nft.Media.PreviewURL)
+									} else if nft.Media.MediaURL != "" {
+										nftURLs = append(nftURLs, nft.Media.MediaURL)
+									} else {
+										i--
+										continue
+									}
+								}
+								membershipOwner.PreviewNFTs = nftURLs
+							}
+						} else {
+							membershipOwner.Address = event.FromAccount.Address
+						}
+						owners = append(owners, membershipOwner)
+					}
+					ownersChan <- owners
+				}(e)
+			}
+			for i := 0; i < len(events); i++ {
+				incomingOwners := <-ownersChan
+				tier.Owners = append(tier.Owners, incomingOwners...)
+			}
+			go membershipRepository.UpsertByTokenID(pCtx, id, tier)
+			tierChan <- tier
+		}(v)
+	}
+
+	for i := 0; i < len(middleware.RequiredNFTs); i++ {
+		membershipTiers[i] = <-tierChan
+	}
+	return membershipTiers, nil
+}
+
+// recursively fetches all membership cards for a token ID
+func openseaFetchMembershipCards(contractAddress persist.Address, tokenID persist.TokenID, pOffset int) ([]opensea.Event, error) {
+
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
+
+	result := []opensea.Event{}
+
+	urlStr := fmt.Sprintf("https://api.opensea.io/api/v1/events?asset_contract_address=%s&token_id=%s&only_opensea=false&offset=%d&limit=100", contractAddress, tokenID.Base10String(), pOffset)
+
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status code: %d - url: %s", resp.StatusCode, urlStr)
+	}
+
+	response := &opensea.Events{}
+	err = util.UnmarshallBody(response, resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	result = append(result, response.Events...)
+	if len(response.Events) == 100 {
+		next, err := openseaFetchMembershipCards(contractAddress, tokenID, pOffset+100)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, next...)
+	}
+
+	return result, nil
+}

--- a/service/persist/membership.go
+++ b/service/persist/membership.go
@@ -10,10 +10,18 @@ type MembershipTier struct {
 	Deleted      bool            `bson:"deleted" json:"-"`
 	LastUpdated  LastUpdatedTime `bson:"last_updated,update_time" json:"last_updated"`
 
-	Name     string   `bson:"name" json:"name"`
-	TokenID  TokenID  `bson:"token_id" json:"token_id"`
-	AssetURL string   `bson:"asset_url" json:"asset_url"`
-	Owners   []string `bson:"owners" json:"owners"`
+	Name     string            `bson:"name" json:"name"`
+	TokenID  TokenID           `bson:"token_id" json:"token_id"`
+	AssetURL string            `bson:"asset_url" json:"asset_url"`
+	Owners   []MembershipOwner `bson:"owners" json:"owners"`
+}
+
+// MembershipOwner represents a user who owns a membership card
+type MembershipOwner struct {
+	UserID      DBID     `bson:"user_id" json:"user_id"`
+	Address     Address  `bson:"address" json:"address"`
+	Username    string   `bson:"username" json:"username"`
+	PreviewNFTs []string `bson:"preview_nfts" json:"preview_nfts"`
 }
 
 // MembershipRepository represents the interface for interacting with the persisted state of users


### PR DESCRIPTION
Changes:

- **Changed** update membership tiers background process to store more data for the potential user who owns a membership card such as:

1. Owner Address (will always be available)
2. Username
3. User ID
4. some preview URLs for NFTs they own 