### PR TITLE
Community endpoint fixes

### DIFF
--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -422,10 +422,10 @@ func communityToModel(ctx context.Context, community persist.Community) *model.C
 	lastUpdated := community.LastUpdated.Time()
 
 	owners := make([]*model.CommunityOwner, len(community.Owners))
-	for i, owner := range community.Owners {
+	for i, _ := range community.Owners {
 		owners[i] = &model.CommunityOwner{
 			Address:  &community.Owners[i].Address,
-			Username: util.StringToPointer(owner.Username.String()),
+			Username: util.StringToPointer(community.Owners[i].Username.String()),
 		}
 	}
 

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -424,7 +424,7 @@ func communityToModel(ctx context.Context, community persist.Community) *model.C
 	owners := make([]*model.CommunityOwner, len(community.Owners))
 	for i, owner := range community.Owners {
 		owners[i] = &model.CommunityOwner{
-			Address:  &owner.Address,
+			Address:  &community.Owners[i].Address,
 			Username: util.StringToPointer(owner.Username.String()),
 		}
 	}


### PR DESCRIPTION
## What's new?
- [GraphQL only] `CommunityOwner.address` no longer returns the same address for every owner
- [GraphQL + REST] Users are omitted from the community results if they (a) can't be found in the database by their address, or (b) have an empty username