### PR TITLE
Read test-wallet.json from _internal directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           command: sudo apt-get -y install unzip
       - run:
           name: "Unzip secrets file"
-          command: echo "A" | unzip _internal.zip
+          command: echo "A" | unzip _internal.zip -d _internal
       - run:
           name: Run integration-tests
           command: |

--- a/server/t__server_integration_test.go
+++ b/server/t__server_integration_test.go
@@ -32,7 +32,7 @@ const (
 	blockchainEth = "ethereum"
 
 	// live wallets
-	testWalletFileEthMainnet = "../test-wallet.json"
+	testWalletFileEthMainnet = "../_internal/test-wallet.json"
 )
 
 var (


### PR DESCRIPTION
Small tweak to read test-wallet.json from `_internal`, since that's where it ends up by default on a developer's machine