### PR TITLE
Jarrel/use dockertest for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,17 +32,38 @@ jobs:
           key: go-mod-v5-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+  # using a machine executor to run docker, which in turn installs postgres + redis and runs underlying tests
+  # https://circleci.com/docs/2.0/executor-types/#using-machine
   unit-tests:
     working_directory: ~/go-gallery
-    docker:
-      - image: cimg/go:1.16
-      - image: redis:6
-      - image: bcgallery/gallery-postgres:circle
+    machine:
+      image: ubuntu-2004:202111-02
+      docker_layer_caching: false  # can enable when on performance plan
+    environment:
+      GO_VERSION: 1.16.13
+      GOTESTSUM_VERSION: 1.7.0
     steps:
       - checkout
+      - run:
+          name: Install Go
+          command: |
+            mkdir -p ~/bin ~/go
+            curl -L --output - https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz | tar xz -C ~/bin
+            echo 'export GOROOT=~/bin/go' >> $BASH_ENV
+            echo 'export GOPATH=~/go' >> $BASH_ENV
+            echo 'export PATH=$GOROOT/bin:$GOPATH/bin:$PATH' >> $BASH_ENV
       - restore_cache:
           keys:
             - go-mod-v5-{{ checksum "go.sum" }}
+      - run:
+          name: Install Dependencies
+          command: |
+            go mod download
+            go get gotest.tools/gotestsum@v$GOTESTSUM_VERSION
+      - save_cache:
+          key: go-mod-v5-{{ checksum "go.sum" }}
+          paths:
+            - "~/go/pkg/mod"
       - run:
           name: Run tests
           command: |
@@ -50,8 +71,6 @@ jobs:
             gotestsum --junitfile /tmp/test-reports/unit-tests.xml -- -short ./...
       - store_test_results:
           path: /tmp/test-reports
-  # using a machine executor to run docker, which in turn installs postgres + redis and runs underlying tests
-  # https://circleci.com/docs/2.0/executor-types/#using-machine
   integration-tests:
     working_directory: ~/go-gallery
     machine:

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -1,0 +1,24 @@
+package migrate
+
+import (
+	"database/sql"
+
+	"github.com/golang-migrate/migrate/v4"
+	pgdriver "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+)
+
+func RunMigration(migrationDir string, client *sql.DB) error {
+	d, err := pgdriver.WithInstance(client, &pgdriver.Config{})
+	if err != nil {
+		return err
+	}
+
+	m, err := migrate.NewWithDatabaseInstance("file://"+migrationDir, "postgres", d)
+	if err != nil {
+		return err
+	}
+	m.Up()
+
+	return nil
+}

--- a/db/migrate.go
+++ b/db/migrate.go
@@ -6,15 +6,21 @@ import (
 	"github.com/golang-migrate/migrate/v4"
 	pgdriver "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/mikeydub/go-gallery/util"
 )
 
-func RunMigration(migrationDir string, client *sql.DB) error {
+func RunMigration(client *sql.DB) error {
+	dir, err := util.FindFile("./db/migrations", 3)
+	if err != nil {
+		return err
+	}
+
 	d, err := pgdriver.WithInstance(client, &pgdriver.Config{})
 	if err != nil {
 		return err
 	}
 
-	m, err := migrate.NewWithDatabaseInstance("file://"+migrationDir, "postgres", d)
+	m, err := migrate.NewWithDatabaseInstance("file://"+dir, "postgres", d)
 	if err != nil {
 		return err
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -1,0 +1,189 @@
+package docker
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/asottile/dockerfile"
+	"github.com/mikeydub/go-gallery/service/memstore/redis"
+	"github.com/ory/dockertest"
+	"github.com/ory/dockertest/docker"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+)
+
+// N.B. This isn't the entire Docker Compose spec...
+type ComposeFile struct {
+	Version  string             `yaml:"version"`
+	Services map[string]Service `yaml:"services"`
+}
+
+type Service struct {
+	Image       string                 `yaml:"image"`
+	Ports       []string               `yaml:"ports"`
+	Build       map[string]interface{} `yaml:"build"`
+	Environment []string               `yaml:"environment"`
+	Command     string                 `yaml:"command"`
+}
+
+func configureContainerCleanup(config *docker.HostConfig) {
+	config.AutoRemove = true
+	config.RestartPolicy = docker.RestartPolicy{Name: "no"}
+}
+
+func waitOnDB() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("db is not available")
+		}
+	}()
+
+	db, err := sql.Open(
+		"pgx",
+		fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s",
+			viper.GetString("POSTGRES_HOST"),
+			viper.GetInt("POSTGRES_PORT"),
+			viper.GetString("POSTGRES_USER"),
+			viper.GetString("POSTGRES_PASSWORD"),
+			viper.GetString("POSTGRES_DB"),
+		),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := db.Ping(); err != nil {
+		panic(err)
+	}
+
+	db.Close()
+	return
+}
+
+func waitOnCache() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("cache is not available")
+		}
+	}()
+	redis.NewCache(0).Close(false)
+	return
+}
+
+func loadComposeFile(path string) (f ComposeFile) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = yaml.Unmarshal(data, &f)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return
+}
+
+func getImageAndVersion(s string) ([]string, error) {
+	imgAndVer := strings.Split(s, ":")
+	if len(imgAndVer) != 2 {
+		return nil, errors.New("no version specified for image")
+	}
+	return imgAndVer, nil
+}
+
+func getBuildImage(path string, s Service) ([]string, error) {
+	dockerPath := filepath.Join(filepath.Dir(path), s.Build["dockerfile"].(string))
+	absPath, _ := filepath.Abs(dockerPath)
+	res, err := dockerfile.ParseFile(absPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, cmd := range res {
+		if cmd.Cmd == "FROM" {
+			return getImageAndVersion(cmd.Value[0])
+		}
+	}
+
+	return nil, errors.New("no `FROM` directive found in dockerfile")
+}
+
+func InitPostgres(composePath string) *dockertest.Resource {
+	pool, err := dockertest.NewPool("")
+	pool.MaxWait = 3 * time.Minute
+	if err != nil {
+		log.Fatalf("could not connect to docker: %s", err)
+	}
+
+	absPath, _ := filepath.Abs(composePath)
+	apps := loadComposeFile(absPath)
+	imgAndVer, err := getBuildImage(absPath, apps.Services["postgres"])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pg, err := pool.RunWithOptions(
+		&dockertest.RunOptions{
+			Repository: imgAndVer[0],
+			Tag:        imgAndVer[1],
+			Env:        apps.Services["postgres"].Environment,
+		}, configureContainerCleanup,
+	)
+	if err != nil {
+		log.Fatalf("could not start postgres: %s", err)
+	}
+
+	// Patch environment to use container
+	hostAndPort := strings.Split(pg.GetHostPort("5432/tcp"), ":")
+	viper.SetDefault("POSTGRES_HOST", hostAndPort[0])
+	viper.SetDefault("POSTGRES_PORT", hostAndPort[1])
+	viper.Set("POSTGRES_USER", "postgres")
+	viper.Set("POSTGRES_PASSWORD", "")
+	viper.Set("POSTGRES_DB", "postgres")
+	viper.Set("ENV", "local")
+
+	if err = pool.Retry(waitOnDB); err != nil {
+		log.Fatalf("could not connect to postgres: %s", err)
+	}
+
+	return pg
+}
+
+func InitRedis(composePath string) *dockertest.Resource {
+	pool, err := dockertest.NewPool("")
+	pool.MaxWait = 3 * time.Minute
+	if err != nil {
+		log.Fatalf("could not connect to docker: %s", err)
+	}
+
+	apps := loadComposeFile(composePath)
+	imgAndVer, err := getImageAndVersion(apps.Services["redis"].Image)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rd, err := pool.RunWithOptions(
+		&dockertest.RunOptions{
+			Repository: imgAndVer[0],
+			Tag:        imgAndVer[1],
+		}, configureContainerCleanup,
+	)
+	if err != nil {
+		log.Fatalf("could not start redis: %s", err)
+	}
+
+	// Patch environment to use container
+	viper.SetDefault("REDIS_URL", rd.GetHostPort("6379/tcp"))
+	if err = pool.Retry(waitOnCache); err != nil {
+		log.Fatalf("could not connect to redis: %s", err)
+	}
+
+	return rd
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,9 +1,12 @@
 package server
 
 import (
-	"cloud.google.com/go/storage"
 	"context"
 	"database/sql"
+	"net/http"
+	"strings"
+
+	"cloud.google.com/go/storage"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/getsentry/sentry-go"
 	sentrygin "github.com/getsentry/sentry-go/gin"
@@ -22,8 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"google.golang.org/api/option"
-	"net/http"
-	"strings"
 )
 
 // Init initializes the server

--- a/server/t__opensea_test.go
+++ b/server/t__opensea_test.go
@@ -10,156 +10,161 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
-func TestOpenseaSync_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-	ctx := context.Background()
+func TestOpensea(t *testing.T) {
 
-	mike := persist.User{UsernameIdempotent: "mikey", Username: "mikey", Addresses: []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}}
+	setupDoubles(t)
 
-	mikeUserID, err := tc.repos.UserRepository.Create(ctx, mike)
-	assert.Nil(err)
+	t.Run("opensea sync success", func(t *testing.T) {
+		assert := setupTest(t, 1)
+		ctx := context.Background()
 
-	nft1 := persist.NFT{
-		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-		Name:         "poop",
-		OpenseaID:    46062326,
-	}
-	nft2 := persist.NFT{
-		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-		Name:         "baby",
-		OpenseaID:    46062320,
-	}
+		mike := persist.User{UsernameIdempotent: "mikey", Username: "mikey", Addresses: []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}}
 
-	nft3 := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
-		Name:         "wow",
-		OpenseaID:    46062322,
-	}
-	nft4 := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
-		Name:         "baby",
-		OpenseaID:    61355517,
-	}
+		mikeUserID, err := tc.repos.UserRepository.Create(ctx, mike)
+		assert.Nil(err)
 
-	ids, err := tc.repos.NftRepository.CreateBulk(ctx, []persist.NFT{nft1, nft2, nft3, nft4})
-	assert.Nil(err)
+		nft1 := persist.NFT{
+			OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
+			Name:         "poop",
+			OpenseaID:    46062326,
+		}
+		nft2 := persist.NFT{
+			OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
+			Name:         "baby",
+			OpenseaID:    46062320,
+		}
 
-	nft1DB, err := tc.repos.NftRepository.GetByID(ctx, ids[0])
-	assert.NoError(err)
-	nft2DB, err := tc.repos.NftRepository.GetByID(ctx, ids[1])
-	assert.NoError(err)
-	nft3DB, err := tc.repos.NftRepository.GetByID(ctx, ids[2])
-	assert.NoError(err)
-	nft4DB, err := tc.repos.NftRepository.GetByID(ctx, ids[3])
-	assert.NoError(err)
+		nft3 := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
+			Name:         "wow",
+			OpenseaID:    46062322,
+		}
+		nft4 := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
+			Name:         "baby",
+			OpenseaID:    61355517,
+		}
 
-	mikeCollNFTs := []persist.DBID{}
-	if nft1DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[0])
-	}
-	if nft2DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[1])
-	}
-	if nft3DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[2])
-	}
-	if nft4DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[3])
-	}
+		ids, err := tc.repos.NftRepository.CreateBulk(ctx, []persist.NFT{nft1, nft2, nft3, nft4})
+		assert.Nil(err)
 
-	coll := persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", NFTs: mikeCollNFTs}
-	collID, err := tc.repos.CollectionRepository.Create(ctx, coll)
-	assert.NoError(err)
+		nft1DB, err := tc.repos.NftRepository.GetByID(ctx, ids[0])
+		assert.NoError(err)
+		nft2DB, err := tc.repos.NftRepository.GetByID(ctx, ids[1])
+		assert.NoError(err)
+		nft3DB, err := tc.repos.NftRepository.GetByID(ctx, ids[2])
+		assert.NoError(err)
+		nft4DB, err := tc.repos.NftRepository.GetByID(ctx, ids[3])
+		assert.NoError(err)
 
-	err = opensea.UpdateAssetsForAcc(ctx, mikeUserID, []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}, tc.repos.NftRepository, tc.repos.UserRepository, tc.repos.CollectionRepository, tc.repos.GalleryRepository, tc.repos.BackupRepository)
-	assert.NoError(err)
+		mikeCollNFTs := []persist.DBID{}
+		if nft1DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[0])
+		}
+		if nft2DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[1])
+		}
+		if nft3DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[2])
+		}
+		if nft4DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[3])
+		}
 
-	time.Sleep(time.Second * 3)
+		coll := persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", NFTs: mikeCollNFTs}
+		collID, err := tc.repos.CollectionRepository.Create(ctx, coll)
+		assert.NoError(err)
 
-	mikeColl, err := tc.repos.CollectionRepository.GetByID(ctx, collID, true)
-	assert.NoError(err)
-	assert.Len(mikeColl.NFTs, 1)
+		err = opensea.UpdateAssetsForAcc(ctx, mikeUserID, []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA"))}, tc.repos.NftRepository, tc.repos.UserRepository, tc.repos.CollectionRepository, tc.repos.GalleryRepository, tc.repos.BackupRepository)
+		assert.NoError(err)
 
-	mikeNFTs, err := tc.repos.NftRepository.GetByUserID(ctx, mikeUserID)
-	assert.NoError(err)
+		time.Sleep(time.Second * 3)
 
-	assert.Greater(len(mikeNFTs), 0)
+		mikeColl, err := tc.repos.CollectionRepository.GetByID(ctx, collID, true)
+		assert.NoError(err)
+		assert.Len(mikeColl.NFTs, 1)
 
-}
+		mikeNFTs, err := tc.repos.NftRepository.GetByUserID(ctx, mikeUserID)
+		assert.NoError(err)
 
-func TestOpenseaMultiAddressSync_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-	ctx := context.Background()
+		assert.Greater(len(mikeNFTs), 0)
 
-	mike := persist.User{UsernameIdempotent: "mikey", Username: "mikey", Addresses: []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")), persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFD"))}}
+	})
 
-	mikeUserID, err := tc.repos.UserRepository.Create(ctx, mike)
-	assert.NoError(err)
+	t.Run("opensea multiaddress sync success", func(t *testing.T) {
+		assert := setupTest(t, 1)
+		ctx := context.Background()
 
-	nft1 := persist.NFT{
-		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-		Name:         "poop",
-		OpenseaID:    46062326,
-	}
-	nft2 := persist.NFT{
-		OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
-		Name:         "baby",
-		OpenseaID:    46062320,
-	}
+		mike := persist.User{UsernameIdempotent: "mikey", Username: "mikey", Addresses: []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")), persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFD"))}}
 
-	nft3 := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
-		Name:         "wow",
-		OpenseaID:    46062322,
-	}
-	nft4 := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
-		Name:         "baby",
-		OpenseaID:    61355517,
-	}
+		mikeUserID, err := tc.repos.UserRepository.Create(ctx, mike)
+		assert.NoError(err)
 
-	ids, err := tc.repos.NftRepository.CreateBulk(ctx, []persist.NFT{nft1, nft2, nft3, nft4})
-	assert.NoError(err)
+		nft1 := persist.NFT{
+			OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
+			Name:         "poop",
+			OpenseaID:    46062326,
+		}
+		nft2 := persist.NFT{
+			OwnerAddress: "0x70d04384b5c3a466ec4d8cfb8213efc31c6a9d15",
+			Name:         "baby",
+			OpenseaID:    46062320,
+		}
 
-	nft1DB, err := tc.repos.NftRepository.GetByID(ctx, ids[0])
-	assert.NoError(err)
-	nft2DB, err := tc.repos.NftRepository.GetByID(ctx, ids[1])
-	assert.NoError(err)
-	nft3DB, err := tc.repos.NftRepository.GetByID(ctx, ids[2])
-	assert.NoError(err)
-	nft4DB, err := tc.repos.NftRepository.GetByID(ctx, ids[3])
-	assert.NoError(err)
+		nft3 := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
+			Name:         "wow",
+			OpenseaID:    46062322,
+		}
+		nft4 := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")),
+			Name:         "baby",
+			OpenseaID:    61355517,
+		}
 
