### PR TITLE
fallback to normal data fetching when cache fails

### DIFF
--- a/admin/gallery.go
+++ b/admin/gallery.go
@@ -16,6 +16,10 @@ type getGalleriesInput struct {
 	UserID persist.DBID `form:"user_id"`
 }
 
+type refreshCacheInput struct {
+	UserID persist.DBID `form:"user_id,required"`
+}
+
 func getGalleries(galleryRepo persist.GalleryRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
@@ -46,5 +50,22 @@ func getGalleries(galleryRepo persist.GalleryRepository) gin.HandlerFunc {
 		}
 
 		c.JSON(http.StatusOK, galleries)
+	}
+}
+
+func refreshCache(galleryRepo persist.GalleryRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input refreshCacheInput
+		if err := c.ShouldBindQuery(&input); err != nil {
+			util.ErrResponse(c, http.StatusBadRequest, err)
+			return
+		}
+
+		if err := galleryRepo.RefreshCache(c, input.UserID); err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
 	}
 }

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -28,6 +28,7 @@ func handlersInit(router *gin.Engine, db *sql.DB, stmts *statements, ethcl *ethc
 
 	galleries := api.Group("/galleries")
 	galleries.GET("/get", getGalleries(stmts.galleryRepo))
+	galleries.GET("/refresh", refreshCache(stmts.galleryRepo))
 
 	snapshot := api.Group("/snapshot")
 	snapshot.GET("/get", getSnapshot(stg))


### PR DESCRIPTION
Changes:

- **Changed** get galleries by user ID to fallback to default data fetching when the cache data is invalid and will log invalid data so we can see what put it there
- **Added** endpoint to admin backend for busting cache