### PR TITLE
side effects, organization, handle subscribed logs differently

### DIFF
--- a/features/access.go
+++ b/features/access.go
@@ -85,7 +85,11 @@ func upsertAccessState(pCtx context.Context, userID persist.DBID, userRepo persi
 	for _, feature := range allFeatures {
 		switch feature.TokenType {
 		case persist.TokenTypeERC1155:
-			address, tokenID := feature.RequiredToken.GetParts()
+			address, tokenID, err := feature.RequiredToken.GetParts()
+			if err != nil {
+				logrus.WithError(err).Error("failed to get parts from required token")
+				return err
+			}
 			ca, err := contracts.NewIERC1155Caller(address.Address(), ethClient)
 			if err != nil {
 				logrus.WithError(err).Error("failed to initialize ERC1155 caller")
@@ -102,7 +106,11 @@ func upsertAccessState(pCtx context.Context, userID persist.DBID, userRepo persi
 			}
 			tis[feature.RequiredToken] = totalBal.Uint64()
 		case persist.TokenTypeERC721:
-			address, tokenID := feature.RequiredToken.GetParts()
+			address, tokenID, err := feature.RequiredToken.GetParts()
+			if err != nil {
+				logrus.WithError(err).Error("failed to get parts from required token")
+				return err
+			}
 			ca, err := contracts.NewIERC721Caller(address.Address(), ethClient)
 			if err != nil {
 				logrus.WithError(err).Error("failed to initialize ERC1155 caller")
@@ -120,7 +128,11 @@ func upsertAccessState(pCtx context.Context, userID persist.DBID, userRepo persi
 			}
 			tis[feature.RequiredToken] = uint64(isOwner)
 		case persist.TokenTypeERC20:
-			address, _ := feature.RequiredToken.GetParts()
+			address, _, err := feature.RequiredToken.GetParts()
+			if err != nil {
+				logrus.WithError(err).Error("failed to get parts from required token")
+				return err
+			}
 			ca, err := contracts.NewIERC20Caller(address.Address(), ethClient)
 			if err != nil {
 				logrus.WithError(err).Error("failed to initialize ERC1155 caller")

--- a/features/updater.go
+++ b/features/updater.go
@@ -50,7 +50,10 @@ func trackFeatures(pCtx context.Context, userRepo persist.UserRepository, featur
 
 	addresses := []common.Address{}
 	for _, feature := range allFeatures {
-		address, _ := feature.RequiredToken.GetParts()
+		address, _, err := feature.RequiredToken.GetParts()
+		if err != nil {
+			panic(err)
+		}
 		addresses = append(addresses, address.Address())
 	}
 	topics := [][]common.Hash{{common.HexToHash(string(transferEventHash)), common.HexToHash(string(transferSingleEventHash)), common.HexToHash(string(transferBatchEventHash))}}

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -27,7 +27,7 @@ func coreInit() (*gin.Engine, *Indexer) {
 
 	setDefaults()
 
-	tokenRepo, contractRepo, userRepo := newRepos()
+	tokenRepo, contractRepo, userRepo, collRepo := newRepos()
 	var s *storage.Client
 	var err error
 	if viper.GetString("ENV") != "local" {
@@ -44,7 +44,7 @@ func coreInit() (*gin.Engine, *Indexer) {
 	tq := task.NewQueue()
 
 	events := []eventHash{transferBatchEventHash, transferEventHash, transferSingleEventHash}
-	i := NewIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, userRepo, persist.Chain(viper.GetString("CHAIN")), events, "stats.json")
+	i := NewIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, userRepo, collRepo, persist.Chain(viper.GetString("CHAIN")), events, "stats.json")
 
 	router := gin.Default()
 
@@ -73,8 +73,8 @@ func setDefaults() {
 	viper.AutomaticEnv()
 }
 
-func newRepos() (persist.TokenRepository, persist.ContractRepository, persist.UserRepository) {
+func newRepos() (persist.TokenRepository, persist.ContractRepository, persist.UserRepository, persist.CollectionTokenRepository) {
 	pgClient := postgres.NewClient()
 
-	return postgres.NewTokenRepository(pgClient), postgres.NewContractRepository(pgClient), postgres.NewUserRepository(pgClient)
+	return postgres.NewTokenRepository(pgClient), postgres.NewContractRepository(pgClient), postgres.NewUserRepository(pgClient), postgres.NewCollectionTokenRepository(pgClient)
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -110,7 +110,7 @@ type Indexer struct {
 
 	mostRecentBlock uint64
 
-	badURIs uint64
+	isListening bool
 
 	uniqueMetadatas uniqueMetadatas
 }
@@ -189,6 +189,7 @@ func (i *Indexer) Start() {
 }
 
 func (i *Indexer) startPipeline(start persist.BlockNumber, topics [][]common.Hash) {
+	i.isListening = false
 	uris := make(chan tokenURI)
 	metadatas := make(chan tokenMetadata)
 	balances := make(chan tokenBalances)
@@ -201,6 +202,7 @@ func (i *Indexer) startPipeline(start persist.BlockNumber, topics [][]common.Has
 	i.processTokens(uris, metadatas, owners, previousOwners, balances)
 }
 func (i *Indexer) startNewBlocksPipeline(start persist.BlockNumber, topics [][]common.Hash) {
+	i.isListening = true
 	uris := make(chan tokenURI)
 	metadatas := make(chan tokenMetadata)
 	balances := make(chan tokenBalances)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -638,7 +638,7 @@ func runTransferSideEffects(i *Indexer, contractAddress persist.Address, tokenID
 	if err != nil {
 		return
 	}
-	if bals.from != "" {
+	if bals.fromAmt != nil {
 		if bals.fromAmt.Cmp(bigZero) != 0 {
 			return
 		}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -157,7 +157,7 @@ func (i *Indexer) Start() {
 	cancel()
 
 	remainder := lastSyncedBlock % blocksPerLogsCall
-	lastSyncedBlock -= (remainder + (blocksPerLogsCall * 500))
+	lastSyncedBlock -= (remainder + (blocksPerLogsCall * 50))
 
 	logrus.Infof("Starting indexer from block %d", lastSyncedBlock)
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -506,9 +506,7 @@ func processTransfers(i *Indexer, transfers []transfersAtBlock, uris chan<- toke
 				key := persist.NewTokenIdentifiers(contractAddress, tokenID)
 				// logrus.Infof("Processing transfer %s to %s and from %s ", key, to, from)
 
-				_, _, bals, _, _ := findRequiredTokenFields(i, transfer, key, to, from, contractAddress, tokenID, balances, uris, metadatas, owners, previousOwners)
-
-				runTransferSideEffects(i, key, to, from, bals)
+				findRequiredTokenFields(i, transfer, key, to, from, contractAddress, tokenID, balances, uris, metadatas, owners, previousOwners)
 
 				logrus.WithFields(logrus.Fields{"duration": time.Since(initial)}).Debugf("Processed transfer %s to %s and from %s ", key, to, from)
 			}()

--- a/indexer/server.go
+++ b/indexer/server.go
@@ -67,13 +67,12 @@ func getStatus(i *Indexer, tokenRepository persist.TokenRepository) gin.HandlerF
 		defer cancel()
 
 		mostRecent, _ := tokenRepository.MostRecentBlock(ctx)
-		total, _ := tokenRepository.Count(ctx, persist.CountTypeTotal)
 
 		c.JSON(http.StatusOK, gin.H{
-			"total_tokens": total,
-			"recent_block": i.mostRecentBlock,
-			"most_recent":  mostRecent,
-			"is_listening": i.isListening,
+			"most_recent_indexed": i.mostRecentBlock,
+			"most_recent_db":      mostRecent,
+			"last_synced_block":   i.lastSyncedBlock,
+			"is_listening":        i.isListening,
 		})
 	}
 }

--- a/indexer/server.go
+++ b/indexer/server.go
@@ -65,20 +65,15 @@ func getStatus(i *Indexer, tokenRepository persist.TokenRepository) gin.HandlerF
 	return func(c *gin.Context) {
 		ctx, cancel := context.WithTimeout(c, 10*time.Second)
 		defer cancel()
-		total, _ := tokenRepository.Count(ctx, persist.CountTypeTotal)
+
 		mostRecent, _ := tokenRepository.MostRecentBlock(ctx)
-		noMetadata, _ := tokenRepository.Count(ctx, persist.CountTypeNoMetadata)
-		erc721, _ := tokenRepository.Count(ctx, persist.CountTypeERC721)
-		erc1155, _ := tokenRepository.Count(ctx, persist.CountTypeERC1155)
+		total, _ := tokenRepository.Count(ctx, persist.CountTypeTotal)
 
 		c.JSON(http.StatusOK, gin.H{
 			"total_tokens": total,
 			"recent_block": i.mostRecentBlock,
 			"most_recent":  mostRecent,
-			"bad_uris":     i.badURIs,
-			"no_metadata":  noMetadata,
-			"erc721":       erc721,
-			"erc1155":      erc1155,
+			"is_listening": i.isListening,
 		})
 	}
 }

--- a/indexer/server.go
+++ b/indexer/server.go
@@ -133,6 +133,10 @@ func UpdateMedia(c context.Context, input UpdateMediaInput, tokenRepository pers
 		tokens = res
 	}
 
+	if len(tokens) == 0 {
+		return nil
+	}
+
 	logrus.Infof("Updating %d tokens", len(tokens))
 
 	updateByID := input.OwnerAddress != ""

--- a/server/collection_token.go
+++ b/server/collection_token.go
@@ -81,9 +81,7 @@ func getCollectionsByUserIDToken(collectionsRepository persist.CollectionTokenRe
 			return
 		}
 
-		userID := auth.GetUserIDFromCtx(c)
-		auth := userID == input.UserID
-		colls, err := collectionsRepository.GetByUserID(c, input.UserID, auth)
+		colls, err := collectionsRepository.GetByUserID(c, input.UserID)
 		if len(colls) == 0 || err != nil {
 			colls = []persist.CollectionToken{}
 		}
@@ -104,8 +102,7 @@ func getCollectionByIDToken(collectionsRepository persist.CollectionTokenReposit
 			return
 		}
 
-		auth := c.GetBool(auth.AuthContextKey)
-		coll, err := collectionsRepository.GetByID(c, input.ID, auth)
+		coll, err := collectionsRepository.GetByID(c, input.ID)
 		if err != nil {
 			status := http.StatusInternalServerError
 			if _, ok := err.(persist.ErrCollectionNotFoundByID); ok {

--- a/server/t__routes_collection_token_test.go
+++ b/server/t__routes_collection_token_test.go
@@ -128,7 +128,7 @@ func TestDeleteCollection_Success_Token(t *testing.T) {
 	assertValidResponse(assert, resp)
 
 	// Assert that the collection was deleted
-	coll, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID, false)
+	coll, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID)
 	assert.NotNil(err)
 	assert.Empty(coll.ID)
 }
@@ -294,7 +294,7 @@ func TestUpdateCollectionNfts_Success_Token(t *testing.T) {
 }
 
 func verifyCollectionExistsInDbForIDToken(assert *assert.Assertions, collID persist.DBID) {
-	collectionsBeforeDelete, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID, false)
+	collectionsBeforeDelete, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID)
 	assert.Nil(err)
 	assert.Equal(collectionsBeforeDelete.ID, collID)
 }

--- a/server/t__routes_collection_token_test.go
+++ b/server/t__routes_collection_token_test.go
@@ -183,37 +183,6 @@ func TestGetHiddenCollections_Success_Token(t *testing.T) {
 	assert.Empty(body.Error)
 }
 
-func TestGetNoHiddenCollections_Success_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	nftIDs := seedTokens(assert)
-	_, err := tc.repos.CollectionTokenRepository.Create(context.Background(), persist.CollectionTokenDB{
-		Name:        "very cool collection",
-		OwnerUserID: tc.user1.id,
-		NFTs:        nftIDs[0:1],
-		Hidden:      false,
-	})
-	_, err = tc.repos.CollectionTokenRepository.Create(context.Background(), persist.CollectionTokenDB{
-		Name:        "very cool collection",
-		OwnerUserID: tc.user1.id,
-		NFTs:        nftIDs[1:],
-		Hidden:      true,
-	})
-	assert.Nil(err)
-
-	resp := sendCollUserGetRequestToken(assert, string(tc.user1.id), tc.user2)
-
-	type CollectionsResponse struct {
-		Collections []*persist.Collection `json:"collections"`
-		Error       string                `json:"error"`
-	}
-
-	body := CollectionsResponse{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Len(body.Collections, 1)
-	assert.Empty(body.Error)
-}
-
 func TestUpdateCollectionNftsOrder_Success_Token(t *testing.T) {
 	assert := setupTest(t, 2)
 

--- a/server/t__routes_user_token_test.go
+++ b/server/t__routes_user_token_test.go
@@ -327,7 +327,7 @@ func TestUserRemoveAddresses_Success_Token(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(nfts, 1)
 
-	resultColl, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID, true)
+	resultColl, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID)
 	assert.Nil(err)
 	assert.Len(resultColl.NFTs, 2)
 

--- a/service/persist/collection_token.go
+++ b/service/persist/collection_token.go
@@ -98,8 +98,8 @@ type CollectionTokenUpdateDeletedInput struct {
 // CollectionTokenRepository represents the interface for interacting with the collection persistence layer
 type CollectionTokenRepository interface {
 	Create(context.Context, CollectionTokenDB) (DBID, error)
-	GetByUserID(context.Context, DBID, bool) ([]CollectionToken, error)
-	GetByID(context.Context, DBID, bool) (CollectionToken, error)
+	GetByUserID(context.Context, DBID) ([]CollectionToken, error)
+	GetByID(context.Context, DBID) (CollectionToken, error)
 	Update(context.Context, DBID, DBID, interface{}) error
 	UpdateNFTs(context.Context, DBID, DBID, CollectionTokenUpdateNftsInput) error
 	UpdateUnsafe(context.Context, DBID, interface{}) error

--- a/service/persist/feature.go
+++ b/service/persist/feature.go
@@ -62,10 +62,12 @@ func (t TokenIdentifiers) Valid() bool {
 }
 
 // GetParts returns the parts of the token identifiers
-func (t TokenIdentifiers) GetParts() (Address, TokenID) {
+func (t TokenIdentifiers) GetParts() (Address, TokenID, error) {
 	parts := strings.Split(t.String(), "+")
-
-	return Address(parts[0]), TokenID(parts[1])
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid token identifiers: %s", t)
+	}
+	return Address(Address(parts[0]).String()), TokenID(TokenID(parts[1]).String()), nil
 }
 
 // Value implements the driver.Valuer interface

--- a/service/persist/feature.go
+++ b/service/persist/feature.go
@@ -50,10 +50,7 @@ func NewTokenIdentifiers(pContractAddress Address, pTokenID TokenID) TokenIdenti
 }
 
 func (t TokenIdentifiers) String() string {
-	if t.Valid() {
-		return string(t)
-	}
-	return ""
+	return string(t)
 }
 
 // Valid returns true if the token identifiers are valid

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -167,21 +167,9 @@ func (u *UserRepository) GetByID(pCtx context.Context, pID persist.DBID) (persis
 // GetByAddress gets the user with the given address in their list of addresses
 func (u *UserRepository) GetByAddress(pCtx context.Context, pAddress persist.Address) (persist.User, error) {
 
-	res, err := u.getByAddressStmt.QueryContext(pCtx, pAddress)
-	if err != nil {
-		return persist.User{}, err
-	}
-	defer res.Close()
-
 	var user persist.User
-	for res.Next() {
-		err = res.Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, pq.Array(&user.Addresses), &user.Bio, &user.CreationTime, &user.LastUpdated)
-		if err != nil {
-			return persist.User{}, err
-		}
-	}
-
-	if err = res.Err(); err != nil {
+	err := u.getByAddressStmt.QueryRowContext(pCtx, pAddress).Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, pq.Array(&user.Addresses), &user.Bio, &user.CreationTime, &user.LastUpdated)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return persist.User{}, persist.ErrUserNotFoundByAddress{Address: pAddress}
 		}
@@ -195,27 +183,14 @@ func (u *UserRepository) GetByAddress(pCtx context.Context, pAddress persist.Add
 // GetByUsername gets the user with the given username
 func (u *UserRepository) GetByUsername(pCtx context.Context, pUsername string) (persist.User, error) {
 
-	res, err := u.getByUsernameStmt.QueryContext(pCtx, strings.ToLower(pUsername))
-	if err != nil {
-		return persist.User{}, err
-	}
-	defer res.Close()
-
 	var user persist.User
-	for res.Next() {
-		err = res.Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, pq.Array(&user.Addresses), &user.Bio, &user.CreationTime, &user.LastUpdated)
-		if err != nil {
-			return persist.User{}, err
-		}
-	}
-
-	if err = res.Err(); err != nil {
+	err := u.getByUsernameStmt.QueryRowContext(pCtx, strings.ToLower(pUsername)).Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, pq.Array(&user.Addresses), &user.Bio, &user.CreationTime, &user.LastUpdated)
+	if err != nil {
 		if err == sql.ErrNoRows {
 			return persist.User{}, persist.ErrUserNotFoundByUsername{Username: pUsername}
 		}
 		return persist.User{}, err
 	}
-
 	return user, nil
 
 }


### PR DESCRIPTION
Changes:

- **Added** side effect handling for ensuring that NFTs transferred away from a user leave their collections
- **Added** new indexer pipeline funcs for subscribed logs where we want to grab more data such as media content
- **Changed** the indexer file to be a bit more organized and separated out some common logic

Considerations:

- Right now media content (the media field on a token) is only retrieved in the "listening" stage of the indexer after the initial indexing process. This is because the initial indexing process is very expensive and would be very time consuming if it had to figure out for every NFT if there was a user associated with it and then subsequently grab media content for that NFT which could take anywhere from a few milliseconds to a few minutes (if the context allows for it). I believe handling side-effects like grabbing media content and checking if NFTs are transferred out of someone's collections is fine in the listening stage given that we receive NFTs one at a time and only once an Ethereum block has been produced. 
- I decided that it would be good to handle the side-effect of removing NFTs from collections of users who transferred away the NFTs because that would prevent us from having some sort of manual refresh step for users to get rid of NFTs they no longer have. This side-effect is handled by first checking if the `from` address in a transfer is owned by a user (meaning there is a database call for every NFT that comes through the pipeline) and if there is a user going through their collections to see if they have the NFT anywhere and remove it (2 more database calls). Another option to offload this kind of side-effect being handled for every NFT that comes through the indexer would be to run this when a user logs in. It could be a background process that is async. Kind of like how right now when users transfer NFTs they are still in their collections until they refresh opensea, except rather than refreshing it will happen automatically on the backend on login.