### PR TITLE
.gcloudignore should contain everything in .gitignore

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -13,22 +13,26 @@
 .git
 .gitignore
 
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-# Test binary, build with `go test -c`
-*.test
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-bin
+# IDE
+.idea
+.graphqlconfig
 
-# VSCode settings
-.vscode
+# Misc
+.DS_Store
 *.csv
+scripts/csv_export/
 .env
+
+stats.json
+
+node_modules/
+yarn.lock
+
+# SECRITS
+_deploy*
+_internal*
 
 *.mp4
 *.jpg
+
+refresh.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+##########################################################################
+# KEEP THIS FILE IN SYNC WITH .gcloudignore
+##########################################################################
+# If you add something here, it needs to be added to .gcloudignore too.
+# Otherwise, it'll get uploaded when we deploy to Google Cloud.
+##########################################################################
+
 # IDE
 .idea
 .graphqlconfig


### PR DESCRIPTION
While deploying `go-gallery` to prod, Robin and I noticed that deployment uploaded ~1600 files. From what I can tell, a lot of those were from the `node_modules` directory, which is .gitignored but not .gcloudignored.

This PR updates .gcloudignore to contain everything in .gitignore, and updates .gitignore to let everyone know future modifications should also be added to .gcloudignore.