### PR TITLE
do not clean strings

### DIFF
--- a/service/persist/persist.go
+++ b/service/persist/persist.go
@@ -190,8 +190,7 @@ func (n NullString) Value() (driver.Value, error) {
 	if n.String() == "" {
 		return "", nil
 	}
-	clean := strings.Map(cleanString, n.String())
-	return strings.ToValidUTF8(strings.ReplaceAll(clean, "\\u0000", ""), ""), nil
+	return strings.ToValidUTF8(strings.ReplaceAll(n.String(), "\\u0000", ""), ""), nil
 }
 
 // Scan implements the database/sql Scanner interface for the NullString type

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -591,9 +591,7 @@ func (m TokenMetadata) Value() (driver.Value, error) {
 		return nil, err
 	}
 
-	clean := strings.Map(cleanString, string(val))
-
-	return []byte(strings.ToValidUTF8(strings.ReplaceAll(clean, "\\u0000", ""), "")), nil
+	return []byte(strings.ToValidUTF8(strings.ReplaceAll(string(val), "\\u0000", ""), "")), nil
 }
 
 // Scan implements the database/sql Scanner interface for the AddressAtBlock type


### PR DESCRIPTION
Changes:

- **Removed** clean string for `NullString` and `TokenMetadata` types so that non print characters can show up (such as new lines)