### PR TITLE
instantiate collection in each iteration to reset previous values

### DIFF
--- a/service/persist/postgres/gallery_nft.go
+++ b/service/persist/postgres/gallery_nft.go
@@ -208,9 +208,9 @@ func (g *GalleryRepository) GetByUserID(pCtx context.Context, pUserID persist.DB
 	galleries := make(map[persist.DBID]persist.Gallery)
 	collections := make(map[persist.DBID][]persist.Collection)
 	var gallery persist.Gallery
-	var collection persist.Collection
+	var lastCollID persist.DBID
 	for rows.Next() {
-		lastCollID := collection.ID
+		var collection persist.Collection
 		var nft persist.CollectionNFT
 
 		err := rows.Scan(&gallery.ID, &gallery.Version, &gallery.OwnerUserID, &gallery.CreationTime, &gallery.LastUpdated,
@@ -252,6 +252,7 @@ func (g *GalleryRepository) GetByUserID(pCtx context.Context, pUserID persist.DB
 		}
 
 		collections[gallery.ID] = colls
+		lastCollID = collection.ID
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -306,11 +307,11 @@ func (g *GalleryRepository) GetByID(pCtx context.Context, pID persist.DBID) (per
 	galleries := make(map[persist.DBID]persist.Gallery)
 	collections := make(map[persist.DBID][]persist.Collection)
 	var gallery persist.Gallery
-	var collection persist.Collection
+	var lastCollID persist.DBID
 
 	for rows.Next() {
+		var collection persist.Collection
 		var nft persist.CollectionNFT
-		lastCollID := collection.ID
 
 		err := rows.Scan(&gallery.ID, &gallery.Version, &gallery.OwnerUserID, &gallery.CreationTime, &gallery.LastUpdated,
 			&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote,
@@ -351,7 +352,9 @@ func (g *GalleryRepository) GetByID(pCtx context.Context, pID persist.DBID) (per
 		}
 
 		collections[gallery.ID] = colls
+		lastCollID = collection.ID
 	}
+
 	if err := rows.Err(); err != nil {
 		return persist.Gallery{}, err
 	}

--- a/service/persist/postgres/gallery_token.go
+++ b/service/persist/postgres/gallery_token.go
@@ -360,6 +360,7 @@ func (g *GalleryTokenRepository) GetByID(pCtx context.Context, pID persist.DBID)
 		}
 
 		collections[gallery.ID] = colls
+		lastCollID = collection.ID
 	}
 	if err := rows.Err(); err != nil {
 		return persist.GalleryToken{}, err

--- a/service/persist/postgres/gallery_token.go
+++ b/service/persist/postgres/gallery_token.go
@@ -227,10 +227,11 @@ func (g *GalleryTokenRepository) GetByUserID(pCtx context.Context, pUserID persi
 	galleries := make(map[persist.DBID]persist.GalleryToken)
 	collections := make(map[persist.DBID][]persist.CollectionToken)
 	var gallery persist.GalleryToken
-	var collection persist.CollectionToken
+	var lastCollID persist.DBID
 	for rows.Next() {
+		var collection persist.CollectionToken
 		var nft persist.TokenInCollection
-		lastCollID := collection.ID
+
 		err := rows.Scan(&gallery.ID, &gallery.Version, &gallery.OwnerUserID, &gallery.CreationTime, &gallery.LastUpdated,
 			&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote,
 			&collection.Layout, &collection.Hidden, &collection.CreationTime, &collection.LastUpdated, &nft.ID, &nft.OwnerAddress,
@@ -265,6 +266,7 @@ func (g *GalleryTokenRepository) GetByUserID(pCtx context.Context, pUserID persi
 		}
 
 		collections[gallery.ID] = colls
+		lastCollID = collection.ID
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -319,10 +321,10 @@ func (g *GalleryTokenRepository) GetByID(pCtx context.Context, pID persist.DBID)
 	galleries := make(map[persist.DBID]persist.GalleryToken)
 	collections := make(map[persist.DBID][]persist.CollectionToken)
 	var gallery persist.GalleryToken
-	var collection persist.CollectionToken
-	var nft persist.TokenInCollection
+	var lastCollID persist.DBID
 	for rows.Next() {
-		lastCollID := collection.ID
+		var collection persist.CollectionToken
+		var nft persist.TokenInCollection
 
 		err := rows.Scan(&gallery.ID, &gallery.Version, &gallery.OwnerUserID, &gallery.CreationTime, &gallery.LastUpdated,
 			&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote,


### PR DESCRIPTION
Description: 
This PR tries to fix a bug I saw when testing whitespace blocks.
After saving some collections with whitespaces in a collection, I tried to retrieve my Gallery and found that in the response, collections were getting their whitespace values combined with whitespace values from other collections.

it's easier to see with examples, so here are 2 cases:
2 collections (one with [0,0,0,1] and one with no whitespace)
db: 
<img width="417" alt="Screen Shot 2022-02-18 at 23 45 51" src="https://user-images.githubusercontent.com/80802871/154707791-c116de5f-3235-43b2-89a5-08b69396506c.png">
response:
![CleanShot 2022-02-18 at 23 43 01@2x](https://user-images.githubusercontent.com/80802871/154707817-48205b2a-221e-4409-85d7-ca5d1dfec8d0.png)


2 collections (one with [3,3,3,3,6,7,8] and one with [2,2,2,2,3])
db:
<img width="453" alt="Screen Shot 2022-02-18 at 23 49 45" src="https://user-images.githubusercontent.com/80802871/154707869-b7cf708a-6e24-46d5-b099-ca6c8d5feafe.png">

response:
![CleanShot 2022-02-18 at 23 48 53@2x](https://user-images.githubusercontent.com/80802871/154707883-d3f5883b-05a8-4a82-b91b-3113f2631c68.png)


The db query was fine and returning results as expected. It looks like the issue was with how we hold on to the `collection` value outside of the `rows.Scan` loop. We overwrite fields on `collection` with each iteration, but it looks like if there are any fields that aren't present in the current row, the old value doesn't get cleared. It also appears that when there is a whitespace value present, it doesn't fully replace the previous value, it just overwrites part of the list.

My solution was to re instantiate `collection` in every iteration to eliminate the risk of holding on to any stale values  from the previous row. 

