### PR TITLE
Add post-deploy healthcheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ workflows:
             branches:
               only:
                 - "main"
+      - post-deploy:
+          requires:
+            - deploy
 jobs:
   build:
     working_directory: ~/go-gallery
@@ -161,3 +164,39 @@ jobs:
       # - run:
       #     name: "Deploy Indexer"
       #     command: gcloud beta app deploy --quiet --appyaml app-indexer.yaml
+  post-deploy:
+    working_directory: ~/go-gallery
+    docker:
+      - image: cimg/base:stable
+    environment:
+      - HEALTH_URL: https://api.dev.gallery.so/glry/v1/health
+      - GRACE: 20
+      - TIMES: 5
+      - INTERVAL: 10
+    steps:
+      - run:
+          name: "Ping Backend"
+          command: |
+            echo "-------------------------------"
+            echo " INFO: letting backend startup "
+            echo "-------------------------------"
+            sleep $GRACE
+
+            for ((i=0; i<$TIMES; i++)); do
+            if [[ -z $(curl -XGET -Is $HEALTH_URL | head -n1 | grep 200) ]]; then
+              echo "-------------------------------"
+              echo " INFO: [attempt $i] waiting... "
+              echo "-------------------------------"
+              sleep $INTERVAL
+            else
+              echo "-------------------------------"
+              echo " INFO: backend is operational! "
+              echo "-------------------------------"
+              exit 0
+            fi
+            done
+
+            echo "-------------------------------"
+            echo " ERROR: failed to hit backend! "
+            echo "-------------------------------"
+            exit 1


### PR DESCRIPTION
Adds a check after deployment that pings the server's health endpoint.

Testing:
* Tested by changing the trigger from main to my branch and verifying the job runs successfully in CircleCI: [build](https://app.circleci.com/pipelines/github/gallery-so/go-gallery/985/workflows/e17f37dc-c2fa-4106-8023-e42043570b3d/jobs/1501)