-	mikeCollNFTs := []persist.DBID{}
-	if nft1DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[0])
-	}
-	if nft2DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[1])
-	}
-	if nft3DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[2])
-	}
-	if nft4DB.OwnerAddress == mike.Addresses[0] {
-		mikeCollNFTs = append(mikeCollNFTs, ids[3])
-	}
+		ids, err := tc.repos.NftRepository.CreateBulk(ctx, []persist.NFT{nft1, nft2, nft3, nft4})
+		assert.NoError(err)
 
-	coll := persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", NFTs: mikeCollNFTs}
-	collID, err := tc.repos.CollectionRepository.Create(ctx, coll)
-	assert.NoError(err)
+		nft1DB, err := tc.repos.NftRepository.GetByID(ctx, ids[0])
+		assert.NoError(err)
+		nft2DB, err := tc.repos.NftRepository.GetByID(ctx, ids[1])
+		assert.NoError(err)
+		nft3DB, err := tc.repos.NftRepository.GetByID(ctx, ids[2])
+		assert.NoError(err)
+		nft4DB, err := tc.repos.NftRepository.GetByID(ctx, ids[3])
+		assert.NoError(err)
 
-	err = opensea.UpdateAssetsForAcc(ctx, mikeUserID, []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")), persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFD"))}, tc.repos.NftRepository, tc.repos.UserRepository, tc.repos.CollectionRepository, tc.repos.GalleryRepository, tc.repos.BackupRepository)
-	assert.NoError(err)
+		mikeCollNFTs := []persist.DBID{}
+		if nft1DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[0])
+		}
+		if nft2DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[1])
+		}
+		if nft3DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[2])
+		}
+		if nft4DB.OwnerAddress == mike.Addresses[0] {
+			mikeCollNFTs = append(mikeCollNFTs, ids[3])
+		}
 
-	time.Sleep(time.Second * 3)
+		coll := persist.CollectionDB{OwnerUserID: mikeUserID, Name: "mikey-coll", NFTs: mikeCollNFTs}
+		collID, err := tc.repos.CollectionRepository.Create(ctx, coll)
+		assert.NoError(err)
 
-	mikeColl, err := tc.repos.CollectionRepository.GetByID(ctx, collID, true)
-	assert.NoError(err)
-	assert.Len(mikeColl.NFTs, 1)
+		err = opensea.UpdateAssetsForAcc(ctx, mikeUserID, []persist.Address{persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFA")), persist.Address(strings.ToLower("0x27B0f73721DA882fAAe00B6e43512BD9eC74ECFD"))}, tc.repos.NftRepository, tc.repos.UserRepository, tc.repos.CollectionRepository, tc.repos.GalleryRepository, tc.repos.BackupRepository)
+		assert.NoError(err)
 
-	mikeNFTs, err := tc.repos.NftRepository.GetByUserID(ctx, mikeUserID)
-	assert.NoError(err)
+		time.Sleep(time.Second * 3)
 
-	assert.Greater(len(mikeNFTs), 0)
+		mikeColl, err := tc.repos.CollectionRepository.GetByID(ctx, collID, true)
+		assert.NoError(err)
+		assert.Len(mikeColl.NFTs, 1)
 
+		mikeNFTs, err := tc.repos.NftRepository.GetByUserID(ctx, mikeUserID)
+		assert.NoError(err)
+
+		assert.Greater(len(mikeNFTs), 0)
+
+	})
 }

