### PR TITLE
update current tiers with owners, update in order to reduce rate-limiting, insert last_updated

### DIFF
--- a/server/membership.go
+++ b/server/membership.go
@@ -27,6 +27,9 @@ func getMembershipTiers(membershipRepository persist.MembershipRepository, userR
 			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
+		if input.ForceRefresh {
+			logrus.Infof("Force refresh - updating membership tiers")
+		}
 		allTiers, err := membershipRepository.GetAll(c)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
@@ -92,6 +95,9 @@ func getMembershipTiersToken(membershipRepository persist.MembershipRepository, 
 			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
+		if input.ForceRefresh {
+			logrus.Infof("Force refresh - updating membership tiers")
+		}
 		allTiers, err := membershipRepository.GetAll(c)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
@@ -113,12 +119,6 @@ func getMembershipTiersToken(membershipRepository persist.MembershipRepository, 
 						}
 						allTiers = append(allTiers, newTier)
 					}
-				}
-			}
-
-			for _, tier := range allTiers {
-				if time.Since(tier.LastUpdated.Time()) > time.Hour || input.ForceRefresh {
-
 				}
 			}
 

--- a/server/membership.go
+++ b/server/membership.go
@@ -12,12 +12,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type getMembershipTiersInput struct {
+	ForceRefresh bool `form:"refresh"`
+}
+
 type getMembershipTiersResponse struct {
 	Tiers []persist.MembershipTier `json:"tiers"`
 }
 
 func getMembershipTiers(membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, galleryRepository persist.GalleryRepository, ethClient *ethclient.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		var input getMembershipTiersInput
+		if err := c.ShouldBindQuery(&input); err != nil {
+			util.ErrResponse(c, http.StatusBadRequest, err)
+			return
+		}
 		allTiers, err := membershipRepository.GetAll(c)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
@@ -44,10 +53,22 @@ func getMembershipTiers(membershipRepository persist.MembershipRepository, userR
 
 			}
 
+			tiersToUpdate := make([]persist.TokenID, 0, len(allTiers))
 			for _, tier := range allTiers {
-				if time.Since(tier.LastUpdated.Time()) > time.Hour {
-					go membership.UpdateMembershipTier(tier.TokenID, membershipRepository, userRepository, galleryRepository, ethClient)
+				if time.Since(tier.LastUpdated.Time()) > time.Hour || input.ForceRefresh {
+					logrus.Infof("Tier %s not updated in the last hour - updating membership tier", tier.TokenID)
+					tiersToUpdate = append(tiersToUpdate, tier.TokenID)
 				}
+			}
+			if len(tiersToUpdate) > 0 {
+				go func() {
+					for _, tierID := range tiersToUpdate {
+						_, err := membership.UpdateMembershipTier(tierID, membershipRepository, userRepository, galleryRepository, ethClient)
+						if err != nil {
+							logrus.WithError(err).Errorf("Failed to update membership tier %s", tierID)
+						}
+					}
+				}()
 			}
 
 			c.JSON(http.StatusOK, getMembershipTiersResponse{Tiers: membership.OrderMembershipTiers(allTiers)})
@@ -66,6 +87,11 @@ func getMembershipTiers(membershipRepository persist.MembershipRepository, userR
 
 func getMembershipTiersToken(membershipRepository persist.MembershipRepository, userRepository persist.UserRepository, nftRepository persist.TokenRepository, galleryRepository persist.GalleryTokenRepository, ethClient *ethclient.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		var input getMembershipTiersInput
+		if err := c.ShouldBindQuery(&input); err != nil {
+			util.ErrResponse(c, http.StatusBadRequest, err)
+			return
+		}
 		allTiers, err := membershipRepository.GetAll(c)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
@@ -91,9 +117,27 @@ func getMembershipTiersToken(membershipRepository persist.MembershipRepository, 
 			}
 
 			for _, tier := range allTiers {
-				if time.Since(tier.LastUpdated.Time()) > time.Hour {
-					go membership.UpdateMembershipTierToken(tier.TokenID, membershipRepository, userRepository, nftRepository, galleryRepository, ethClient)
+				if time.Since(tier.LastUpdated.Time()) > time.Hour || input.ForceRefresh {
+
 				}
+			}
+
+			tiersToUpdate := make([]persist.TokenID, 0, len(allTiers))
+			for _, tier := range allTiers {
+				if time.Since(tier.LastUpdated.Time()) > time.Hour || input.ForceRefresh {
+					logrus.Infof("Tier %s not updated in the last hour - updating membership tier", tier.TokenID)
+					tiersToUpdate = append(tiersToUpdate, tier.TokenID)
+				}
+			}
+			if len(tiersToUpdate) > 0 {
+				go func() {
+					for _, tierID := range tiersToUpdate {
+						_, err := membership.UpdateMembershipTierToken(tierID, membershipRepository, userRepository, nftRepository, galleryRepository, ethClient)
+						if err != nil {
+							logrus.WithError(err).Errorf("Failed to update membership tier %s", tierID)
+						}
+					}
+				}()
 			}
 
 			c.JSON(http.StatusOK, getMembershipTiersResponse{Tiers: membership.OrderMembershipTiers(allTiers)})

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -32,7 +32,7 @@ func UpdateMembershipTiers(membershipRepository persist.MembershipRepository, us
 	for _, v := range MembershipTierIDs {
 		events, err := OpenseaFetchMembershipCards(PremiumCards, persist.TokenID(v), 0, 0)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to fetch membership cards for token: %s, %w", v, err)
+			return nil, fmt.Errorf("Failed to fetch membership cards for token: %s, %v", v, err)
 		}
 		if len(events) == 0 {
 			continue
@@ -41,7 +41,7 @@ func UpdateMembershipTiers(membershipRepository persist.MembershipRepository, us
 		go func(id persist.TokenID, events []opensea.Event) {
 			tier, err := processEvents(ctx, id, events, ethClient, userRepository, galleryRepository, membershipRepository)
 			if err != nil {
-				logrus.Errorf("Failed to process membership events for token: %s, %w", id, err)
+				logrus.Errorf("Failed to process membership events for token: %s, %v", id, err)
 			}
 			tierChan <- tier
 		}(v, events)
@@ -59,11 +59,11 @@ func UpdateMembershipTier(pTokenID persist.TokenID, membershipRepository persist
 	defer cancel()
 	_, err := processCurrentTier(ctx, pTokenID, ethClient, userRepository, galleryRepository, membershipRepository)
 	if err != nil {
-		return persist.MembershipTier{}, fmt.Errorf("Failed to process membership events for token: %s, %w", pTokenID, err)
+		return persist.MembershipTier{}, fmt.Errorf("Failed to process membership events for token: %s, %v", pTokenID, err)
 	}
 	events, err := OpenseaFetchMembershipCards(PremiumCards, pTokenID, 0, 0)
 	if err != nil {
-		return persist.MembershipTier{}, fmt.Errorf("Failed to fetch membership cards for token: %s, %w", pTokenID, err)
+		return persist.MembershipTier{}, fmt.Errorf("Failed to fetch membership cards for token: %s, %v", pTokenID, err)
 	}
 	if len(events) == 0 {
 		return persist.MembershipTier{}, fmt.Errorf("No membership cards found for token: %s", pTokenID)
@@ -82,7 +82,7 @@ func UpdateMembershipTiersToken(membershipRepository persist.MembershipRepositor
 		go func(id persist.TokenID) {
 			tier, err := processEventsToken(ctx, id, ethClient, userRepository, nftRepository, galleryRepository, membershipRepository)
 			if err != nil {
-				logrus.Errorf("Failed to process membership events for token: %s, %w", id, err)
+				logrus.Errorf("Failed to process membership events for token: %s, %v", id, err)
 			}
 			tierChan <- tier
 		}(v)
@@ -100,11 +100,11 @@ func UpdateMembershipTierToken(pTokenID persist.TokenID, membershipRepository pe
 	defer cancel()
 	_, err := processCurrentTierToken(ctx, pTokenID, ethClient, userRepository, galleryRepository, membershipRepository)
 	if err != nil {
-		return persist.MembershipTier{}, fmt.Errorf("Failed to process membership events for token: %s, %w", pTokenID, err)
+		return persist.MembershipTier{}, fmt.Errorf("Failed to process membership events for token: %s, %v", pTokenID, err)
 	}
 	events, err := OpenseaFetchMembershipCards(PremiumCards, pTokenID, 0, 0)
 	if err != nil {
-		return persist.MembershipTier{}, fmt.Errorf("Failed to fetch membership cards for token: %s, %w", pTokenID, err)
+		return persist.MembershipTier{}, fmt.Errorf("Failed to fetch membership cards for token: %s, %v", pTokenID, err)
 	}
 	if len(events) == 0 {
 		return persist.MembershipTier{}, fmt.Errorf("No membership cards found for token: %s", pTokenID)

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -401,20 +401,7 @@ func processEventsToken(ctx context.Context, id persist.TokenID, ethClient *ethc
 	for _, t := range tokens {
 		token := t
 		wp.Submit(func() {
-			membershipOwner := persist.MembershipOwner{Address: token.OwnerAddress}
-			if glryUser, err := userRepository.GetByAddress(ctx, token.OwnerAddress); err == nil && glryUser.Username != "" {
-				membershipOwner.Username = glryUser.Username
-				membershipOwner.UserID = glryUser.ID
-
-				galleries, err := galleryRepository.GetByUserID(ctx, glryUser.ID)
-				if err == nil && len(galleries) > 0 {
-					gallery := galleries[0]
-					if gallery.Collections != nil && len(gallery.Collections) > 0 {
-
-						membershipOwner.PreviewNFTs = getPreviewsFromCollectionsToken(gallery.Collections)
-					}
-				}
-			}
+			membershipOwner := fillMembershipOwnerToken(ctx, token.OwnerAddress, id, ethClient, userRepository, galleryRepository)
 			ownersChan <- membershipOwner
 		})
 

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -179,8 +179,9 @@ func processCurrentTier(ctx context.Context, pTokenID persist.TokenID, ethClient
 	wp := workerpool.New(10)
 	ownersChan := make(chan persist.MembershipOwner)
 	for _, v := range tier.Owners {
+		owner := v
 		wp.Submit(func() {
-			owner := fillMembershipOwner(ctx, v.Address, pTokenID, ethClient, userRepository, galleryRepository)
+			owner := fillMembershipOwner(ctx, owner.Address, pTokenID, ethClient, userRepository, galleryRepository)
 			ownersChan <- owner
 		})
 	}
@@ -226,8 +227,9 @@ func processCurrentTierToken(ctx context.Context, pTokenID persist.TokenID, ethC
 	wp := workerpool.New(10)
 	ownersChan := make(chan persist.MembershipOwner)
 	for _, v := range tier.Owners {
+		owner := v
 		wp.Submit(func() {
-			owner := fillMembershipOwnerToken(ctx, v.Address, pTokenID, ethClient, userRepository, galleryRepository)
+			owner := fillMembershipOwnerToken(ctx, owner.Address, pTokenID, ethClient, userRepository, galleryRepository)
 			ownersChan <- owner
 		})
 	}

--- a/service/persist/postgres/membership.go
+++ b/service/persist/postgres/membership.go
@@ -22,7 +22,7 @@ func NewMembershipRepository(db *sql.DB) *MembershipRepository {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	upsertByTokenIDStmt, err := db.PrepareContext(ctx, `INSERT INTO membership (ID,TOKEN_ID,NAME,ASSET_URL,OWNERS) VALUES ($1,$2,$3,$4,$5) ON CONFLICT (TOKEN_ID) DO UPDATE SET NAME = EXCLUDED.NAME, ASSET_URL = EXCLUDED.ASSET_URL, OWNERS = EXCLUDED.OWNERS;`)
+	upsertByTokenIDStmt, err := db.PrepareContext(ctx, `INSERT INTO membership (ID,TOKEN_ID,NAME,ASSET_URL,OWNERS,LAST_UPDATED) VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT (TOKEN_ID) DO UPDATE SET NAME = EXCLUDED.NAME, ASSET_URL = EXCLUDED.ASSET_URL, OWNERS = EXCLUDED.OWNERS, LAST_UPDATED = EXCLUDED.LAST_UPDATED;`)
 	checkNoErr(err)
 
 	getByTokenIDStmt, err := db.PrepareContext(ctx, `SELECT ID,CREATED_AT,LAST_UPDATED,VERSION,NAME,ASSET_URL,OWNERS FROM membership WHERE TOKEN_ID = $1 AND DELETED = false;`)
@@ -36,7 +36,7 @@ func NewMembershipRepository(db *sql.DB) *MembershipRepository {
 
 // UpsertByTokenID upserts the given tier
 func (m *MembershipRepository) UpsertByTokenID(pCtx context.Context, pTokenID persist.TokenID, pTier persist.MembershipTier) error {
-	_, err := m.upsertByTokenIDStmt.ExecContext(pCtx, persist.GenerateID(), pTier.TokenID, pTier.Name, pTier.AssetURL, pq.Array(pTier.Owners))
+	_, err := m.upsertByTokenIDStmt.ExecContext(pCtx, persist.GenerateID(), pTier.TokenID, pTier.Name, pTier.AssetURL, pq.Array(pTier.Owners), pTier.LastUpdated)
 	return err
 }
 


### PR DESCRIPTION
Changes:

- **Added** a step to updating membership tiers that checks if there are owners currently stored for a tier and check if they are users in the database before going to opensea to update again.
- **Changed** upsert tier to also upsert `last_updated` so that we can not spam opensea with requests for tiers not being updated
- **Added** a force refresh query param that will forcibly go and update the tiers