### PR TITLE
Update gallery backup logic

### DIFF
--- a/server/t__integration_utils_test.go
+++ b/server/t__integration_utils_test.go
@@ -413,19 +413,19 @@ func addTokensToTokensRepo(s suite.Suite, tokenRepo persist.TokenRepository, wal
 			Name:            "NFT1",
 			ID:              "id1",
 			TokenID:         persist.TokenID(util.RandHexString(10)),
-			ContractAddress: persist.Address(fmt.Sprintf("0x%s", util.RandHexString(40))),
+			ContractAddress: persist.Address(util.RandEthAddress()),
 		},
 		{
 			OwnerAddress:    wallet.address,
 			Name:            "NFT2",
 			ID:              "id2",
-			ContractAddress: persist.Address(fmt.Sprintf("0x%s", util.RandHexString(40))),
+			ContractAddress: persist.Address(util.RandEthAddress()),
 		},
 		{
 			OwnerAddress:    wallet.address,
 			Name:            "NFT3",
 			ID:              "id3",
-			ContractAddress: persist.Address(fmt.Sprintf("0x%s", util.RandHexString(40))),
+			ContractAddress: persist.Address(util.RandEthAddress()),
 		},
 	}
 	tokenIDs, err := tokenRepo.CreateBulk(context.Background(), tokens)