--- a/server/t__routes_auth_test.go
+++ b/server/t__routes_auth_test.go
@@ -17,426 +17,433 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAuthPreflightUserExists_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	resp := getPreflightRequest(assert, tc.user1)
-	assertValidResponse(assert, resp)
-
-	type PreflightResp struct {
-		auth.GetPreflightOutput
-		Error string `json:"error"`
-	}
-	output := &PreflightResp{}
-	err := util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.Empty(output.Error)
-	assert.True(output.UserExists)
-}
-
-func TestAuthPreflightUserNotExists_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	resp := getPreflightRequest(assert, &TestUser{
-		TestWallet: &TestWallet{address: "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"},
-		client:     &http.Client{}},
-	)
-	assertValidResponse(assert, resp)
-
-	type PreflightResp struct {
-		auth.GetPreflightOutput
-		Error string `json:"error"`
-	}
-	output := &PreflightResp{}
-	err := util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.Empty(output.Error)
-	assert.False(output.UserExists)
-}
-
-func TestAuthPreflightUserNotExistWithJWT_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	j, err := cookiejar.New(nil)
-	assert.Nil(err)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		TestWallet: &TestWallet{address: "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"},
-		client:     client,
-		jwt:        tc.user1.jwt,
-	}
-	getFakeCookie(assert, tu.jwt, tu.client)
-	resp := getPreflightRequest(assert, tu)
-	assertValidResponse(assert, resp)
-
-	type PreflightResp struct {
-		auth.GetPreflightOutput
-		Error string `json:"error"`
-	}
-	output := &PreflightResp{}
-	err = util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.Empty(output.Error)
-	assert.False(output.UserExists)
-}
-
-func TestUserCreate_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
-	assertValidResponse(assert, resp)
-
-	type UserCreateOutput struct {
-		user.CreateUserOutput
-		Error string `json:"error"`
-	}
-	output := &UserCreateOutput{}
-	err = util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.Empty(output.Error)
-	assert.True(output.SignatureValid)
-	assert.NotEmpty(output.UserID)
-}
-
-func TestUserCreate_UserWithEmptyUsernameExists_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	otherUser := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F0AC5"))},
-	}
-	_, err := tc.repos.UserRepository.Create(context.Background(), otherUser)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
-	assertValidResponse(assert, resp)
-
-	type UserCreateOutput struct {
-		user.CreateUserOutput
-		Error string `json:"error"`
-	}
-	output := &UserCreateOutput{}
-	err = util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.Empty(output.Error)
-	assert.True(output.SignatureValid)
-	assert.NotEmpty(output.UserID)
-}
-func TestUserCreate_WrongNonce_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "Wrong Nonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserCreate_WrongSig_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := createUserRequest(assert, "0x0a22246c5feee38a90dc6898b453c944e7e7c2f9850218d7c13f3f17f992ea691bb808s191a59ad2c83a5d7f4b41d85df1e693a96b5a251f0a66751b7dc235091b", nonce.Address)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserCreate_WrongAddress_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3349a3F8AC5")),
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserCreate_NoNonce_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "0x456d569592f15Af845D0dbe984C12BAB8F430e32")
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserLogin_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: user.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
-	assertValidResponse(assert, resp)
-
-	type LoginOutput struct {
-		auth.LoginOutput
-		Error string `json:"error"`
-	}
-	output := &LoginOutput{}
-	err = util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.Empty(output.Error)
-	assert.True(output.SignatureValid)
-	assert.NotEmpty(output.UserID)
-}
-
-func TestUserLoginGnosis_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	nonce := persist.UserNonce{
-		Value:   "TEST NONCE",
-		Address: user.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "", auth.NoncePrepend+"TEST NONCE", nonce.Address, auth.WalletTypeGnosis)
-	assertValidResponse(assert, resp)
-
-	type LoginOutput struct {
-		auth.LoginOutput
-		Error string `json:"error"`
-	}
-	output := &LoginOutput{}
-	err = util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.Empty(output.Error)
-	assert.True(output.SignatureValid)
-	assert.NotEmpty(output.UserID)
-}
-
-func TestUserLoginGnosis_WrongNonce_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	nonce := persist.UserNonce{
-		Value:   "TEST NONCE",
-		Address: user.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "", "0x", nonce.Address, auth.WalletTypeGnosis)
-	assertErrorResponse(assert, resp)
-
-	type LoginOutput struct {
-		auth.LoginOutput
-		Error string `json:"error"`
-	}
-	output := &LoginOutput{}
-	err = util.UnmarshallBody(output, resp.Body)
-	assert.False(output.SignatureValid)
-	assert.Empty(output.UserID)
-}
-
-func TestUserLoginGnosis_WrongSig_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	nonce := persist.UserNonce{
-		Value:   " TEST NONCE",
-		Address: user.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "", " TEST NONCE", nonce.Address, auth.WalletTypeGnosis)
-	assertErrorResponse(assert, resp)
-
-	type LoginOutput struct {
-		auth.LoginOutput
-		Error string `json:"error"`
-	}
-	output := &LoginOutput{}
-	err = util.UnmarshallBody(output, resp.Body)
-	assert.False(output.SignatureValid)
-	assert.Empty(output.UserID)
-}
-func TestUserLogin_WrongNonce_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	nonce := persist.UserNonce{
-		Value:   "Wrong Nonce",
-		Address: user.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserLogin_WrongSig_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: user.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "0x0a22246c5feee38a80dc6898b453c944e7e7c2f9850218d7c13f3f17f992ea691bb8083191a59ad2c83a5d7f4b41d85df1e693a96b5a251f0a66751b7dc235091b", "", nonce.Address, auth.WalletTypeEOA)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserLogin_WrongAddr_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: user.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9", auth.WalletTypeEOA)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserLogin_NoNonce_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-
-	_, err := tc.repos.UserRepository.Create(context.Background(), user)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5", auth.WalletTypeEOA)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserLogin_UserNotExist_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserLogin_UserNotOwnAddress_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5",
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
-	assertErrorResponse(assert, resp)
-}
-
-func TestJwtValid_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-	resp := jwtValidRequest(assert, tc.user1)
-	assertValidJSONResponse(assert, resp)
-
-	output := &auth.JWTValidateResponse{}
-	err := util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.True(output.IsValid)
-	assert.Equal(tc.user1.id, output.UserID)
-}
-
-func TestJwtValid_WrongSignatureAndClaims_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-	resp := jwtValidRequest(assert, generateTestUser(assert, tc.repos, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IiwiaWF0IjoxNjMzMDE1MTM1LCJleHAiOjE2NjQ1NTExMzUsImF1ZCI6InRlc3QiLCJzdWIiOiJ0ZXN0IiwiVGVzdCI6IlRlc3QifQ.ewGO4x1xEN01CCZTp5vg0d_rxzdzH_rY0zBXVT1OVJY"))
-	assertValidJSONResponse(assert, resp)
-
-	output := &auth.JWTValidateResponse{}
-	err := util.UnmarshallBody(output, resp.Body)
-	assert.Nil(err)
-	assert.False(output.IsValid)
+func TestAuthRoutes(t *testing.T) {
+
+	setupDoubles(t)
+
+	t.Run("preflight user exists", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		resp := getPreflightRequest(assert, tc.user1)
+		assertValidResponse(assert, resp)
+
+		type PreflightResp struct {
+			auth.GetPreflightOutput
+			Error string `json:"error"`
+		}
+		output := &PreflightResp{}
+		err := util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.Empty(output.Error)
+		assert.True(output.UserExists)
+	})
+
+	t.Run("preflight user does not exist", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		resp := getPreflightRequest(assert, &TestUser{
+			TestWallet: &TestWallet{address: "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"},
+			client:     &http.Client{}},
+		)
+		assertValidResponse(assert, resp)
+
+		type PreflightResp struct {
+			auth.GetPreflightOutput
+			Error string `json:"error"`
+		}
+		output := &PreflightResp{}
+		err := util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.Empty(output.Error)
+		assert.False(output.UserExists)
+	})
+
+	t.Run("user does not exist with JWT", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		j, err := cookiejar.New(nil)
+		assert.Nil(err)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			TestWallet: &TestWallet{address: "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"},
+			client:     client,
+			jwt:        tc.user1.jwt,
+		}
+		getFakeCookie(assert, tu.jwt, tu.client)
+		resp := getPreflightRequest(assert, tu)
+		assertValidResponse(assert, resp)
+
+		type PreflightResp struct {
+			auth.GetPreflightOutput
+			Error string `json:"error"`
+		}
+		output := &PreflightResp{}
+		err = util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.Empty(output.Error)
+		assert.False(output.UserExists)
+	})
+
+	t.Run("user create success", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
+		assertValidResponse(assert, resp)
+
+		type UserCreateOutput struct {
+			user.CreateUserOutput
+			Error string `json:"error"`
+		}
+		output := &UserCreateOutput{}
+		err = util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.Empty(output.Error)
+		assert.True(output.SignatureValid)
+		assert.NotEmpty(output.UserID)
+	})
+
+	t.Run("user create empty username exist is successful", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		otherUser := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F0AC5"))},
+		}
+		_, err := tc.repos.UserRepository.Create(context.Background(), otherUser)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
+		assertValidResponse(assert, resp)
+
+		type UserCreateOutput struct {
+			user.CreateUserOutput
+			Error string `json:"error"`
+		}
+		output := &UserCreateOutput{}
+		err = util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.Empty(output.Error)
+		assert.True(output.SignatureValid)
+		assert.NotEmpty(output.UserID)
+	})
+
+	t.Run("user create wrong nonce fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		nonce := persist.UserNonce{
+			Value:   "Wrong Nonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user create wrong signature fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := createUserRequest(assert, "0x0a22246c5feee38a90dc6898b453c944e7e7c2f9850218d7c13f3f17f992ea691bb808s191a59ad2c83a5d7f4b41d85df1e693a96b5a251f0a66751b7dc235091b", nonce.Address)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user create wrong address fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3349a3F8AC5")),
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", nonce.Address)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user create no nonce fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		resp := createUserRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "0x456d569592f15Af845D0dbe984C12BAB8F430e32")
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user logins in success", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: user.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
+		assertValidResponse(assert, resp)
+
+		type LoginOutput struct {
+			auth.LoginOutput
+			Error string `json:"error"`
+		}
+		output := &LoginOutput{}
+		err = util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.Empty(output.Error)
+		assert.True(output.SignatureValid)
+		assert.NotEmpty(output.UserID)
+	})
+
+	t.Run("user logins with Gnosis success", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   "TEST NONCE",
+			Address: user.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "", auth.NoncePrepend+"TEST NONCE", nonce.Address, auth.WalletTypeGnosis)
+		assertValidResponse(assert, resp)
+
+		type LoginOutput struct {
+			auth.LoginOutput
+			Error string `json:"error"`
+		}
+		output := &LoginOutput{}
+		err = util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.Empty(output.Error)
+		assert.True(output.SignatureValid)
+		assert.NotEmpty(output.UserID)
+	})
+
+	t.Run("user logins with Gnosis wrong nonce fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   "TEST NONCE",
+			Address: user.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "", "0x", nonce.Address, auth.WalletTypeGnosis)
+		assertErrorResponse(assert, resp)
+
+		type LoginOutput struct {
+			auth.LoginOutput
+			Error string `json:"error"`
+		}
+		output := &LoginOutput{}
+		err = util.UnmarshallBody(output, resp.Body)
+		assert.False(output.SignatureValid)
+		assert.Empty(output.UserID)
+	})
+
+	t.Run("user logins with Gnosis wrong signature fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x60facEcd4dBF14f1ae647Afc3d1D071B1C29ACE4"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   " TEST NONCE",
+			Address: user.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "", " TEST NONCE", nonce.Address, auth.WalletTypeGnosis)
+		assertErrorResponse(assert, resp)
+
+		type LoginOutput struct {
+			auth.LoginOutput
+			Error string `json:"error"`
+		}
+		output := &LoginOutput{}
+		err = util.UnmarshallBody(output, resp.Body)
+		assert.False(output.SignatureValid)
+		assert.Empty(output.UserID)
+	})
+
+	t.Run("user login wrong nonce fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   "Wrong Nonce",
+			Address: user.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user login wrong signature fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: user.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "0x0a22246c5feee38a80dc6898b453c944e7e7c2f9850218d7c13f3f17f992ea691bb8083191a59ad2c83a5d7f4b41d85df1e693a96b5a251f0a66751b7dc235091b", "", nonce.Address, auth.WalletTypeEOA)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user login with wrong address fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: user.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9", auth.WalletTypeEOA)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user login with wrong nonce fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		user := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+
+		_, err := tc.repos.UserRepository.Create(context.Background(), user)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5", auth.WalletTypeEOA)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user login user does not exist fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("user login not own address fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: "0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5",
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		resp := loginRequest(assert, "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b", "", nonce.Address, auth.WalletTypeEOA)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("valid JWT success", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		resp := jwtValidRequest(assert, tc.user1)
+		assertValidJSONResponse(assert, resp)
+
+		output := &auth.JWTValidateResponse{}
+		err := util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.True(output.IsValid)
+		assert.Equal(tc.user1.id, output.UserID)
+	})
+
+	t.Run("valid JWT wrong signature and claims fails", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		resp := jwtValidRequest(assert, generateTestUser(assert, tc.repos, "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IiwiaWF0IjoxNjMzMDE1MTM1LCJleHAiOjE2NjQ1NTExMzUsImF1ZCI6InRlc3QiLCJzdWIiOiJ0ZXN0IiwiVGVzdCI6IlRlc3QifQ.ewGO4x1xEN01CCZTp5vg0d_rxzdzH_rY0zBXVT1OVJY"))
+		assertValidJSONResponse(assert, resp)
+
+		output := &auth.JWTValidateResponse{}
+		err := util.UnmarshallBody(output, resp.Body)
+		assert.Nil(err)
+		assert.False(output.IsValid)
+	})
 }
 
 func jwtValidRequest(assert *assert.Assertions, t *TestUser) *http.Response {
-	req, err := http.NewRequest("GET",
-		fmt.Sprintf("%s/auth/jwt_valid", tc.serverURL),
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/auth/jwt_valid", tc.serverURL),
 		nil)
 	assert.Nil(err)
 
@@ -446,8 +453,7 @@ func jwtValidRequest(assert *assert.Assertions, t *TestUser) *http.Response {
 }
 
 func getPreflightRequest(assert *assert.Assertions, t *TestUser) *http.Response {
-	req, err := http.NewRequest("GET",
-		fmt.Sprintf("%s/auth/get_preflight?address=%s", tc.serverURL, t.address),
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/auth/get_preflight?address=%s", tc.serverURL, t.address),
 		nil)
 	assert.Nil(err)
 	resp, err := t.client.Do(req)

--- a/server/t__routes_gallery_test.go
+++ b/server/t__routes_gallery_test.go
@@ -15,42 +15,47 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpdateGalleryById_ReorderCollections_Success(t *testing.T) {
-	assert := setupTest(t, 1)
+func TestGalleryRoutes(t *testing.T) {
 
-	initialCollectionOrder := []persist.DBID{}
+	setupDoubles(t)
 
-	// SET UP
-	// Seed DB with collection
-	for i := 0; i < 4; i++ {
-		collID := createCollectionInDbForUserID(assert, fmt.Sprintf("Collection #%d", i), tc.user1.id)
-		initialCollectionOrder = append(initialCollectionOrder, collID)
-	}
-	// Seed DB with gallery
-	id, err := tc.repos.GalleryRepository.Create(context.Background(), persist.GalleryDB{
-		OwnerUserID: tc.user1.id,
-		Collections: initialCollectionOrder,
+	t.Run("update gallery by ID reorder collections", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		initialCollectionOrder := []persist.DBID{}
+
+		// SET UP
+		// Seed DB with collection
+		for i := 0; i < 4; i++ {
+			collID := createCollectionInDbForUserID(assert, fmt.Sprintf("Collection #%d", i), tc.user1.id)
+			initialCollectionOrder = append(initialCollectionOrder, collID)
+		}
+		// Seed DB with gallery
+		id, err := tc.repos.GalleryRepository.Create(context.Background(), persist.GalleryDB{
+			OwnerUserID: tc.user1.id,
+			Collections: initialCollectionOrder,
+		})
+		assert.Nil(err)
+
+		// Validate the initial order of the gallery's collections
+		validateCollectionsOrderInGallery(assert, initialCollectionOrder)
+
+		// UPDATE COLLECTION ORDER
+		// build update request body
+		updatedCollectionOrder := []persist.DBID{
+			initialCollectionOrder[3],
+			initialCollectionOrder[2],
+			initialCollectionOrder[1],
+			initialCollectionOrder[0],
+		}
+		update := galleryTokenUpdateInput{Collections: updatedCollectionOrder, ID: id}
+		updateTestGallery(assert, update)
+
+		time.Sleep(time.Second * 3)
+
+		// Validate the updated order of the gallery's collections
+		validateCollectionsOrderInGallery(assert, updatedCollectionOrder)
 	})
-	assert.Nil(err)
-
-	// Validate the initial order of the gallery's collections
-	validateCollectionsOrderInGallery(assert, initialCollectionOrder)
-
-	// UPDATE COLLECTION ORDER
-	// build update request body
-	updatedCollectionOrder := []persist.DBID{
-		initialCollectionOrder[3],
-		initialCollectionOrder[2],
-		initialCollectionOrder[1],
-		initialCollectionOrder[0],
-	}
-	update := galleryTokenUpdateInput{Collections: updatedCollectionOrder, ID: id}
-	updateTestGallery(assert, update)
-
-	time.Sleep(time.Second * 3)
-
-	// Validate the updated order of the gallery's collections
-	validateCollectionsOrderInGallery(assert, updatedCollectionOrder)
 }
 
 // Retrieve the user's gallery and verify that the collections are in the expected order

--- a/server/t__routes_health_test.go
+++ b/server/t__routes_health_test.go
@@ -8,15 +8,20 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 )
 
-func TestHealthcheck(t *testing.T) {
-	assert := setupTest(t, 1)
+func TestHealthRoutes(t *testing.T) {
 
-	resp, err := http.Get(fmt.Sprintf("%s/health", tc.serverURL))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
+	setupDoubles(t)
 
-	body := healthcheckResponse{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal("gallery operational", body.Message)
-	assert.Equal("local", body.Env)
+	t.Run("healthcheck", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		resp, err := http.Get(fmt.Sprintf("%s/health", tc.serverURL))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
+
+		body := healthcheckResponse{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal("gallery operational", body.Message)
+		assert.Equal("local", body.Env)
+	})
 }

--- a/server/t__routes_user_test.go
+++ b/server/t__routes_user_test.go
@@ -18,592 +18,594 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetUserByID_Success(t *testing.T) {
-	setupTest(t, 1)
+func TestUserRoutes(t *testing.T) {
 
-	assert := assert.New(t)
+	setupDoubles(t)
 
-	resp, err := http.Get(fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, tc.user1.id))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
+	t.Run("get user by ID", func(t *testing.T) {
+		setupTest(t, 1)
 
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(tc.user1.username, body.Username.String())
-}
+		assert := assert.New(t)
 
-func TestGetUserByAddress_Success(t *testing.T) {
-	assert := setupTest(t, 1)
+		resp, err := http.Get(fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, tc.user1.id))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
 
-	resp, err := http.Get(fmt.Sprintf("%s/users/get?address=%s", tc.serverURL, tc.user2.address))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(tc.user2.username, body.Username.String())
-}
-
-func TestGetUserByUsername_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	resp, err := http.Get(fmt.Sprintf("%s/users/get?username=%s", tc.serverURL, tc.user1.username))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(tc.user1.username, body.Username.String())
-}
-
-func TestGetUserAuthenticated_ShouldIncludeAddress(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	userID := tc.user1.id
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, userID), nil)
-	assert.Nil(err)
-
-	resp, err := tc.user1.client.Do(req)
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(userID, body.ID)
-	assert.NotEmpty(body.Addresses)
-}
-
-func TestUpdateUserAuthenticated_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	update := user.UpdateUserInput{
-		UserName: "kaito",
-	}
-	resp := updateUserInfoRequest(assert, update, tc.user1)
-	assertValidJSONResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.Equal(update.UserName, user.Username.String())
-}
-
-// Updating the username to itself should not trigger an error, despite the DB
-// having a user entity with that username already
-func TestUpdateUserAuthenticated_NoChange_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	update := user.UpdateUserInput{
-		UserName: "bob",
-	}
-	resp := updateUserInfoRequest(assert, update, tc.user1)
-	assertValidJSONResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.Equal(update.UserName, user.Username.String())
-}
-
-func TestUpdateUserUnauthenticated_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	update := user.UpdateUserInput{
-		UserName: "kaito",
-	}
-	resp := updateUserInfoNoAuthRequest(assert, update)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUpdateUserAuthenticated_UsernameTaken_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	user2, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user2.id)
-	assert.Nil(err)
-	log.Println(user2.Username)
-
-	update := user.UpdateUserInput{
-		UserName: tc.user2.username,
-	}
-	resp := updateUserInfoRequest(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.NotEqual(update.UserName, user.Username)
-}
-func TestUpdateUserAuthenticated_UsernameInvalid_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	update := user.UpdateUserInput{
-		UserName: "92ks&$m__",
-	}
-	resp := updateUserInfoRequest(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.NotEqual(update.UserName, user.Username)
-}
-
-func TestUserAddAddresses_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	update := user.AddUserAddressesInput{
-		Address:   persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-		Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-	}
-	resp := userAddAddressesRequest(assert, update, tc.user1)
-	assertValidJSONResponse(assert, resp)
-
-	errResp := &util.ErrorResponse{}
-	err = util.UnmarshallBody(errResp, resp.Body)
-	assert.Nil(err)
-	assert.Empty(errResp.Error)
-
-	updatedUser, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.Equal(update.Address, updatedUser.Addresses[1])
-}
-
-func TestUserAddAddresses_WrongNonce_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	nonce := persist.UserNonce{
-		Value:   "Wrong Nonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	update := user.AddUserAddressesInput{
-		Address:   persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-		Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-	}
-	resp := userAddAddressesRequest(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserAddAddresses_OtherUserOwnsAddress_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	u := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-	_, err := tc.repos.UserRepository.Create(context.Background(), u)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	update := user.AddUserAddressesInput{
-		Address:   persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-		Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-	}
-	resp := userAddAddressesRequest(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserRemoveAddresses_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	u := persist.User{
-		Addresses:          []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9", persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-		Username:           "TestUser",
-		UsernameIdempotent: "testuser",
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
-
-	nft := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-		Name:         "test",
-	}
-	nftID, err := tc.repos.NftRepository.Create(context.Background(), nft)
-
-	nft2 := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9")),
-		Name:         "blah",
-	}
-	nftID2, err := tc.repos.NftRepository.Create(context.Background(), nft2)
-
-	coll := persist.CollectionDB{
-		NFTs:        []persist.DBID{nftID, nftID2},
-		Name:        "test-coll",
-		OwnerUserID: userID,
-	}
-	collID, err := tc.repos.CollectionRepository.Create(context.Background(), coll)
-
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
-
-	update := user.RemoveUserAddressesInput{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-	j, err := cookiejar.New(nil)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		id:     userID,
-		jwt:    jwt,
-		client: client,
-	}
-	getFakeCookie(assert, jwt, client)
-
-	resp := userRemoveAddressesRequest(assert, update, tu)
-	assertValidJSONResponse(assert, resp)
-
-	errResp := &util.ErrorResponse{}
-	util.UnmarshallBody(errResp, resp.Body)
-	assert.Empty(errResp.Error)
-
-	nfts, err := tc.repos.NftRepository.GetByUserID(context.Background(), userID)
-	assert.Nil(err)
-	assert.Len(nfts, 1)
-
-	res, err := tc.repos.CollectionRepository.GetByID(context.Background(), collID, true)
-	assert.Nil(err)
-	assert.Len(res.NFTs, 2)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
-	assert.Nil(err)
-	assert.Len(user.Addresses, 1)
-
-}
-
-func TestUserRemoveAddresses_MoveNFTs_Success(t *testing.T) {
-	assert := setupTest(t, 1)
-
-	u := persist.User{
-		Addresses:          []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9", persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-		Username:           "TestUser",
-		UsernameIdempotent: "testuser",
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.NoError(err)
-
-	nft := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
-		Name:         "test",
-		OpenseaID:    2,
-	}
-	nftID, err := tc.repos.NftRepository.Create(context.Background(), nft)
-
-	nft2 := persist.NFT{
-		OwnerAddress: persist.Address(strings.ToLower("0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9")),
-		Name:         "blah",
-		OpenseaID:    1,
-	}
-	nftID2, err := tc.repos.NftRepository.Create(context.Background(), nft2)
-
-	coll := persist.CollectionDB{
-		NFTs:        []persist.DBID{nftID, nftID2},
-		Name:        "test-coll",
-		OwnerUserID: userID,
-	}
-	collID, err := tc.repos.CollectionRepository.Create(context.Background(), coll)
-
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.NoError(err)
-
-	update := user.RemoveUserAddressesInput{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-	j, err := cookiejar.New(nil)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		id:     userID,
-		jwt:    jwt,
-		client: client,
-	}
-	getFakeCookie(assert, jwt, client)
-
-	resp := userRemoveAddressesRequest(assert, update, tu)
-	assertValidJSONResponse(assert, resp)
-
-	errResp := &util.ErrorResponse{}
-	util.UnmarshallBody(errResp, resp.Body)
-	assert.Empty(errResp.Error)
-
-	nfts, err := tc.repos.NftRepository.GetByUserID(context.Background(), userID)
-	assert.NoError(err)
-	assert.Len(nfts, 1)
-
-	res, err := tc.repos.CollectionRepository.GetByID(context.Background(), collID, true)
-	assert.NoError(err)
-	assert.Len(res.NFTs, 2)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
-	assert.NoError(err)
-	assert.Len(user.Addresses, 1)
-
-	err = tc.repos.NftRepository.UpdateByIDUnsafe(context.Background(), nftID2, persist.NFTUpdateOwnerAddressInput{
-		OwnerAddress: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(tc.user1.username, body.Username.String())
 	})
-	assert.NoError(err)
 
-	newNFT2, err := tc.repos.NftRepository.GetByID(context.Background(), nftID2)
-	assert.NoError(err)
-	assert.Equal(newNFT2.OwnerAddress, persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")))
+	t.Run("get user by address", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	// This would happen in an opensea refresh
-	err = tc.repos.CollectionRepository.RemoveNFTsOfOldAddresses(context.Background(), userID)
-	assert.NoError(err)
+		resp, err := http.Get(fmt.Sprintf("%s/users/get?address=%s", tc.serverURL, tc.user2.address))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
 
-	res, err = tc.repos.CollectionRepository.GetByID(context.Background(), collID, true)
-	assert.NoError(err)
-	assert.Len(res.NFTs, 0)
-}
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(tc.user2.username, body.Username.String())
+	})
 
-func TestUserRemoveAddresses_NotOwnAddress_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
+	t.Run("get user by username", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	u := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")), "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
+		resp, err := http.Get(fmt.Sprintf("%s/users/get?username=%s", tc.serverURL, tc.user1.username))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
 
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(tc.user1.username, body.Username.String())
+	})
 
-	update := user.RemoveUserAddressesInput{
-		Addresses: []persist.Address{tc.user1.address},
-	}
+	t.Run("get authenticated user includes address", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	j, err := cookiejar.New(nil)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		id:     userID,
-		jwt:    jwt,
-		client: client,
-	}
-	getFakeCookie(assert, jwt, client)
+		userID := tc.user1.id
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, userID), nil)
+		assert.Nil(err)
 
-	resp := userRemoveAddressesRequest(assert, update, tu)
-	assertErrorResponse(assert, resp)
+		resp, err := tc.user1.client.Do(req)
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
 
-}
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(userID, body.ID)
+		assert.NotEmpty(body.Addresses)
+	})
 
