### PR TITLE
GraphQL Updates

### DIFF
--- a/graphql/dataloader/dataloaders.go
+++ b/graphql/dataloader/dataloaders.go
@@ -28,6 +28,9 @@ const defaultWaitTime = 2 * time.Millisecond
 // a single request, nor should they be shared between requests (since the data returned is
 // relative to the current request context, including the user and their auth status).
 type Loaders struct {
+
+	// Every entry here must have a corresponding entry in the Clear___Caches methods below
+
 	UserByUserId             UserLoaderByID
 	UserByUsername           UserLoaderByString
 	UserByAddress            UserLoaderByAddress
@@ -118,6 +121,74 @@ func NewLoaders(ctx context.Context, q *sqlc.Queries) *Loaders {
 	}
 
 	return loaders
+}
+
+// These are pretty verbose and repetitive; hopefully generics make this cleaner in the future
+
+func (l *Loaders) ClearAllCaches() {
+	l.ClearUserCaches()
+	l.ClearGalleryCaches()
+	l.ClearCollectionCaches()
+	l.ClearNftCaches()
+	l.ClearMembershipCaches()
+}
+
+func (l *Loaders) ClearUserCaches() {
+	l.UserByUserId.mu.Lock()
+	l.UserByUserId.cache = nil
+	l.UserByUserId.mu.Unlock()
+
+	l.UserByAddress.mu.Lock()
+	l.UserByAddress.cache = nil
+	l.UserByAddress.mu.Unlock()
+
+	l.UserByUsername.mu.Lock()
+	l.UserByUsername.cache = nil
+	l.UserByUsername.mu.Unlock()
+}
+
+func (l *Loaders) ClearGalleryCaches() {
+	l.GalleryByGalleryId.mu.Lock()
+	l.GalleryByGalleryId.cache = nil
+	l.GalleryByGalleryId.mu.Unlock()
+
+	l.GalleryByCollectionId.mu.Lock()
+	l.GalleryByCollectionId.cache = nil
+	l.GalleryByCollectionId.mu.Unlock()
+
+	l.GalleriesByUserId.mu.Lock()
+	l.GalleriesByUserId.cache = nil
+	l.GalleriesByUserId.mu.Unlock()
+}
+
+func (l *Loaders) ClearCollectionCaches() {
+	l.CollectionByCollectionId.mu.Lock()
+	l.CollectionByCollectionId.cache = nil
+	l.CollectionByCollectionId.mu.Unlock()
+
+	l.CollectionsByGalleryId.mu.Lock()
+	l.CollectionsByGalleryId.cache = nil
+	l.CollectionsByGalleryId.mu.Unlock()
+}
+
+func (l *Loaders) ClearNftCaches() {
+	l.NftByNftId.mu.Lock()
+	l.NftByNftId.cache = nil
+	l.NftByNftId.mu.Unlock()
+
+	l.NftsByOwnerAddress.mu.Lock()
+	l.NftsByOwnerAddress.cache = nil
+	l.NftsByOwnerAddress.mu.Unlock()
+
+	l.NftsByCollectionId.mu.Lock()
+	l.NftsByCollectionId.cache = nil
+	l.NftsByCollectionId.mu.Unlock()
+}
+
+func (l *Loaders) ClearMembershipCaches() {
+	l.MembershipByMembershipId.mu.Lock()
+	l.MembershipByMembershipId.cache = nil
+	l.MembershipByMembershipId.mu.Unlock()
 }
 
 func loadUserByUserId(ctx context.Context, loaders *Loaders, q *sqlc.Queries) func([]persist.DBID) ([]sqlc.User, []error) {

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -163,6 +163,13 @@ type ComplexityRoot struct {
 		Wallets             func(childComplexity int) int
 	}
 
+	GltfMedia struct {
+		ContentRenderURL func(childComplexity int) int
+		MediaType        func(childComplexity int) int
+		MediaURL         func(childComplexity int) int
+		PreviewURLs      func(childComplexity int) int
+	}
+
 	HtmlMedia struct {
 		ContentRenderURL func(childComplexity int) int
 		MediaType        func(childComplexity int) int
@@ -743,6 +750,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GalleryUser.Wallets(childComplexity), true
+
+	case "GltfMedia.contentRenderURL":
+		if e.complexity.GltfMedia.ContentRenderURL == nil {
+			break
+		}
+
+		return e.complexity.GltfMedia.ContentRenderURL(childComplexity), true
+
+	case "GltfMedia.mediaType":
+		if e.complexity.GltfMedia.MediaType == nil {
+			break
+		}
+
+		return e.complexity.GltfMedia.MediaType(childComplexity), true
+
+	case "GltfMedia.mediaURL":
+		if e.complexity.GltfMedia.MediaURL == nil {
+			break
+		}
+
+		return e.complexity.GltfMedia.MediaURL(childComplexity), true
+
+	case "GltfMedia.previewURLs":
+		if e.complexity.GltfMedia.PreviewURLs == nil {
+			break
+		}
+
+		return e.complexity.GltfMedia.PreviewURLs(childComplexity), true
 
 	case "HtmlMedia.contentRenderURL":
 		if e.complexity.HtmlMedia.ContentRenderURL == nil {
@@ -1666,6 +1701,7 @@ union MediaSubtype =
   | TextMedia
   | HtmlMedia
   | JsonMedia
+  | GltfMedia
   | UnknownMedia
   | InvalidMedia
 
@@ -1746,6 +1782,14 @@ type HtmlMedia implements Media {
 }
 
 type JsonMedia implements Media {
+  previewURLs: PreviewURLSet
+  mediaURL: String
+  mediaType: String
+
+  contentRenderURL: String
+}
+
+type GltfMedia implements Media {
   previewURLs: PreviewURLSet
   mediaURL: String
   mediaType: String
@@ -4025,6 +4069,134 @@ func (ec *executionContext) _GalleryUser_isAuthenticatedUser(ctx context.Context
 	res := resTmp.(*bool)
 	fc.Result = res
 	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GltfMedia_previewURLs(ctx context.Context, field graphql.CollectedField, obj *model.GltfMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GltfMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PreviewURLs, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.PreviewURLSet)
+	fc.Result = res
+	return ec.marshalOPreviewURLSet2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPreviewURLSet(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GltfMedia_mediaURL(ctx context.Context, field graphql.CollectedField, obj *model.GltfMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GltfMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MediaURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GltfMedia_mediaType(ctx context.Context, field graphql.CollectedField, obj *model.GltfMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GltfMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MediaType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _GltfMedia_contentRenderURL(ctx context.Context, field graphql.CollectedField, obj *model.GltfMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "GltfMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContentRenderURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _HtmlMedia_previewURLs(ctx context.Context, field graphql.CollectedField, obj *model.HTMLMedia) (ret graphql.Marshaler) {
@@ -9572,6 +9744,13 @@ func (ec *executionContext) _Media(ctx context.Context, sel ast.SelectionSet, ob
 			return graphql.Null
 		}
 		return ec._JsonMedia(ctx, sel, obj)
+	case model.GltfMedia:
+		return ec._GltfMedia(ctx, sel, &obj)
+	case *model.GltfMedia:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._GltfMedia(ctx, sel, obj)
 	case model.UnknownMedia:
 		return ec._UnknownMedia(ctx, sel, &obj)
 	case *model.UnknownMedia:
@@ -9637,6 +9816,13 @@ func (ec *executionContext) _MediaSubtype(ctx context.Context, sel ast.Selection
 			return graphql.Null
 		}
 		return ec._JsonMedia(ctx, sel, obj)
+	case model.GltfMedia:
+		return ec._GltfMedia(ctx, sel, &obj)
+	case *model.GltfMedia:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._GltfMedia(ctx, sel, obj)
 	case model.UnknownMedia:
 		return ec._UnknownMedia(ctx, sel, &obj)
 	case *model.UnknownMedia:
@@ -10792,6 +10978,55 @@ func (ec *executionContext) _GalleryUser(ctx context.Context, sel ast.SelectionS
 		case "isAuthenticatedUser":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._GalleryUser_isAuthenticatedUser(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var gltfMediaImplementors = []string{"GltfMedia", "MediaSubtype", "Media"}
+
+func (ec *executionContext) _GltfMedia(ctx context.Context, sel ast.SelectionSet, obj *model.GltfMedia) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, gltfMediaImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GltfMedia")
+		case "previewURLs":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._GltfMedia_previewURLs(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "mediaURL":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._GltfMedia_mediaURL(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "mediaType":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._GltfMedia_mediaType(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "contentRenderURL":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._GltfMedia_contentRenderURL(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -38,8 +38,8 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	Collection() CollectionResolver
 	Gallery() GalleryResolver
-	GalleryCollection() GalleryCollectionResolver
 	GalleryUser() GalleryUserResolver
 	MembershipOwner() MembershipOwnerResolver
 	Mutation() MutationResolver
@@ -69,6 +69,29 @@ type ComplexityRoot struct {
 	AuthNonce struct {
 		Nonce      func(childComplexity int) int
 		UserExists func(childComplexity int) int
+	}
+
+	Collection struct {
+		CollectorsNote func(childComplexity int) int
+		Dbid           func(childComplexity int) int
+		Gallery        func(childComplexity int) int
+		Hidden         func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Layout         func(childComplexity int) int
+		Name           func(childComplexity int) int
+		Nfts           func(childComplexity int) int
+		Version        func(childComplexity int) int
+	}
+
+	CollectionLayout struct {
+		Columns    func(childComplexity int) int
+		Whitespace func(childComplexity int) int
+	}
+
+	CollectionNft struct {
+		Collection func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Nft        func(childComplexity int) int
 	}
 
 	CreateCollectionPayload struct {
@@ -128,29 +151,6 @@ type ComplexityRoot struct {
 		Dbid        func(childComplexity int) int
 		ID          func(childComplexity int) int
 		Owner       func(childComplexity int) int
-	}
-
-	GalleryCollection struct {
-		CollectorsNote func(childComplexity int) int
-		Dbid           func(childComplexity int) int
-		Gallery        func(childComplexity int) int
-		Hidden         func(childComplexity int) int
-		ID             func(childComplexity int) int
-		Layout         func(childComplexity int) int
-		Name           func(childComplexity int) int
-		Nfts           func(childComplexity int) int
-		Version        func(childComplexity int) int
-	}
-
-	GalleryCollectionLayout struct {
-		Columns    func(childComplexity int) int
-		Whitespace func(childComplexity int) int
-	}
-
-	GalleryNft struct {
-		Collection func(childComplexity int) int
-		ID         func(childComplexity int) int
-		Nft        func(childComplexity int) int
 	}
 
 	GalleryUser struct {
@@ -343,14 +343,14 @@ type ComplexityRoot struct {
 	}
 }
 
+type CollectionResolver interface {
+	Gallery(ctx context.Context, obj *model.Collection) (*model.Gallery, error)
+
+	Nfts(ctx context.Context, obj *model.Collection) ([]*model.CollectionNft, error)
+}
 type GalleryResolver interface {
 	Owner(ctx context.Context, obj *model.Gallery) (*model.GalleryUser, error)
-	Collections(ctx context.Context, obj *model.Gallery) ([]*model.GalleryCollection, error)
-}
-type GalleryCollectionResolver interface {
-	Gallery(ctx context.Context, obj *model.GalleryCollection) (*model.Gallery, error)
-
-	Nfts(ctx context.Context, obj *model.GalleryCollection) ([]*model.GalleryNft, error)
+	Collections(ctx context.Context, obj *model.Gallery) ([]*model.Collection, error)
 }
 type GalleryUserResolver interface {
 	Galleries(ctx context.Context, obj *model.GalleryUser) ([]*model.Gallery, error)
@@ -456,6 +456,104 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AuthNonce.UserExists(childComplexity), true
+
+	case "Collection.collectorsNote":
+		if e.complexity.Collection.CollectorsNote == nil {
+			break
+		}
+
+		return e.complexity.Collection.CollectorsNote(childComplexity), true
+
+	case "Collection.dbid":
+		if e.complexity.Collection.Dbid == nil {
+			break
+		}
+
+		return e.complexity.Collection.Dbid(childComplexity), true
+
+	case "Collection.gallery":
+		if e.complexity.Collection.Gallery == nil {
+			break
+		}
+
+		return e.complexity.Collection.Gallery(childComplexity), true
+
+	case "Collection.hidden":
+		if e.complexity.Collection.Hidden == nil {
+			break
+		}
+
+		return e.complexity.Collection.Hidden(childComplexity), true
+
+	case "Collection.id":
+		if e.complexity.Collection.ID == nil {
+			break
+		}
+
+		return e.complexity.Collection.ID(childComplexity), true
+
+	case "Collection.layout":
+		if e.complexity.Collection.Layout == nil {
+			break
+		}
+
+		return e.complexity.Collection.Layout(childComplexity), true
+
+	case "Collection.name":
+		if e.complexity.Collection.Name == nil {
+			break
+		}
+
+		return e.complexity.Collection.Name(childComplexity), true
+
+	case "Collection.nfts":
+		if e.complexity.Collection.Nfts == nil {
+			break
+		}
+
+		return e.complexity.Collection.Nfts(childComplexity), true
+
+	case "Collection.version":
+		if e.complexity.Collection.Version == nil {
+			break
+		}
+
+		return e.complexity.Collection.Version(childComplexity), true
+
+	case "CollectionLayout.columns":
+		if e.complexity.CollectionLayout.Columns == nil {
+			break
+		}
+
+		return e.complexity.CollectionLayout.Columns(childComplexity), true
+
+	case "CollectionLayout.whitespace":
+		if e.complexity.CollectionLayout.Whitespace == nil {
+			break
+		}
+
+		return e.complexity.CollectionLayout.Whitespace(childComplexity), true
+
+	case "CollectionNft.collection":
+		if e.complexity.CollectionNft.Collection == nil {
+			break
+		}
+
+		return e.complexity.CollectionNft.Collection(childComplexity), true
+
+	case "CollectionNft.id":
+		if e.complexity.CollectionNft.ID == nil {
+			break
+		}
+
+		return e.complexity.CollectionNft.ID(childComplexity), true
+
+	case "CollectionNft.nft":
+		if e.complexity.CollectionNft.Nft == nil {
+			break
+		}
+
+		return e.complexity.CollectionNft.Nft(childComplexity), true
 
 	case "CreateCollectionPayload.collection":
 		if e.complexity.CreateCollectionPayload.Collection == nil {
@@ -596,104 +694,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Gallery.Owner(childComplexity), true
-
-	case "GalleryCollection.collectorsNote":
-		if e.complexity.GalleryCollection.CollectorsNote == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.CollectorsNote(childComplexity), true
-
-	case "GalleryCollection.dbid":
-		if e.complexity.GalleryCollection.Dbid == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.Dbid(childComplexity), true
-
-	case "GalleryCollection.gallery":
-		if e.complexity.GalleryCollection.Gallery == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.Gallery(childComplexity), true
-
-	case "GalleryCollection.hidden":
-		if e.complexity.GalleryCollection.Hidden == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.Hidden(childComplexity), true
-
-	case "GalleryCollection.id":
-		if e.complexity.GalleryCollection.ID == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.ID(childComplexity), true
-
-	case "GalleryCollection.layout":
-		if e.complexity.GalleryCollection.Layout == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.Layout(childComplexity), true
-
-	case "GalleryCollection.name":
-		if e.complexity.GalleryCollection.Name == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.Name(childComplexity), true
-
-	case "GalleryCollection.nfts":
-		if e.complexity.GalleryCollection.Nfts == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.Nfts(childComplexity), true
-
-	case "GalleryCollection.version":
-		if e.complexity.GalleryCollection.Version == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollection.Version(childComplexity), true
-
-	case "GalleryCollectionLayout.columns":
-		if e.complexity.GalleryCollectionLayout.Columns == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollectionLayout.Columns(childComplexity), true
-
-	case "GalleryCollectionLayout.whitespace":
-		if e.complexity.GalleryCollectionLayout.Whitespace == nil {
-			break
-		}
-
-		return e.complexity.GalleryCollectionLayout.Whitespace(childComplexity), true
-
-	case "GalleryNft.collection":
-		if e.complexity.GalleryNft.Collection == nil {
-			break
-		}
-
-		return e.complexity.GalleryNft.Collection(childComplexity), true
-
-	case "GalleryNft.id":
-		if e.complexity.GalleryNft.ID == nil {
-			break
-		}
-
-		return e.complexity.GalleryNft.ID(childComplexity), true
-
-	case "GalleryNft.nft":
-		if e.complexity.GalleryNft.Nft == nil {
-			break
-		}
-
-		return e.complexity.GalleryNft.Nft(childComplexity), true
 
 	case "GalleryUser.bio":
 		if e.complexity.GalleryUser.Bio == nil {
@@ -1810,34 +1810,34 @@ type OwnerAtBlock {
   blockNumber: String # source is uint64
 }
 
-type GalleryNft implements Node @goEmbedHelper @goGqlId(fields:["nftId", "collectionId"]) {
+type CollectionNft implements Node @goEmbedHelper @goGqlId(fields:["nftId", "collectionId"]) {
   id: ID!
   nft: Nft
-  collection: GalleryCollection
+  collection: Collection
 }
 
-type GalleryCollectionLayout {
+type CollectionLayout {
   columns: Int
   whitespace: [Int]
 }
 
-type GalleryCollection implements Node {
+type Collection implements Node {
   id: ID!
   dbid: DBID!
   version: Int
   name: String
   collectorsNote: String
   gallery: Gallery @goField(forceResolver: true)
-  layout: GalleryCollectionLayout
+  layout: CollectionLayout
   hidden: Boolean
-  nfts: [GalleryNft] @goField(forceResolver: true)
+  nfts: [CollectionNft] @goField(forceResolver: true)
 }
 
 type Gallery implements Node {
   id: ID!
   dbid: DBID!
   owner: GalleryUser @goField(forceResolver: true)
-  collections: [GalleryCollection] @goField(forceResolver: true)
+  collections: [Collection] @goField(forceResolver: true)
 }
 
 type MembershipOwner {
@@ -1874,7 +1874,7 @@ type ErrCollectionNotFound implements Error {
   message: String!
 }
 
-union CollectionByIdOrError = ErrCollectionNotFound | GalleryCollection
+union CollectionByIdOrError = ErrCollectionNotFound | Collection
 
 type Query {
   node(id: ID!): Node
@@ -1884,7 +1884,7 @@ type Query {
   collectionById(id: DBID!): CollectionByIdOrError
 }
 
-input GalleryCollectionLayoutInput {
+input CollectionLayoutInput {
   columns: Int!
   whitespace: [Int!]!
 }
@@ -1894,7 +1894,7 @@ input CreateCollectionInput {
   name: String!
   collectorsNote: String!
   nfts: [DBID!]!
-  layout: GalleryCollectionLayoutInput!
+  layout: CollectionLayoutInput!
 }
 
 union CreateCollectionPayloadOrError =
@@ -1903,7 +1903,7 @@ union CreateCollectionPayloadOrError =
   | ErrInvalidInput
 
 type CreateCollectionPayload {
-  collection: GalleryCollection
+  collection: Collection
 }
 
 union DeleteCollectionPayloadOrError =
@@ -1928,13 +1928,13 @@ union UpdateCollectionInfoPayloadOrError =
   | ErrInvalidInput
 
 type UpdateCollectionInfoPayload {
-  collection: GalleryCollection
+  collection: Collection
 }
 
 input UpdateCollectionNftsInput {
   collectionId: DBID!
   nfts: [DBID!]!
-  layout: GalleryCollectionLayoutInput!
+  layout: CollectionLayoutInput!
 }
 
 union UpdateCollectionNftsPayloadOrError =
@@ -1943,7 +1943,7 @@ union UpdateCollectionNftsPayloadOrError =
   | ErrInvalidInput
 
 type UpdateCollectionNftsPayload {
-  collection: GalleryCollection
+  collection: Collection
 }
 
 input UpdateGalleryCollectionsInput {
@@ -2658,6 +2658,463 @@ func (ec *executionContext) _AuthNonce_userExists(ctx context.Context, field gra
 	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Collection_id(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.GqlID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGqlID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_dbid(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Dbid, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(persist.DBID)
+	fc.Result = res
+	return ec.marshalNDBID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_version(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Version, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_name(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_collectorsNote(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CollectorsNote, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_gallery(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Collection().Gallery(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Gallery)
+	fc.Result = res
+	return ec.marshalOGallery2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGallery(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_layout(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Layout, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.CollectionLayout)
+	fc.Result = res
+	return ec.marshalOCollectionLayout2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayout(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_hidden(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Hidden, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_nfts(ctx context.Context, field graphql.CollectedField, obj *model.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Collection().Nfts(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CollectionNft)
+	fc.Result = res
+	return ec.marshalOCollectionNft2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionNft(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CollectionLayout_columns(ctx context.Context, field graphql.CollectedField, obj *model.CollectionLayout) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CollectionLayout",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Columns, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CollectionLayout_whitespace(ctx context.Context, field graphql.CollectedField, obj *model.CollectionLayout) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CollectionLayout",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Whitespace, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚕᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CollectionNft_id(ctx context.Context, field graphql.CollectedField, obj *model.CollectionNft) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CollectionNft",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.GqlID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGqlID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CollectionNft_nft(ctx context.Context, field graphql.CollectedField, obj *model.CollectionNft) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CollectionNft",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Nft, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Nft)
+	fc.Result = res
+	return ec.marshalONft2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐNft(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CollectionNft_collection(ctx context.Context, field graphql.CollectedField, obj *model.CollectionNft) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CollectionNft",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Collection, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Collection)
+	fc.Result = res
+	return ec.marshalOCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _CreateCollectionPayload_collection(ctx context.Context, field graphql.CollectedField, obj *model.CreateCollectionPayload) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -2685,9 +3142,9 @@ func (ec *executionContext) _CreateCollectionPayload_collection(ctx context.Cont
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.GalleryCollection)
+	res := resTmp.(*model.Collection)
 	fc.Result = res
-	return ec.marshalOGalleryCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx, field.Selections, res)
+	return ec.marshalOCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CreateUserPayload_userId(ctx context.Context, field graphql.CollectedField, obj *model.CreateUserPayload) (ret graphql.Marshaler) {
@@ -3335,466 +3792,9 @@ func (ec *executionContext) _Gallery_collections(ctx context.Context, field grap
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*model.GalleryCollection)
+	res := resTmp.([]*model.Collection)
 	fc.Result = res
-	return ec.marshalOGalleryCollection2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_id(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(model.GqlID)
-	fc.Result = res
-	return ec.marshalNID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGqlID(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_dbid(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Dbid, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(persist.DBID)
-	fc.Result = res
-	return ec.marshalNDBID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_version(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Version, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*int)
-	fc.Result = res
-	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_name(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Name, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_collectorsNote(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.CollectorsNote, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_gallery(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.GalleryCollection().Gallery(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Gallery)
-	fc.Result = res
-	return ec.marshalOGallery2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGallery(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_layout(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Layout, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.GalleryCollectionLayout)
-	fc.Result = res
-	return ec.marshalOGalleryCollectionLayout2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollectionLayout(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_hidden(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Hidden, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*bool)
-	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollection_nfts(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollection",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.GalleryCollection().Nfts(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.GalleryNft)
-	fc.Result = res
-	return ec.marshalOGalleryNft2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryNft(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollectionLayout_columns(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollectionLayout) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollectionLayout",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Columns, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*int)
-	fc.Result = res
-	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryCollectionLayout_whitespace(ctx context.Context, field graphql.CollectedField, obj *model.GalleryCollectionLayout) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryCollectionLayout",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Whitespace, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*int)
-	fc.Result = res
-	return ec.marshalOInt2ᚕᚖint(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryNft_id(ctx context.Context, field graphql.CollectedField, obj *model.GalleryNft) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryNft",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   true,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ID(), nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(model.GqlID)
-	fc.Result = res
-	return ec.marshalNID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGqlID(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryNft_nft(ctx context.Context, field graphql.CollectedField, obj *model.GalleryNft) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryNft",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Nft, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Nft)
-	fc.Result = res
-	return ec.marshalONft2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐNft(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _GalleryNft_collection(ctx context.Context, field graphql.CollectedField, obj *model.GalleryNft) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "GalleryNft",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Collection, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.GalleryCollection)
-	fc.Result = res
-	return ec.marshalOGalleryCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx, field.Selections, res)
+	return ec.marshalOCollection2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _GalleryUser_id(ctx context.Context, field graphql.CollectedField, obj *model.GalleryUser) (ret graphql.Marshaler) {
@@ -7108,9 +7108,9 @@ func (ec *executionContext) _UpdateCollectionInfoPayload_collection(ctx context.
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.GalleryCollection)
+	res := resTmp.(*model.Collection)
 	fc.Result = res
-	return ec.marshalOGalleryCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx, field.Selections, res)
+	return ec.marshalOCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _UpdateCollectionNftsPayload_collection(ctx context.Context, field graphql.CollectedField, obj *model.UpdateCollectionNftsPayload) (ret graphql.Marshaler) {
@@ -7140,9 +7140,9 @@ func (ec *executionContext) _UpdateCollectionNftsPayload_collection(ctx context.
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.GalleryCollection)
+	res := resTmp.(*model.Collection)
 	fc.Result = res
-	return ec.marshalOGalleryCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx, field.Selections, res)
+	return ec.marshalOCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _UpdateGalleryCollectionsPayload_gallery(ctx context.Context, field graphql.CollectedField, obj *model.UpdateGalleryCollectionsPayload) (ret graphql.Marshaler) {
@@ -8877,6 +8877,37 @@ func (ec *executionContext) unmarshalInputAuthMechanism(ctx context.Context, obj
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCollectionLayoutInput(ctx context.Context, obj interface{}) (model.CollectionLayoutInput, error) {
+	var it model.CollectionLayoutInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "columns":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("columns"))
+			it.Columns, err = ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "whitespace":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("whitespace"))
+			it.Whitespace, err = ec.unmarshalNInt2ᚕintᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateCollectionInput(ctx context.Context, obj interface{}) (model.CreateCollectionInput, error) {
 	var it model.CreateCollectionInput
 	asMap := map[string]interface{}{}
@@ -8922,7 +8953,7 @@ func (ec *executionContext) unmarshalInputCreateCollectionInput(ctx context.Cont
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layout"))
-			it.Layout, err = ec.unmarshalNGalleryCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollectionLayoutInput(ctx, v)
+			it.Layout, err = ec.unmarshalNCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayoutInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -8962,37 +8993,6 @@ func (ec *executionContext) unmarshalInputEthereumEoaAuth(ctx context.Context, o
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("signature"))
 			it.Signature, err = ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputGalleryCollectionLayoutInput(ctx context.Context, obj interface{}) (model.GalleryCollectionLayoutInput, error) {
-	var it model.GalleryCollectionLayoutInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	for k, v := range asMap {
-		switch k {
-		case "columns":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("columns"))
-			it.Columns, err = ec.unmarshalNInt2int(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "whitespace":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("whitespace"))
-			it.Whitespace, err = ec.unmarshalNInt2ᚕintᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9101,7 +9101,7 @@ func (ec *executionContext) unmarshalInputUpdateCollectionNftsInput(ctx context.
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layout"))
-			it.Layout, err = ec.unmarshalNGalleryCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollectionLayoutInput(ctx, v)
+			it.Layout, err = ec.unmarshalNCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayoutInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -9255,13 +9255,13 @@ func (ec *executionContext) _CollectionByIdOrError(ctx context.Context, sel ast.
 			return graphql.Null
 		}
 		return ec._ErrCollectionNotFound(ctx, sel, obj)
-	case model.GalleryCollection:
-		return ec._GalleryCollection(ctx, sel, &obj)
-	case *model.GalleryCollection:
+	case model.Collection:
+		return ec._Collection(ctx, sel, &obj)
+	case *model.Collection:
 		if obj == nil {
 			return graphql.Null
 		}
-		return ec._GalleryCollection(ctx, sel, obj)
+		return ec._Collection(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -9681,20 +9681,20 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Nft(ctx, sel, obj)
-	case model.GalleryNft:
-		return ec._GalleryNft(ctx, sel, &obj)
-	case *model.GalleryNft:
+	case model.CollectionNft:
+		return ec._CollectionNft(ctx, sel, &obj)
+	case *model.CollectionNft:
 		if obj == nil {
 			return graphql.Null
 		}
-		return ec._GalleryNft(ctx, sel, obj)
-	case model.GalleryCollection:
-		return ec._GalleryCollection(ctx, sel, &obj)
-	case *model.GalleryCollection:
+		return ec._CollectionNft(ctx, sel, obj)
+	case model.Collection:
+		return ec._Collection(ctx, sel, &obj)
+	case *model.Collection:
 		if obj == nil {
 			return graphql.Null
 		}
-		return ec._GalleryCollection(ctx, sel, obj)
+		return ec._Collection(ctx, sel, obj)
 	case model.Gallery:
 		return ec._Gallery(ctx, sel, &obj)
 	case *model.Gallery:
@@ -10041,6 +10041,196 @@ func (ec *executionContext) _AuthNonce(ctx context.Context, sel ast.SelectionSet
 		case "userExists":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._AuthNonce_userExists(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var collectionImplementors = []string{"Collection", "Node", "CollectionByIdOrError"}
+
+func (ec *executionContext) _Collection(ctx context.Context, sel ast.SelectionSet, obj *model.Collection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, collectionImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Collection")
+		case "id":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_id(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "dbid":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_dbid(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "version":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_version(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "name":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_name(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "collectorsNote":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_collectorsNote(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "gallery":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Collection_gallery(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "layout":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_layout(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "hidden":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_hidden(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "nfts":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Collection_nfts(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var collectionLayoutImplementors = []string{"CollectionLayout"}
+
+func (ec *executionContext) _CollectionLayout(ctx context.Context, sel ast.SelectionSet, obj *model.CollectionLayout) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, collectionLayoutImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CollectionLayout")
+		case "columns":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._CollectionLayout_columns(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "whitespace":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._CollectionLayout_whitespace(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var collectionNftImplementors = []string{"CollectionNft", "Node"}
+
+func (ec *executionContext) _CollectionNft(ctx context.Context, sel ast.SelectionSet, obj *model.CollectionNft) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, collectionNftImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CollectionNft")
+		case "id":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._CollectionNft_id(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "nft":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._CollectionNft_nft(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "collection":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._CollectionNft_collection(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)
@@ -10520,196 +10710,6 @@ func (ec *executionContext) _Gallery(ctx context.Context, sel ast.SelectionSet, 
 				return innerFunc(ctx)
 
 			})
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var galleryCollectionImplementors = []string{"GalleryCollection", "Node", "CollectionByIdOrError"}
-
-func (ec *executionContext) _GalleryCollection(ctx context.Context, sel ast.SelectionSet, obj *model.GalleryCollection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, galleryCollectionImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("GalleryCollection")
-		case "id":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollection_id(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
-		case "dbid":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollection_dbid(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
-		case "version":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollection_version(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "name":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollection_name(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "collectorsNote":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollection_collectorsNote(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "gallery":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._GalleryCollection_gallery(ctx, field, obj)
-				return res
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
-		case "layout":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollection_layout(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "hidden":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollection_hidden(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "nfts":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._GalleryCollection_nfts(ctx, field, obj)
-				return res
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var galleryCollectionLayoutImplementors = []string{"GalleryCollectionLayout"}
-
-func (ec *executionContext) _GalleryCollectionLayout(ctx context.Context, sel ast.SelectionSet, obj *model.GalleryCollectionLayout) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, galleryCollectionLayoutImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("GalleryCollectionLayout")
-		case "columns":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollectionLayout_columns(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "whitespace":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryCollectionLayout_whitespace(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var galleryNftImplementors = []string{"GalleryNft", "Node"}
-
-func (ec *executionContext) _GalleryNft(ctx context.Context, sel ast.SelectionSet, obj *model.GalleryNft) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, galleryNftImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("GalleryNft")
-		case "id":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryNft_id(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "nft":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryNft_nft(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "collection":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._GalleryNft_collection(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12736,6 +12736,11 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayoutInput(ctx context.Context, v interface{}) (*model.CollectionLayoutInput, error) {
+	res, err := ec.unmarshalInputCollectionLayoutInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNCreateCollectionInput2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCreateCollectionInput(ctx context.Context, v interface{}) (model.CreateCollectionInput, error) {
 	res, err := ec.unmarshalInputCreateCollectionInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -12787,11 +12792,6 @@ func (ec *executionContext) marshalNDBID2ᚕgithubᚗcomᚋmikeydubᚋgoᚑgalle
 	}
 
 	return ret
-}
-
-func (ec *executionContext) unmarshalNGalleryCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollectionLayoutInput(ctx context.Context, v interface{}) (*model.GalleryCollectionLayoutInput, error) {
-	res, err := ec.unmarshalInputGalleryCollectionLayoutInput(ctx, v)
-	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGqlID(ctx context.Context, v interface{}) (model.GqlID, error) {
@@ -13243,11 +13243,114 @@ func (ec *executionContext) marshalOChain2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgall
 	return v
 }
 
+func (ec *executionContext) marshalOCollection2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx context.Context, sel ast.SelectionSet, v []*model.Collection) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx context.Context, sel ast.SelectionSet, v *model.Collection) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Collection(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOCollectionByIdOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionByIDOrError(ctx context.Context, sel ast.SelectionSet, v model.CollectionByIDOrError) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
 	return ec._CollectionByIdOrError(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOCollectionLayout2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayout(ctx context.Context, sel ast.SelectionSet, v *model.CollectionLayout) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CollectionLayout(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOCollectionNft2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionNft(ctx context.Context, sel ast.SelectionSet, v []*model.CollectionNft) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOCollectionNft2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionNft(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOCollectionNft2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionNft(ctx context.Context, sel ast.SelectionSet, v *model.CollectionNft) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CollectionNft(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOCreateCollectionPayloadOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCreateCollectionPayloadOrError(ctx context.Context, sel ast.SelectionSet, v model.CreateCollectionPayloadOrError) graphql.Marshaler {
@@ -13342,109 +13445,6 @@ func (ec *executionContext) marshalOGallery2ᚖgithubᚗcomᚋmikeydubᚋgoᚑga
 		return graphql.Null
 	}
 	return ec._Gallery(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOGalleryCollection2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx context.Context, sel ast.SelectionSet, v []*model.GalleryCollection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOGalleryCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOGalleryCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollection(ctx context.Context, sel ast.SelectionSet, v *model.GalleryCollection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._GalleryCollection(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOGalleryCollectionLayout2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryCollectionLayout(ctx context.Context, sel ast.SelectionSet, v *model.GalleryCollectionLayout) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._GalleryCollectionLayout(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOGalleryNft2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryNft(ctx context.Context, sel ast.SelectionSet, v []*model.GalleryNft) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOGalleryNft2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryNft(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOGalleryNft2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryNft(ctx context.Context, sel ast.SelectionSet, v *model.GalleryNft) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._GalleryNft(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOGalleryUser2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryUser(ctx context.Context, sel ast.SelectionSet, v *model.GalleryUser) graphql.Marshaler {

--- a/graphql/model/models.go
+++ b/graphql/model/models.go
@@ -7,15 +7,15 @@ import (
 
 type GqlID string
 
-func (r *GalleryNft) GetGqlIDField_NftID() string {
+func (r *CollectionNft) GetGqlIDField_NftID() string {
 	return r.NftId.String()
 }
 
-func (r *GalleryNft) GetGqlIDField_CollectionID() string {
+func (r *CollectionNft) GetGqlIDField_CollectionID() string {
 	return r.CollectionId.String()
 }
 
-type HelperGalleryNftData struct {
+type HelperCollectionNftData struct {
 	NftId        persist.DBID
 	CollectionId persist.DBID
 }

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -299,6 +299,16 @@ func (GalleryUser) IsNode()                  {}
 func (GalleryUser) IsGalleryUserOrWallet()   {}
 func (GalleryUser) IsUserByUsernameOrError() {}
 
+type GltfMedia struct {
+	PreviewURLs      *PreviewURLSet `json:"previewURLs"`
+	MediaURL         *string        `json:"mediaURL"`
+	MediaType        *string        `json:"mediaType"`
+	ContentRenderURL *string        `json:"contentRenderURL"`
+}
+
+func (GltfMedia) IsMediaSubtype() {}
+func (GltfMedia) IsMedia()        {}
+
 type GnosisSafeAuth struct {
 	Address persist.Address `json:"address"`
 	Nonce   string          `json:"nonce"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -59,6 +59,10 @@ type MediaSubtype interface {
 	IsMediaSubtype()
 }
 
+type NftByIDOrError interface {
+	IsNftByIDOrError()
+}
+
 type Node interface {
 	IsNode()
 }
@@ -233,6 +237,13 @@ type ErrInvalidToken struct {
 func (ErrInvalidToken) IsAuthorizationError() {}
 func (ErrInvalidToken) IsError()              {}
 
+type ErrNftNotFound struct {
+	Message string `json:"message"`
+}
+
+func (ErrNftNotFound) IsNftByIDOrError() {}
+func (ErrNftNotFound) IsError()          {}
+
 type ErrNoCookie struct {
 	Message string `json:"message"`
 }
@@ -405,7 +416,8 @@ type Nft struct {
 	BlockNumber      *string             `json:"blockNumber"`
 }
 
-func (Nft) IsNode() {}
+func (Nft) IsNode()           {}
+func (Nft) IsNftByIDOrError() {}
 
 type OwnerAtBlock struct {
 	Owner       GalleryUserOrWallet `json:"owner"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -23,6 +23,10 @@ type CollectionByIDOrError interface {
 	IsCollectionByIDOrError()
 }
 
+type CollectionNftByIDOrError interface {
+	IsCollectionNftByIDOrError()
+}
+
 type CreateCollectionPayloadOrError interface {
 	IsCreateCollectionPayloadOrError()
 }
@@ -157,7 +161,8 @@ type CollectionNft struct {
 	Collection *Collection `json:"collection"`
 }
 
-func (CollectionNft) IsNode() {}
+func (CollectionNft) IsNode()                     {}
+func (CollectionNft) IsCollectionNftByIDOrError() {}
 
 type CreateCollectionInput struct {
 	GalleryID      persist.DBID           `json:"galleryId"`
@@ -201,6 +206,7 @@ type ErrCollectionNotFound struct {
 
 func (ErrCollectionNotFound) IsError()                          {}
 func (ErrCollectionNotFound) IsCollectionByIDOrError()          {}
+func (ErrCollectionNotFound) IsCollectionNftByIDOrError()       {}
 func (ErrCollectionNotFound) IsDeleteCollectionPayloadOrError() {}
 
 type ErrDoesNotOwnRequiredNft struct {
@@ -241,8 +247,9 @@ type ErrNftNotFound struct {
 	Message string `json:"message"`
 }
 
-func (ErrNftNotFound) IsNftByIDOrError() {}
-func (ErrNftNotFound) IsError()          {}
+func (ErrNftNotFound) IsNftByIDOrError()           {}
+func (ErrNftNotFound) IsError()                    {}
+func (ErrNftNotFound) IsCollectionNftByIDOrError() {}
 
 type ErrNoCookie struct {
 	Message string `json:"message"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -123,16 +123,48 @@ type AuthNonce struct {
 
 func (AuthNonce) IsGetAuthNoncePayloadOrError() {}
 
+type Collection struct {
+	Dbid           persist.DBID      `json:"dbid"`
+	Version        *int              `json:"version"`
+	Name           *string           `json:"name"`
+	CollectorsNote *string           `json:"collectorsNote"`
+	Gallery        *Gallery          `json:"gallery"`
+	Layout         *CollectionLayout `json:"layout"`
+	Hidden         *bool             `json:"hidden"`
+	Nfts           []*CollectionNft  `json:"nfts"`
+}
+
+func (Collection) IsNode()                  {}
+func (Collection) IsCollectionByIDOrError() {}
+
+type CollectionLayout struct {
+	Columns    *int   `json:"columns"`
+	Whitespace []*int `json:"whitespace"`
+}
+
+type CollectionLayoutInput struct {
+	Columns    int   `json:"columns"`
+	Whitespace []int `json:"whitespace"`
+}
+
+type CollectionNft struct {
+	HelperCollectionNftData
+	Nft        *Nft        `json:"nft"`
+	Collection *Collection `json:"collection"`
+}
+
+func (CollectionNft) IsNode() {}
+
 type CreateCollectionInput struct {
-	GalleryID      persist.DBID                  `json:"galleryId"`
-	Name           string                        `json:"name"`
-	CollectorsNote string                        `json:"collectorsNote"`
-	Nfts           []persist.DBID                `json:"nfts"`
-	Layout         *GalleryCollectionLayoutInput `json:"layout"`
+	GalleryID      persist.DBID           `json:"galleryId"`
+	Name           string                 `json:"name"`
+	CollectorsNote string                 `json:"collectorsNote"`
+	Nfts           []persist.DBID         `json:"nfts"`
+	Layout         *CollectionLayoutInput `json:"layout"`
 }
 
 type CreateCollectionPayload struct {
-	Collection *GalleryCollection `json:"collection"`
+	Collection *Collection `json:"collection"`
 }
 
 func (CreateCollectionPayload) IsCreateCollectionPayloadOrError() {}
@@ -247,44 +279,12 @@ type EthereumEoaAuth struct {
 }
 
 type Gallery struct {
-	Dbid        persist.DBID         `json:"dbid"`
-	Owner       *GalleryUser         `json:"owner"`
-	Collections []*GalleryCollection `json:"collections"`
+	Dbid        persist.DBID  `json:"dbid"`
+	Owner       *GalleryUser  `json:"owner"`
+	Collections []*Collection `json:"collections"`
 }
 
 func (Gallery) IsNode() {}
-
-type GalleryCollection struct {
-	Dbid           persist.DBID             `json:"dbid"`
-	Version        *int                     `json:"version"`
-	Name           *string                  `json:"name"`
-	CollectorsNote *string                  `json:"collectorsNote"`
-	Gallery        *Gallery                 `json:"gallery"`
-	Layout         *GalleryCollectionLayout `json:"layout"`
-	Hidden         *bool                    `json:"hidden"`
-	Nfts           []*GalleryNft            `json:"nfts"`
-}
-
-func (GalleryCollection) IsNode()                  {}
-func (GalleryCollection) IsCollectionByIDOrError() {}
-
-type GalleryCollectionLayout struct {
-	Columns    *int   `json:"columns"`
-	Whitespace []*int `json:"whitespace"`
-}
-
-type GalleryCollectionLayoutInput struct {
-	Columns    int   `json:"columns"`
-	Whitespace []int `json:"whitespace"`
-}
-
-type GalleryNft struct {
-	HelperGalleryNftData
-	Nft        *Nft               `json:"nft"`
-	Collection *GalleryCollection `json:"collection"`
-}
-
-func (GalleryNft) IsNode() {}
 
 type GalleryUser struct {
 	Dbid                persist.DBID `json:"dbid"`
@@ -448,19 +448,19 @@ type UpdateCollectionInfoInput struct {
 }
 
 type UpdateCollectionInfoPayload struct {
-	Collection *GalleryCollection `json:"collection"`
+	Collection *Collection `json:"collection"`
 }
 
 func (UpdateCollectionInfoPayload) IsUpdateCollectionInfoPayloadOrError() {}
 
 type UpdateCollectionNftsInput struct {
-	CollectionID persist.DBID                  `json:"collectionId"`
-	Nfts         []persist.DBID                `json:"nfts"`
-	Layout       *GalleryCollectionLayoutInput `json:"layout"`
+	CollectionID persist.DBID           `json:"collectionId"`
+	Nfts         []persist.DBID         `json:"nfts"`
+	Layout       *CollectionLayoutInput `json:"layout"`
 }
 
 type UpdateCollectionNftsPayload struct {
-	Collection *GalleryCollection `json:"collection"`
+	Collection *Collection `json:"collection"`
 }
 
 func (UpdateCollectionNftsPayload) IsUpdateCollectionNftsPayloadOrError() {}

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -18,6 +18,11 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
+	"CollectionNftByIdOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(CollectionNftByIDOrError)
+		return obj, ok
+	},
+
 	"CreateCollectionPayloadOrError": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(CreateCollectionPayloadOrError)
 		return obj, ok

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -63,6 +63,11 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
+	"NftByIdOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(NftByIDOrError)
+		return obj, ok
+	},
+
 	"Node": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(Node)
 		return obj, ok

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -342,6 +342,10 @@ func (r *queryResolver) CollectionByID(ctx context.Context, id persist.DBID) (mo
 	return resolveCollectionByCollectionID(ctx, id)
 }
 
+func (r *queryResolver) NftByID(ctx context.Context, id persist.DBID) (model.NftByIDOrError, error) {
+	return resolveNftByNftID(ctx, id)
+}
+
 func (r *viewerResolver) User(ctx context.Context, obj *model.Viewer) (*model.GalleryUser, error) {
 	gc := util.GinContextFromContext(ctx)
 	userID := auth.GetUserIDFromCtx(gc)

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -346,6 +346,10 @@ func (r *queryResolver) NftByID(ctx context.Context, id persist.DBID) (model.Nft
 	return resolveNftByNftID(ctx, id)
 }
 
+func (r *queryResolver) CollectionNftByID(ctx context.Context, nftID persist.DBID, collectionID persist.DBID) (model.CollectionNftByIDOrError, error) {
+	return resolveCollectionNftByIDs(ctx, nftID, collectionID)
+}
+
 func (r *viewerResolver) User(ctx context.Context, obj *model.Viewer) (*model.GalleryUser, error) {
 	gc := util.GinContextFromContext(ctx)
 	userID := auth.GetUserIDFromCtx(gc)

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -180,7 +180,7 @@ func resolveCollectionNftByIDs(ctx context.Context, nftID persist.DBID, collecti
 		return nil, err
 	}
 
-	galleryNft := &model.CollectionNft{
+	collectionNft := &model.CollectionNft{
 		HelperCollectionNftData: model.HelperCollectionNftData{
 			NftId:        nftID,
 			CollectionId: collectionID,
@@ -189,7 +189,7 @@ func resolveCollectionNftByIDs(ctx context.Context, nftID persist.DBID, collecti
 		Collection: collection,
 	}
 
-	return galleryNft, nil
+	return collectionNft, nil
 }
 
 func resolveGalleryByGalleryID(ctx context.Context, galleryID persist.DBID) (*model.Gallery, error) {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -430,7 +430,8 @@ func getMediaForNft(nft sqlc.Nft) model.MediaSubtype {
 	case "html":
 		return getHtmlMedia(nft)
 	case "glb":
-		return getUnknownMedia(nft)
+	case "gltf":
+		return getGltfMedia(nft)
 	}
 	// Note: default in v1 frontend mapping was "animation"
 	return getUnknownMedia(nft)
@@ -517,6 +518,15 @@ func getHtmlMedia(nft sqlc.Nft) model.HTMLMedia {
 
 func getJsonMedia(nft sqlc.Nft) model.JSONMedia {
 	return model.JSONMedia{
+		PreviewURLs:      getPreviewUrls(nft),
+		MediaURL:         getFirstNonEmptyString(nft.AnimationOriginalUrl.String, nft.AnimationUrl.String),
+		MediaType:        nil,
+		ContentRenderURL: &nft.AnimationUrl.String,
+	}
+}
+
+func getGltfMedia(nft sqlc.Nft) model.GltfMedia {
+	return model.GltfMedia{
 		PreviewURLs:      getPreviewUrls(nft),
 		MediaURL:         getFirstNonEmptyString(nft.AnimationOriginalUrl.String, nft.AnimationUrl.String),
 		MediaType:        nil,

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -21,15 +21,15 @@ import (
 var errNoAuthMechanismFound = fmt.Errorf("no auth mechanism found")
 
 var nodeFetcher = model.NodeFetcher{
-	OnGallery:           resolveGalleryByGalleryID,
-	OnGalleryCollection: resolveGalleryCollectionByCollectionID,
-	OnGalleryUser:       resolveGalleryUserByUserID,
-	OnMembershipTier:    resolveMembershipTierByMembershipId,
-	OnNft:               resolveNftByNftID,
-	OnWallet:            resolveWalletByAddress,
+	OnGallery:        resolveGalleryByGalleryID,
+	OnCollection:     resolveCollectionByCollectionID,
+	OnGalleryUser:    resolveGalleryUserByUserID,
+	OnMembershipTier: resolveMembershipTierByMembershipId,
+	OnNft:            resolveNftByNftID,
+	OnWallet:         resolveWalletByAddress,
 
-	OnGalleryNft: func(ctx context.Context, nftId string, collectionId string) (*model.GalleryNft, error) {
-		return resolveGalleryNftByIDs(ctx, persist.DBID(nftId), persist.DBID(collectionId))
+	OnCollectionNft: func(ctx context.Context, nftId string, collectionId string) (*model.CollectionNft, error) {
+		return resolveCollectionNftByIDs(ctx, persist.DBID(nftId), persist.DBID(collectionId))
 	},
 }
 
@@ -144,7 +144,7 @@ func resolveGalleriesByUserID(ctx context.Context, userID persist.DBID) ([]*mode
 	return output, nil
 }
 
-func resolveGalleryCollectionByCollectionID(ctx context.Context, collectionID persist.DBID) (*model.GalleryCollection, error) {
+func resolveCollectionByCollectionID(ctx context.Context, collectionID persist.DBID) (*model.Collection, error) {
 	collection, err := publicapi.For(ctx).Collection.GetCollectionById(ctx, collectionID)
 	if err != nil {
 		return nil, err
@@ -153,13 +153,13 @@ func resolveGalleryCollectionByCollectionID(ctx context.Context, collectionID pe
 	return collectionToModel(ctx, *collection), nil
 }
 
-func resolveGalleryCollectionsByGalleryID(ctx context.Context, galleryID persist.DBID) ([]*model.GalleryCollection, error) {
+func resolveCollectionsByGalleryID(ctx context.Context, galleryID persist.DBID) ([]*model.Collection, error) {
 	collections, err := publicapi.For(ctx).Collection.GetCollectionsByGalleryId(ctx, galleryID)
 	if err != nil {
 		return nil, err
 	}
 
-	var output = make([]*model.GalleryCollection, len(collections))
+	var output = make([]*model.Collection, len(collections))
 	for i, collection := range collections {
 		output[i] = collectionToModel(ctx, collection)
 	}
@@ -167,19 +167,19 @@ func resolveGalleryCollectionsByGalleryID(ctx context.Context, galleryID persist
 	return output, nil
 }
 
-func resolveGalleryNftByIDs(ctx context.Context, nftID persist.DBID, collectionID persist.DBID) (*model.GalleryNft, error) {
+func resolveCollectionNftByIDs(ctx context.Context, nftID persist.DBID, collectionID persist.DBID) (*model.CollectionNft, error) {
 	nft, err := resolveNftByNftID(ctx, nftID)
 	if err != nil {
 		return nil, err
 	}
 
-	collection, err := resolveGalleryCollectionByCollectionID(ctx, collectionID)
+	collection, err := resolveCollectionByCollectionID(ctx, collectionID)
 	if err != nil {
 		return nil, err
 	}
 
-	galleryNft := &model.GalleryNft{
-		HelperGalleryNftData: model.HelperGalleryNftData{
+	galleryNft := &model.CollectionNft{
+		HelperCollectionNftData: model.HelperCollectionNftData{
 			NftId:        nftID,
 			CollectionId: collectionID,
 		},
@@ -270,14 +270,14 @@ func galleryToModel(ctx context.Context, gallery sqlc.Gallery) *model.Gallery {
 	}
 }
 
-func layoutToModel(ctx context.Context, layout sqlc.TokenLayout) *model.GalleryCollectionLayout {
+func layoutToModel(ctx context.Context, layout sqlc.TokenLayout) *model.CollectionLayout {
 	whitespace := make([]*int, len(layout.Whitespace))
 	for i, w := range layout.Whitespace {
 		w := w
 		whitespace[i] = &w
 	}
 
-	return &model.GalleryCollectionLayout{
+	return &model.CollectionLayout{
 		Columns:    &layout.Columns,
 		Whitespace: whitespace,
 	}
@@ -310,10 +310,10 @@ func addressToModel(ctx context.Context, address persist.Address) *model.Wallet 
 	}
 }
 
-func collectionToModel(ctx context.Context, collection sqlc.Collection) *model.GalleryCollection {
+func collectionToModel(ctx context.Context, collection sqlc.Collection) *model.Collection {
 	version := int(collection.Version.Int32)
 
-	return &model.GalleryCollection{
+	return &model.Collection{
 		Dbid:           collection.ID,
 		Version:        &version,
 		Name:           &collection.Name.String,

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -56,6 +56,8 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 		mappedErr = model.ErrUserAlreadyExists{Message: message}
 	case persist.ErrCollectionNotFoundByID:
 		mappedErr = model.ErrCollectionNotFound{Message: message}
+	case persist.ErrNFTNotFoundByID:
+		mappedErr = model.ErrNftNotFound{Message: message}
 	case publicapi.ErrInvalidInput:
 		validationErr, _ := err.(publicapi.ErrInvalidInput)
 		mappedErr = model.ErrInvalidInput{Message: message, Parameters: validationErr.Parameters, Reasons: validationErr.Reasons}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -69,6 +69,7 @@ union MediaSubtype =
   | TextMedia
   | HtmlMedia
   | JsonMedia
+  | GltfMedia
   | UnknownMedia
   | InvalidMedia
 
@@ -149,6 +150,14 @@ type HtmlMedia implements Media {
 }
 
 type JsonMedia implements Media {
+  previewURLs: PreviewURLSet
+  mediaURL: String
+  mediaType: String
+
+  contentRenderURL: String
+}
+
+type GltfMedia implements Media {
   previewURLs: PreviewURLSet
   mediaURL: String
   mediaType: String

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -286,7 +286,13 @@ type ErrCollectionNotFound implements Error {
   message: String!
 }
 
-union CollectionByIdOrError = ErrCollectionNotFound | Collection
+union NftByIdOrError = Nft | ErrNftNotFound
+
+type ErrNftNotFound implements Error {
+  message: String!
+}
+
+union CollectionByIdOrError = Collection | ErrCollectionNotFound
 
 type Query {
   node(id: ID!): Node
@@ -294,6 +300,7 @@ type Query {
   userByUsername(username: String!): UserByUsernameOrError
   membershipTiers(forceRefresh: Boolean): [MembershipTier]
   collectionById(id: DBID!): CollectionByIdOrError
+  nftById(id: DBID!): NftByIdOrError
 }
 
 input CollectionLayoutInput {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -213,34 +213,34 @@ type OwnerAtBlock {
   blockNumber: String # source is uint64
 }
 
-type GalleryNft implements Node @goEmbedHelper @goGqlId(fields:["nftId", "collectionId"]) {
+type CollectionNft implements Node @goEmbedHelper @goGqlId(fields:["nftId", "collectionId"]) {
   id: ID!
   nft: Nft
-  collection: GalleryCollection
+  collection: Collection
 }
 
-type GalleryCollectionLayout {
+type CollectionLayout {
   columns: Int
   whitespace: [Int]
 }
 
-type GalleryCollection implements Node {
+type Collection implements Node {
   id: ID!
   dbid: DBID!
   version: Int
   name: String
   collectorsNote: String
   gallery: Gallery @goField(forceResolver: true)
-  layout: GalleryCollectionLayout
+  layout: CollectionLayout
   hidden: Boolean
-  nfts: [GalleryNft] @goField(forceResolver: true)
+  nfts: [CollectionNft] @goField(forceResolver: true)
 }
 
 type Gallery implements Node {
   id: ID!
   dbid: DBID!
   owner: GalleryUser @goField(forceResolver: true)
-  collections: [GalleryCollection] @goField(forceResolver: true)
+  collections: [Collection] @goField(forceResolver: true)
 }
 
 type MembershipOwner {
@@ -277,7 +277,7 @@ type ErrCollectionNotFound implements Error {
   message: String!
 }
 
-union CollectionByIdOrError = ErrCollectionNotFound | GalleryCollection
+union CollectionByIdOrError = ErrCollectionNotFound | Collection
 
 type Query {
   node(id: ID!): Node
@@ -287,7 +287,7 @@ type Query {
   collectionById(id: DBID!): CollectionByIdOrError
 }
 
-input GalleryCollectionLayoutInput {
+input CollectionLayoutInput {
   columns: Int!
   whitespace: [Int!]!
 }
@@ -297,7 +297,7 @@ input CreateCollectionInput {
   name: String!
   collectorsNote: String!
   nfts: [DBID!]!
-  layout: GalleryCollectionLayoutInput!
+  layout: CollectionLayoutInput!
 }
 
 union CreateCollectionPayloadOrError =
@@ -306,7 +306,7 @@ union CreateCollectionPayloadOrError =
   | ErrInvalidInput
 
 type CreateCollectionPayload {
-  collection: GalleryCollection
+  collection: Collection
 }
 
 union DeleteCollectionPayloadOrError =
@@ -331,13 +331,13 @@ union UpdateCollectionInfoPayloadOrError =
   | ErrInvalidInput
 
 type UpdateCollectionInfoPayload {
-  collection: GalleryCollection
+  collection: Collection
 }
 
 input UpdateCollectionNftsInput {
   collectionId: DBID!
   nfts: [DBID!]!
-  layout: GalleryCollectionLayoutInput!
+  layout: CollectionLayoutInput!
 }
 
 union UpdateCollectionNftsPayloadOrError =
@@ -346,7 +346,7 @@ union UpdateCollectionNftsPayloadOrError =
   | ErrInvalidInput
 
 type UpdateCollectionNftsPayload {
-  collection: GalleryCollection
+  collection: Collection
 }
 
 input UpdateGalleryCollectionsInput {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -294,6 +294,8 @@ type ErrNftNotFound implements Error {
 
 union CollectionByIdOrError = Collection | ErrCollectionNotFound
 
+union CollectionNftByIdOrError = CollectionNft | ErrCollectionNotFound | ErrNftNotFound
+
 type Query {
   node(id: ID!): Node
   viewer: ViewerOrError @authRequired
@@ -301,6 +303,7 @@ type Query {
   membershipTiers(forceRefresh: Boolean): [MembershipTier]
   collectionById(id: DBID!): CollectionByIdOrError
   nftById(id: DBID!): NftByIdOrError
+  collectionNftById(nftId: DBID!, collectionId: DBID!): CollectionNftByIdOrError
 }
 
 input CollectionLayoutInput {

--- a/publicapi/gallery.go
+++ b/publicapi/gallery.go
@@ -90,6 +90,7 @@ func (api GalleryAPI) UpdateGalleryCollections(ctx context.Context, galleryID pe
 		return err
 	}
 
+	api.loaders.ClearAllCaches()
 	backupGalleriesForUser(ctx, userID, api.repos)
 
 	return nil

--- a/publicapi/nft.go
+++ b/publicapi/nft.go
@@ -80,5 +80,12 @@ func (api NftAPI) RefreshOpenSeaNfts(ctx context.Context, addresses string) erro
 		return err
 	}
 
-	return nft.RefreshOpenseaNFTs(ctx, userID, addresses, api.repos.NftRepository, api.repos.UserRepository)
+	err = nft.RefreshOpenseaNFTs(ctx, userID, addresses, api.repos.NftRepository, api.repos.UserRepository)
+	if err != nil {
+		return err
+	}
+
+	api.loaders.ClearAllCaches()
+
+	return nil
 }


### PR DESCRIPTION
## What's new?

### Renamed some schema types
Apologies for the annoying refactor, but we were talking about users having multiple galleries recently, and I figured this would be a good time to standardize in case we need a `GalleryCollection` in the future to represent a gallery in a collection.
- GalleryNft -> CollectionNft
- GalleryCollection -> Collection
- GalleryCollectionLayout -> CollectionLayout
- GalleryCollectionLayoutInput -> CollectionLayoutInput

### New queries
- `nftById(id: DBID!)`
- `collectionNftById(nftId: DBID!, collectionId: DBID!)`

### New media subtype
Added `GltfMedia` as a `MediaSubtype`. We'll use this media type when we see a `.glb` or `.gltf` extension.

### Dataloader cache clearing
Any public API function that writes to the database will now clear all dataloader caches to ensure that we return the latest data to the caller.