--- a/server/t__routes_collection_token_test.go
+++ b/server/t__routes_collection_token_test.go
@@ -366,9 +366,9 @@ func createCollectionInDbForUserIDToken(assert *assert.Assertions, collectionNam
 
 func seedTokens(assert *assert.Assertions) []persist.DBID {
 	nfts := []persist.Token{
-		{CollectorsNote: "asd", OwnerAddress: tc.user1.address, TokenID: persist.TokenID(util.RandHexString(10)), ContractAddress: persist.Address(fmt.Sprintf("0x%s", util.RandHexString(40)))},
-		{CollectorsNote: "bbb", OwnerAddress: tc.user1.address, TokenID: persist.TokenID(util.RandHexString(10)), ContractAddress: persist.Address(fmt.Sprintf("0x%s", util.RandHexString(40)))},
-		{CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address, TokenID: persist.TokenID(util.RandHexString(10)), ContractAddress: persist.Address(fmt.Sprintf("0x%s", util.RandHexString(40)))},
+		{CollectorsNote: "asd", OwnerAddress: tc.user1.address, TokenID: persist.TokenID(util.RandHexString(10)), ContractAddress: persist.Address(util.RandEthAddress())},
+		{CollectorsNote: "bbb", OwnerAddress: tc.user1.address, TokenID: persist.TokenID(util.RandHexString(10)), ContractAddress: persist.Address(util.RandEthAddress())},
+		{CollectorsNote: "wowowowow", OwnerAddress: tc.user1.address, TokenID: persist.TokenID(util.RandHexString(10)), ContractAddress: persist.Address(util.RandEthAddress())},
 	}
 	nftIDs, err := tc.repos.TokenRepository.CreateBulk(context.Background(), nfts)
 	assert.Nil(err)

--- a/service/persist/postgres/backup.go
+++ b/service/persist/postgres/backup.go
@@ -120,6 +120,10 @@ func (b *BackupRepository) Insert(pCtx context.Context, pGallery persist.Gallery
 		}
 	}
 
+	// Backup pruning rules:
+	// - backups in the past 24 hours should be stored no more often than every 5 minutes
+	// - backups in the past 7 days should be stored no more often than every 1 hour
+	// - backups beyond the past 7 days should be stored no more often than every 1 day
 	if len(currentBackups) >= 2 {
 		day := time.Hour * 24
 		week := day * 7

--- a/service/persist/postgres/backup.go
+++ b/service/persist/postgres/backup.go
@@ -49,7 +49,7 @@ func NewBackupRepository(db *sql.DB) *BackupRepository {
 	deleteBackupStmt, err := db.PrepareContext(ctx, `DELETE FROM backups WHERE ID = $1;`)
 	checkNoErr(err)
 
-	insertBackupStmt, err := db.PrepareContext(ctx, `INSERT INTO backups (ID, GALLERY_ID, VERSION, GALLERY) VALUES ($1, $2, $3, $4);`)
+	insertBackupStmt, err := db.PrepareContext(ctx, `INSERT INTO backups (ID, GALLERY_ID, VERSION, GALLERY, CREATED_AT) VALUES ($1, $2, $3, $4, $5);`)
 	checkNoErr(err)
 
 	getUserAddressesStmt, err := db.PrepareContext(ctx, `SELECT ADDRESSES FROM users WHERE ID = $1;`)
@@ -139,7 +139,7 @@ func (b *BackupRepository) Insert(pCtx context.Context, pGallery persist.Gallery
 				continue
 			}
 
-			// if two backups are under a week old, but over a day old, and within an hour apart, keep the older one
+			// if two backups are under a week old, over a day old, and within an hour apart, keep the older one
 			if time.Since(prevCreationTime) < week &&
 				time.Since(currCreationTime) < week &&
 				time.Since(prevCreationTime) > day &&
@@ -162,7 +162,7 @@ func (b *BackupRepository) Insert(pCtx context.Context, pGallery persist.Gallery
 		}
 	}
 
-	_, err = b.insertBackupStmt.ExecContext(pCtx, persist.GenerateID(), pGallery.ID, pGallery.Version, pGallery)
+	_, err = b.insertBackupStmt.ExecContext(pCtx, persist.GenerateID(), pGallery.ID, pGallery.Version, pGallery, persist.CreationTime(time.Now()))
 	if err != nil {
 		return err
 	}

--- a/service/persist/postgres/t__backup_test.go
+++ b/service/persist/postgres/t__backup_test.go
@@ -120,3 +120,80 @@ func TestNoThrottle_Success(t *testing.T) {
 	a.Len(backups, 2)
 	a.Len(backups[0].Gallery.Collections, 1)
 }
+
+// Backup pruning rules:
+// - backups in the past 24 hours should be stored no more often than every 5 minutes
+// - backups in the past 7 days should be stored no more often than every 1 hour
+// - backups beyond the past 7 days should be stored no more often than every 1 day
+func TestPrune_Success(t *testing.T) {
+	// timestamps within past 24h
+	d1 := time.Now().Add(-6 * time.Minute)
+	d2 := time.Now().Add(-7 * time.Minute)
+	d3 := time.Now().Add(-15 * time.Minute)
+	d4 := time.Now().Add(-25 * time.Minute)
+	d5 := time.Now().Add(-1 * time.Hour)
+	d6 := time.Now().Add(-2 * time.Hour)
+	d7 := time.Now().Add(-2*time.Hour - 1*time.Minute)
+	d8 := time.Now().Add(-15 * time.Hour)
+	// timestamps within past 7d
+	day := 24 * time.Hour
+	w1 := time.Now().Add(-3 * day)
+	w2 := time.Now().Add(-3*day - 20*time.Minute)
+	w3 := time.Now().Add(-3*day - 30*time.Minute)
+	w4 := time.Now().Add(-3*day - 40*time.Minute)
+	w5 := time.Now().Add(-3*day - 120*time.Minute)
+	w6 := time.Now().Add(-5 * day)
+	w7 := time.Now().Add(-6 * day)
+	// timestamps beyond 7d
+	t1 := time.Now().Add(-10 * day)
+	t2 := time.Now().Add(-10*day - 30*time.Minute)
+	t3 := time.Now().Add(-11 * day)
+	t4 := time.Now().Add(-12*day - 30*time.Minute)
+	t5 := time.Now().Add(-13 * day)
+	t6 := time.Now().Add(-30 * day)
+	t7 := time.Now().Add(-60 * day)
+
+	testCases := []struct {
+		input    []time.Time
+		expected []time.Time
+	}{
+		{input: []time.Time{d1, d2, d3, d4}, expected: []time.Time{d1, d3, d4}},
+		{input: []time.Time{d1, d3, d6, d7}, expected: []time.Time{d1, d3, d6}},
+		{input: []time.Time{d1, d2, d3, d4, d5, d6, d7, d8}, expected: []time.Time{d1, d3, d4, d5, d6, d8}},
+		{input: []time.Time{w1, w2, w3, w4}, expected: []time.Time{w1}},
+		{input: []time.Time{w2, w4, w5, w6, w7}, expected: []time.Time{w2, w5, w6, w7}},
+		{input: []time.Time{t1, t2, t3, t4, t5}, expected: []time.Time{t1, t3, t4}},
+		{input: []time.Time{t2, t3, t5, t6, t7}, expected: []time.Time{t2, t5, t6, t7}},
+		{input: []time.Time{
+			d1, d2, d3, d4, d5, d6, d7, d8,
+			w1, w2, w3, w4, w5, w6, w7,
+			t1, t2, t3, t4, t5, t6, t7,
+		}, expected: []time.Time{
+			d1, d3, d4, d5, d6, d8, w1, w5,
+			w6, w7, t1, t3, t4, t6, t7,
+		}},
+	}
+
+	for _, tc := range testCases {
+		a, db := setupTest(t)
+		userID, _, _, g, backupRepo, _, _, _, _ := createMockGallery(t, a, db)
+
+		// manually seed all inputs except for the first one
+		for _, inputTimestamp := range tc.input {
+			backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(inputTimestamp))
+		}
+
+		// officially insert a gallery via .Insert() to trigger underlying pruning
+		backupRepo.Insert(context.Background(), g)
+
+		backups, err := backupRepo.Get(context.Background(), userID)
+		a.NoError(err)
+		// should have a length of the expected seeded backups *plus* the officially inserted gallery via .Insert()
+		a.Len(backups, len(tc.expected)+1)
+		for i := 0; i < len(backups)-1; i++ {
+			backup := backups[i]
+			// queried results are returned in reverse of insert order
+			a.True(time.Time(backup.CreationTime).Equal(tc.expected[len(tc.expected)-1-i]))
+		}
+	}
+}

--- a/service/persist/postgres/t__backup_test.go
+++ b/service/persist/postgres/t__backup_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/mikeydub/go-gallery/service/memstore/redis"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -107,7 +108,8 @@ func TestBackupRestore_Success(t *testing.T) {
 	a.Len(galleries[0].Collections, 1)
 }
 