-func TestUserRemoveAddresses_AllAddresses_Failure(t *testing.T) {
-	assert := setupTest(t, 1)
+	t.Run("can update user if authenticated", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	u := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")), "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
+		update := user.UpdateUserInput{
+			UserName: "kaito",
+		}
+		resp := updateUserInfoRequest(assert, update, tc.user1)
+		assertValidJSONResponse(assert, resp)
 
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.Equal(update.UserName, user.Username.String())
+	})
 
-	update := user.RemoveUserAddressesInput{
-		Addresses: u.Addresses,
-	}
+	// Updating the username to itself should not trigger an error, despite the DB
+	// having a user entity with that username already
+	t.Run("can update user with no change", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	j, err := cookiejar.New(nil)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		id:     userID,
-		jwt:    jwt,
-		client: client,
-	}
-	getFakeCookie(assert, jwt, client)
+		update := user.UpdateUserInput{
+			UserName: "bob",
+		}
+		resp := updateUserInfoRequest(assert, update, tc.user1)
+		assertValidJSONResponse(assert, resp)
 
-	resp := userRemoveAddressesRequest(assert, update, tu)
-	assertErrorResponse(assert, resp)
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.Equal(update.UserName, user.Username.String())
+	})
 
-}
+	t.Run("can't update user if not authenticated", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-func TestGetUserPreviews_Success(t *testing.T) {
-	assert := setupTest(t, 1)
+		update := user.UpdateUserInput{
+			UserName: "kaito",
+		}
+		resp := updateUserInfoNoAuthRequest(assert, update)
+		assertErrorResponse(assert, resp)
+	})
 
-	nfts := []persist.NFT{
-		{
-			OwnerAddress:      tc.user1.address,
-			Name:              "test",
-			OpenseaTokenID:    "10",
-			OpenseaID:         2,
-			ImageURL:          "https://example.com/test.png",
-			ImagePreviewURL:   "https://example.com/test.png",
-			ImageThumbnailURL: "https://example.com/test.png",
-		},
-		{
-			OwnerAddress:      tc.user1.address,
-			Name:              "test",
-			OpenseaTokenID:    "9",
-			OpenseaID:         1,
-			ImageURL:          "https://example.com/test.png",
-			ImagePreviewURL:   "https://example.com/test.png",
-			ImageThumbnailURL: "https://example.com/test.png",
-		},
-		{
-			OwnerAddress:      tc.user1.address,
-			Name:              "test",
-			OpenseaTokenID:    "8",
-			OpenseaID:         10,
-			ImageURL:          "https://example.com/test.png",
-			ImagePreviewURL:   "https://example.com/test.png",
-			ImageThumbnailURL: "https://example.com/test.png",
-		},
-	}
-	nftIDs, err := tc.repos.NftRepository.CreateBulk(context.Background(), nfts)
-	assert.Nil(err)
+	t.Run("can't update username to already existing username", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	coll := persist.CollectionDB{
-		Name:           "test",
-		CollectorsNote: "test",
-		NFTs:           nftIDs,
-		OwnerUserID:    tc.user1.id,
-	}
-	collID, err := tc.repos.CollectionRepository.Create(context.Background(), coll)
-	assert.Nil(err)
+		user2, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user2.id)
+		assert.Nil(err)
+		log.Println(user2.Username)
 
-	gallery := persist.GalleryDB{
-		OwnerUserID: tc.user1.id,
-		Collections: []persist.DBID{collID},
-	}
-	_, err = tc.repos.GalleryRepository.Create(context.Background(), gallery)
-	assert.Nil(err)
+		update := user.UpdateUserInput{
+			UserName: tc.user2.username,
+		}
+		resp := updateUserInfoRequest(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
 
-	resp, err := http.Get(fmt.Sprintf("%s/users/previews?user_id=%s", tc.serverURL, tc.user1.id))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.NotEqual(update.UserName, user.Username)
+	})
 
