### PR TITLE
add endpoint to get current user and change logout to POST

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -32,7 +32,7 @@ func authHandlersInitToken(parent *gin.RouterGroup, repos *repositories, ethClie
 	authGroup.GET("/get_preflight", middleware.AuthOptional(), getAuthPreflight(repos.userRepository, repos.nonceRepository, ethClient))
 	authGroup.GET("/jwt_valid", middleware.AuthOptional(), auth.ValidateJWT())
 	authGroup.GET("/is_member", middleware.AuthOptional(), hasNFTs(repos.userRepository, ethClient, membership.PremiumCards, membership.MembershipTierIDs))
-	authGroup.GET("/logout", logout())
+	authGroup.POST("/logout", logout())
 
 	// USER
 
@@ -41,6 +41,7 @@ func authHandlersInitToken(parent *gin.RouterGroup, repos *repositories, ethClie
 	usersGroup.POST("/update/addresses/add", middleware.AuthRequired(repos.userRepository, ethClient), addUserAddress(repos.userRepository, repos.nonceRepository, ethClient, psub))
 	usersGroup.POST("/update/addresses/remove", middleware.AuthRequired(repos.userRepository, ethClient), removeAddressesToken(repos.userRepository, repos.collectionTokenRepository))
 	usersGroup.GET("/get", middleware.AuthOptional(), getUser(repos.userRepository))
+	usersGroup.GET("/get/current", middleware.AuthOptional(), getCurrentUser(repos.userRepository))
 	usersGroup.GET("/membership", getMembershipTiersToken(repos.membershipRepository, repos.userRepository, repos.tokenRepository, repos.galleryTokenRepository, ethClient))
 	usersGroup.POST("/create", createUserToken(repos.userRepository, repos.nonceRepository, repos.galleryTokenRepository, psub, ethClient))
 
@@ -56,7 +57,7 @@ func authHandlersInitNFT(parent *gin.RouterGroup, repos *repositories, ethClient
 	authGroup.GET("/get_preflight", middleware.AuthOptional(), getAuthPreflight(repos.userRepository, repos.nonceRepository, ethClient))
 	authGroup.GET("/jwt_valid", middleware.AuthOptional(), auth.ValidateJWT())
 	authGroup.GET("/is_member", middleware.AuthOptional(), hasNFTs(repos.userRepository, ethClient, membership.PremiumCards, membership.MembershipTierIDs))
-	authGroup.GET("/logout", logout())
+	authGroup.POST("/logout", logout())
 
 	// USER
 
@@ -65,6 +66,7 @@ func authHandlersInitNFT(parent *gin.RouterGroup, repos *repositories, ethClient
 	usersGroup.POST("/update/addresses/add", middleware.AuthRequired(repos.userRepository, ethClient), addUserAddress(repos.userRepository, repos.nonceRepository, ethClient, psub))
 	usersGroup.POST("/update/addresses/remove", middleware.AuthRequired(repos.userRepository, ethClient), removeAddresses(repos.userRepository, repos.collectionRepository))
 	usersGroup.GET("/get", middleware.AuthOptional(), getUser(repos.userRepository))
+	usersGroup.GET("/get/current", middleware.AuthOptional(), getCurrentUser(repos.userRepository))
 	usersGroup.GET("/membership", getMembershipTiers(repos.membershipRepository, repos.userRepository, repos.galleryRepository, ethClient))
 	usersGroup.POST("/create", createUser(repos.userRepository, repos.nonceRepository, repos.galleryRepository, psub, ethClient))
 

--- a/server/user_token.go
+++ b/server/user_token.go
@@ -17,7 +17,6 @@ var errUserIDNotInCtx = errors.New("expected user ID to be in request context")
 
 func updateUserInfo(userRepository persist.UserRepository, ethClient *ethclient.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
-
 		input := user.UpdateUserInput{}
 
 		if err := c.ShouldBindJSON(&input); err != nil {
@@ -76,7 +75,7 @@ func getCurrentUser(userRepository persist.UserRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authed := c.GetBool(auth.AuthContextKey)
 		if !authed {
-			util.ErrResponse(c, http.StatusUnauthorized, errors.New("not authorized"))
+			c.JSON(http.StatusNoContent, util.SuccessResponse{Success: false})
 			return
 		}
 		userID := auth.GetUserIDFromCtx(c)

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -54,7 +54,7 @@ var errAddressSignatureMismatch = errors.New("address does not match signature")
 var ErrNonceMismatch = errors.New("incorrect nonce input")
 
 // ErrInvalidJWT is returned when the JWT is invalid
-var ErrInvalidJWT = errors.New("invalid JWT")
+var ErrInvalidJWT = errors.New("invalid or expired auth token")
 
 // ErrNoJWT is returned when there is no JWT in the request
 var ErrNoJWT = errors.New("no jwt passed as cookie")


### PR DESCRIPTION
## Context:
On the front end we are removing all JWT related code. This means that we are no longer storing the jwt in local storage which we used to quickly determine the user's 'authenticated' state upon page load.

This PR adds an endpoint that returns the currently authenticated user if a valid cookie is included in the request, which will allow the front end to continue to determine the user's logged in state.


## Changes:
- Added a new endpoint `users/get/current` to retrieve the currently authenticated user
  - If a user is found for the auth cookie, return the user
  - If there is no auth cookie or the provided auth cookie is invalid, return a 204 No Content
  - If the auth cookie is valid but no corresponding user is found, return a 500
- Added related tests for the endpoint
  - success: valid cookie return user
  - fail: no cookie returns 204
  - fail: invalid cookie returns 204 

I also changed the following to support related front end changes
- Changed /logout from GET to POST