-func TestOneBackupADay_Success(t *testing.T) {
+// backups made within 5 mins of each other should be de-duped
+func TestThrottle_Success(t *testing.T) {
 	a, db := setupTest(t)
 
 	galleryRepo := NewGalleryRepository(db, redis.NewCache(0))
@@ -117,7 +119,6 @@ func TestOneBackupADay_Success(t *testing.T) {
 	backupRepo := NewBackupRepository(db)
 
 	user := persist.User{
-
 		Username:           "username",
 		UsernameIdempotent: "username-idempotent",
 		Addresses: []persist.Address{
@@ -192,5 +193,92 @@ func TestOneBackupADay_Success(t *testing.T) {
 	backups, err = backupRepo.Get(context.Background(), userID)
 	a.NoError(err)
 	a.Len(backups, 1)
+	a.Len(backups[0].Gallery.Collections, 1)
+}
+
+// backups made over 5 mins of each other should be added
+func TestNoThrottle_Success(t *testing.T) {
+	a, db := setupTest(t)
+
+	galleryRepo := NewGalleryRepository(db, redis.NewCache(0))
+	collectionRepo := NewCollectionRepository(db, galleryRepo)
+	nftRepo := NewNFTRepository(db, galleryRepo)
+	userRepo := NewUserRepository(db)
+	backupRepo := NewBackupRepository(db)
+
+	user := persist.User{
+		Username:           "username",
+		UsernameIdempotent: "username-idempotent",
+		Addresses: []persist.Address{
+			"0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+		},
+	}
+
+	userID, err := userRepo.Create(context.Background(), user)
+	a.NoError(err)
+
+	nfts := []persist.NFT{
+		{
+			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+			Name:         "name",
+			OpenseaID:    1,
+		},
+		{
+			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+			Name:         "blah blah",
+			OpenseaID:    10,
+		},
+	}
+
+	ids, err := nftRepo.CreateBulk(context.Background(), nfts)
+	a.NoError(err)
+
+	collection := persist.CollectionDB{
+		Name:        "name",
+		OwnerUserID: userID,
+		NFTs:        ids,
+	}
+
+	collID, err := collectionRepo.Create(context.Background(), collection)
+	a.NoError(err)
+
+	gallery := persist.GalleryDB{
+		OwnerUserID: userID,
+		Collections: []persist.DBID{collID},
+	}
+
+	id, err := galleryRepo.Create(context.Background(), gallery)
+	a.NoError(err)
+
+	g, err := galleryRepo.GetByID(context.Background(), id)
+	a.NoError(err)
+
+	err = backupRepo.Insert(context.Background(), g)
+	a.NoError(err)
+
+	backups, err := backupRepo.Get(context.Background(), userID)
+	a.NoError(err)
+	a.Len(backups, 1)
+	a.Len(backups[0].Gallery.Collections, 1)
+
+	collection2 := persist.CollectionDB{
+		Name:        "name2",
+		OwnerUserID: userID,
+		NFTs:        ids,
+	}
+
+	collID2, err := collectionRepo.Create(context.Background(), collection2)
+	a.NoError(err)
+
+	err = galleryRepo.Update(context.Background(), id, userID, persist.GalleryUpdateInput{
+		Collections: []persist.DBID{collID, collID2},
+	})
+	a.NoError(err)
+
+	backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(time.Now().Local().Add(time.Hour)))
+
+	backups, err = backupRepo.Get(context.Background(), userID)
+	a.NoError(err)
+	a.Len(backups, 2)
 	a.Len(backups[0].Gallery.Collections, 1)
 }

--- a/service/persist/postgres/t__backup_test.go
+++ b/service/persist/postgres/t__backup_test.go
@@ -5,72 +5,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mikeydub/go-gallery/service/memstore/redis"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/sirupsen/logrus"
 )
 
 func TestBackupRestore_Success(t *testing.T) {
 	a, db := setupTest(t)
+	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, nftRepo, _ := createMockGallery(t, a, db)
 
-	galleryRepo := NewGalleryRepository(db, redis.NewCache(0))
-	collectionRepo := NewCollectionRepository(db, galleryRepo)
-	nftRepo := NewNFTRepository(db, galleryRepo)
-	userRepo := NewUserRepository(db)
-	backupRepo := NewBackupRepository(db)
-
-	user := persist.User{
-
-		Username:           "username",
-		UsernameIdempotent: "username-idempotent",
-		Addresses: []persist.Address{
-			"0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-		},
-	}
-
-	userID, err := userRepo.Create(context.Background(), user)
-	a.NoError(err)
-
-	logrus.Infof("userID: %s", userID)
-	nfts := []persist.NFT{
-		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-			Name:         "name",
-			OpenseaID:    1,
-		},
-		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-			Name:         "blah blah",
-			OpenseaID:    10,
-		},
-	}
-
-	ids, err := nftRepo.CreateBulk(context.Background(), nfts)
-	a.NoError(err)
-
-	collection := persist.CollectionDB{
-		Name:        "name",
-		OwnerUserID: userID,
-		NFTs:        ids,
-	}
-
-	collID, err := collectionRepo.Create(context.Background(), collection)
-	a.NoError(err)
-
-	gallery := persist.GalleryDB{
-		OwnerUserID: userID,
-		Collections: []persist.DBID{collID},
-	}
-
-	id, err := galleryRepo.Create(context.Background(), gallery)
-	a.NoError(err)
-
-	g, err := galleryRepo.GetByID(context.Background(), id)
-	a.NoError(err)
-
-	logrus.Infof("gallery owner %s", g.OwnerUserID)
-
-	err = backupRepo.Insert(context.Background(), g)
+	err := backupRepo.Insert(context.Background(), g)
 	a.NoError(err)
 
 	backups, err := backupRepo.Get(context.Background(), userID)
@@ -81,18 +23,18 @@ func TestBackupRestore_Success(t *testing.T) {
 	collection2 := persist.CollectionDB{
 		Name:        "name2",
 		OwnerUserID: userID,
-		NFTs:        ids,
+		NFTs:        nftIDs,
 	}
 
 	collID2, err := collectionRepo.Create(context.Background(), collection2)
 	a.NoError(err)
 
-	err = galleryRepo.Update(context.Background(), id, userID, persist.GalleryUpdateInput{
+	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
 		Collections: []persist.DBID{collID, collID2},
 	})
 	a.NoError(err)
 
-	err = nftRepo.UpdateByID(context.Background(), ids[0], userID, persist.NFTUpdateOwnerAddressInput{
+	err = nftRepo.UpdateByID(context.Background(), nftIDs[0], userID, persist.NFTUpdateOwnerAddressInput{
 		OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d3",
 	})
 	a.NoError(err)
@@ -111,61 +53,9 @@ func TestBackupRestore_Success(t *testing.T) {
 // backups made within 5 mins of each other should be de-duped
 func TestThrottle_Success(t *testing.T) {
 	a, db := setupTest(t)
+	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
 
-	galleryRepo := NewGalleryRepository(db, redis.NewCache(0))
-	collectionRepo := NewCollectionRepository(db, galleryRepo)
-	nftRepo := NewNFTRepository(db, galleryRepo)
-	userRepo := NewUserRepository(db)
-	backupRepo := NewBackupRepository(db)
-
-	user := persist.User{
-		Username:           "username",
-		UsernameIdempotent: "username-idempotent",
-		Addresses: []persist.Address{
-			"0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-		},
-	}
-
-	userID, err := userRepo.Create(context.Background(), user)
-	a.NoError(err)
-
-	nfts := []persist.NFT{
-		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-			Name:         "name",
-			OpenseaID:    1,
-		},
-		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-			Name:         "blah blah",
-			OpenseaID:    10,
-		},
-	}
-
-	ids, err := nftRepo.CreateBulk(context.Background(), nfts)
-	a.NoError(err)
-
-	collection := persist.CollectionDB{
-		Name:        "name",
-		OwnerUserID: userID,
-		NFTs:        ids,
-	}
-
-	collID, err := collectionRepo.Create(context.Background(), collection)
-	a.NoError(err)
-
-	gallery := persist.GalleryDB{
-		OwnerUserID: userID,
-		Collections: []persist.DBID{collID},
-	}
-
-	id, err := galleryRepo.Create(context.Background(), gallery)
-	a.NoError(err)
-
-	g, err := galleryRepo.GetByID(context.Background(), id)
-	a.NoError(err)
-
-	err = backupRepo.Insert(context.Background(), g)
+	err := backupRepo.Insert(context.Background(), g)
 	a.NoError(err)
 
 	backups, err := backupRepo.Get(context.Background(), userID)
@@ -176,13 +66,13 @@ func TestThrottle_Success(t *testing.T) {
 	collection2 := persist.CollectionDB{
 		Name:        "name2",
 		OwnerUserID: userID,
-		NFTs:        ids,
+		NFTs:        nftIDs,
 	}
 
 	collID2, err := collectionRepo.Create(context.Background(), collection2)
 	a.NoError(err)
 
-	err = galleryRepo.Update(context.Background(), id, userID, persist.GalleryUpdateInput{
+	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
 		Collections: []persist.DBID{collID, collID2},
 	})
 	a.NoError(err)
@@ -199,61 +89,9 @@ func TestThrottle_Success(t *testing.T) {
 // backups made over 5 mins of each other should be added
 func TestNoThrottle_Success(t *testing.T) {
 	a, db := setupTest(t)
+	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
 
-	galleryRepo := NewGalleryRepository(db, redis.NewCache(0))
-	collectionRepo := NewCollectionRepository(db, galleryRepo)
-	nftRepo := NewNFTRepository(db, galleryRepo)
-	userRepo := NewUserRepository(db)
-	backupRepo := NewBackupRepository(db)
-
-	user := persist.User{
-		Username:           "username",
-		UsernameIdempotent: "username-idempotent",
-		Addresses: []persist.Address{
-			"0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-		},
-	}
-
-	userID, err := userRepo.Create(context.Background(), user)
-	a.NoError(err)
-
-	nfts := []persist.NFT{
-		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-			Name:         "name",
-			OpenseaID:    1,
-		},
-		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-			Name:         "blah blah",
-			OpenseaID:    10,
-		},
-	}
-
-	ids, err := nftRepo.CreateBulk(context.Background(), nfts)
-	a.NoError(err)
-
-	collection := persist.CollectionDB{
-		Name:        "name",
-		OwnerUserID: userID,
-		NFTs:        ids,
-	}
-
-	collID, err := collectionRepo.Create(context.Background(), collection)
-	a.NoError(err)
-
-	gallery := persist.GalleryDB{
-		OwnerUserID: userID,
-		Collections: []persist.DBID{collID},
-	}
-
-	id, err := galleryRepo.Create(context.Background(), gallery)
-	a.NoError(err)
-
-	g, err := galleryRepo.GetByID(context.Background(), id)
-	a.NoError(err)
-
-	err = backupRepo.Insert(context.Background(), g)
+	err := backupRepo.Insert(context.Background(), g)
 	a.NoError(err)
 
 	backups, err := backupRepo.Get(context.Background(), userID)
@@ -264,13 +102,13 @@ func TestNoThrottle_Success(t *testing.T) {
 	collection2 := persist.CollectionDB{
 		Name:        "name2",
 		OwnerUserID: userID,
-		NFTs:        ids,
+		NFTs:        nftIDs,
 	}
 
 	collID2, err := collectionRepo.Create(context.Background(), collection2)
 	a.NoError(err)
 
-	err = galleryRepo.Update(context.Background(), id, userID, persist.GalleryUpdateInput{
+	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
 		Collections: []persist.DBID{collID, collID2},
 	})
 	a.NoError(err)

--- a/service/persist/postgres/t__backup_test.go
+++ b/service/persist/postgres/t__backup_test.go
@@ -193,7 +193,9 @@ func TestPrune_Success(t *testing.T) {
 		for i := 0; i < len(backups)-1; i++ {
 			backup := backups[i]
 			// queried results are returned in reverse of insert order
-			a.True(time.Time(backup.CreationTime).Equal(tc.expected[len(tc.expected)-1-i]))
+			actualCreationTime := time.Time(backup.CreationTime).Round(time.Second)
+			expectedCreationTime := tc.expected[len(tc.expected)-1-i].Round(time.Second)
+			a.True(actualCreationTime.Equal(expectedCreationTime))
 		}
 	}
 }

--- a/service/persist/postgres/t__utils_test.go
+++ b/service/persist/postgres/t__utils_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mikeydub/go-gallery/service/memstore/redis"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -40,12 +41,12 @@ func createMockGallery(t *testing.T, a *assert.Assertions, db *sql.DB) (persist.
 	userRepo := NewUserRepository(db)
 	backupRepo := NewBackupRepository(db)
 
+	address := util.RandEthAddress()
+
 	user := persist.User{
 		Username:           "username",
 		UsernameIdempotent: "username-idempotent",
-		Addresses: []persist.Address{
-			"0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
-		},
+		Addresses:          []persist.Address{persist.Address(address)},
 	}
 
 	userID, err := userRepo.Create(context.Background(), user)
@@ -53,12 +54,12 @@ func createMockGallery(t *testing.T, a *assert.Assertions, db *sql.DB) (persist.
 
 	nfts := []persist.NFT{
 		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+			OwnerAddress: persist.Address(address),
 			Name:         "name",
 			OpenseaID:    1,
 		},
 		{
-			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+			OwnerAddress: persist.Address(address),
 			Name:         "blah blah",
 			OpenseaID:    10,
 		},

--- a/service/persist/postgres/t__utils_test.go
+++ b/service/persist/postgres/t__utils_test.go
@@ -1,9 +1,12 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
+	"github.com/mikeydub/go-gallery/service/memstore/redis"
+	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,4 +31,61 @@ func setupTest(t *testing.T) (*assert.Assertions, *sql.DB) {
 	})
 
 	return assert.New(t), db
+}
+
+func createMockGallery(t *testing.T, a *assert.Assertions, db *sql.DB) (persist.DBID, persist.DBID, []persist.DBID, persist.Gallery, *BackupRepository, *GalleryRepository, *CollectionRepository, *NFTRepository, *UserRepository) {
+	galleryRepo := NewGalleryRepository(db, redis.NewCache(0))
+	collectionRepo := NewCollectionRepository(db, galleryRepo)
+	nftRepo := NewNFTRepository(db, galleryRepo)
+	userRepo := NewUserRepository(db)
+	backupRepo := NewBackupRepository(db)
+
+	user := persist.User{
+		Username:           "username",
+		UsernameIdempotent: "username-idempotent",
+		Addresses: []persist.Address{
+			"0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+		},
+	}
+
+	userID, err := userRepo.Create(context.Background(), user)
+	a.NoError(err)
+
+	nfts := []persist.NFT{
+		{
+			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+			Name:         "name",
+			OpenseaID:    1,
+		},
+		{
+			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d2",
+			Name:         "blah blah",
+			OpenseaID:    10,
+		},
+	}
+
+	nftIDs, err := nftRepo.CreateBulk(context.Background(), nfts)
+	a.NoError(err)
+
+	collection := persist.CollectionDB{
+		Name:        "name",
+		OwnerUserID: userID,
+		NFTs:        nftIDs,
+	}
+
+	collID, err := collectionRepo.Create(context.Background(), collection)
+	a.NoError(err)
+
+	gallery := persist.GalleryDB{
+		OwnerUserID: userID,
+		Collections: []persist.DBID{collID},
+	}
+
+	id, err := galleryRepo.Create(context.Background(), gallery)
+	a.NoError(err)
+
+	g, err := galleryRepo.GetByID(context.Background(), id)
+	a.NoError(err)
+
+	return userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, nftRepo, userRepo
 }

--- a/util/random.go
+++ b/util/random.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"math/rand"
 )
 
@@ -25,4 +26,9 @@ func RandHexString(n int) string {
 		b[i] = hex[rand.Intn(len(hex))]
 	}
 	return string(b)
+}
+
+// RandEthAddress returns a random ethereum address
+func RandEthAddress() string {
+	return fmt.Sprintf("0x%s", RandHexString(40))
 }


### PR DESCRIPTION
### Changes

Updated behavior:
- **Store up to 50 backups per gallery.** Will keep an eye on the size of this DB ballooning. Cool thing is if this is too frequent, we can simply update the pruning rules to slowly clear out the DB.
- **Reduce backup frequency from 12 hours to 5 mins**, if change was made in past 24h

New behavior:
- Backups in the past 7 days should be stored no more often than every 1 hour
- Backups beyond the past 7 days should be stored no more often than every 1 day

(See additional notes in files)

- [x] Automated tests
- [x] Manual testing in dev

### Manual Testing on Dev

Initial state:
![Screen Shot 2022-03-29 at 2 14 53 AM](https://user-images.githubusercontent.com/12162433/160546497-b7f32137-c3f0-4f8c-9460-41ea26c6913e.png)

The latest backup inserted was at `03-29 06:11`. I made changes to my gallery at `06:12`, `06:13`, etc. and did not see any inserts to the DB. This was expected because the changes were within 5 minutes of the previous update ✅

I then made an update to a collection at `06:18`, 7 minutes after the last insert:
![Screen Shot 2022-03-29 at 2 20 02 AM](https://user-images.githubusercontent.com/12162433/160546885-2b9b250b-31ca-425c-b2f3-e6f79dfbe5bc.png)

The `06:18` backup was inserted. ✅

The previous `06:11` backup remained intact, since it had been >5 minutes since the last update. ✅

All but one entry from `03-24` were pruned, since the changes occurred within 1 hour of each other. Specifically, the latest one was kept. ✅