-	type previews struct {
-		Previews []string `json:"previews"`
-	}
-	var body previews
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Len(body.Previews, 3)
-}
-func TestMergeUsers_Success(t *testing.T) {
-	assert := setupTest(t, 1)
+	t.Run("can't update username if username is invalid", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	// Create user
-	u := persist.User{
-		Addresses: []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
+		update := user.UpdateUserInput{
+			UserName: "92ks&$m__",
+		}
+		resp := updateUserInfoRequest(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
 
-	nft := persist.NFT{
-		OwnerAddress:   persist.Address(strings.ToLower("0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9")),
-		OpenseaTokenID: "1",
-	}
-	galleryID := fillGallery(assert, nft, userID)
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.NotEqual(update.UserName, user.Username)
+	})
 
-	// Set up cookie to make an authenticated request
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
-	tu := createCookieAndSetOnUser(assert, userID, jwt)
+	t.Run("can add addresses", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	u2 := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-	userID2, err := tc.repos.UserRepository.Create(context.Background(), u2)
-	assert.Nil(err)
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
 
-	nft2 := persist.NFT{
-		OwnerAddress:   u2.Addresses[0],
-		OpenseaTokenID: "2",
-	}
-	deletedGallery := fillGallery(assert, nft2, userID2)
+		update := user.AddUserAddressesInput{
+			Address:   persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+			Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+		}
+		resp := userAddAddressesRequest(assert, update, tc.user1)
+		assertValidJSONResponse(assert, resp)
 
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: u2.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
+		errResp := &util.ErrorResponse{}
+		err = util.UnmarshallBody(errResp, resp.Body)
+		assert.Nil(err)
+		assert.Empty(errResp.Error)
 
-	mergeInput := user.MergeUsersInput{
-		SecondUserID: userID2,
-		Signature:    "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-		Nonce:        "TestNonce",
-		Address:      u2.Addresses[0],
-		WalletType:   auth.WalletTypeEOA,
-	}
+		updatedUser, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.Equal(update.Address, updatedUser.Addresses[1])
+	})
 
-	resp := mergeUserRequest(assert, mergeInput, tu)
-	defer resp.Body.Close()
-	assertValidResponse(assert, resp)
+	t.Run("can't add address if wrong nonce", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	errResp := util.ErrorResponse{}
-	err = json.NewDecoder(resp.Body).Decode(&errResp)
-	assert.Nil(err)
-	assert.Empty(errResp.Error)
+		nonce := persist.UserNonce{
+			Value:   "Wrong Nonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
 
-	newInitialUser, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
-	assert.Nil(err)
-	assert.Len(newInitialUser.Addresses, 2)
+		update := user.AddUserAddressesInput{
+			Address:   persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+			Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+		}
+		resp := userAddAddressesRequest(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
+	})
 
-	newGallery, err := tc.repos.GalleryRepository.GetByID(context.Background(), galleryID)
-	assert.Nil(err)
-	assert.Len(newGallery.Collections, 2)
+	t.Run("can't add address if other user owns address", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	_, err = tc.repos.GalleryRepository.GetByID(context.Background(), deletedGallery)
-	assert.NotNil(err)
+		u := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+		_, err := tc.repos.UserRepository.Create(context.Background(), u)
 
-	_, err = tc.repos.UserRepository.GetByID(context.Background(), userID2)
-	assert.NotNil(err)
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
 
-}
+		update := user.AddUserAddressesInput{
+			Address:   persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+			Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+		}
+		resp := userAddAddressesRequest(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
+	})
 
-func TestMergeUsers_NoGalleries_Success(t *testing.T) {
-	assert := setupTest(t, 1)
+	t.Run("can remove address", func(t *testing.T) {
+		assert := setupTest(t, 1)
 
-	// Create user
-	u := persist.User{
-		Addresses: []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
+		u := persist.User{
+			Addresses:          []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9", persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+			Username:           "TestUser",
+			UsernameIdempotent: "testuser",
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
 
-	// Set up cookie to make an authenticated request
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
-	tu := createCookieAndSetOnUser(assert, userID, jwt)
+		nft := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+			Name:         "test",
+		}
+		nftID, err := tc.repos.NftRepository.Create(context.Background(), nft)
 
-	u2 := persist.User{
-		Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
-	}
-	userID2, err := tc.repos.UserRepository.Create(context.Background(), u2)
-	assert.Nil(err)
+		nft2 := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9")),
+			Name:         "blah",
+		}
+		nftID2, err := tc.repos.NftRepository.Create(context.Background(), nft2)
 
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: u2.Addresses[0],
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
+		coll := persist.CollectionDB{
+			NFTs:        []persist.DBID{nftID, nftID2},
+			Name:        "test-coll",
+			OwnerUserID: userID,
+		}
+		collID, err := tc.repos.CollectionRepository.Create(context.Background(), coll)
 
-	mergeInput := user.MergeUsersInput{
-		SecondUserID: userID2,
-		Signature:    "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-		Nonce:        "TestNonce",
-		Address:      u2.Addresses[0],
-		WalletType:   auth.WalletTypeEOA,
-	}
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
 
-	resp := mergeUserRequest(assert, mergeInput, tu)
-	defer resp.Body.Close()
-	assertValidResponse(assert, resp)
+		update := user.RemoveUserAddressesInput{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+		j, err := cookiejar.New(nil)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			id:     userID,
+			jwt:    jwt,
+			client: client,
+		}
+		getFakeCookie(assert, jwt, client)
 
-	newInitialUser, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
-	assert.Nil(err)
-	assert.Len(newInitialUser.Addresses, 2)
+		resp := userRemoveAddressesRequest(assert, update, tu)
+		assertValidJSONResponse(assert, resp)
 
-	_, err = tc.repos.UserRepository.GetByID(context.Background(), userID2)
-	assert.NotNil(err)
+		errResp := &util.ErrorResponse{}
+		util.UnmarshallBody(errResp, resp.Body)
+		assert.Empty(errResp.Error)
 
+		nfts, err := tc.repos.NftRepository.GetByUserID(context.Background(), userID)
+		assert.Nil(err)
+		assert.Len(nfts, 1)
+
+		res, err := tc.repos.CollectionRepository.GetByID(context.Background(), collID, true)
+		assert.Nil(err)
+		assert.Len(res.NFTs, 2)
+
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
+		assert.Nil(err)
+		assert.Len(user.Addresses, 1)
+	})
+
+	t.Run("removing address moves NFTS", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		u := persist.User{
+			Addresses:          []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9", persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+			Username:           "TestUser",
+			UsernameIdempotent: "testuser",
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.NoError(err)
+
+		nft := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+			Name:         "test",
+			OpenseaID:    2,
+		}
+		nftID, err := tc.repos.NftRepository.Create(context.Background(), nft)
+
+		nft2 := persist.NFT{
+			OwnerAddress: persist.Address(strings.ToLower("0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9")),
+			Name:         "blah",
+			OpenseaID:    1,
+		}
+		nftID2, err := tc.repos.NftRepository.Create(context.Background(), nft2)
+
+		coll := persist.CollectionDB{
+			NFTs:        []persist.DBID{nftID, nftID2},
+			Name:        "test-coll",
+			OwnerUserID: userID,
+		}
+		collID, err := tc.repos.CollectionRepository.Create(context.Background(), coll)
+
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.NoError(err)
+
+		update := user.RemoveUserAddressesInput{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+		j, err := cookiejar.New(nil)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			id:     userID,
+			jwt:    jwt,
+			client: client,
+		}
+		getFakeCookie(assert, jwt, client)
+
+		resp := userRemoveAddressesRequest(assert, update, tu)
+		assertValidJSONResponse(assert, resp)
+
+		errResp := &util.ErrorResponse{}
+		util.UnmarshallBody(errResp, resp.Body)
+		assert.Empty(errResp.Error)
+
+		nfts, err := tc.repos.NftRepository.GetByUserID(context.Background(), userID)
+		assert.NoError(err)
+		assert.Len(nfts, 1)
+
+		res, err := tc.repos.CollectionRepository.GetByID(context.Background(), collID, true)
+		assert.NoError(err)
+		assert.Len(res.NFTs, 2)
+
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
+		assert.NoError(err)
+		assert.Len(user.Addresses, 1)
+
+		err = tc.repos.NftRepository.UpdateByIDUnsafe(context.Background(), nftID2, persist.NFTUpdateOwnerAddressInput{
+			OwnerAddress: persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")),
+		})
+		assert.NoError(err)
+
+		newNFT2, err := tc.repos.NftRepository.GetByID(context.Background(), nftID2)
+		assert.NoError(err)
+		assert.Equal(newNFT2.OwnerAddress, persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")))
+
+		// This would happen in an opensea refresh
+		err = tc.repos.CollectionRepository.RemoveNFTsOfOldAddresses(context.Background(), userID)
+		assert.NoError(err)
+
+		res, err = tc.repos.CollectionRepository.GetByID(context.Background(), collID, true)
+		assert.NoError(err)
+		assert.Len(res.NFTs, 0)
+	})
+
+	t.Run("can't remove address if not owned by user", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		u := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")), "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+
+		update := user.RemoveUserAddressesInput{
+			Addresses: []persist.Address{tc.user1.address},
+		}
+
+		j, err := cookiejar.New(nil)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			id:     userID,
+			jwt:    jwt,
+			client: client,
+		}
+		getFakeCookie(assert, jwt, client)
+
+		resp := userRemoveAddressesRequest(assert, update, tu)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("can't remove all addresses", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		u := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5")), "0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+
+		update := user.RemoveUserAddressesInput{
+			Addresses: u.Addresses,
+		}
+
+		j, err := cookiejar.New(nil)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			id:     userID,
+			jwt:    jwt,
+			client: client,
+		}
+		getFakeCookie(assert, jwt, client)
+
+		resp := userRemoveAddressesRequest(assert, update, tu)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("get user previews", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		nfts := []persist.NFT{
+			{
+				OwnerAddress:      tc.user1.address,
+				Name:              "test",
+				OpenseaTokenID:    "10",
+				OpenseaID:         2,
+				ImageURL:          "https://example.com/test.png",
+				ImagePreviewURL:   "https://example.com/test.png",
+				ImageThumbnailURL: "https://example.com/test.png",
+			},
+			{
+				OwnerAddress:      tc.user1.address,
+				Name:              "test",
+				OpenseaTokenID:    "9",
+				OpenseaID:         1,
+				ImageURL:          "https://example.com/test.png",
+				ImagePreviewURL:   "https://example.com/test.png",
+				ImageThumbnailURL: "https://example.com/test.png",
+			},
+			{
+				OwnerAddress:      tc.user1.address,
+				Name:              "test",
+				OpenseaTokenID:    "8",
+				OpenseaID:         10,
+				ImageURL:          "https://example.com/test.png",
+				ImagePreviewURL:   "https://example.com/test.png",
+				ImageThumbnailURL: "https://example.com/test.png",
+			},
+		}
+		nftIDs, err := tc.repos.NftRepository.CreateBulk(context.Background(), nfts)
+		assert.Nil(err)
+
+		coll := persist.CollectionDB{
+			Name:           "test",
+			CollectorsNote: "test",
+			NFTs:           nftIDs,
+			OwnerUserID:    tc.user1.id,
+		}
+		collID, err := tc.repos.CollectionRepository.Create(context.Background(), coll)
+		assert.Nil(err)
+
+		gallery := persist.GalleryDB{
+			OwnerUserID: tc.user1.id,
+			Collections: []persist.DBID{collID},
+		}
+		_, err = tc.repos.GalleryRepository.Create(context.Background(), gallery)
+		assert.Nil(err)
+
+		resp, err := http.Get(fmt.Sprintf("%s/users/previews?user_id=%s", tc.serverURL, tc.user1.id))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
+
+		type previews struct {
+			Previews []string `json:"previews"`
+		}
+		var body previews
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Len(body.Previews, 3)
+	})
+
+	t.Run("can merge users", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		// Create user
+		u := persist.User{
+			Addresses: []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		nft := persist.NFT{
+			OwnerAddress:   persist.Address(strings.ToLower("0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9")),
+			OpenseaTokenID: "1",
+		}
+		galleryID := fillGallery(assert, nft, userID)
+
+		// Set up cookie to make an authenticated request
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+		tu := createCookieAndSetOnUser(assert, userID, jwt)
+
+		u2 := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+		userID2, err := tc.repos.UserRepository.Create(context.Background(), u2)
+		assert.Nil(err)
+
+		nft2 := persist.NFT{
+			OwnerAddress:   u2.Addresses[0],
+			OpenseaTokenID: "2",
+		}
+		deletedGallery := fillGallery(assert, nft2, userID2)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: u2.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		mergeInput := user.MergeUsersInput{
+			SecondUserID: userID2,
+			Signature:    "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+			Nonce:        "TestNonce",
+			Address:      u2.Addresses[0],
+			WalletType:   auth.WalletTypeEOA,
+		}
+
+		resp := mergeUserRequest(assert, mergeInput, tu)
+		defer resp.Body.Close()
+		assertValidResponse(assert, resp)
+
+		errResp := util.ErrorResponse{}
+		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		assert.Nil(err)
+		assert.Empty(errResp.Error)
+
+		newInitialUser, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
+		assert.Nil(err)
+		assert.Len(newInitialUser.Addresses, 2)
+
+		newGallery, err := tc.repos.GalleryRepository.GetByID(context.Background(), galleryID)
+		assert.Nil(err)
+		assert.Len(newGallery.Collections, 2)
+
+		_, err = tc.repos.GalleryRepository.GetByID(context.Background(), deletedGallery)
+		assert.NotNil(err)
+
+		_, err = tc.repos.UserRepository.GetByID(context.Background(), userID2)
+		assert.NotNil(err)
+	})
+
+	t.Run("can merge users with no galleries", func(t *testing.T) {
+		assert := setupTest(t, 1)
+
+		// Create user
+		u := persist.User{
+			Addresses: []persist.Address{"0xcb1b78568d0Ef81585f074b0Dfd6B743959070D9"},
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		// Set up cookie to make an authenticated request
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+		tu := createCookieAndSetOnUser(assert, userID, jwt)
+
+		u2 := persist.User{
+			Addresses: []persist.Address{persist.Address(strings.ToLower("0x9a3f9764B21adAF3C6fDf6f947e6D3340a3F8AC5"))},
+		}
+		userID2, err := tc.repos.UserRepository.Create(context.Background(), u2)
+		assert.Nil(err)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: u2.Addresses[0],
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		mergeInput := user.MergeUsersInput{
+			SecondUserID: userID2,
+			Signature:    "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+			Nonce:        "TestNonce",
+			Address:      u2.Addresses[0],
+			WalletType:   auth.WalletTypeEOA,
+		}
+
+		resp := mergeUserRequest(assert, mergeInput, tu)
+		defer resp.Body.Close()
+		assertValidResponse(assert, resp)
+
+		newInitialUser, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
+		assert.Nil(err)
+		assert.Len(newInitialUser.Addresses, 2)
+
+		_, err = tc.repos.UserRepository.GetByID(context.Background(), userID2)
+		assert.NotNil(err)
+	})
 }
 
 func fillGallery(assert *assert.Assertions, nft persist.NFT, userID persist.DBID) persist.DBID {

--- a/server/t__routes_user_token_test.go
+++ b/server/t__routes_user_token_test.go
@@ -18,382 +18,388 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetUserByID_Success_Token(t *testing.T) {
-	setupTest(t, 2)
-
-	assert := assert.New(t)
-
-	resp, err := http.Get(fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, tc.user1.id))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(tc.user1.username, body.Username.String())
-}
-
-func TestGetUserByAddress_Success_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	resp, err := http.Get(fmt.Sprintf("%s/users/get?address=%s", tc.serverURL, tc.user2.address))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(tc.user2.username, body.Username.String())
-}
-
-func TestGetUserByUsername_Success_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	resp, err := http.Get(fmt.Sprintf("%s/users/get?username=%s", tc.serverURL, tc.user1.username))
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(tc.user1.username, body.Username.String())
-}
-
-func TestGetUserAuthenticated_ShouldIncludeAddress_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	userID := tc.user1.id
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, userID), nil)
-	assert.Nil(err)
-	resp, err := tc.user1.client.Do(req)
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(userID, body.ID)
-	assert.NotEmpty(body.Addresses)
-}
-
-func TestGetCurrentUser_ValidCookieReturnsUser_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	// Create user
-	u := persist.User{}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
-
-	// Set up cookie to make an authenticated request
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
-	tu := createCookieAndSetOnUser(assert, userID, jwt)
-
-	// Make request
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get/current", tc.serverURL), nil)
-	assert.Nil(err)
-
-	resp, err := tu.client.Do(req)
-	assert.Nil(err)
-	assertValidJSONResponse(assert, resp)
-
-	body := persist.User{}
-	util.UnmarshallBody(&body, resp.Body)
-	assert.Equal(tu.id.String(), body.ID.String())
-}
-
-func TestGetCurrentUser_NoCookieReturnsNoContent_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	resp, err := http.Get(fmt.Sprintf("%s/users/get/current", tc.serverURL))
-	assert.Nil(err)
-	assert.Equal(http.StatusNoContent, resp.StatusCode)
-}
-
-func TestGetCurrentUser_InvalidCookieReturnsNoContent_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	// Create user
-	u := persist.User{}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
-
-	// Set up invalid cookie
-	tu := createCookieAndSetOnUser(assert, userID, "invalid token")
-
-	// Make request
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get/current", tc.serverURL), nil)
-	assert.Nil(err)
-
-	resp, err := tu.client.Do(req)
-	assert.Nil(err)
-	assert.Equal(http.StatusNoContent, resp.StatusCode)
-}
-
-func TestUpdateUserAuthenticated_Success_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	update := user.UpdateUserInput{
-		UserName: "kaito",
-	}
-	resp := updateUserInfoRequestToken(assert, update, tc.user1)
-	assertValidJSONResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.Equal(update.UserName, user.Username.String())
-}
-
-// Updating the username to itself should not trigger an error, despite the DB
-// having a user entity with that username already
-func TestUpdateUserAuthenticated_NoChange_Success_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	update := user.UpdateUserInput{
-		UserName: "bob",
-	}
-	resp := updateUserInfoRequestToken(assert, update, tc.user1)
-	assertValidJSONResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.Equal(update.UserName, user.Username.String())
-}
-
-func TestUpdateUserUnauthenticated_Failure_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	update := user.UpdateUserInput{
-		UserName: "kaito",
-	}
-	resp := updateUserInfoNoAuthRequestToken(assert, update)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUpdateUserAuthenticated_UsernameTaken_Failure_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	user2, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user2.id)
-	assert.Nil(err)
-	log.Println(user2.Username)
-
-	update := user.UpdateUserInput{
-		UserName: tc.user2.username,
-	}
-	resp := updateUserInfoRequestToken(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.NotEqual(update.UserName, user.Username)
-}
-func TestUpdateUserAuthenticated_UsernameInvalid_Failure_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	update := user.UpdateUserInput{
-		UserName: "92ks&$m__",
-	}
-	resp := updateUserInfoRequestToken(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.NotEqual(update.UserName, user.Username)
-}
-
-func TestUserAddAddresses_Success_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	update := user.AddUserAddressesInput{
-		Address:   persist.Address(strings.ToLower("0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5")),
-		Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-	}
-	resp := userAddAddressesRequestToken(assert, update, tc.user1)
-	assertValidJSONResponse(assert, resp)
-
-	errResp := &util.ErrorResponse{}
-	err = util.UnmarshallBody(errResp, resp.Body)
-	assert.Nil(err)
-	assert.Empty(errResp.Error)
-
-	updatedUser, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
-	assert.Nil(err)
-	assert.Equal(update.Address, updatedUser.Addresses[1])
-}
-
-func TestUserAddAddresses_WrongNonce_Failure_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	nonce := persist.UserNonce{
-		Value:   "Wrong Nonce",
-		Address: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
-	}
-	err := tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	update := user.AddUserAddressesInput{
-		Address:   "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
-		Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-	}
-	resp := userAddAddressesRequestToken(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserAddAddresses_OtherUserOwnsAddress_Failure_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	u := persist.User{
-		Addresses: []persist.Address{"0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"},
-	}
-	_, err := tc.repos.UserRepository.Create(context.Background(), u)
-
-	nonce := persist.UserNonce{
-		Value:   "TestNonce",
-		Address: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
-	}
-	err = tc.repos.NonceRepository.Create(context.Background(), nonce)
-	assert.Nil(err)
-
-	update := user.AddUserAddressesInput{
-		Address:   "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
-		Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
-	}
-	resp := userAddAddressesRequestToken(assert, update, tc.user1)
-	assertErrorResponse(assert, resp)
-}
-
-func TestUserRemoveAddresses_Success_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	u := persist.User{
-		Addresses:          []persist.Address{"0xcb1b78568d0ef81585f074b0dfd6b743959070d9", "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"},
-		Username:           "TestUser",
-		UsernameIdempotent: "testuser",
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
-
-	nft := persist.Token{
-		OwnerAddress:    "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
-		TokenID:         "10",
-		ContractAddress: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
-		Name:            "test",
-	}
-	nftID, err := tc.repos.TokenRepository.Create(context.Background(), nft)
-	assert.Nil(err)
-
-	nft2 := persist.Token{
-		OwnerAddress:    "0xcb1b78568d0ef81585f074b0dfd6b743959070d9",
-		TokenID:         "11",
-		ContractAddress: "0xcb1b78568d0ef81585f074b0dfd6b743959070d9",
-		Name:            "test2",
-	}
-	nftID2, err := tc.repos.TokenRepository.Create(context.Background(), nft2)
-	assert.Nil(err)
-
-	coll := persist.CollectionTokenDB{
-		NFTs:        []persist.DBID{nftID, nftID2},
-		Name:        "test-coll",
-		OwnerUserID: userID,
-	}
-	collID, err := tc.repos.CollectionTokenRepository.Create(context.Background(), coll)
-
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
-
-	update := user.RemoveUserAddressesInput{
-		Addresses: []persist.Address{"0xcb1b78568d0ef81585f074b0dfd6b743959070d9"},
-	}
-	j, err := cookiejar.New(nil)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		id:     userID,
-		jwt:    jwt,
-		client: client,
-	}
-	getFakeCookie(assert, jwt, client)
-
-	resp := userRemoveAddressesRequestToken(assert, update, tu)
-	assertValidJSONResponse(assert, resp)
-
-	errResp := &util.ErrorResponse{}
-	util.UnmarshallBody(errResp, resp.Body)
-	assert.Empty(errResp.Error)
-
-	nfts, err := tc.repos.TokenRepository.GetByUserID(context.Background(), userID, -1, 0)
-	assert.Nil(err)
-	assert.Len(nfts, 1)
-
-	resultColl, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID)
-	assert.Nil(err)
-	assert.Len(resultColl.NFTs, 2)
-
-	user, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
-	assert.Nil(err)
-	assert.Len(user.Addresses, 1)
-
-}
-
-func TestUserRemoveAddresses_NotOwnAddress_Failure_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	u := persist.User{
-		Addresses: []persist.Address{"0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5", "0xcb1b78568d0ef81585f074b0dfd6b743959070d9"},
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
-
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
-
-	update := user.RemoveUserAddressesInput{
-		Addresses: []persist.Address{tc.user1.address},
-	}
-
-	j, err := cookiejar.New(nil)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		id:     userID,
-		jwt:    jwt,
-		client: client,
-	}
-	getFakeCookie(assert, jwt, client)
-
-	resp := userRemoveAddressesRequestToken(assert, update, tu)
-	assertErrorResponse(assert, resp)
-
-}
-
-func TestUserRemoveAddresses_AllAddresses_Failure_Token(t *testing.T) {
-	assert := setupTest(t, 2)
-
-	u := persist.User{
-		Addresses: []persist.Address{"0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5", "0xcb1b78568d0ef81585f074b0dfd6b743959070d9"},
-	}
-	userID, err := tc.repos.UserRepository.Create(context.Background(), u)
-	assert.Nil(err)
-
-	jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
-	assert.Nil(err)
-
-	update := user.RemoveUserAddressesInput{
-		Addresses: u.Addresses,
-	}
-	j, err := cookiejar.New(nil)
-	client := &http.Client{Jar: j}
-	tu := &TestUser{
-		id:     userID,
-		jwt:    jwt,
-		client: client,
-	}
-	getFakeCookie(assert, jwt, client)
-
-	resp := userRemoveAddressesRequestToken(assert, update, tu)
-	assertErrorResponse(assert, resp)
+func TestUserTokenRoutes(t *testing.T) {
+
+	setupDoubles(t)
 
+	t.Run("get user by ID", func(t *testing.T) {
+		setupTest(t, 2)
+
+		assert := assert.New(t)
+
+		resp, err := http.Get(fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, tc.user1.id))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
+
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(tc.user1.username, body.Username.String())
+	})
+
+	t.Run("get user by address", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		resp, err := http.Get(fmt.Sprintf("%s/users/get?address=%s", tc.serverURL, tc.user2.address))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
+
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(tc.user2.username, body.Username.String())
+	})
+
+	t.Run("get user by username", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		resp, err := http.Get(fmt.Sprintf("%s/users/get?username=%s", tc.serverURL, tc.user1.username))
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
+
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(tc.user1.username, body.Username.String())
+	})
+
+	t.Run("get authenticated user includes address", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		userID := tc.user1.id
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get?user_id=%s", tc.serverURL, userID), nil)
+		assert.Nil(err)
+		resp, err := tc.user1.client.Do(req)
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
+
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(userID, body.ID)
+		assert.NotEmpty(body.Addresses)
+	})
+
+	t.Run("get current user with cookie includes user token", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		// Create user
+		u := persist.User{}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		// Set up cookie to make an authenticated request
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+		tu := createCookieAndSetOnUser(assert, userID, jwt)
+
+		// Make request
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get/current", tc.serverURL), nil)
+		assert.Nil(err)
+
+		resp, err := tu.client.Do(req)
+		assert.Nil(err)
+		assertValidJSONResponse(assert, resp)
+
+		body := persist.User{}
+		util.UnmarshallBody(&body, resp.Body)
+		assert.Equal(tu.id.String(), body.ID.String())
+	})
+
+	t.Run("get current user with no cookie has no token", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		resp, err := http.Get(fmt.Sprintf("%s/users/get/current", tc.serverURL))
+		assert.Nil(err)
+		assert.Equal(http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("get current user with invalid cookie returns no content", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		// Create user
+		u := persist.User{}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		// Set up invalid cookie
+		tu := createCookieAndSetOnUser(assert, userID, "invalid token")
+
+		// Make request
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/users/get/current", tc.serverURL), nil)
+		assert.Nil(err)
+
+		resp, err := tu.client.Do(req)
+		assert.Nil(err)
+		assert.Equal(http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("can update user if authenticated", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		update := user.UpdateUserInput{
+			UserName: "kaito",
+		}
+		resp := updateUserInfoRequestToken(assert, update, tc.user1)
+		assertValidJSONResponse(assert, resp)
+
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.Equal(update.UserName, user.Username.String())
+	})
+
+	// Updating the username to itself should not trigger an error, despite the DB
+	// having a user entity with that username already
+	t.Run("can update user with no change", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		update := user.UpdateUserInput{
+			UserName: "bob",
+		}
+		resp := updateUserInfoRequestToken(assert, update, tc.user1)
+		assertValidJSONResponse(assert, resp)
+
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.Equal(update.UserName, user.Username.String())
+	})
+
+	t.Run("can't update user if not authenticated", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		update := user.UpdateUserInput{
+			UserName: "kaito",
+		}
+		resp := updateUserInfoNoAuthRequestToken(assert, update)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("can't update username to already existing username", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		user2, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user2.id)
+		assert.Nil(err)
+		log.Println(user2.Username)
+
+		update := user.UpdateUserInput{
+			UserName: tc.user2.username,
+		}
+		resp := updateUserInfoRequestToken(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
+
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.NotEqual(update.UserName, user.Username)
+	})
+
+	t.Run("can't update username if username is invalid", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		update := user.UpdateUserInput{
+			UserName: "92ks&$m__",
+		}
+		resp := updateUserInfoRequestToken(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
+
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.NotEqual(update.UserName, user.Username)
+	})
+
+	t.Run("can add addresses", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		update := user.AddUserAddressesInput{
+			Address:   persist.Address(strings.ToLower("0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5")),
+			Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+		}
+		resp := userAddAddressesRequestToken(assert, update, tc.user1)
+		assertValidJSONResponse(assert, resp)
+
+		errResp := &util.ErrorResponse{}
+		err = util.UnmarshallBody(errResp, resp.Body)
+		assert.Nil(err)
+		assert.Empty(errResp.Error)
+
+		updatedUser, err := tc.repos.UserRepository.GetByID(context.Background(), tc.user1.id)
+		assert.Nil(err)
+		assert.Equal(update.Address, updatedUser.Addresses[1])
+	})
+
+	t.Run("can't add address if wrong nonce", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		nonce := persist.UserNonce{
+			Value:   "Wrong Nonce",
+			Address: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
+		}
+		err := tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		update := user.AddUserAddressesInput{
+			Address:   "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
+			Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+		}
+		resp := userAddAddressesRequestToken(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("can't add address if other user owns address", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		u := persist.User{
+			Addresses: []persist.Address{"0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"},
+		}
+		_, err := tc.repos.UserRepository.Create(context.Background(), u)
+
+		nonce := persist.UserNonce{
+			Value:   "TestNonce",
+			Address: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
+		}
+		err = tc.repos.NonceRepository.Create(context.Background(), nonce)
+		assert.Nil(err)
+
+		update := user.AddUserAddressesInput{
+			Address:   "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
+			Signature: "0x7d3b810c5ae6efa6e5457f5ed85fe048f623b0f1127a7825f119a86714b72fec444d3fa301c05887ba1b94b77e5d68c8567171404cff43b7790e8f4d928b752a1b",
+		}
+		resp := userAddAddressesRequestToken(assert, update, tc.user1)
+		assertErrorResponse(assert, resp)
+	})
+
+	t.Run("can remove address", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		u := persist.User{
+			Addresses:          []persist.Address{"0xcb1b78568d0ef81585f074b0dfd6b743959070d9", "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"},
+			Username:           "TestUser",
+			UsernameIdempotent: "testuser",
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		nft := persist.Token{
+			OwnerAddress:    "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
+			TokenID:         "10",
+			ContractAddress: "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5",
+			Name:            "test",
+		}
+		nftID, err := tc.repos.TokenRepository.Create(context.Background(), nft)
+		assert.Nil(err)
+
+		nft2 := persist.Token{
+			OwnerAddress:    "0xcb1b78568d0ef81585f074b0dfd6b743959070d9",
+			TokenID:         "11",
+			ContractAddress: "0xcb1b78568d0ef81585f074b0dfd6b743959070d9",
+			Name:            "test2",
+		}
+		nftID2, err := tc.repos.TokenRepository.Create(context.Background(), nft2)
+		assert.Nil(err)
+
+		coll := persist.CollectionTokenDB{
+			NFTs:        []persist.DBID{nftID, nftID2},
+			Name:        "test-coll",
+			OwnerUserID: userID,
+		}
+		collID, err := tc.repos.CollectionTokenRepository.Create(context.Background(), coll)
+
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+
+		update := user.RemoveUserAddressesInput{
+			Addresses: []persist.Address{"0xcb1b78568d0ef81585f074b0dfd6b743959070d9"},
+		}
+		j, err := cookiejar.New(nil)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			id:     userID,
+			jwt:    jwt,
+			client: client,
+		}
+		getFakeCookie(assert, jwt, client)
+
+		resp := userRemoveAddressesRequestToken(assert, update, tu)
+		assertValidJSONResponse(assert, resp)
+
+		errResp := &util.ErrorResponse{}
+		util.UnmarshallBody(errResp, resp.Body)
+		assert.Empty(errResp.Error)
+
+		nfts, err := tc.repos.TokenRepository.GetByUserID(context.Background(), userID, -1, 0)
+		assert.Nil(err)
+		assert.Len(nfts, 1)
+
+		resultColl, err := tc.repos.CollectionTokenRepository.GetByID(context.Background(), collID)
+		assert.Nil(err)
+		assert.Len(resultColl.NFTs, 2)
+
+		user, err := tc.repos.UserRepository.GetByID(context.Background(), userID)
+		assert.Nil(err)
+		assert.Len(user.Addresses, 1)
+
+	})
+
+	t.Run("can't remove address if not owned by user", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		u := persist.User{
+			Addresses: []persist.Address{"0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5", "0xcb1b78568d0ef81585f074b0dfd6b743959070d9"},
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+
+		update := user.RemoveUserAddressesInput{
+			Addresses: []persist.Address{tc.user1.address},
+		}
+
+		j, err := cookiejar.New(nil)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			id:     userID,
+			jwt:    jwt,
+			client: client,
+		}
+		getFakeCookie(assert, jwt, client)
+
+		resp := userRemoveAddressesRequestToken(assert, update, tu)
+		assertErrorResponse(assert, resp)
+
+	})
+
+	t.Run("can't remove all addresses", func(t *testing.T) {
+		assert := setupTest(t, 2)
+
+		u := persist.User{
+			Addresses: []persist.Address{"0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5", "0xcb1b78568d0ef81585f074b0dfd6b743959070d9"},
+		}
+		userID, err := tc.repos.UserRepository.Create(context.Background(), u)
+		assert.Nil(err)
+
+		jwt, err := auth.JWTGeneratePipeline(context.Background(), userID)
+		assert.Nil(err)
+
+		update := user.RemoveUserAddressesInput{
+			Addresses: u.Addresses,
+		}
+		j, err := cookiejar.New(nil)
+		client := &http.Client{Jar: j}
+		tu := &TestUser{
+			id:     userID,
+			jwt:    jwt,
+			client: client,
+		}
+		getFakeCookie(assert, jwt, client)
+
+		resp := userRemoveAddressesRequestToken(assert, update, tu)
+		assertErrorResponse(assert, resp)
+
+	})
 }
 
 func createCookieAndSetOnUser(assert *assert.Assertions, userID persist.DBID, jwt string) *TestUser {

--- a/server/t__server_integration_test.go
+++ b/server/t__server_integration_test.go
@@ -114,10 +114,11 @@ func (i *IntegrationTest) setupTest(a *assert.Assertions, version int) *Integrat
 	rd := docker.InitRedis("../docker-compose.yml")
 
 	pgClient := postgres.NewClient()
+	pgxClient := postgres.NewPgxClient()
 	migrate.RunMigration("../db/migrations", pgClient)
 
 	return &IntegrationTestConfig{
-		TestConfig:    initializeTestServer(pgClient, a, version),
+		TestConfig:    initializeTestServer(pgClient, pgxClient, a, version),
 		pgResource:    pg,
 		redisResource: rd,
 		db:            pgClient,

--- a/server/t__server_integration_test.go
+++ b/server/t__server_integration_test.go
@@ -112,12 +112,12 @@ func setBlockchainContext(t TestTarget) {
 }
 
 func (i *IntegrationTest) setupTest(a *assert.Assertions, version int) *IntegrationTestConfig {
-	pg, pgUnpatch := docker.InitPostgres("../docker-compose.yml")
-	rd, rdUnpatch := docker.InitRedis("../docker-compose.yml")
+	pg, pgUnpatch := docker.InitPostgres()
+	rd, rdUnpatch := docker.InitRedis()
 
 	pgClient := postgres.NewClient()
 	pgxClient := postgres.NewPgxClient()
-	migrate.RunMigration("../db/migrations", pgClient)
+	migrate.RunMigration(pgClient)
 
 	return &IntegrationTestConfig{
 		TestConfig:    initializeTestServer(pgClient, pgxClient, a, version),

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -166,9 +166,8 @@ func setupDoubles(t *testing.T) {
 }
 
 func setupTest(t *testing.T, v int) *assert.Assertions {
-	// cpy := *t
 	a := assert.New(t)
-	tc = initializeTestServer(postgres.NewClient(), a, v)
+	tc = initializeTestServer(postgres.NewClient(), pgx, a, v)
 	t.Cleanup(teardown)
 	return a
 }

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -150,13 +150,15 @@ func assertErrorResponse(assert *assert.Assertions, resp *http.Response) {
 func setupDoubles(t *testing.T) {
 	setDefaults()
 
-	pg := docker.InitPostgres("../docker-compose.yml")
-	rd := docker.InitRedis("../docker-compose.yml")
+	pg, pgUnpatch := docker.InitPostgres("../docker-compose.yml")
+	rd, rdUnpatch := docker.InitRedis("../docker-compose.yml")
 
 	db = postgres.NewClient()
 	migrate.RunMigration("../db/migrations", db)
 
 	t.Cleanup(func() {
+		defer pgUnpatch()
+		defer rdUnpatch()
 		for _, r := range []*dockertest.Resource{pg, rd} {
 			if err := r.Close(); err != nil {
 				log.Fatalf("could not purge resource: %s", err)

--- a/server/t__test_utils_test.go
+++ b/server/t__test_utils_test.go
@@ -150,11 +150,11 @@ func assertErrorResponse(assert *assert.Assertions, resp *http.Response) {
 func setupDoubles(t *testing.T) {
 	setDefaults()
 
-	pg, pgUnpatch := docker.InitPostgres("../docker-compose.yml")
-	rd, rdUnpatch := docker.InitRedis("../docker-compose.yml")
+	pg, pgUnpatch := docker.InitPostgres()
+	rd, rdUnpatch := docker.InitRedis()
 
 	db = postgres.NewClient()
-	migrate.RunMigration("../db/migrations", db)
+	migrate.RunMigration(db)
 
 	t.Cleanup(func() {
 		defer pgUnpatch()

--- a/service/memstore/redis/redis.go
+++ b/service/memstore/redis/redis.go
@@ -27,21 +27,6 @@ func NewCache(db int) *Cache {
 	if err := client.Ping(ctx).Err(); err != nil {
 		panic(err)
 	}
-	// var err error
-	// for i := 1; i < 5; i++ {
-	// 	err := client.Ping(ctx).Err()
-
-	// 	if err == nil {
-	// 		break
-	// 	}
-
-	// 	time.Sleep(5 * time.Second)
-	// }
-
-	// if err != nil {
-	// 	panic(err)
-	// }
-
 	return &Cache{client: client}
 }
 

--- a/service/memstore/redis/redis.go
+++ b/service/memstore/redis/redis.go
@@ -27,6 +27,21 @@ func NewCache(db int) *Cache {
 	if err := client.Ping(ctx).Err(); err != nil {
 		panic(err)
 	}
+	// var err error
+	// for i := 1; i < 5; i++ {
+	// 	err := client.Ping(ctx).Err()
+
+	// 	if err == nil {
+	// 		break
+	// 	}
+
+	// 	time.Sleep(5 * time.Second)
+	// }
+
+	// if err != nil {
+	// 	panic(err)
+	// }
+
 	return &Cache{client: client}
 }
 

--- a/service/memstore/t__utils_test.go
+++ b/service/memstore/t__utils_test.go
@@ -1,0 +1,20 @@
+package memstore
+
+import (
+	"testing"
+
+	"github.com/mikeydub/go-gallery/docker"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupTest(t *testing.T) *assert.Assertions {
+	rd := docker.InitRedis("../../docker-compose.yml")
+
+	t.Cleanup(func() {
+		if err := rd.Close(); err != nil {
+			t.Fatalf("could not purge resource: %s", err)
+		}
+	})
+
+	return assert.New(t)
+}

--- a/service/memstore/t__utils_test.go
+++ b/service/memstore/t__utils_test.go
@@ -8,9 +8,10 @@ import (
 )
 
 func setupTest(t *testing.T) *assert.Assertions {
-	rd := docker.InitRedis("../../docker-compose.yml")
+	rd, rdUnpatch := docker.InitRedis("../../docker-compose.yml")
 
 	t.Cleanup(func() {
+		defer rdUnpatch()
 		if err := rd.Close(); err != nil {
 			t.Fatalf("could not purge resource: %s", err)
 		}

--- a/service/memstore/t__utils_test.go
+++ b/service/memstore/t__utils_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func setupTest(t *testing.T) *assert.Assertions {
-	rd, rdUnpatch := docker.InitRedis("../../docker-compose.yml")
+	rd, rdUnpatch := docker.InitRedis()
 
 	t.Cleanup(func() {
 		defer rdUnpatch()

--- a/service/persist/postgres/t__backup_test.go
+++ b/service/persist/postgres/t__backup_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/mikeydub/go-gallery/service/persist"
 )
@@ -52,152 +53,152 @@ func TestBackup(t *testing.T) {
 	})
 
 	// backups made within 5 mins of each other should be de-duped
-	// t.Run("backups are deduped", func(t *testing.T) {
-	// 	a, db := setupTest(t)
-	// 	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
+	t.Run("backups are deduped", func(t *testing.T) {
+		a, db := setupTest(t)
+		userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
 
-	// 	err := backupRepo.Insert(context.Background(), g)
-	// 	a.NoError(err)
+		err := backupRepo.Insert(context.Background(), g)
+		a.NoError(err)
 
-	// 	backups, err := backupRepo.Get(context.Background(), userID)
-	// 	a.NoError(err)
-	// 	a.Len(backups, 1)
-	// 	a.Len(backups[0].Gallery.Collections, 1)
+		backups, err := backupRepo.Get(context.Background(), userID)
+		a.NoError(err)
+		a.Len(backups, 1)
+		a.Len(backups[0].Gallery.Collections, 1)
 
-	// 	collection2 := persist.CollectionDB{
-	// 		Name:        "name2",
-	// 		OwnerUserID: userID,
-	// 		NFTs:        nftIDs,
-	// 	}
+		collection2 := persist.CollectionDB{
+			Name:        "name2",
+			OwnerUserID: userID,
+			NFTs:        nftIDs,
+		}
 
-	// 	collID2, err := collectionRepo.Create(context.Background(), collection2)
-	// 	a.NoError(err)
+		collID2, err := collectionRepo.Create(context.Background(), collection2)
+		a.NoError(err)
 
-	// 	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
-	// 		Collections: []persist.DBID{collID, collID2},
-	// 	})
-	// 	a.NoError(err)
+		err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
+			Collections: []persist.DBID{collID, collID2},
+		})
+		a.NoError(err)
 
-	// 	err = backupRepo.Insert(context.Background(), g)
-	// 	a.NoError(err)
+		err = backupRepo.Insert(context.Background(), g)
+		a.NoError(err)
 
-	// 	backups, err = backupRepo.Get(context.Background(), userID)
-	// 	a.NoError(err)
-	// 	a.Len(backups, 1)
-	// 	a.Len(backups[0].Gallery.Collections, 1)
-	// })
+		backups, err = backupRepo.Get(context.Background(), userID)
+		a.NoError(err)
+		a.Len(backups, 1)
+		a.Len(backups[0].Gallery.Collections, 1)
+	})
 
-	// // backups made over 5 mins of each other should be added
-	// t.Run("backups not throttled are stored", func(t *testing.T) {
-	// 	a, db := setupTest(t)
-	// 	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
+	// backups made over 5 mins of each other should be added
+	t.Run("backups not throttled are stored", func(t *testing.T) {
+		a, db := setupTest(t)
+		userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
 
-	// 	err := backupRepo.Insert(context.Background(), g)
-	// 	a.NoError(err)
+		err := backupRepo.Insert(context.Background(), g)
+		a.NoError(err)
 
-	// 	backups, err := backupRepo.Get(context.Background(), userID)
-	// 	a.NoError(err)
-	// 	a.Len(backups, 1)
-	// 	a.Len(backups[0].Gallery.Collections, 1)
+		backups, err := backupRepo.Get(context.Background(), userID)
+		a.NoError(err)
+		a.Len(backups, 1)
+		a.Len(backups[0].Gallery.Collections, 1)
 
-	// 	collection2 := persist.CollectionDB{
-	// 		Name:        "name2",
-	// 		OwnerUserID: userID,
-	// 		NFTs:        nftIDs,
-	// 	}
+		collection2 := persist.CollectionDB{
+			Name:        "name2",
+			OwnerUserID: userID,
+			NFTs:        nftIDs,
+		}
 
-	// 	collID2, err := collectionRepo.Create(context.Background(), collection2)
-	// 	a.NoError(err)
+		collID2, err := collectionRepo.Create(context.Background(), collection2)
+		a.NoError(err)
 
-	// 	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
-	// 		Collections: []persist.DBID{collID, collID2},
-	// 	})
-	// 	a.NoError(err)
+		err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
+			Collections: []persist.DBID{collID, collID2},
+		})
+		a.NoError(err)
 
-	// 	backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(time.Now().Local().Add(time.Hour)))
+		backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(time.Now().Local().Add(time.Hour)))
 
-	// 	backups, err = backupRepo.Get(context.Background(), userID)
-	// 	a.NoError(err)
-	// 	a.Len(backups, 2)
-	// 	a.Len(backups[0].Gallery.Collections, 1)
-	// })
+		backups, err = backupRepo.Get(context.Background(), userID)
+		a.NoError(err)
+		a.Len(backups, 2)
+		a.Len(backups[0].Gallery.Collections, 1)
+	})
 
-	// // Backup pruning rules:
-	// // - backups in the past 24 hours should be stored no more often than every 5 minutes
-	// // - backups in the past 7 days should be stored no more often than every 1 hour
-	// // - backups beyond the past 7 days should be stored no more often than every 1 day
-	// t.Run("backups are pruned correctly", func(t *testing.T) {
-	// 	// timestamps within past 24h
-	// 	d1 := time.Now().Add(-6 * time.Minute)
-	// 	d2 := time.Now().Add(-7 * time.Minute)
-	// 	d3 := time.Now().Add(-15 * time.Minute)
-	// 	d4 := time.Now().Add(-25 * time.Minute)
-	// 	d5 := time.Now().Add(-1 * time.Hour)
-	// 	d6 := time.Now().Add(-2 * time.Hour)
-	// 	d7 := time.Now().Add(-2*time.Hour - 1*time.Minute)
-	// 	d8 := time.Now().Add(-15 * time.Hour)
-	// 	// timestamps within past 7d
-	// 	day := 24 * time.Hour
-	// 	w1 := time.Now().Add(-3 * day)
-	// 	w2 := time.Now().Add(-3*day - 20*time.Minute)
-	// 	w3 := time.Now().Add(-3*day - 30*time.Minute)
-	// 	w4 := time.Now().Add(-3*day - 40*time.Minute)
-	// 	w5 := time.Now().Add(-3*day - 120*time.Minute)
-	// 	w6 := time.Now().Add(-5 * day)
-	// 	w7 := time.Now().Add(-6 * day)
-	// 	// timestamps beyond 7d
-	// 	t1 := time.Now().Add(-10 * day)
-	// 	t2 := time.Now().Add(-10*day - 30*time.Minute)
-	// 	t3 := time.Now().Add(-11 * day)
-	// 	t4 := time.Now().Add(-12*day - 30*time.Minute)
-	// 	t5 := time.Now().Add(-13 * day)
-	// 	t6 := time.Now().Add(-30 * day)
-	// 	t7 := time.Now().Add(-60 * day)
+	// Backup pruning rules:
+	// - backups in the past 24 hours should be stored no more often than every 5 minutes
+	// - backups in the past 7 days should be stored no more often than every 1 hour
+	// - backups beyond the past 7 days should be stored no more often than every 1 day
+	t.Run("backups are pruned correctly", func(t *testing.T) {
+		// timestamps within past 24h
+		d1 := time.Now().Add(-6 * time.Minute)
+		d2 := time.Now().Add(-7 * time.Minute)
+		d3 := time.Now().Add(-15 * time.Minute)
+		d4 := time.Now().Add(-25 * time.Minute)
+		d5 := time.Now().Add(-1 * time.Hour)
+		d6 := time.Now().Add(-2 * time.Hour)
+		d7 := time.Now().Add(-2*time.Hour - 1*time.Minute)
+		d8 := time.Now().Add(-15 * time.Hour)
+		// timestamps within past 7d
+		day := 24 * time.Hour
+		w1 := time.Now().Add(-3 * day)
+		w2 := time.Now().Add(-3*day - 20*time.Minute)
+		w3 := time.Now().Add(-3*day - 30*time.Minute)
+		w4 := time.Now().Add(-3*day - 40*time.Minute)
+		w5 := time.Now().Add(-3*day - 120*time.Minute)
+		w6 := time.Now().Add(-5 * day)
+		w7 := time.Now().Add(-6 * day)
+		// timestamps beyond 7d
+		t1 := time.Now().Add(-10 * day)
+		t2 := time.Now().Add(-10*day - 30*time.Minute)
+		t3 := time.Now().Add(-11 * day)
+		t4 := time.Now().Add(-12*day - 30*time.Minute)
+		t5 := time.Now().Add(-13 * day)
+		t6 := time.Now().Add(-30 * day)
+		t7 := time.Now().Add(-60 * day)
 
-	// 	testCases := []struct {
-	// 		input    []time.Time
-	// 		expected []time.Time
-	// 	}{
-	// 		{input: []time.Time{d1, d2, d3, d4}, expected: []time.Time{d1, d3, d4}},
-	// 		{input: []time.Time{d1, d3, d6, d7}, expected: []time.Time{d1, d3, d6}},
-	// 		{input: []time.Time{d1, d2, d3, d4, d5, d6, d7, d8}, expected: []time.Time{d1, d3, d4, d5, d6, d8}},
-	// 		{input: []time.Time{w1, w2, w3, w4}, expected: []time.Time{w1}},
-	// 		{input: []time.Time{w2, w4, w5, w6, w7}, expected: []time.Time{w2, w5, w6, w7}},
-	// 		{input: []time.Time{t1, t2, t3, t4, t5}, expected: []time.Time{t1, t3, t4}},
-	// 		{input: []time.Time{t2, t3, t5, t6, t7}, expected: []time.Time{t2, t5, t6, t7}},
-	// 		{input: []time.Time{
-	// 			d1, d2, d3, d4, d5, d6, d7, d8,
-	// 			w1, w2, w3, w4, w5, w6, w7,
-	// 			t1, t2, t3, t4, t5, t6, t7,
-	// 		}, expected: []time.Time{
-	// 			d1, d3, d4, d5, d6, d8, w1, w5,
-	// 			w6, w7, t1, t3, t4, t6, t7,
-	// 		}},
-	// 	}
+		testCases := []struct {
+			input    []time.Time
+			expected []time.Time
+		}{
+			{input: []time.Time{d1, d2, d3, d4}, expected: []time.Time{d1, d3, d4}},
+			{input: []time.Time{d1, d3, d6, d7}, expected: []time.Time{d1, d3, d6}},
+			{input: []time.Time{d1, d2, d3, d4, d5, d6, d7, d8}, expected: []time.Time{d1, d3, d4, d5, d6, d8}},
+			{input: []time.Time{w1, w2, w3, w4}, expected: []time.Time{w1}},
+			{input: []time.Time{w2, w4, w5, w6, w7}, expected: []time.Time{w2, w5, w6, w7}},
+			{input: []time.Time{t1, t2, t3, t4, t5}, expected: []time.Time{t1, t3, t4}},
+			{input: []time.Time{t2, t3, t5, t6, t7}, expected: []time.Time{t2, t5, t6, t7}},
+			{input: []time.Time{
+				d1, d2, d3, d4, d5, d6, d7, d8,
+				w1, w2, w3, w4, w5, w6, w7,
+				t1, t2, t3, t4, t5, t6, t7,
+			}, expected: []time.Time{
+				d1, d3, d4, d5, d6, d8, w1, w5,
+				w6, w7, t1, t3, t4, t6, t7,
+			}},
+		}
 
-	// 	for _, tc := range testCases {
-	// 		a, db := setupTest(t)
-	// 		userID, _, _, g, backupRepo, _, _, _, _ := createMockGallery(t, a, db)
+		for _, tc := range testCases {
+			a, db := setupTest(t)
+			userID, _, _, g, backupRepo, _, _, _, _ := createMockGallery(t, a, db)
 
-	// 		// manually seed all inputs except for the first one
-	// 		for _, inputTimestamp := range tc.input {
-	// 			backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(inputTimestamp))
-	// 		}
+			// manually seed all inputs except for the first one
+			for _, inputTimestamp := range tc.input {
+				backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(inputTimestamp))
+			}
 
-	// 		// officially insert a gallery via .Insert() to trigger underlying pruning
-	// 		backupRepo.Insert(context.Background(), g)
+			// officially insert a gallery via .Insert() to trigger underlying pruning
+			backupRepo.Insert(context.Background(), g)
 
-	// 		backups, err := backupRepo.Get(context.Background(), userID)
-	// 		a.NoError(err)
-	// 		// should have a length of the expected seeded backups *plus* the officially inserted gallery via .Insert()
-	// 		a.Len(backups, len(tc.expected)+1)
-	// 		for i := 0; i < len(backups)-1; i++ {
-	// 			backup := backups[i]
-	// 			// queried results are returned in reverse of insert order
-	// 			actualCreationTime := time.Time(backup.CreationTime).Round(time.Second)
-	// 			expectedCreationTime := tc.expected[len(tc.expected)-1-i].Round(time.Second)
-	// 			a.True(actualCreationTime.Equal(expectedCreationTime))
-	// 		}
-	// 	}
-	// })
+			backups, err := backupRepo.Get(context.Background(), userID)
+			a.NoError(err)
+			// should have a length of the expected seeded backups *plus* the officially inserted gallery via .Insert()
+			a.Len(backups, len(tc.expected)+1)
+			for i := 0; i < len(backups)-1; i++ {
+				backup := backups[i]
+				// queried results are returned in reverse of insert order
+				actualCreationTime := time.Time(backup.CreationTime).Round(time.Second)
+				expectedCreationTime := tc.expected[len(tc.expected)-1-i].Round(time.Second)
+				a.True(actualCreationTime.Equal(expectedCreationTime))
+			}
+		}
+	})
 }

--- a/service/persist/postgres/t__backup_test.go
+++ b/service/persist/postgres/t__backup_test.go
@@ -3,199 +3,201 @@ package postgres
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
-func TestBackupRestore_Success(t *testing.T) {
-	a, db := setupTest(t)
-	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, nftRepo, _ := createMockGallery(t, a, db)
+func TestBackup(t *testing.T) {
 
-	err := backupRepo.Insert(context.Background(), g)
-	a.NoError(err)
-
-	backups, err := backupRepo.Get(context.Background(), userID)
-	a.NoError(err)
-	a.Len(backups, 1)
-	a.Len(backups[0].Gallery.Collections, 1)
-
-	collection2 := persist.CollectionDB{
-		Name:        "name2",
-		OwnerUserID: userID,
-		NFTs:        nftIDs,
-	}
-
-	collID2, err := collectionRepo.Create(context.Background(), collection2)
-	a.NoError(err)
-
-	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
-		Collections: []persist.DBID{collID, collID2},
-	})
-	a.NoError(err)
-
-	err = nftRepo.UpdateByID(context.Background(), nftIDs[0], userID, persist.NFTUpdateOwnerAddressInput{
-		OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d3",
-	})
-	a.NoError(err)
-
-	err = backupRepo.Restore(context.Background(), backups[0].ID, userID)
-	a.NoError(err)
-
-	galleries, err := galleryRepo.GetByUserID(context.Background(), userID)
-	a.NoError(err)
-
-	a.Len(galleries, 1)
-
-	a.Len(galleries[0].Collections, 1)
-}
-
-// backups made within 5 mins of each other should be de-duped
-func TestThrottle_Success(t *testing.T) {
-	a, db := setupTest(t)
-	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
-
-	err := backupRepo.Insert(context.Background(), g)
-	a.NoError(err)
-
-	backups, err := backupRepo.Get(context.Background(), userID)
-	a.NoError(err)
-	a.Len(backups, 1)
-	a.Len(backups[0].Gallery.Collections, 1)
-
-	collection2 := persist.CollectionDB{
-		Name:        "name2",
-		OwnerUserID: userID,
-		NFTs:        nftIDs,
-	}
-
-	collID2, err := collectionRepo.Create(context.Background(), collection2)
-	a.NoError(err)
-
-	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
-		Collections: []persist.DBID{collID, collID2},
-	})
-	a.NoError(err)
-
-	err = backupRepo.Insert(context.Background(), g)
-	a.NoError(err)
-
-	backups, err = backupRepo.Get(context.Background(), userID)
-	a.NoError(err)
-	a.Len(backups, 1)
-	a.Len(backups[0].Gallery.Collections, 1)
-}
-
-// backups made over 5 mins of each other should be added
-func TestNoThrottle_Success(t *testing.T) {
-	a, db := setupTest(t)
-	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
-
-	err := backupRepo.Insert(context.Background(), g)
-	a.NoError(err)
-
-	backups, err := backupRepo.Get(context.Background(), userID)
-	a.NoError(err)
-	a.Len(backups, 1)
-	a.Len(backups[0].Gallery.Collections, 1)
-
-	collection2 := persist.CollectionDB{
-		Name:        "name2",
-		OwnerUserID: userID,
-		NFTs:        nftIDs,
-	}
-
-	collID2, err := collectionRepo.Create(context.Background(), collection2)
-	a.NoError(err)
-
-	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
-		Collections: []persist.DBID{collID, collID2},
-	})
-	a.NoError(err)
-
-	backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(time.Now().Local().Add(time.Hour)))
-
-	backups, err = backupRepo.Get(context.Background(), userID)
-	a.NoError(err)
-	a.Len(backups, 2)
-	a.Len(backups[0].Gallery.Collections, 1)
-}
-
-// Backup pruning rules:
-// - backups in the past 24 hours should be stored no more often than every 5 minutes
-// - backups in the past 7 days should be stored no more often than every 1 hour
-// - backups beyond the past 7 days should be stored no more often than every 1 day
-func TestPrune_Success(t *testing.T) {
-	// timestamps within past 24h
-	d1 := time.Now().Add(-6 * time.Minute)
-	d2 := time.Now().Add(-7 * time.Minute)
-	d3 := time.Now().Add(-15 * time.Minute)
-	d4 := time.Now().Add(-25 * time.Minute)
-	d5 := time.Now().Add(-1 * time.Hour)
-	d6 := time.Now().Add(-2 * time.Hour)
-	d7 := time.Now().Add(-2*time.Hour - 1*time.Minute)
-	d8 := time.Now().Add(-15 * time.Hour)
-	// timestamps within past 7d
-	day := 24 * time.Hour
-	w1 := time.Now().Add(-3 * day)
-	w2 := time.Now().Add(-3*day - 20*time.Minute)
-	w3 := time.Now().Add(-3*day - 30*time.Minute)
-	w4 := time.Now().Add(-3*day - 40*time.Minute)
-	w5 := time.Now().Add(-3*day - 120*time.Minute)
-	w6 := time.Now().Add(-5 * day)
-	w7 := time.Now().Add(-6 * day)
-	// timestamps beyond 7d
-	t1 := time.Now().Add(-10 * day)
-	t2 := time.Now().Add(-10*day - 30*time.Minute)
-	t3 := time.Now().Add(-11 * day)
-	t4 := time.Now().Add(-12*day - 30*time.Minute)
-	t5 := time.Now().Add(-13 * day)
-	t6 := time.Now().Add(-30 * day)
-	t7 := time.Now().Add(-60 * day)
-
-	testCases := []struct {
-		input    []time.Time
-		expected []time.Time
-	}{
-		{input: []time.Time{d1, d2, d3, d4}, expected: []time.Time{d1, d3, d4}},
-		{input: []time.Time{d1, d3, d6, d7}, expected: []time.Time{d1, d3, d6}},
-		{input: []time.Time{d1, d2, d3, d4, d5, d6, d7, d8}, expected: []time.Time{d1, d3, d4, d5, d6, d8}},
-		{input: []time.Time{w1, w2, w3, w4}, expected: []time.Time{w1}},
-		{input: []time.Time{w2, w4, w5, w6, w7}, expected: []time.Time{w2, w5, w6, w7}},
-		{input: []time.Time{t1, t2, t3, t4, t5}, expected: []time.Time{t1, t3, t4}},
-		{input: []time.Time{t2, t3, t5, t6, t7}, expected: []time.Time{t2, t5, t6, t7}},
-		{input: []time.Time{
-			d1, d2, d3, d4, d5, d6, d7, d8,
-			w1, w2, w3, w4, w5, w6, w7,
-			t1, t2, t3, t4, t5, t6, t7,
-		}, expected: []time.Time{
-			d1, d3, d4, d5, d6, d8, w1, w5,
-			w6, w7, t1, t3, t4, t6, t7,
-		}},
-	}
-
-	for _, tc := range testCases {
+	t.Run("backup restores gallery", func(t *testing.T) {
 		a, db := setupTest(t)
-		userID, _, _, g, backupRepo, _, _, _, _ := createMockGallery(t, a, db)
+		userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, nftRepo, _ := createMockGallery(t, a, db)
 
-		// manually seed all inputs except for the first one
-		for _, inputTimestamp := range tc.input {
-			backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(inputTimestamp))
-		}
-
-		// officially insert a gallery via .Insert() to trigger underlying pruning
-		backupRepo.Insert(context.Background(), g)
+		err := backupRepo.Insert(context.Background(), g)
+		a.NoError(err)
 
 		backups, err := backupRepo.Get(context.Background(), userID)
 		a.NoError(err)
-		// should have a length of the expected seeded backups *plus* the officially inserted gallery via .Insert()
-		a.Len(backups, len(tc.expected)+1)
-		for i := 0; i < len(backups)-1; i++ {
-			backup := backups[i]
-			// queried results are returned in reverse of insert order
-			actualCreationTime := time.Time(backup.CreationTime).Round(time.Second)
-			expectedCreationTime := tc.expected[len(tc.expected)-1-i].Round(time.Second)
-			a.True(actualCreationTime.Equal(expectedCreationTime))
+		a.Len(backups, 1)
+		a.Len(backups[0].Gallery.Collections, 1)
+
+		collection2 := persist.CollectionDB{
+			Name:        "name2",
+			OwnerUserID: userID,
+			NFTs:        nftIDs,
 		}
-	}
+
+		collID2, err := collectionRepo.Create(context.Background(), collection2)
+		a.NoError(err)
+
+		err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
+			Collections: []persist.DBID{collID, collID2},
+		})
+		a.NoError(err)
+
+		err = nftRepo.UpdateByID(context.Background(), nftIDs[0], userID, persist.NFTUpdateOwnerAddressInput{
+			OwnerAddress: "0x8914496dc01efcc49a2fa340331fb90969b6f1d3",
+		})
+		a.NoError(err)
+
+		err = backupRepo.Restore(context.Background(), backups[0].ID, userID)
+		a.NoError(err)
+
+		galleries, err := galleryRepo.GetByUserID(context.Background(), userID)
+		a.NoError(err)
+
+		a.Len(galleries, 1)
+
+		a.Len(galleries[0].Collections, 1)
+	})
+
+	// backups made within 5 mins of each other should be de-duped
+	// t.Run("backups are deduped", func(t *testing.T) {
+	// 	a, db := setupTest(t)
+	// 	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
+
+	// 	err := backupRepo.Insert(context.Background(), g)
+	// 	a.NoError(err)
+
+	// 	backups, err := backupRepo.Get(context.Background(), userID)
+	// 	a.NoError(err)
+	// 	a.Len(backups, 1)
+	// 	a.Len(backups[0].Gallery.Collections, 1)
+
+	// 	collection2 := persist.CollectionDB{
+	// 		Name:        "name2",
+	// 		OwnerUserID: userID,
+	// 		NFTs:        nftIDs,
+	// 	}
+
+	// 	collID2, err := collectionRepo.Create(context.Background(), collection2)
+	// 	a.NoError(err)
+
+	// 	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
+	// 		Collections: []persist.DBID{collID, collID2},
+	// 	})
+	// 	a.NoError(err)
+
+	// 	err = backupRepo.Insert(context.Background(), g)
+	// 	a.NoError(err)
+
+	// 	backups, err = backupRepo.Get(context.Background(), userID)
+	// 	a.NoError(err)
+	// 	a.Len(backups, 1)
+	// 	a.Len(backups[0].Gallery.Collections, 1)
+	// })
+
+	// // backups made over 5 mins of each other should be added
+	// t.Run("backups not throttled are stored", func(t *testing.T) {
+	// 	a, db := setupTest(t)
+	// 	userID, collID, nftIDs, g, backupRepo, galleryRepo, collectionRepo, _, _ := createMockGallery(t, a, db)
+
+	// 	err := backupRepo.Insert(context.Background(), g)
+	// 	a.NoError(err)
+
+	// 	backups, err := backupRepo.Get(context.Background(), userID)
+	// 	a.NoError(err)
+	// 	a.Len(backups, 1)
+	// 	a.Len(backups[0].Gallery.Collections, 1)
+
+	// 	collection2 := persist.CollectionDB{
+	// 		Name:        "name2",
+	// 		OwnerUserID: userID,
+	// 		NFTs:        nftIDs,
+	// 	}
+
+	// 	collID2, err := collectionRepo.Create(context.Background(), collection2)
+	// 	a.NoError(err)
+
+	// 	err = galleryRepo.Update(context.Background(), g.ID, userID, persist.GalleryUpdateInput{
+	// 		Collections: []persist.DBID{collID, collID2},
+	// 	})
+	// 	a.NoError(err)
+
+	// 	backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(time.Now().Local().Add(time.Hour)))
+
+	// 	backups, err = backupRepo.Get(context.Background(), userID)
+	// 	a.NoError(err)
+	// 	a.Len(backups, 2)
+	// 	a.Len(backups[0].Gallery.Collections, 1)
+	// })
+
+	// // Backup pruning rules:
+	// // - backups in the past 24 hours should be stored no more often than every 5 minutes
+	// // - backups in the past 7 days should be stored no more often than every 1 hour
+	// // - backups beyond the past 7 days should be stored no more often than every 1 day
+	// t.Run("backups are pruned correctly", func(t *testing.T) {
+	// 	// timestamps within past 24h
+	// 	d1 := time.Now().Add(-6 * time.Minute)
+	// 	d2 := time.Now().Add(-7 * time.Minute)
+	// 	d3 := time.Now().Add(-15 * time.Minute)
+	// 	d4 := time.Now().Add(-25 * time.Minute)
+	// 	d5 := time.Now().Add(-1 * time.Hour)
+	// 	d6 := time.Now().Add(-2 * time.Hour)
+	// 	d7 := time.Now().Add(-2*time.Hour - 1*time.Minute)
+	// 	d8 := time.Now().Add(-15 * time.Hour)
+	// 	// timestamps within past 7d
+	// 	day := 24 * time.Hour
+	// 	w1 := time.Now().Add(-3 * day)
+	// 	w2 := time.Now().Add(-3*day - 20*time.Minute)
+	// 	w3 := time.Now().Add(-3*day - 30*time.Minute)
+	// 	w4 := time.Now().Add(-3*day - 40*time.Minute)
+	// 	w5 := time.Now().Add(-3*day - 120*time.Minute)
+	// 	w6 := time.Now().Add(-5 * day)
+	// 	w7 := time.Now().Add(-6 * day)
+	// 	// timestamps beyond 7d
+	// 	t1 := time.Now().Add(-10 * day)
+	// 	t2 := time.Now().Add(-10*day - 30*time.Minute)
+	// 	t3 := time.Now().Add(-11 * day)
+	// 	t4 := time.Now().Add(-12*day - 30*time.Minute)
+	// 	t5 := time.Now().Add(-13 * day)
+	// 	t6 := time.Now().Add(-30 * day)
+	// 	t7 := time.Now().Add(-60 * day)
+
+	// 	testCases := []struct {
+	// 		input    []time.Time
+	// 		expected []time.Time
+	// 	}{
+	// 		{input: []time.Time{d1, d2, d3, d4}, expected: []time.Time{d1, d3, d4}},
+	// 		{input: []time.Time{d1, d3, d6, d7}, expected: []time.Time{d1, d3, d6}},
+	// 		{input: []time.Time{d1, d2, d3, d4, d5, d6, d7, d8}, expected: []time.Time{d1, d3, d4, d5, d6, d8}},
+	// 		{input: []time.Time{w1, w2, w3, w4}, expected: []time.Time{w1}},
+	// 		{input: []time.Time{w2, w4, w5, w6, w7}, expected: []time.Time{w2, w5, w6, w7}},
+	// 		{input: []time.Time{t1, t2, t3, t4, t5}, expected: []time.Time{t1, t3, t4}},
+	// 		{input: []time.Time{t2, t3, t5, t6, t7}, expected: []time.Time{t2, t5, t6, t7}},
+	// 		{input: []time.Time{
+	// 			d1, d2, d3, d4, d5, d6, d7, d8,
+	// 			w1, w2, w3, w4, w5, w6, w7,
+	// 			t1, t2, t3, t4, t5, t6, t7,
+	// 		}, expected: []time.Time{
+	// 			d1, d3, d4, d5, d6, d8, w1, w5,
+	// 			w6, w7, t1, t3, t4, t6, t7,
+	// 		}},
+	// 	}
+
+	// 	for _, tc := range testCases {
+	// 		a, db := setupTest(t)
+	// 		userID, _, _, g, backupRepo, _, _, _, _ := createMockGallery(t, a, db)
+
+	// 		// manually seed all inputs except for the first one
+	// 		for _, inputTimestamp := range tc.input {
+	// 			backupRepo.insertBackupStmt.ExecContext(context.Background(), persist.GenerateID(), g.ID, g.Version, g, persist.CreationTime(inputTimestamp))
+	// 		}
+
+	// 		// officially insert a gallery via .Insert() to trigger underlying pruning
+	// 		backupRepo.Insert(context.Background(), g)
+
+	// 		backups, err := backupRepo.Get(context.Background(), userID)
+	// 		a.NoError(err)
+	// 		// should have a length of the expected seeded backups *plus* the officially inserted gallery via .Insert()
+	// 		a.Len(backups, len(tc.expected)+1)
+	// 		for i := 0; i < len(backups)-1; i++ {
+	// 			backup := backups[i]
+	// 			// queried results are returned in reverse of insert order
+	// 			actualCreationTime := time.Time(backup.CreationTime).Round(time.Second)
+	// 			expectedCreationTime := tc.expected[len(tc.expected)-1-i].Round(time.Second)
+	// 			a.True(actualCreationTime.Equal(expectedCreationTime))
+	// 		}
+	// 	}
+	// })
 }

--- a/service/persist/postgres/t__utils_test.go
+++ b/service/persist/postgres/t__utils_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 func setupTest(t *testing.T) (*assert.Assertions, *sql.DB) {
-	pg, pgUnpatch := docker.InitPostgres("../../../docker-compose.yml")
-	rd, rdUnpatch := docker.InitRedis("../../../docker-compose.yml")
+	pg, pgUnpatch := docker.InitPostgres()
+	rd, rdUnpatch := docker.InitRedis()
 
 	db := NewClient()
-	err := migrate.RunMigration("../../../db/migrations", db)
+	err := migrate.RunMigration(db)
 	if err != nil {
 		t.Fatalf("failed to seed db: %s", err)
 	}

--- a/service/persist/postgres/t__utils_test.go
+++ b/service/persist/postgres/t__utils_test.go
@@ -5,29 +5,31 @@ import (
 	"database/sql"
 	"testing"
 
+	migrate "github.com/mikeydub/go-gallery/db"
+	"github.com/mikeydub/go-gallery/docker"
 	"github.com/mikeydub/go-gallery/service/memstore/redis"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
+	"github.com/ory/dockertest"
 	"github.com/stretchr/testify/assert"
 )
 
 func setupTest(t *testing.T) (*assert.Assertions, *sql.DB) {
-	viper.Set("POSTGRES_HOST", "0.0.0.0")
-	viper.Set("POSTGRES_PORT", 5432)
-	viper.Set("POSTGRES_USER", "postgres")
-	viper.Set("POSTGRES_PASSWORD", "")
-	viper.Set("POSTGRES_DB", "postgres")
-	viper.Set("ENV", "local")
+	pg := docker.InitPostgres("../../../docker-compose.yml")
+	rd := docker.InitRedis("../../../docker-compose.yml")
 
 	db := NewClient()
+	err := migrate.RunMigration("../../../db/migrations", db)
+	if err != nil {
+		t.Fatalf("failed to seed db: %s", err)
+	}
 
 	t.Cleanup(func() {
 		defer db.Close()
-		dropSQL := `TRUNCATE users, nfts, collections, galleries;`
-		_, err := db.Exec(dropSQL)
-		if err != nil {
-			t.Logf("error dropping tables: %v", err)
+		for _, r := range []*dockertest.Resource{pg, rd} {
+			if err := r.Close(); err != nil {
+				t.Fatalf("could not purge resource: %s", err)
+			}
 		}
 	})
 

--- a/service/persist/postgres/t__utils_test.go
+++ b/service/persist/postgres/t__utils_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func setupTest(t *testing.T) (*assert.Assertions, *sql.DB) {
-	pg := docker.InitPostgres("../../../docker-compose.yml")
-	rd := docker.InitRedis("../../../docker-compose.yml")
+	pg, pgUnpatch := docker.InitPostgres("../../../docker-compose.yml")
+	rd, rdUnpatch := docker.InitRedis("../../../docker-compose.yml")
 
 	db := NewClient()
 	err := migrate.RunMigration("../../../db/migrations", db)
@@ -26,6 +26,8 @@ func setupTest(t *testing.T) (*assert.Assertions, *sql.DB) {
 
 	t.Cleanup(func() {
 		defer db.Close()
+		defer pgUnpatch()
+		defer rdUnpatch()
 		for _, r := range []*dockertest.Resource{pg, rd} {
 			if err := r.Close(); err != nil {
 				t.Fatalf("could not purge resource: %s", err)

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/gin-gonic/gin"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 // DefaultSearchDepth represents the maximum amount of nested maps (aka recursions) that can be searched
@@ -103,6 +106,7 @@ func CopyMax(writer io.Writer, it io.Reader, max int64) error {
 	}
 	return nil
 }
+
 // StringToPointer simply returns a pointer to the parameter string. It's useful for taking the address of a string concatenation,
 // a function that returns a string, or any other string that would otherwise need to be assigned to a variable before becoming addressable.
 func StringToPointer(str string) *string {
@@ -129,4 +133,22 @@ func GinContextFromContext(ctx context.Context) *gin.Context {
 	}
 
 	return gc
+}
+
+// FindFile finds a file relative to the working directory
+// by searching outer directories up to the search depth.
+// Mostly for testing purposes.
+func FindFile(f string, searchDepth int) (string, error) {
+	if _, err := os.Stat(f); err == nil {
+		return f, nil
+	}
+
+	for i := 0; i < searchDepth; i++ {
+		f = filepath.Join("..", f)
+		if _, err := os.Stat(f); err == nil {
+			return f, nil
+		}
+	}
+
+	return "", errors.New("could not find file in path")
 }


### PR DESCRIPTION
**Changes**
Unit tests start a new container per test file (the tests were super flaky if containers were started each test), instead of using the local containers and volumes for testing. The `setupDoubles` fixture is used to set up the containers and tear them down and patches the environment. The `setupTest` fixture sets up the server and wipes the tables after each unit test. 

Also moved some functions previously in `server` to `docker` and `db` so they can be re-used.

**Testing**
Ran `go test -short ./...`