### PR TITLE
use wacky collectors note

### DIFF
--- a/service/persist/postgres/t__nft_test.go
+++ b/service/persist/postgres/t__nft_test.go
@@ -17,31 +17,25 @@ func TestNFTCreate_Success(t *testing.T) {
 		Version:      1,
 		OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
 		Name:         "name",
-	}
+		CollectorsNote: `I
+		like
+		line
+		breaks
+		😨
+		[oh yeah](https://shoobiedoobie.com)
+		<>
+		{\""\"}
 
-	_, err := nftRepo.Create(context.Background(), nft)
-	a.NoError(err)
-
-}
-
-func TestNFTGetByID_Success(t *testing.T) {
-	a, db := setupTest(t)
-
-	nftRepo := NewNFTRepository(db, nil)
-
-	nft := persist.NFT{
-		Deleted:      false,
-		Version:      1,
-		OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-		Name:         "name",
+		*#%&^%$#@!
+		`,
 	}
 
 	id, err := nftRepo.Create(context.Background(), nft)
 	a.NoError(err)
-
 	nft2, err := nftRepo.GetByID(context.Background(), id)
 	a.NoError(err)
 	a.Equal(id, nft2.ID)
 	a.Equal(nft.OwnerAddress, nft2.OwnerAddress)
 	a.Equal(nft.Name, nft2.Name)
+	a.Equal(nft.CollectorsNote, nft2.CollectorsNote)
 }


### PR DESCRIPTION
Changes:

- **Changed** nft test to use a wacky collectors note to ensure that the sanitization rules do not break notes