### PR TITLE
Public API: Use the correct functionality to refresh Opensea NFTs

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -256,7 +256,7 @@ type ComplexityRoot struct {
 		DeleteCollection         func(childComplexity int, collectionID persist.DBID) int
 		GetAuthNonce             func(childComplexity int, address persist.Address) int
 		Login                    func(childComplexity int, authMechanism model.AuthMechanism) int
-		RefreshOpenSeaNfts       func(childComplexity int, addresses string) int
+		RefreshOpenSeaNfts       func(childComplexity int, addresses *string) int
 		RemoveUserAddresses      func(childComplexity int, addresses []persist.Address) int
 		UpdateCollectionHidden   func(childComplexity int, input model.UpdateCollectionHiddenInput) int
 		UpdateCollectionInfo     func(childComplexity int, input model.UpdateCollectionInfoInput) int
@@ -415,7 +415,7 @@ type MutationResolver interface {
 	UpdateCollectionNfts(ctx context.Context, input model.UpdateCollectionNftsInput) (model.UpdateCollectionNftsPayloadOrError, error)
 	UpdateCollectionHidden(ctx context.Context, input model.UpdateCollectionHiddenInput) (model.UpdateCollectionHiddenPayloadOrError, error)
 	UpdateNftInfo(ctx context.Context, input model.UpdateNftInfoInput) (model.UpdateNftInfoPayloadOrError, error)
-	RefreshOpenSeaNfts(ctx context.Context, addresses string) (model.RefreshOpenSeaNftsPayloadOrError, error)
+	RefreshOpenSeaNfts(ctx context.Context, addresses *string) (model.RefreshOpenSeaNftsPayloadOrError, error)
 	GetAuthNonce(ctx context.Context, address persist.Address) (model.GetAuthNoncePayloadOrError, error)
 	CreateUser(ctx context.Context, authMechanism model.AuthMechanism) (model.CreateUserPayloadOrError, error)
 	Login(ctx context.Context, authMechanism model.AuthMechanism) (model.LoginPayloadOrError, error)
@@ -1206,7 +1206,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.RefreshOpenSeaNfts(childComplexity, args["addresses"].(string)), true
+		return e.complexity.Mutation.RefreshOpenSeaNfts(childComplexity, args["addresses"].(*string)), true
 
 	case "Mutation.removeUserAddresses":
 		if e.complexity.Mutation.RemoveUserAddresses == nil {
@@ -2434,7 +2434,7 @@ type Mutation {
     updateNftInfo(input: UpdateNftInfoInput!): UpdateNftInfoPayloadOrError @authRequired
 
     # Mirroring the existing input (comma-separated list of addresses) because we expect to drop this functionality soon
-    refreshOpenSeaNfts(addresses: String!): RefreshOpenSeaNftsPayloadOrError @authRequired
+    refreshOpenSeaNfts(addresses: String): RefreshOpenSeaNftsPayloadOrError @authRequired
 
     getAuthNonce(address: Address!): GetAuthNoncePayloadOrError
 
@@ -2551,10 +2551,10 @@ func (ec *executionContext) field_Mutation_login_args(ctx context.Context, rawAr
 func (ec *executionContext) field_Mutation_refreshOpenSeaNfts_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
-	var arg0 string
+	var arg0 *string
 	if tmp, ok := rawArgs["addresses"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("addresses"))
-		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -6566,7 +6566,7 @@ func (ec *executionContext) _Mutation_refreshOpenSeaNfts(ctx context.Context, fi
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().RefreshOpenSeaNfts(rctx, args["addresses"].(string))
+			return ec.resolvers.Mutation().RefreshOpenSeaNfts(rctx, args["addresses"].(*string))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.AuthRequired == nil {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -281,10 +281,15 @@ func (r *mutationResolver) UpdateNftInfo(ctx context.Context, input model.Update
 	return output, nil
 }
 
-func (r *mutationResolver) RefreshOpenSeaNfts(ctx context.Context, addresses string) (model.RefreshOpenSeaNftsPayloadOrError, error) {
+func (r *mutationResolver) RefreshOpenSeaNfts(ctx context.Context, addresses *string) (model.RefreshOpenSeaNftsPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
-	err := api.Nft.RefreshOpenSeaNfts(ctx, addresses)
+	addressList := ""
+	if addresses != nil {
+		addressList = *addresses
+	}
+
+	err := api.Nft.RefreshOpenSeaNfts(ctx, addressList)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -586,7 +586,7 @@ type Mutation {
     updateNftInfo(input: UpdateNftInfoInput!): UpdateNftInfoPayloadOrError @authRequired
 
     # Mirroring the existing input (comma-separated list of addresses) because we expect to drop this functionality soon
-    refreshOpenSeaNfts(addresses: String!): RefreshOpenSeaNftsPayloadOrError @authRequired
+    refreshOpenSeaNfts(addresses: String): RefreshOpenSeaNftsPayloadOrError @authRequired
 
     getAuthNonce(address: Address!): GetAuthNoncePayloadOrError
 

--- a/publicapi/nft.go
+++ b/publicapi/nft.go
@@ -71,19 +71,14 @@ func (api NftAPI) GetNftsByOwnerAddress(ctx context.Context, ownerAddress persis
 }
 
 func (api NftAPI) RefreshOpenSeaNfts(ctx context.Context, addresses string) error {
-	// Validate
-	if err := validateFields(api.validator, validationMap{
-		"addresses": {addresses, "required"},
-	}); err != nil {
-		return err
-	}
+	// No validation to do here -- addresses is an optional comma-separated list of addresses
 
 	userID, err := getAuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = nftservice.RefreshOpenseaNFTs(ctx, userID, addresses, api.repos.NftRepository, api.repos.UserRepository)
+	err = nftservice.GetOpenseaNFTs(ctx, userID, addresses, api.repos.NftRepository, api.repos.UserRepository, api.repos.CollectionRepository, api.repos.GalleryRepository, api.repos.BackupRepository)
 	if err != nil {
 		return err
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -249,7 +249,7 @@ func nftHandlersInit(parent *gin.RouterGroup, repos *persist.Repositories, ethCl
 	nftsGroup.GET("/get", middleware.AuthOptional(), getNftByID(repos.NftRepository))
 	nftsGroup.GET("/user_get", middleware.AuthOptional(), getNftsForUser(repos.NftRepository))
 	nftsGroup.GET("/opensea/get", middleware.AuthRequired(repos.UserRepository, ethClient), getNftsFromOpensea(repos.NftRepository, repos.UserRepository, repos.CollectionRepository, repos.GalleryRepository, repos.BackupRepository))
-	nftsGroup.POST("/opensea/refresh", middleware.AuthRequired(repos.UserRepository, ethClient), refreshOpenseaNFTsREST(repos.NftRepository, repos.UserRepository))
+	nftsGroup.POST("/opensea/refresh", middleware.AuthRequired(repos.UserRepository, ethClient), refreshOpenseaNFTs(repos.NftRepository, repos.UserRepository))
 	nftsGroup.POST("/update", middleware.AuthRequired(repos.UserRepository, ethClient), updateNftByID(repos.NftRepository))
 	nftsGroup.GET("/unassigned/get", middleware.AuthRequired(repos.UserRepository, ethClient), getUnassignedNftsForUser(repos.CollectionRepository))
 	nftsGroup.POST("/unassigned/refresh", middleware.AuthRequired(repos.UserRepository, ethClient), refreshUnassignedNftsForUser(repos.CollectionRepository))


### PR DESCRIPTION
GraphQL / Public API now calls the "get opensea NFTs" flow instead of the "refresh opensea NFTs" flow when refreshing a user's NFTs. This is consistent with how we use the REST API.