### PR TITLE
community endpoints

### DIFF
--- a/db/migrations/000001_create_core_tables.down.sql
+++ b/db/migrations/000001_create_core_tables.down.sql
@@ -1,13 +1,27 @@
 DROP TABLE IF EXISTS users;
+
 DROP TABLE IF EXISTS galleries;
+
 DROP TABLE IF EXISTS nfts;
+
 DROP TABLE IF EXISTS collections;
+
 DROP TABLE IF EXISTS collections_v2;
+
 DROP TABLE IF EXISTS nonces;
+
 DROP TABLE IF EXISTS tokens;
+
 DROP TABLE IF EXISTS contracts;
+
 DROP TABLE IF EXISTS login_attempts;
+
 DROP TABLE IF EXISTS features;
+
 DROP TABLE IF EXISTS backups;
+
 DROP TABLE IF EXISTS membership;
+
 DROP TABLE IF EXISTS access;
+
+DROP TABLE IF EXISTS community;

--- a/db/migrations/000001_create_core_tables.up.sql
+++ b/db/migrations/000001_create_core_tables.up.sql
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS nfts (
     ACQUISITION_DATE varchar,
     TOKEN_METADATA_URL varchar
 );
+
 CREATE UNIQUE INDEX IF NOT EXISTS opensea_id_owner_address_inx ON nfts (OPENSEA_ID, OWNER_ADDRESS);
 
 CREATE TABLE IF NOT EXISTS collections (
@@ -194,6 +195,23 @@ CREATE TABLE IF NOT EXISTS membership (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS token_id_idx ON membership (TOKEN_ID);
+
+CREATE TABLE IF NOT EXISTS community (
+    ID varchar(255) PRIMARY KEY,
+    DELETED boolean NOT NULL DEFAULT false,
+    VERSION int,
+    CREATED_AT timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    LAST_UPDATED timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONTRACT_ADDRESS varchar,
+    TOKEN_ID_RANGES jsonb [],
+    NAME varchar,
+    DESCRIPTION varchar,
+    PROFILE_IMAGE_URL varchar,
+    BANNER_IMAGE_URL varchar,
+    OWNERS jsonb []
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS contract_address_com_idx ON community (CONTRACT_ADDRESS);
 
 CREATE TABLE IF NOT EXISTS access (
     ID varchar(255) PRIMARY KEY,

--- a/docker/postgres/03_init.sql
+++ b/docker/postgres/03_init.sql
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS nfts (
     ACQUISITION_DATE varchar,
     TOKEN_METADATA_URL varchar
 );
+
 CREATE UNIQUE INDEX IF NOT EXISTS opensea_id_owner_address_inx ON nfts (OPENSEA_ID, OWNER_ADDRESS);
 
 CREATE TABLE IF NOT EXISTS collections (
@@ -194,6 +195,23 @@ CREATE TABLE IF NOT EXISTS membership (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS token_id_idx ON membership (TOKEN_ID);
+
+CREATE TABLE IF NOT EXISTS community (
+    ID varchar(255) PRIMARY KEY,
+    DELETED boolean NOT NULL DEFAULT false,
+    VERSION int,
+    CREATED_AT timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    LAST_UPDATED timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONTRACT_ADDRESS varchar,
+    TOKEN_ID_RANGES jsonb [],
+    NAME varchar,
+    DESCRIPTION varchar,
+    PROFILE_IMAGE_URL varchar,
+    BANNER_IMAGE_URL varchar,
+    OWNERS jsonb []
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS contract_address_com_idx ON community (CONTRACT_ADDRESS);
 
 CREATE TABLE IF NOT EXISTS access (
     ID varchar(255) PRIMARY KEY,

--- a/server/community.go
+++ b/server/community.go
@@ -1,0 +1,65 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mikeydub/go-gallery/service/community"
+	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/util"
+	"github.com/sirupsen/logrus"
+)
+
+type getCommunityInput struct {
+	ContractAddress persist.Address `uri:"address"`
+}
+type getCommunityOutput struct {
+	Community persist.Community `json:"community"`
+}
+type getCommunitiesOutput struct {
+	Communities []persist.Community `json:"communities"`
+}
+
+func getAllCommunities(communityRepository persist.CommunityRepository, nftRepository persist.NFTRepository, galleryRepository persist.GalleryRepository, userRepository persist.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		communities, err := communityRepository.GetAll(c)
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+		c.JSON(http.StatusOK, getCommunitiesOutput{Communities: communities})
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+		defer cancel()
+		for _, com := range communities {
+			if time.Since(com.LastUpdated.Time()) > time.Hour*24 {
+				go community.UpdateCommunity(ctx, com.ContractAddress, nftRepository, userRepository, galleryRepository, communityRepository)
+			}
+		}
+	}
+}
+
+func getCommunity(communityRepository persist.CommunityRepository, nftRepository persist.NFTRepository, galleryRepository persist.GalleryRepository, userRepository persist.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input getCommunityInput
+		if err := c.ShouldBindUri(&input); err != nil {
+			util.ErrResponse(c, http.StatusBadRequest, err)
+			return
+		}
+		com, err := communityRepository.GetByContract(c, input.ContractAddress)
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+		c.JSON(http.StatusOK, getCommunityOutput{Community: com})
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+		defer cancel()
+		if time.Since(com.LastUpdated.Time()) > time.Hour*24 {
+			err := community.UpdateCommunity(ctx, input.ContractAddress, nftRepository, userRepository, galleryRepository, communityRepository)
+			if err != nil {
+				logrus.WithError(err).Errorf("Error updating community: %s", input.ContractAddress)
+			}
+		}
+	}
+}

--- a/server/community.go
+++ b/server/community.go
@@ -62,6 +62,12 @@ func getCommunity(communityRepository persist.CommunityRepository, nftRepository
 					util.ErrResponse(c, http.StatusInternalServerError, err)
 					return
 				}
+				com, err = communityRepository.GetByContract(c, input.ContractAddress)
+				if err != nil {
+					util.ErrResponse(c, http.StatusInternalServerError, err)
+					return
+				}
+				c.JSON(http.StatusOK, getCommunityOutput{Community: com})
 				return
 			}
 			util.ErrResponse(c, http.StatusInternalServerError, err)

--- a/server/handler.go
+++ b/server/handler.go
@@ -9,7 +9,7 @@ import (
 	shell "github.com/ipfs/go-ipfs-api"
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
 	"github.com/mikeydub/go-gallery/graphql/generated"
-	"github.com/mikeydub/go-gallery/graphql/resolver"
+	graphql "github.com/mikeydub/go-gallery/graphql/resolver"
 	"github.com/mikeydub/go-gallery/middleware"
 	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
@@ -89,6 +89,8 @@ func authHandlersInitToken(parent *gin.RouterGroup, repos *persist.Repositories,
 	usersGroup.POST("/create", createUserToken(repos.UserRepository, repos.NonceRepository, repos.GalleryTokenRepository, psub, ethClient))
 	usersGroup.GET("/previews", getNFTPreviewsToken(repos.GalleryTokenRepository, repos.UserRepository))
 	usersGroup.POST("/merge", middleware.AuthRequired(repos.UserRepository, ethClient), mergeUsers(repos.UserRepository, repos.NonceRepository, ethClient))
+	usersGroup.GET("/communities", getAllCommunities(repos.CommunityRepository, repos.NftRepository, repos.GalleryRepository, repos.UserRepository))
+	usersGroup.GET("/communities/:address", getCommunity(repos.CommunityRepository, repos.NftRepository, repos.GalleryRepository, repos.UserRepository))
 }
 
 func authHandlersInitNFT(parent *gin.RouterGroup, repos *persist.Repositories, ethClient *ethclient.Client, psub pubsub.PubSub) {

--- a/server/handler.go
+++ b/server/handler.go
@@ -89,8 +89,6 @@ func authHandlersInitToken(parent *gin.RouterGroup, repos *persist.Repositories,
 	usersGroup.POST("/create", createUserToken(repos.UserRepository, repos.NonceRepository, repos.GalleryTokenRepository, psub, ethClient))
 	usersGroup.GET("/previews", getNFTPreviewsToken(repos.GalleryTokenRepository, repos.UserRepository))
 	usersGroup.POST("/merge", middleware.AuthRequired(repos.UserRepository, ethClient), mergeUsers(repos.UserRepository, repos.NonceRepository, ethClient))
-	usersGroup.GET("/communities", getAllCommunities(repos.CommunityRepository, repos.NftRepository, repos.GalleryRepository, repos.UserRepository))
-	usersGroup.GET("/communities/:address", getCommunity(repos.CommunityRepository, repos.NftRepository, repos.GalleryRepository, repos.UserRepository))
 }
 
 func authHandlersInitNFT(parent *gin.RouterGroup, repos *persist.Repositories, ethClient *ethclient.Client, psub pubsub.PubSub) {
@@ -117,6 +115,8 @@ func authHandlersInitNFT(parent *gin.RouterGroup, repos *persist.Repositories, e
 	usersGroup.POST("/create", createUser(repos.UserRepository, repos.NonceRepository, repos.GalleryRepository, psub, ethClient))
 	usersGroup.GET("/previews", getNFTPreviews(repos.GalleryRepository, repos.UserRepository))
 	usersGroup.POST("/merge", middleware.AuthRequired(repos.UserRepository, ethClient), mergeUsers(repos.UserRepository, repos.NonceRepository, ethClient))
+	usersGroup.GET("/communities", getAllCommunities(repos.CommunityRepository, repos.NftRepository, repos.GalleryRepository, repos.UserRepository))
+	usersGroup.GET("/communities/:address", getCommunity(repos.CommunityRepository, repos.NftRepository, repos.GalleryRepository, repos.UserRepository))
 
 }
 

--- a/server/nft.go
+++ b/server/nft.go
@@ -177,7 +177,7 @@ func getNftsFromOpensea(nftRepo persist.NFTRepository, userRepo persist.UserRepo
 				return
 			}
 			if !ownsWallet {
-				util.ErrResponse(c, http.StatusBadRequest, nft.ErrDoesNotOwnWallets{userID, addresses})
+				util.ErrResponse(c, http.StatusBadRequest, nft.ErrDoesNotOwnWallets{UserID: userID, Addresses: addresses})
 				return
 			}
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -133,6 +133,7 @@ func newRepos(db *sql.DB) *persist.Repositories {
 		ContractRepository:        postgres.NewContractRepository(db),
 		BackupRepository:          postgres.NewBackupRepository(db),
 		MembershipRepository:      postgres.NewMembershipRepository(db),
+		CommunityRepository:       postgres.NewCommunityRepository(db),
 	}
 }
 

--- a/service/community/community.go
+++ b/service/community/community.go
@@ -17,9 +17,9 @@ type communityData struct {
 	TokenIDRanges   []persist.TokenIDRange
 }
 
-// right now these communities are hard coded, if we wanted to have this be dynamic we can get all of the information we need on a collection
+// Communities - right now these Communities are hard coded, if we wanted to have this be dynamic we can get all of the information we need on a collection
 // from opensea or the indexed NFTs (indexed NFTs won't have a banner image)
-var communities = map[persist.Address]communityData{
+var Communities = map[persist.Address]communityData{
 	// cryptocoven
 	"0x5180db8f5c931aae63c74266b211f580155ecac8": {
 		Name:            "CryptoCoven",
@@ -59,7 +59,7 @@ var communities = map[persist.Address]communityData{
 // UpdateCommunities updates the communities in the database
 func UpdateCommunities(pCtx context.Context, communityRepository persist.CommunityRepository, galleryRepository persist.GalleryRepository, userRepository persist.UserRepository, nftRepository persist.NFTRepository) error {
 	done := make(chan error)
-	for a := range communities {
+	for a := range Communities {
 		go func(addr persist.Address) {
 			if err := UpdateCommunity(pCtx, addr, nftRepository, userRepository, galleryRepository, communityRepository); err != nil {
 				done <- err
@@ -67,7 +67,7 @@ func UpdateCommunities(pCtx context.Context, communityRepository persist.Communi
 			}
 		}(a)
 	}
-	for i := 0; i < len(communities); i++ {
+	for i := 0; i < len(Communities); i++ {
 		if err := <-done; err != nil {
 			return err
 		}
@@ -77,7 +77,7 @@ func UpdateCommunities(pCtx context.Context, communityRepository persist.Communi
 
 // UpdateCommunity updates a community in the database
 func UpdateCommunity(pCtx context.Context, addr persist.Address, nftRepository persist.NFTRepository, userRepository persist.UserRepository, galleryRepository persist.GalleryRepository, communityRepository persist.CommunityRepository) error {
-	data, ok := communities[addr]
+	data, ok := Communities[addr]
 	if !ok {
 		return fmt.Errorf("community %s not found", addr)
 	}
@@ -162,7 +162,7 @@ func filterValidRanges(ranges []persist.TokenIDRange, nfts []persist.NFT) []pers
 // UpdateCommunitiesToken updates the communities in the database
 func UpdateCommunitiesToken(pCtx context.Context, communityRepository persist.CommunityRepository, galleryRepository persist.GalleryTokenRepository, userRepository persist.UserRepository, tokenRepository persist.TokenRepository) error {
 	done := make(chan error)
-	for a := range communities {
+	for a := range Communities {
 		go func(addr persist.Address) {
 			if err := UpdateCommunityToken(pCtx, addr, tokenRepository, userRepository, galleryRepository, communityRepository); err != nil {
 				done <- err
@@ -170,7 +170,7 @@ func UpdateCommunitiesToken(pCtx context.Context, communityRepository persist.Co
 			}
 		}(a)
 	}
-	for i := 0; i < len(communities); i++ {
+	for i := 0; i < len(Communities); i++ {
 		if err := <-done; err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func UpdateCommunitiesToken(pCtx context.Context, communityRepository persist.Co
 
 // UpdateCommunityToken updates a community in the database
 func UpdateCommunityToken(pCtx context.Context, addr persist.Address, tokenRepository persist.TokenRepository, userRepository persist.UserRepository, galleryRepository persist.GalleryTokenRepository, communityRepository persist.CommunityRepository) error {
-	data := communities[addr]
+	data := Communities[addr]
 	community := persist.Community{
 		ContractAddress: addr,
 		TokenIDRanges:   data.TokenIDRanges,

--- a/service/community/community.go
+++ b/service/community/community.go
@@ -3,6 +3,7 @@ package community
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/mikeydub/go-gallery/service/nft"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -25,6 +26,33 @@ var communities = map[persist.Address]communityData{
 		Description:     "it's the season of the witch. 🌙",
 		BannerImageURL:  "https://lh3.googleusercontent.com/M42Xf9Vbu_yodzKVFA1I6TYXIx5Hz699gEtp2lDg9vGT7g-S4z_5cx2iYPub1kytnOlexV5WDdGOmpGeuH4-N0CYXi7FaC_iqEm4gQ=h600",
 		ProfileImageURL: "https://lh3.googleusercontent.com/E8MVasG7noxC0Fa_duhnexc2xze1PzT1jzyeaHsytOC4722C2Zeo7EhUR8-T6mSem9-4XE5ylrCtoAsceZ_lXez_kTaMufV5pfLc3Fk=s130",
+	},
+	// poolsuite exec
+	"0xb228d7b6e099618ca71bd5522b3a8c3788a8f172": {
+		Name:            "Poolsuite - Executive Member",
+		ProfileImageURL: "https://lh3.googleusercontent.com/p2lvRuQZalsroxpmS-q57pGRzyseAzEkLOGGsR6N6tXh_d4x6osxQtZBKqUMRreepnXJcuR80d-9YRIeMy5XnEsPp8aQQcWOyyPqjg=s130",
+		BannerImageURL:  "https://lh3.googleusercontent.com/pN8dsrbR5TnTRCtTD7qNqZABzny1JB1tx5xXSSz3XdlovlptmEymNcQ7JE1DZJTZZHEqDg2dzArvcucoUL0dDHdnAMLxU_Nf-gsFSQ=h600",
+	},
+	// poolsuite member
+	"0x123214ef2bb526d1b3fb84a6d448985f537d9763": {
+		Name:            "Poolsuite - Pool Member",
+		ProfileImageURL: "https://lh3.googleusercontent.com/y8b77O5wH-7pd2jK2eRBDkkJV_SO56FkCPqx3_L6UVdKLFXx1IxqUUYoGSh0m-2jQhyzS4TKdmFPNnsBZlVRQ6rxjLVPaLUOjQS-Gfk=s130",
+		BannerImageURL:  "https://lh3.googleusercontent.com/S-Zjma4LRM3_Krpb_Uu_lPEStcOQ5vgolc3yqfafCOzc3o6O1ZKRCmdKwN2Dpg5cIJ54XFP639D11wOQT7dx6rADnsb1AR9f8PNi=h600",
+	},
+	// poolsuite patron
+	"0x364547adfc7a180744d762056df35eeaea803ec4": {
+		Name:            "Poolsuite - Patron of the Pool",
+		ProfileImageURL: "https://lh3.googleusercontent.com/9U-ga_5kztUukT_6bpEBtyFVbmTM9ywObB7MDbB_9iwnY9ML1cpCh63yeU2H2Q43thMlGuGhNAOZDrpN8ATAQU1Y9O_Ffqprvk-U=s130",
+		BannerImageURL:  "https://lh3.googleusercontent.com/MAkRl41geA5QaqEk4EYBEazEUkVZyvzNOQSn63QcX4kKMDKqj-okb23UtF6q5Mw0Ry_bHUyPb_nzuHj-PjRCHE2tT_PEE8Od0O9S=h600",
+	},
+	"0x13aae6f9599880edbb7d144bb13f1212cee99533": {
+		Name:        "The Leggendas",
+		Description: "Future pasts, lost civilisations. A reminiscence of the new renaissance. What will remain of us, at the end of time? Who will stand, to tell our story?",
+		TokenIDRanges: []persist.TokenIDRange{
+			{Start: persist.TokenID(big.NewInt(1000000).Text(16)), End: persist.TokenID(big.NewInt(1000887).Text(16))},
+		},
+		BannerImageURL:  "https://lh3.googleusercontent.com/l4j8nhI86Jj80fBrhnvHXksaXBr4Ou4yW4mvoqlzC2fsSi-MlE1mErg8mf5PGiUQjUufq2A9A3Mheg0eSnu8i_wxoLP8gVzgmcpMXaw=h600",
+		ProfileImageURL: "https://lh3.googleusercontent.com/ParWg5Mn9HltQgoBapkIDzmeG4N2yIYtwdnQuibiscX8FIjFc8bfOeAl7Qt3ccrkU1BAUjeGqyMW3AeKbNMvcQEVET2tIME6fi0-ns8=w192",
 	},
 }
 
@@ -68,9 +96,13 @@ func UpdateCommunity(pCtx context.Context, addr persist.Address, nftRepository p
 	}
 	allNFTs = filterValidRanges(data.TokenIDRanges, allNFTs)
 
+	seenUsers := make(map[persist.DBID]bool)
 	for _, anN := range allNFTs {
 		user, err := userRepository.GetByAddress(pCtx, anN.OwnerAddress)
 		if err != nil {
+			continue
+		}
+		if seenUsers[user.ID] {
 			continue
 		}
 		galleries, err := galleryRepository.GetByUserID(pCtx, user.ID)
@@ -95,6 +127,7 @@ func UpdateCommunity(pCtx context.Context, addr persist.Address, nftRepository p
 				}
 			}
 		}
+		seenUsers[user.ID] = true
 	}
 	community.Owners = owners
 	err = communityRepository.UpsertByContract(pCtx, addr, community)

--- a/service/community/community.go
+++ b/service/community/community.go
@@ -64,6 +64,8 @@ func UpdateCommunities(pCtx context.Context, communityRepository persist.Communi
 			if err := UpdateCommunity(pCtx, addr, nftRepository, userRepository, galleryRepository, communityRepository); err != nil {
 				done <- err
 				return
+			} else {
+				done <- nil
 			}
 		}(a)
 	}

--- a/service/community/community.go
+++ b/service/community/community.go
@@ -1,0 +1,222 @@
+package community
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mikeydub/go-gallery/service/nft"
+	"github.com/mikeydub/go-gallery/service/persist"
+)
+
+type communityData struct {
+	Name            string
+	Description     string
+	ProfileImageURL string
+	BannerImageURL  string
+	TokenIDRanges   []persist.TokenIDRange
+}
+
+// right now these communities are hard coded, if we wanted to have this be dynamic we can get all of the information we need on a collection
+// from opensea or the indexed NFTs (indexed NFTs won't have a banner image)
+var communities = map[persist.Address]communityData{
+	// cryptocoven
+	"0x5180db8f5c931aae63c74266b211f580155ecac8": {
+		Name:            "CryptoCoven",
+		Description:     "it's the season of the witch. 🌙",
+		BannerImageURL:  "https://lh3.googleusercontent.com/M42Xf9Vbu_yodzKVFA1I6TYXIx5Hz699gEtp2lDg9vGT7g-S4z_5cx2iYPub1kytnOlexV5WDdGOmpGeuH4-N0CYXi7FaC_iqEm4gQ=h600",
+		ProfileImageURL: "https://lh3.googleusercontent.com/E8MVasG7noxC0Fa_duhnexc2xze1PzT1jzyeaHsytOC4722C2Zeo7EhUR8-T6mSem9-4XE5ylrCtoAsceZ_lXez_kTaMufV5pfLc3Fk=s130",
+	},
+}
+
+// UpdateCommunities updates the communities in the database
+func UpdateCommunities(pCtx context.Context, communityRepository persist.CommunityRepository, galleryRepository persist.GalleryRepository, userRepository persist.UserRepository, nftRepository persist.NFTRepository) error {
+	done := make(chan error)
+	for a := range communities {
+		go func(addr persist.Address) {
+			if err := UpdateCommunity(pCtx, addr, nftRepository, userRepository, galleryRepository, communityRepository); err != nil {
+				done <- err
+				return
+			}
+		}(a)
+	}
+	for i := 0; i < len(communities); i++ {
+		if err := <-done; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpdateCommunity updates a community in the database
+func UpdateCommunity(pCtx context.Context, addr persist.Address, nftRepository persist.NFTRepository, userRepository persist.UserRepository, galleryRepository persist.GalleryRepository, communityRepository persist.CommunityRepository) error {
+	data, ok := communities[addr]
+	if !ok {
+		return fmt.Errorf("community %s not found", addr)
+	}
+	community := persist.Community{
+		ContractAddress: addr,
+		TokenIDRanges:   data.TokenIDRanges,
+		Name:            persist.NullString(data.Name),
+		Description:     persist.NullString(data.Description),
+		ProfileImageURL: persist.NullString(data.ProfileImageURL),
+		BannerImageURL:  persist.NullString(data.BannerImageURL),
+	}
+	owners := make([]persist.CommunityTokenOwner, 0, 50)
+	allNFTs, err := nftRepository.GetByContractAddress(pCtx, addr)
+	if err != nil {
+		return err
+	}
+	allNFTs = filterValidRanges(data.TokenIDRanges, allNFTs)
+
+	for _, anN := range allNFTs {
+		user, err := userRepository.GetByAddress(pCtx, anN.OwnerAddress)
+		if err != nil {
+			continue
+		}
+		galleries, err := galleryRepository.GetByUserID(pCtx, user.ID)
+		if err != nil {
+			continue
+		}
+	outer:
+		for _, gallery := range galleries {
+			for _, collection := range gallery.Collections {
+				for _, n := range collection.NFTs {
+					for _, tokenIDRange := range data.TokenIDRanges {
+						if tokenIDRange.Contains(n.OpenseaTokenID) {
+							community.Owners = append(owners, persist.CommunityTokenOwner{
+								UserID:      user.ID,
+								Address:     n.OwnerAddress,
+								Username:    user.Username,
+								PreviewNFTs: nft.GetPreviewsFromCollections(gallery.Collections),
+							})
+							break outer
+						}
+					}
+				}
+			}
+		}
+	}
+	community.Owners = owners
+	err = communityRepository.UpsertByContract(pCtx, addr, community)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func filterValidRanges(ranges []persist.TokenIDRange, nfts []persist.NFT) []persist.NFT {
+	if ranges == nil || len(ranges) == 0 {
+		return nfts
+	}
+	done := make(map[persist.TokenIdentifiers]bool)
+	newNFTs := make([]persist.NFT, 0, len(nfts))
+	for _, r := range ranges {
+		for _, n := range nfts {
+			tid := persist.NewTokenIdentifiers(n.Contract.ContractAddress, n.OpenseaTokenID)
+			if done[tid] {
+				continue
+			}
+			if r.Contains(n.OpenseaTokenID) {
+				done[tid] = true
+				newNFTs = append(newNFTs, n)
+			}
+		}
+	}
+	return newNFTs
+
+}
+
+// UpdateCommunitiesToken updates the communities in the database
+func UpdateCommunitiesToken(pCtx context.Context, communityRepository persist.CommunityRepository, galleryRepository persist.GalleryTokenRepository, userRepository persist.UserRepository, tokenRepository persist.TokenRepository) error {
+	done := make(chan error)
+	for a := range communities {
+		go func(addr persist.Address) {
+			if err := UpdateCommunityToken(pCtx, addr, tokenRepository, userRepository, galleryRepository, communityRepository); err != nil {
+				done <- err
+				return
+			}
+		}(a)
+	}
+	for i := 0; i < len(communities); i++ {
+		if err := <-done; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpdateCommunityToken updates a community in the database
+func UpdateCommunityToken(pCtx context.Context, addr persist.Address, tokenRepository persist.TokenRepository, userRepository persist.UserRepository, galleryRepository persist.GalleryTokenRepository, communityRepository persist.CommunityRepository) error {
+	data := communities[addr]
+	community := persist.Community{
+		ContractAddress: addr,
+		TokenIDRanges:   data.TokenIDRanges,
+		Name:            persist.NullString(data.Name),
+		Description:     persist.NullString(data.Description),
+		ProfileImageURL: persist.NullString(data.ProfileImageURL),
+		BannerImageURL:  persist.NullString(data.BannerImageURL),
+	}
+	owners := make([]persist.CommunityTokenOwner, 0, 50)
+	allNFTs, err := tokenRepository.GetByContract(pCtx, addr, -1, -1)
+	if err != nil {
+		return err
+	}
+	allNFTs = filterValidRangesToken(data.TokenIDRanges, allNFTs)
+
+	for _, anN := range allNFTs {
+		user, err := userRepository.GetByAddress(pCtx, anN.OwnerAddress)
+		if err != nil {
+			continue
+		}
+		galleries, err := galleryRepository.GetByUserID(pCtx, user.ID)
+		if err != nil {
+			continue
+		}
+	outer:
+		for _, gallery := range galleries {
+			for _, collection := range gallery.Collections {
+				for _, n := range collection.NFTs {
+					for _, tokenIDRange := range data.TokenIDRanges {
+						if tokenIDRange.Contains(n.TokenID) {
+							community.Owners = append(owners, persist.CommunityTokenOwner{
+								UserID:      user.ID,
+								Address:     n.OwnerAddress,
+								Username:    user.Username,
+								PreviewNFTs: nft.GetPreviewsFromCollectionsToken(gallery.Collections),
+							})
+							break outer
+						}
+					}
+				}
+			}
+		}
+	}
+	community.Owners = owners
+	err = communityRepository.UpsertByContract(pCtx, addr, community)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func filterValidRangesToken(ranges []persist.TokenIDRange, nfts []persist.Token) []persist.Token {
+	if ranges == nil || len(ranges) == 0 {
+		return nfts
+	}
+	done := make(map[persist.TokenIdentifiers]bool)
+	newNFTs := make([]persist.Token, 0, len(nfts))
+	for _, r := range ranges {
+		for _, n := range nfts {
+			tid := persist.NewTokenIdentifiers(n.ContractAddress, n.TokenID)
+			if done[tid] {
+				continue
+			}
+			if r.Contains(n.TokenID) {
+				done[tid] = true
+				newNFTs = append(newNFTs, n)
+			}
+		}
+	}
+	return newNFTs
+
+}

--- a/service/nft/nft.go
+++ b/service/nft/nft.go
@@ -144,7 +144,7 @@ func RefreshOpenseaNFTs(ctx context.Context, userID persist.DBID, walletAddresse
 		}
 
 		if !ownsWallet {
-			return ErrDoesNotOwnWallets{Id: userID, Addresses: addresses}
+			return ErrDoesNotOwnWallets{UserID: userID, Addresses: addresses}
 		}
 	}
 
@@ -175,10 +175,10 @@ func ContainsWalletAddresses(a []persist.Address, b persist.Address) bool {
 }
 
 type ErrDoesNotOwnWallets struct {
-	Id        persist.DBID
+	UserID    persist.DBID
 	Addresses []persist.Address
 }
 
 func (e ErrDoesNotOwnWallets) Error() string {
-	return fmt.Sprintf("user with ID %s does not own all wallets: %+v", e.Id, e.Addresses)
+	return fmt.Sprintf("user with ID %s does not own all wallets: %+v", e.UserID, e.Addresses)
 }

--- a/service/persist/community.go
+++ b/service/persist/community.go
@@ -1,0 +1,86 @@
+package persist
+
+import (
+	"context"
+	"database/sql/driver"
+	"encoding/json"
+)
+
+// Community represents a community
+type Community struct {
+	Version         NullInt32             `json:"version"` // schema version for this model
+	ID              DBID                  `json:"id" binding:"required"`
+	CreationTime    CreationTime          `json:"created_at"`
+	Deleted         NullBool              `json:"-"`
+	LastUpdated     LastUpdatedTime       `json:"last_updated"`
+	Name            NullString            `json:"name"`
+	Description     NullString            `json:"description"`
+	ContractAddress Address               `json:"contract_address"`
+	TokenIDRanges   []TokenIDRange        `json:"token_id_ranges"`
+	ProfileImageURL NullString            `json:"profile_image_url"`
+	BannerImageURL  NullString            `json:"banner_image_url"`
+	Owners          []CommunityTokenOwner `json:"owners"`
+}
+
+// CommunityTokenOwner represents a user who owns a community token
+type CommunityTokenOwner struct {
+	UserID      DBID         `json:"user_id"`
+	Address     Address      `json:"address"`
+	Username    NullString   `json:"username"`
+	PreviewNFTs []NullString `json:"preview_nfts"`
+}
+
+// TokenIDRange represents a range of token ids
+type TokenIDRange struct {
+	Start TokenID
+	End   TokenID
+}
+
+// CommunityRepository represents the interface for interacting with the persisted state of users
+type CommunityRepository interface {
+	UpsertByContract(context.Context, Address, Community) error
+	GetByContract(context.Context, Address) (Community, error)
+	GetAll(context.Context) ([]Community, error)
+}
+
+// Value implements the database/sql/driver Valuer interface for the membership owner type
+func (o CommunityTokenOwner) Value() (driver.Value, error) {
+	return json.Marshal(o)
+}
+
+// Scan implements the database/sql Scanner interface for the membership owner type
+func (o *CommunityTokenOwner) Scan(src interface{}) error {
+	if src == nil {
+		*o = CommunityTokenOwner{}
+		return nil
+	}
+	return json.Unmarshal(src.([]uint8), o)
+}
+
+// Value implements the database/sql/driver Valuer interface for the membership owner type
+func (t TokenIDRange) Value() (driver.Value, error) {
+	return json.Marshal(t)
+}
+
+// Scan implements the database/sql Scanner interface for the membership owner type
+func (t *TokenIDRange) Scan(src interface{}) error {
+	if src == nil {
+		*t = TokenIDRange{}
+		return nil
+	}
+	return json.Unmarshal(src.([]uint8), t)
+}
+
+// Contains returns true if the token id is within the token id range
+func (t TokenIDRange) Contains(id TokenID) bool {
+	return t.Start <= id && id <= t.End
+}
+
+// ErrCommunityNotFoundByAddress represents an error when a membership is not found by contract address
+type ErrCommunityNotFoundByAddress struct {
+	ContractAddress Address
+}
+
+func (e ErrCommunityNotFoundByAddress) Error() string {
+	return "membership not found by token id: " + e.ContractAddress.String()
+}

--- a/service/persist/community.go
+++ b/service/persist/community.go
@@ -82,5 +82,5 @@ type ErrCommunityNotFoundByAddress struct {
 }
 
 func (e ErrCommunityNotFoundByAddress) Error() string {
-	return "membership not found by token id: " + e.ContractAddress.String()
+	return "community not found by token id: " + e.ContractAddress.String()
 }

--- a/service/persist/membership.go
+++ b/service/persist/membership.go
@@ -53,15 +53,6 @@ type ErrMembershipNotFoundByTokenID struct {
 	TokenID TokenID
 }
 
-// ErrMembershipNotFoundByName represents an error when a membership is not found by name
-type ErrMembershipNotFoundByName struct {
-	Name string
-}
-
-func (e ErrMembershipNotFoundByName) Error() string {
-	return "membership not found by name: " + e.Name
-}
-
 func (e ErrMembershipNotFoundByTokenID) Error() string {
 	return "membership not found by token id: " + e.TokenID.String()
 }

--- a/service/persist/nft.go
+++ b/service/persist/nft.go
@@ -60,6 +60,7 @@ type CollectionNFT struct {
 	Name NullString `json:"name"`
 
 	Contract            ContractCollectionNFT `json:"asset_contract"`
+	OpenseaTokenID      TokenID               `json:"opensea_token_id"`
 	TokenCollectionName NullString            `json:"token_collection_name"`
 	CreatorAddress      Address               `json:"creator_address"`
 	CreatorName         NullString            `json:"creator_name"`
@@ -113,6 +114,7 @@ type NFTRepository interface {
 	GetByAddresses(context.Context, []Address) ([]NFT, error)
 	GetByID(context.Context, DBID) (NFT, error)
 	GetByContractData(context.Context, TokenID, Address) ([]NFT, error)
+	GetByContractAddress(context.Context, Address) ([]NFT, error)
 	GetByOpenseaID(context.Context, NullInt64, Address) ([]NFT, error)
 	UpdateByID(context.Context, DBID, DBID, interface{}) error
 	UpdateByIDUnsafe(context.Context, DBID, interface{}) error
@@ -155,7 +157,13 @@ type ErrNFTNotFoundByID struct {
 
 // ErrNFTNotFoundByContractData is an error that occurs when an NFT is not found by its contract data (token ID and contract address)
 type ErrNFTNotFoundByContractData struct {
-	TokenID, ContractAddress string
+	TokenID         TokenID
+	ContractAddress Address
+}
+
+// ErrNFTNotFoundByContractAddress is an error that occurs when an NFT is not found by its contract address
+type ErrNFTNotFoundByContractAddress struct {
+	ContractAddress Address
 }
 
 func (e ErrNFTNotFoundByID) Error() string {
@@ -163,5 +171,9 @@ func (e ErrNFTNotFoundByID) Error() string {
 }
 
 func (e ErrNFTNotFoundByContractData) Error() string {
-	return fmt.Sprintf("could not find NFT with contract address %v and token ID %v", e.ContractAddress, e.TokenID)
+	return fmt.Sprintf("could not find NFT with contract address %s and token ID %s", e.ContractAddress, e.TokenID)
+}
+
+func (e ErrNFTNotFoundByContractAddress) Error() string {
+	return fmt.Sprintf("could not find NFT with contract address %s", e.ContractAddress)
 }

--- a/service/persist/persist.go
+++ b/service/persist/persist.go
@@ -45,6 +45,7 @@ type Repositories struct {
 	ContractRepository        ContractRepository
 	BackupRepository          BackupRepository
 	MembershipRepository      MembershipRepository
+	CommunityRepository       CommunityRepository
 }
 
 // GenerateID generates a application-wide unique ID

--- a/service/persist/postgres/collection_nft.go
+++ b/service/persist/postgres/collection_nft.go
@@ -46,7 +46,7 @@ func NewCollectionRepository(db *sql.DB) *CollectionRepository {
 
 	getByUserIDOwnerStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,
 	c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,n.ID,n.OWNER_ADDRESS,
-	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
+	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.OPENSEA_TOKEN_ID,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
 	n.IMAGE_URL,n.IMAGE_THUMBNAIL_URL,n.IMAGE_PREVIEW_URL,n.ANIMATION_ORIGINAL_URL,n.ANIMATION_URL,n.CREATED_AT 
 	FROM collections c, unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality)
 	LEFT JOIN nfts n ON n.ID = nft
@@ -58,7 +58,7 @@ func NewCollectionRepository(db *sql.DB) *CollectionRepository {
 
 	getByUserIDStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,
 	c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,n.ID,n.OWNER_ADDRESS,
-	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
+	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.OPENSEA_TOKEN_ID,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
 	n.IMAGE_URL,n.IMAGE_THUMBNAIL_URL,n.IMAGE_PREVIEW_URL,n.ANIMATION_ORIGINAL_URL,n.ANIMATION_URL,n.CREATED_AT 
 	FROM collections c,unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality) 
 	LEFT JOIN nfts n ON n.ID = nft 
@@ -69,7 +69,7 @@ func NewCollectionRepository(db *sql.DB) *CollectionRepository {
 
 	getByIDOwnerStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,
 	c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,n.ID,n.OWNER_ADDRESS,
-	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
+	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.OPENSEA_TOKEN_ID,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
 	n.IMAGE_URL,n.IMAGE_THUMBNAIL_URL,n.IMAGE_PREVIEW_URL,n.ANIMATION_ORIGINAL_URL,n.ANIMATION_URL,n.CREATED_AT 
 	FROM collections c, unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality)
 	LEFT JOIN nfts n ON n.ID = nft
@@ -81,7 +81,7 @@ func NewCollectionRepository(db *sql.DB) *CollectionRepository {
 
 	getByIDStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,
 	c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,n.ID,n.OWNER_ADDRESS,
-	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME,
+	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.OPENSEA_TOKEN_ID,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME,
 	n.IMAGE_URL,n.IMAGE_THUMBNAIL_URL,n.IMAGE_PREVIEW_URL,n.ANIMATION_ORIGINAL_URL,n.ANIMATION_URL,n.CREATED_AT 
 	FROM collections c, unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality)
 	LEFT JOIN nfts n ON n.ID = nft
@@ -166,7 +166,7 @@ func (c *CollectionRepository) GetByUserID(pCtx context.Context, pUserID persist
 	for res.Next() {
 		var collection persist.Collection
 		var nft persist.CollectionNFT
-		err = res.Scan(&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote, &collection.Layout, &collection.Hidden, &collection.CreationTime, &collection.LastUpdated, &nft.ID, &nft.OwnerAddress, &nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName, &nft.ImageURL, &nft.ImageThumbnailURL, &nft.ImagePreviewURL, &nft.AnimationOriginalURL, &nft.AnimationURL, &nft.CreationTime)
+		err = res.Scan(&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote, &collection.Layout, &collection.Hidden, &collection.CreationTime, &collection.LastUpdated, &nft.ID, &nft.OwnerAddress, &nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.OpenseaTokenID, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName, &nft.ImageURL, &nft.ImageThumbnailURL, &nft.ImagePreviewURL, &nft.AnimationOriginalURL, &nft.AnimationURL, &nft.CreationTime)
 		if err != nil {
 			return nil, err
 		}
@@ -238,7 +238,7 @@ func (c *CollectionRepository) GetByID(pCtx context.Context, pID persist.DBID, p
 	for ; res.Next(); i++ {
 		colID := collection.ID
 		var nft persist.CollectionNFT
-		err = res.Scan(&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote, &collection.Layout, &collection.Hidden, &collection.CreationTime, &collection.LastUpdated, &nft.ID, &nft.OwnerAddress, &nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName, &nft.ImageURL, &nft.ImageThumbnailURL, &nft.ImagePreviewURL, &nft.AnimationOriginalURL, &nft.AnimationURL, &nft.CreationTime)
+		err = res.Scan(&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote, &collection.Layout, &collection.Hidden, &collection.CreationTime, &collection.LastUpdated, &nft.ID, &nft.OwnerAddress, &nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.OpenseaTokenID, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName, &nft.ImageURL, &nft.ImageThumbnailURL, &nft.ImagePreviewURL, &nft.AnimationOriginalURL, &nft.AnimationURL, &nft.CreationTime)
 		if err != nil {
 			return persist.Collection{}, err
 		}

--- a/service/persist/postgres/community.go
+++ b/service/persist/postgres/community.go
@@ -1,0 +1,80 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/mikeydub/go-gallery/service/persist"
+)
+
+// CommunityRepository is a repository for storing community information in the database
+type CommunityRepository struct {
+	db                   *sql.DB
+	upsertByContractStmt *sql.Stmt
+	getByContractStmt    *sql.Stmt
+	getAllStmt           *sql.Stmt
+}
+
+// NewCommunityRepository creates a new postgres repository for interacting with communities
+func NewCommunityRepository(db *sql.DB) *CommunityRepository {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	upsertByContractStmt, err := db.PrepareContext(ctx, `INSERT INTO community (ID,CONTRACT_ADDRESS,TOKEN_ID_RANGES,NAME,DESCRIPTION,PROFILE_IMAGE_URL,BANNER_IMAGE_URL,OWNERS,LAST_UPDATED) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) ON CONFLICT (CONTRACT_ADDRESS) DO UPDATE SET NAME = EXCLUDED.NAME, DESCRIPTION = EXCLUDED.DESCRIPTION, BANNER_IMAGE_URL = EXCLUDED.BANNER_IMAGE_URL, PROFILE_IMAGE_URL = EXCLUDED.PROFILE_IMAGE_URL, OWNERS = EXCLUDED.OWNERS, LAST_UPDATED = EXCLUDED.LAST_UPDATED;`)
+	checkNoErr(err)
+
+	getByContractStmt, err := db.PrepareContext(ctx, `SELECT ID,CREATED_AT,LAST_UPDATED,VERSION,TOKEN_ID_RANGES,NAME,DESCRIPTION,BANNER_IMAGE_URL,PROFILE_IMAGE_URL,OWNERS FROM community WHERE CONTRACT_ADDRESS = $1 AND DELETED = false;`)
+	checkNoErr(err)
+
+	getAllStmt, err := db.PrepareContext(ctx, `SELECT ID,CONTRACT_ADDRESS,TOKEN_ID_RANGES,NAME,DESCRIPTION,BANNER_IMAGE_URL,PROFILE_IMAGE_URL,OWNERS,CREATED_AT,LAST_UPDATED FROM community WHERE DELETED = false;`)
+	checkNoErr(err)
+
+	return &CommunityRepository{db: db, upsertByContractStmt: upsertByContractStmt, getByContractStmt: getByContractStmt, getAllStmt: getAllStmt}
+}
+
+// UpsertByContract upserts the given tier
+func (m *CommunityRepository) UpsertByContract(pCtx context.Context, pAddress persist.Address, pTier persist.Community) error {
+	_, err := m.upsertByContractStmt.ExecContext(pCtx, persist.GenerateID(), pAddress, pTier.TokenIDRanges, pTier.Name, pTier.Description, pTier.BannerImageURL, pTier.ProfileImageURL, pq.Array(pTier.Owners), pTier.LastUpdated)
+	return err
+}
+
+// GetByContract returns the tier with the given token ID
+func (m *CommunityRepository) GetByContract(pCtx context.Context, pContractAddress persist.Address) (persist.Community, error) {
+	tier := persist.Community{ContractAddress: pContractAddress}
+	err := m.getByContractStmt.QueryRowContext(pCtx, pContractAddress).Scan(&tier.ID, &tier.CreationTime, &tier.LastUpdated, &tier.Version, pq.Array(&tier.TokenIDRanges), &tier.Name, &tier.Description, &tier.BannerImageURL, &tier.ProfileImageURL, pq.Array(&tier.Owners))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return persist.Community{}, persist.ErrCommunityNotFoundByAddress{ContractAddress: pContractAddress}
+		}
+		return persist.Community{}, err
+	}
+
+	return tier, nil
+}
+
+// GetAll returns all the tiers
+func (m *CommunityRepository) GetAll(pCtx context.Context) ([]persist.Community, error) {
+	rows, err := m.getAllStmt.QueryContext(pCtx)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tiers := make([]persist.Community, 0, 10)
+	for rows.Next() {
+		tier := persist.Community{}
+		err := rows.Scan(&tier.ID, &tier.ContractAddress, pq.Array(&tier.TokenIDRanges), &tier.Name, &tier.Description, &tier.BannerImageURL, &tier.ProfileImageURL, pq.Array(&tier.Owners), &tier.CreationTime, &tier.LastUpdated)
+		if err != nil {
+			return nil, err
+		}
+		tiers = append(tiers, tier)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return tiers, nil
+}

--- a/service/persist/postgres/gallery_nft.go
+++ b/service/persist/postgres/gallery_nft.go
@@ -51,7 +51,7 @@ func NewGalleryRepository(db *sql.DB, gCache memstore.Cache) *GalleryRepository 
 	c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,
 	c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,
 	n.ID,n.OWNER_ADDRESS,
-	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME,
+	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.OPENSEA_TOKEN_ID,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME,
 	n.IMAGE_URL,n.IMAGE_THUMBNAIL_URL,n.IMAGE_PREVIEW_URL,n.ANIMATION_ORIGINAL_URL,n.ANIMATION_URL,n.CREATED_AT 
 	FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord)
 	LEFT JOIN collections c ON c.ID = coll AND c.DELETED = false
@@ -62,7 +62,7 @@ func NewGalleryRepository(db *sql.DB, gCache memstore.Cache) *GalleryRepository 
 	getByIDStmt, err := db.PrepareContext(ctx, `SELECT g.ID,g.VERSION,g.OWNER_USER_ID,g.CREATED_AT,g.LAST_UPDATED,
 	c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,
 	c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,n.ID,n.OWNER_ADDRESS,
-	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
+	n.MULTIPLE_OWNERS,n.NAME,n.CONTRACT,n.OPENSEA_TOKEN_ID,n.TOKEN_COLLECTION_NAME,n.CREATOR_ADDRESS,n.CREATOR_NAME, 
 	n.IMAGE_URL,n.IMAGE_THUMBNAIL_URL,n.IMAGE_PREVIEW_URL,n.ANIMATION_ORIGINAL_URL,n.ANIMATION_URL,n.CREATED_AT 
 	FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord)
 	LEFT JOIN collections c ON c.ID = coll AND c.DELETED = false
@@ -245,7 +245,7 @@ func (g *GalleryRepository) GetByUserID(pCtx context.Context, pUserID persist.DB
 		err := rows.Scan(&gallery.ID, &gallery.Version, &gallery.OwnerUserID, &gallery.CreationTime, &gallery.LastUpdated,
 			&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote,
 			&collection.Layout, &collection.Hidden, &collection.CreationTime, &collection.LastUpdated, &nft.ID, &nft.OwnerAddress,
-			&nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName,
+			&nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.OpenseaTokenID, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName,
 			&nft.ImageURL, &nft.ImageThumbnailURL, &nft.ImagePreviewURL, &nft.AnimationOriginalURL, &nft.AnimationURL, &nft.CreationTime)
 		if err != nil {
 			return nil, err
@@ -345,7 +345,7 @@ func (g *GalleryRepository) GetByID(pCtx context.Context, pID persist.DBID) (per
 		err := rows.Scan(&gallery.ID, &gallery.Version, &gallery.OwnerUserID, &gallery.CreationTime, &gallery.LastUpdated,
 			&collection.ID, &collection.OwnerUserID, &collection.Name, &collection.Version, &collection.Deleted, &collection.CollectorsNote,
 			&collection.Layout, &collection.Hidden, &collection.CreationTime, &collection.LastUpdated, &nft.ID, &nft.OwnerAddress,
-			&nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName,
+			&nft.MultipleOwners, &nft.Name, &nft.Contract, &nft.OpenseaTokenID, &nft.TokenCollectionName, &nft.CreatorAddress, &nft.CreatorName,
 			&nft.ImageURL, &nft.ImageThumbnailURL, &nft.ImagePreviewURL, &nft.AnimationOriginalURL, &nft.AnimationURL, &nft.CreationTime)
 		if err != nil {
 			return persist.Gallery{}, err


### PR DESCRIPTION
Changes:

- **Added** new table in DB for communities that is very similar to membership tiers
- **Added** persist code for getting and upserting communities
- **Added** package for updating community data
- **Added** endpoints for getting specific communities and all communities

Considerations:

- Do we want to be able to dynamically get data on any community or have a specific list of communities we want pages for? Right now, these endpoints work with a specific list we hard code but with a quick call to opensea we can get the necessary data to fill out data for any "community" (any opensea collection).

TODO:

- [ ] Tests
- [ ] GraphQL Resolver (maybe not required for this PR)