### PR TITLE
GraphQL auth updates

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -233,6 +233,10 @@ type ComplexityRoot struct {
 		UserID func(childComplexity int) int
 	}
 
+	LogoutPayload struct {
+		Success func(childComplexity int) int
+	}
+
 	MembershipOwner struct {
 		Address     func(childComplexity int) int
 		Dbid        func(childComplexity int) int
@@ -256,6 +260,7 @@ type ComplexityRoot struct {
 		DeleteCollection         func(childComplexity int, collectionID persist.DBID) int
 		GetAuthNonce             func(childComplexity int, address persist.Address) int
 		Login                    func(childComplexity int, authMechanism model.AuthMechanism) int
+		Logout                   func(childComplexity int) int
 		RefreshOpenSeaNfts       func(childComplexity int, addresses *string) int
 		RemoveUserAddresses      func(childComplexity int, addresses []persist.Address) int
 		UpdateCollectionHidden   func(childComplexity int, input model.UpdateCollectionHiddenInput) int
@@ -420,6 +425,7 @@ type MutationResolver interface {
 	GetAuthNonce(ctx context.Context, address persist.Address) (model.GetAuthNoncePayloadOrError, error)
 	CreateUser(ctx context.Context, authMechanism model.AuthMechanism) (model.CreateUserPayloadOrError, error)
 	Login(ctx context.Context, authMechanism model.AuthMechanism) (model.LoginPayloadOrError, error)
+	Logout(ctx context.Context) (*model.LogoutPayload, error)
 }
 type NftResolver interface {
 	Owner(ctx context.Context, obj *model.Nft) (model.GalleryUserOrWallet, error)
@@ -1056,6 +1062,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LoginPayload.UserID(childComplexity), true
 
+	case "LogoutPayload.success":
+		if e.complexity.LogoutPayload.Success == nil {
+			break
+		}
+
+		return e.complexity.LogoutPayload.Success(childComplexity), true
+
 	case "MembershipOwner.address":
 		if e.complexity.MembershipOwner.Address == nil {
 			break
@@ -1197,6 +1210,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.Login(childComplexity, args["authMechanism"].(model.AuthMechanism)), true
+
+	case "Mutation.logout":
+		if e.complexity.Mutation.Logout == nil {
+			break
+		}
+
+		return e.complexity.Mutation.Logout(childComplexity), true
 
 	case "Mutation.refreshOpenSeaNfts":
 		if e.complexity.Mutation.RefreshOpenSeaNfts == nil {
@@ -2413,6 +2433,10 @@ type LoginPayload {
     userId: DBID
 }
 
+type LogoutPayload {
+    success: Boolean
+}
+
 union CreateUserPayloadOrError =
     CreateUserPayload
     | ErrUserAlreadyExists
@@ -2450,6 +2474,7 @@ type Mutation {
 
     createUser(authMechanism: AuthMechanism!): CreateUserPayloadOrError
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
+    logout: LogoutPayload
 }
 `, BuiltIn: false},
 }
@@ -5631,6 +5656,38 @@ func (ec *executionContext) _LoginPayload_userId(ctx context.Context, field grap
 	return ec.marshalODBID2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _LogoutPayload_success(ctx context.Context, field graphql.CollectedField, obj *model.LogoutPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "LogoutPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Success, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _MembershipOwner_dbid(ctx context.Context, field graphql.CollectedField, obj *model.MembershipOwner) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -6724,6 +6781,38 @@ func (ec *executionContext) _Mutation_login(ctx context.Context, field graphql.C
 	res := resTmp.(model.LoginPayloadOrError)
 	fc.Result = res
 	return ec.marshalOLoginPayloadOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐLoginPayloadOrError(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Mutation_logout(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().Logout(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.LogoutPayload)
+	fc.Result = res
+	return ec.marshalOLogoutPayload2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐLogoutPayload(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Nft_id(ctx context.Context, field graphql.CollectedField, obj *model.Nft) (ret graphql.Marshaler) {
@@ -12866,6 +12955,34 @@ func (ec *executionContext) _LoginPayload(ctx context.Context, sel ast.Selection
 	return out
 }
 
+var logoutPayloadImplementors = []string{"LogoutPayload"}
+
+func (ec *executionContext) _LogoutPayload(ctx context.Context, sel ast.SelectionSet, obj *model.LogoutPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, logoutPayloadImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LogoutPayload")
+		case "success":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._LogoutPayload_success(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var membershipOwnerImplementors = []string{"MembershipOwner"}
 
 func (ec *executionContext) _MembershipOwner(ctx context.Context, sel ast.SelectionSet, obj *model.MembershipOwner) graphql.Marshaler {
@@ -13110,6 +13227,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "login":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_login(ctx, field)
+			}
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, innerFunc)
+
+		case "logout":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_logout(ctx, field)
 			}
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, innerFunc)
@@ -15596,6 +15720,13 @@ func (ec *executionContext) marshalOLoginPayloadOrError2githubᚗcomᚋmikeydub�
 		return graphql.Null
 	}
 	return ec._LoginPayloadOrError(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOLogoutPayload2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐLogoutPayload(ctx context.Context, sel ast.SelectionSet, v *model.LogoutPayload) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._LogoutPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOMediaSubtype2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMediaSubtype(ctx context.Context, sel ast.SelectionSet, v model.MediaSubtype) graphql.Marshaler {

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -117,6 +117,7 @@ type ComplexityRoot struct {
 	CreateUserPayload struct {
 		GalleryID func(childComplexity int) int
 		UserID    func(childComplexity int) int
+		Viewer    func(childComplexity int) int
 	}
 
 	DeleteCollectionPayload struct {
@@ -231,10 +232,11 @@ type ComplexityRoot struct {
 
 	LoginPayload struct {
 		UserID func(childComplexity int) int
+		Viewer func(childComplexity int) int
 	}
 
 	LogoutPayload struct {
-		Success func(childComplexity int) int
+		Viewer func(childComplexity int) int
 	}
 
 	MembershipOwner struct {
@@ -705,6 +707,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.CreateUserPayload.UserID(childComplexity), true
 
+	case "CreateUserPayload.viewer":
+		if e.complexity.CreateUserPayload.Viewer == nil {
+			break
+		}
+
+		return e.complexity.CreateUserPayload.Viewer(childComplexity), true
+
 	case "DeleteCollectionPayload.gallery":
 		if e.complexity.DeleteCollectionPayload.Gallery == nil {
 			break
@@ -1062,12 +1071,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LoginPayload.UserID(childComplexity), true
 
-	case "LogoutPayload.success":
-		if e.complexity.LogoutPayload.Success == nil {
+	case "LoginPayload.viewer":
+		if e.complexity.LoginPayload.Viewer == nil {
 			break
 		}
 
-		return e.complexity.LogoutPayload.Success(childComplexity), true
+		return e.complexity.LoginPayload.Viewer(childComplexity), true
+
+	case "LogoutPayload.viewer":
+		if e.complexity.LogoutPayload.Viewer == nil {
+			break
+		}
+
+		return e.complexity.LogoutPayload.Viewer(childComplexity), true
 
 	case "MembershipOwner.address":
 		if e.complexity.MembershipOwner.Address == nil {
@@ -2430,11 +2446,13 @@ union LoginPayloadOrError =
     | ErrDoesNotOwnRequiredNFT
 
 type LoginPayload {
+    # TODO: Remove userId in favor of viewer
     userId: DBID
+    viewer: Viewer
 }
 
 type LogoutPayload {
-    success: Boolean
+    viewer: Viewer
 }
 
 union CreateUserPayloadOrError =
@@ -2446,6 +2464,8 @@ union CreateUserPayloadOrError =
 type CreateUserPayload {
     userId: DBID
     galleryId: DBID
+    # TODO: Remove userId and galleryId in favor of viewer
+    viewer: Viewer
 }
 
 type Mutation {
@@ -3968,6 +3988,38 @@ func (ec *executionContext) _CreateUserPayload_galleryId(ctx context.Context, fi
 	res := resTmp.(*persist.DBID)
 	fc.Result = res
 	return ec.marshalODBID2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CreateUserPayload_viewer(ctx context.Context, field graphql.CollectedField, obj *model.CreateUserPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CreateUserPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Viewer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Viewer)
+	fc.Result = res
+	return ec.marshalOViewer2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐViewer(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _DeleteCollectionPayload_gallery(ctx context.Context, field graphql.CollectedField, obj *model.DeleteCollectionPayload) (ret graphql.Marshaler) {
@@ -5656,7 +5708,39 @@ func (ec *executionContext) _LoginPayload_userId(ctx context.Context, field grap
 	return ec.marshalODBID2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _LogoutPayload_success(ctx context.Context, field graphql.CollectedField, obj *model.LogoutPayload) (ret graphql.Marshaler) {
+func (ec *executionContext) _LoginPayload_viewer(ctx context.Context, field graphql.CollectedField, obj *model.LoginPayload) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "LoginPayload",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Viewer, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Viewer)
+	fc.Result = res
+	return ec.marshalOViewer2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐViewer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _LogoutPayload_viewer(ctx context.Context, field graphql.CollectedField, obj *model.LogoutPayload) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
 			ec.Error(ctx, ec.Recover(ctx, r))
@@ -5674,7 +5758,7 @@ func (ec *executionContext) _LogoutPayload_success(ctx context.Context, field gr
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Success, nil
+		return obj.Viewer, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -5683,9 +5767,9 @@ func (ec *executionContext) _LogoutPayload_success(ctx context.Context, field gr
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*bool)
+	res := resTmp.(*model.Viewer)
 	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+	return ec.marshalOViewer2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐViewer(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _MembershipOwner_dbid(ctx context.Context, field graphql.CollectedField, obj *model.MembershipOwner) (ret graphql.Marshaler) {
@@ -12062,6 +12146,13 @@ func (ec *executionContext) _CreateUserPayload(ctx context.Context, sel ast.Sele
 
 			out.Values[i] = innerFunc(ctx)
 
+		case "viewer":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._CreateUserPayload_viewer(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12944,6 +13035,13 @@ func (ec *executionContext) _LoginPayload(ctx context.Context, sel ast.Selection
 
 			out.Values[i] = innerFunc(ctx)
 
+		case "viewer":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._LoginPayload_viewer(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12965,9 +13063,9 @@ func (ec *executionContext) _LogoutPayload(ctx context.Context, sel ast.Selectio
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("LogoutPayload")
-		case "success":
+		case "viewer":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._LogoutPayload_success(ctx, field, obj)
+				return ec._LogoutPayload_viewer(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -211,6 +211,7 @@ func (CreateCollectionPayload) IsCreateCollectionPayloadOrError() {}
 type CreateUserPayload struct {
 	UserID    *persist.DBID `json:"userId"`
 	GalleryID *persist.DBID `json:"galleryId"`
+	Viewer    *Viewer       `json:"viewer"`
 }
 
 func (CreateUserPayload) IsCreateUserPayloadOrError() {}
@@ -422,12 +423,13 @@ func (JSONMedia) IsMedia()        {}
 
 type LoginPayload struct {
 	UserID *persist.DBID `json:"userId"`
+	Viewer *Viewer       `json:"viewer"`
 }
 
 func (LoginPayload) IsLoginPayloadOrError() {}
 
 type LogoutPayload struct {
-	Success *bool `json:"success"`
+	Viewer *Viewer `json:"viewer"`
 }
 
 type MembershipOwner struct {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -426,6 +426,10 @@ type LoginPayload struct {
 
 func (LoginPayload) IsLoginPayloadOrError() {}
 
+type LogoutPayload struct {
+	Success *bool `json:"success"`
+}
+
 type MembershipOwner struct {
 	Dbid        persist.DBID     `json:"dbid"`
 	Address     *persist.Address `json:"address"`

--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -62,6 +62,11 @@ func AuthRequiredDirectiveHandler(ethClient *ethclient.Client) func(ctx context.
 		}
 
 		if authError := auth.GetAuthErrorFromCtx(gc); authError != nil {
+			if authError != auth.ErrNoCookie {
+				// Clear the user's cookie on any auth error (except for ErrNoCookie, since there is no cookie set)
+				auth.Logout(ctx)
+			}
+
 			var gqlModel model.AuthorizationError
 			errorMsg := authError.Error()
 

--- a/graphql/resolver/resolver.go
+++ b/graphql/resolver/resolver.go
@@ -1,10 +1,5 @@
 package graphql
 
-import (
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/mikeydub/go-gallery/service/persist"
-)
-
 // Add gqlgen to "go generate"
 //go:generate go run generate.go
 
@@ -12,7 +7,4 @@ import (
 //
 // It serves as dependency injection for your app, add any dependencies you require here.
 
-type Resolver struct {
-	Repos     *persist.Repositories
-	EthClient *ethclient.Client
-}
+type Resolver struct{}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -342,6 +342,16 @@ func (r *mutationResolver) Login(ctx context.Context, authMechanism model.AuthMe
 	return output, nil
 }
 
+func (r *mutationResolver) Logout(ctx context.Context) (*model.LogoutPayload, error) {
+	publicapi.For(ctx).User.Logout(ctx)
+
+	// Logging out never fails! We always clear the cookie.
+	success := true
+
+	output := &model.LogoutPayload{Success: &success}
+	return output, nil
+}
+
 func (r *nftResolver) Owner(ctx context.Context, obj *model.Nft) (model.GalleryUserOrWallet, error) {
 	return resolveNftOwnerByNftID(ctx, obj.Dbid)
 }

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/user"
 	"github.com/mikeydub/go-gallery/util"
 )
 
@@ -321,9 +320,14 @@ func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.A
 		return nil, err
 	}
 
-	output, err := user.CreateUser(ctx, authenticator, r.Repos.UserRepository, r.Repos.GalleryRepository)
+	userID, galleryID, err := publicapi.For(ctx).User.CreateUser(ctx, authenticator)
 	if err != nil {
 		return nil, err
+	}
+
+	output := &model.CreateUserPayload{
+		UserID:    &userID,
+		GalleryID: &galleryID,
 	}
 
 	return output, nil

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -10,9 +10,7 @@ import (
 	"github.com/mikeydub/go-gallery/graphql/generated"
 	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/publicapi"
-	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/util"
 )
 
 func (r *collectionResolver) Gallery(ctx context.Context, obj *model.Collection) (*model.Gallery, error) {
@@ -424,15 +422,12 @@ func (r *queryResolver) GeneralAllowlist(ctx context.Context) ([]persist.Address
 }
 
 func (r *viewerResolver) User(ctx context.Context, obj *model.Viewer) (*model.GalleryUser, error) {
-	gc := util.GinContextFromContext(ctx)
-	userID := auth.GetUserIDFromCtx(gc)
+	userID := publicapi.For(ctx).Auth.GetLoggedInUserId(ctx)
 	return resolveGalleryUserByUserID(ctx, userID)
 }
 
 func (r *viewerResolver) ViewerGalleries(ctx context.Context, obj *model.Viewer) ([]*model.ViewerGallery, error) {
-	gc := util.GinContextFromContext(ctx)
-	userID := auth.GetUserIDFromCtx(gc)
-
+	userID := publicapi.For(ctx).Auth.GetLoggedInUserId(ctx)
 	galleries, err := resolveGalleriesByUserID(ctx, userID)
 
 	if err != nil {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -334,11 +334,12 @@ func (r *mutationResolver) Login(ctx context.Context, authMechanism model.AuthMe
 		return nil, err
 	}
 
-	output, err := auth.Login(ctx, authenticator)
+	userId, err := publicapi.For(ctx).User.Login(ctx, authenticator)
 	if err != nil {
 		return nil, err
 	}
 
+	output := &model.LoginPayload{UserID: &userId}
 	return output, nil
 }
 

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -334,7 +334,7 @@ func (r *mutationResolver) Login(ctx context.Context, authMechanism model.AuthMe
 		return nil, err
 	}
 
-	userId, err := publicapi.For(ctx).User.Login(ctx, authenticator)
+	userId, err := publicapi.For(ctx).Auth.Login(ctx, authenticator)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (r *mutationResolver) Login(ctx context.Context, authMechanism model.AuthMe
 }
 
 func (r *mutationResolver) Logout(ctx context.Context) (*model.LogoutPayload, error) {
-	publicapi.For(ctx).User.Logout(ctx)
+	publicapi.For(ctx).Auth.Logout(ctx)
 
 	// Logging out never fails! We always clear the cookie.
 	success := true

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -356,7 +356,7 @@ func (r *mutationResolver) Logout(ctx context.Context) (*model.LogoutPayload, er
 	publicapi.For(ctx).Auth.Logout(ctx)
 
 	output := &model.LogoutPayload{
-		Viewer: nil,
+		Viewer: resolveViewer(ctx),
 	}
 
 	return output, nil

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -73,7 +73,7 @@ func (r *membershipOwnerResolver) User(ctx context.Context, obj *model.Membershi
 func (r *mutationResolver) AddUserAddress(ctx context.Context, address persist.Address, authMechanism model.AuthMechanism) (model.AddUserAddressPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
-	authenticator, err := r.authMechanismToAuthenticator(authMechanism)
+	authenticator, err := r.authMechanismToAuthenticator(ctx, authMechanism)
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +315,7 @@ func (r *mutationResolver) GetAuthNonce(ctx context.Context, address persist.Add
 }
 
 func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.AuthMechanism) (model.CreateUserPayloadOrError, error) {
-	authenticator, err := r.authMechanismToAuthenticator(authMechanism)
+	authenticator, err := r.authMechanismToAuthenticator(ctx, authMechanism)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.A
 }
 
 func (r *mutationResolver) Login(ctx context.Context, authMechanism model.AuthMechanism) (model.LoginPayloadOrError, error) {
-	authenticator, err := r.authMechanismToAuthenticator(authMechanism)
+	authenticator, err := r.authMechanismToAuthenticator(ctx, authMechanism)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -422,12 +422,12 @@ func (r *queryResolver) GeneralAllowlist(ctx context.Context) ([]persist.Address
 }
 
 func (r *viewerResolver) User(ctx context.Context, obj *model.Viewer) (*model.GalleryUser, error) {
-	userID := publicapi.For(ctx).Auth.GetLoggedInUserId(ctx)
+	userID := publicapi.For(ctx).User.GetLoggedInUserId(ctx)
 	return resolveGalleryUserByUserID(ctx, userID)
 }
 
 func (r *viewerResolver) ViewerGalleries(ctx context.Context, obj *model.Viewer) ([]*model.ViewerGallery, error) {
-	userID := publicapi.For(ctx).Auth.GetLoggedInUserId(ctx)
+	userID := publicapi.For(ctx).User.GetLoggedInUserId(ctx)
 	galleries, err := resolveGalleriesByUserID(ctx, userID)
 
 	if err != nil {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -302,13 +302,14 @@ func (r *mutationResolver) RefreshOpenSeaNfts(ctx context.Context, addresses *st
 }
 
 func (r *mutationResolver) GetAuthNonce(ctx context.Context, address persist.Address) (model.GetAuthNoncePayloadOrError, error) {
-	gc := util.GinContextFromContext(ctx)
-
-	authed := auth.GetUserAuthedFromCtx(gc)
-	output, err := auth.GetAuthNonce(gc, address, authed, r.Repos.UserRepository, r.Repos.NonceRepository, r.EthClient)
-
+	nonce, userExists, err := publicapi.For(ctx).Auth.GetAuthNonce(ctx, address)
 	if err != nil {
 		return nil, err
+	}
+
+	output := &model.AuthNonce{
+		Nonce:      &nonce,
+		UserExists: &userExists,
 	}
 
 	return output, nil

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -328,6 +328,7 @@ func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.A
 	output := &model.CreateUserPayload{
 		UserID:    &userID,
 		GalleryID: &galleryID,
+		Viewer:    resolveViewer(ctx),
 	}
 
 	return output, nil
@@ -344,17 +345,20 @@ func (r *mutationResolver) Login(ctx context.Context, authMechanism model.AuthMe
 		return nil, err
 	}
 
-	output := &model.LoginPayload{UserID: &userId}
+	output := &model.LoginPayload{
+		UserID: &userId,
+		Viewer: resolveViewer(ctx),
+	}
 	return output, nil
 }
 
 func (r *mutationResolver) Logout(ctx context.Context) (*model.LogoutPayload, error) {
 	publicapi.For(ctx).Auth.Logout(ctx)
 
-	// Logging out never fails! We always clear the cookie.
-	success := true
+	output := &model.LogoutPayload{
+		Viewer: nil,
+	}
 
-	output := &model.LogoutPayload{Success: &success}
 	return output, nil
 }
 

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -238,7 +238,7 @@ func resolveWalletByAddress(ctx context.Context, address persist.Address) (*mode
 }
 
 func resolveViewer(ctx context.Context) *model.Viewer {
-	if !publicapi.For(ctx).Auth.IsUserLoggedIn(ctx) {
+	if !publicapi.For(ctx).User.IsUserLoggedIn(ctx) {
 		return nil
 	}
 
@@ -293,8 +293,8 @@ func layoutToModel(ctx context.Context, layout sqlc.TokenLayout) *model.Collecti
 
 // userToModel converts a sqlc.User to a model.User
 func userToModel(ctx context.Context, user sqlc.User) *model.GalleryUser {
-	authApi := publicapi.For(ctx).Auth
-	isAuthenticatedUser := authApi.IsUserLoggedIn(ctx) && authApi.GetLoggedInUserId(ctx) == user.ID
+	userApi := publicapi.For(ctx).User
+	isAuthenticatedUser := userApi.IsUserLoggedIn(ctx) && userApi.GetLoggedInUserId(ctx) == user.ID
 
 	wallets := make([]*model.Wallet, len(user.Addresses))
 	for i, address := range user.Addresses {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -293,8 +293,8 @@ func layoutToModel(ctx context.Context, layout sqlc.TokenLayout) *model.Collecti
 
 // userToModel converts a sqlc.User to a model.User
 func userToModel(ctx context.Context, user sqlc.User) *model.GalleryUser {
-	gc := util.GinContextFromContext(ctx)
-	isAuthenticatedUser := auth.GetUserAuthedFromCtx(gc) && auth.GetUserIDFromCtx(gc) == user.ID
+	authApi := publicapi.For(ctx).Auth
+	isAuthenticatedUser := authApi.IsUserLoggedIn(ctx) && authApi.GetLoggedInUserId(ctx) == user.ID
 
 	wallets := make([]*model.Wallet, len(user.Addresses))
 	for i, address := range user.Addresses {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/user"
+	userservice "github.com/mikeydub/go-gallery/service/user"
 	"github.com/mikeydub/go-gallery/util"
 )
 
@@ -54,7 +54,7 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 		mappedErr = model.ErrDoesNotOwnRequiredNft{Message: message}
 	case persist.ErrUserNotFound:
 		mappedErr = model.ErrUserNotFound{Message: message}
-	case user.ErrUserAlreadyExists:
+	case userservice.ErrUserAlreadyExists:
 		mappedErr = model.ErrUserAlreadyExists{Message: message}
 	case persist.ErrCollectionNotFoundByID:
 		mappedErr = model.ErrCollectionNotFound{Message: message}
@@ -78,28 +78,16 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 }
 
 // authMechanismToAuthenticator takes a GraphQL AuthMechanism and returns an Authenticator that can be used for auth
-func (r *Resolver) authMechanismToAuthenticator(m model.AuthMechanism) (auth.Authenticator, error) {
-
-	ethNonceAuth := func(address persist.Address, nonce string, signature string, walletType auth.WalletType) auth.Authenticator {
-		authenticator := auth.EthereumNonceAuthenticator{
-			Address:    address,
-			Nonce:      nonce,
-			Signature:  signature,
-			WalletType: walletType,
-			UserRepo:   r.Repos.UserRepository,
-			NonceRepo:  r.Repos.NonceRepository,
-			EthClient:  r.EthClient,
-		}
-		return authenticator
-	}
+func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.AuthMechanism) (auth.Authenticator, error) {
+	authApi := publicapi.For(ctx).Auth
 
 	if m.EthereumEoa != nil {
-		return ethNonceAuth(m.EthereumEoa.Address, m.EthereumEoa.Nonce, m.EthereumEoa.Signature, auth.WalletTypeEOA), nil
+		return authApi.NewEthereumNonceAuthenticator(m.EthereumEoa.Address, m.EthereumEoa.Nonce, m.EthereumEoa.Signature, auth.WalletTypeEOA), nil
 	}
 
 	if m.GnosisSafe != nil {
 		// GnosisSafe passes an empty signature
-		return ethNonceAuth(m.GnosisSafe.Address, m.GnosisSafe.Nonce, "0x", auth.WalletTypeGnosis), nil
+		return authApi.NewEthereumNonceAuthenticator(m.GnosisSafe.Address, m.GnosisSafe.Nonce, "0x", auth.WalletTypeGnosis), nil
 	}
 
 	return nil, errNoAuthMechanismFound

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -238,6 +238,10 @@ func resolveWalletByAddress(ctx context.Context, address persist.Address) (*mode
 }
 
 func resolveViewer(ctx context.Context) *model.Viewer {
+	if !publicapi.For(ctx).Auth.IsUserLoggedIn(ctx) {
+		return nil
+	}
+
 	viewer := &model.Viewer{
 		User:            nil, // handled by dedicated resolver
 		ViewerGalleries: nil, // handled by dedicated resolver

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -556,6 +556,10 @@ type LoginPayload {
     userId: DBID
 }
 
+type LogoutPayload {
+    success: Boolean
+}
+
 union CreateUserPayloadOrError =
     CreateUserPayload
     | ErrUserAlreadyExists
@@ -593,4 +597,5 @@ type Mutation {
 
     createUser(authMechanism: AuthMechanism!): CreateUserPayloadOrError
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
+    logout: LogoutPayload
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -553,11 +553,13 @@ union LoginPayloadOrError =
     | ErrDoesNotOwnRequiredNFT
 
 type LoginPayload {
+    # TODO: Remove userId in favor of viewer
     userId: DBID
+    viewer: Viewer
 }
 
 type LogoutPayload {
-    success: Boolean
+    viewer: Viewer
 }
 
 union CreateUserPayloadOrError =
@@ -569,6 +571,8 @@ union CreateUserPayloadOrError =
 type CreateUserPayload {
     userId: DBID
     galleryId: DBID
+    # TODO: Remove userId and galleryId in favor of viewer
+    viewer: Viewer
 }
 
 type Mutation {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -129,6 +129,12 @@ func AddAuthToContext() gin.HandlerFunc {
 
 		jwt, err := c.Cookie(auth.JWTCookieKey)
 
+		// Treat empty cookies the same way we treat missing cookies, since setting a cookie to the empty
+		// string is how we "delete" them.
+		if err == nil && jwt == "" {
+			err = http.ErrNoCookie
+		}
+
 		if err != nil {
 			if err == http.ErrNoCookie {
 				err = auth.ErrNoCookie

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -32,6 +32,16 @@ func (api AuthAPI) NewEthereumNonceAuthenticator(address persist.Address, nonce 
 	return authenticator
 }
 
+func (api AuthAPI) GetLoggedInUserId(ctx context.Context) persist.DBID {
+	gc := util.GinContextFromContext(ctx)
+	return auth.GetUserIDFromCtx(gc)
+}
+
+func (api AuthAPI) IsUserLoggedIn(ctx context.Context) bool {
+	gc := util.GinContextFromContext(ctx)
+	return auth.GetUserAuthedFromCtx(gc)
+}
+
 func (api AuthAPI) GetAuthNonce(ctx context.Context, address persist.Address) (nonce string, userExists bool, err error) {
 	gc := util.GinContextFromContext(ctx)
 	authed := auth.GetUserAuthedFromCtx(gc)

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -1,0 +1,29 @@
+package publicapi
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/go-playground/validator/v10"
+	"github.com/mikeydub/go-gallery/db/sqlc"
+	"github.com/mikeydub/go-gallery/graphql/dataloader"
+	"github.com/mikeydub/go-gallery/service/auth"
+	"github.com/mikeydub/go-gallery/service/persist"
+)
+
+type AuthAPI struct {
+	repos     *persist.Repositories
+	queries   *sqlc.Queries
+	loaders   *dataloader.Loaders
+	validator *validator.Validate
+	ethClient *ethclient.Client
+}
+
+func (api AuthAPI) Login(ctx context.Context, authenticator auth.Authenticator) (persist.DBID, error) {
+	// Nothing to validate
+	return auth.Login(ctx, authenticator)
+}
+
+func (api AuthAPI) Logout(ctx context.Context) {
+	// Nothing to validate
+	auth.Logout(ctx)
+}

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -18,6 +18,19 @@ type AuthAPI struct {
 	ethClient *ethclient.Client
 }
 
+func (api AuthAPI) NewEthereumNonceAuthenticator(address persist.Address, nonce string, signature string, walletType auth.WalletType) auth.Authenticator {
+	authenticator := auth.EthereumNonceAuthenticator{
+		Address:    address,
+		Nonce:      nonce,
+		Signature:  signature,
+		WalletType: walletType,
+		UserRepo:   api.repos.UserRepository,
+		NonceRepo:  api.repos.NonceRepository,
+		EthClient:  api.ethClient,
+	}
+	return authenticator
+}
+
 func (api AuthAPI) Login(ctx context.Context, authenticator auth.Authenticator) (persist.DBID, error) {
 	// Nothing to validate
 	return auth.Login(ctx, authenticator)

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/util"
 )
 
 type AuthAPI struct {
@@ -29,6 +30,13 @@ func (api AuthAPI) NewEthereumNonceAuthenticator(address persist.Address, nonce 
 		EthClient:  api.ethClient,
 	}
 	return authenticator
+}
+
+func (api AuthAPI) GetAuthNonce(ctx context.Context, address persist.Address) (nonce string, userExists bool, err error) {
+	gc := util.GinContextFromContext(ctx)
+	authed := auth.GetUserAuthedFromCtx(gc)
+
+	return auth.GetAuthNonce(ctx, address, authed, api.repos.UserRepository, api.repos.NonceRepository, api.ethClient)
 }
 
 func (api AuthAPI) Login(ctx context.Context, authenticator auth.Authenticator) (persist.DBID, error) {

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -32,16 +32,6 @@ func (api AuthAPI) NewEthereumNonceAuthenticator(address persist.Address, nonce 
 	return authenticator
 }
 
-func (api AuthAPI) GetLoggedInUserId(ctx context.Context) persist.DBID {
-	gc := util.GinContextFromContext(ctx)
-	return auth.GetUserIDFromCtx(gc)
-}
-
-func (api AuthAPI) IsUserLoggedIn(ctx context.Context) bool {
-	gc := util.GinContextFromContext(ctx)
-	return auth.GetUserAuthedFromCtx(gc)
-}
-
 func (api AuthAPI) GetAuthNonce(ctx context.Context, address persist.Address) (nonce string, userExists bool, err error) {
 	gc := util.GinContextFromContext(ctx)
 	authed := auth.GetUserAuthedFromCtx(gc)

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -25,6 +25,7 @@ type PublicAPI struct {
 	queries    *sqlc.Queries
 	loaders    *dataloader.Loaders
 	validator  *validator.Validate
+	Auth       *AuthAPI
 	Collection *CollectionAPI
 	Gallery    *GalleryAPI
 	User       *UserAPI
@@ -41,6 +42,7 @@ func AddTo(ctx *gin.Context, repos *persist.Repositories, queries *sqlc.Queries,
 		queries:    queries,
 		loaders:    loaders,
 		validator:  validator,
+		Auth:       &AuthAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient},
 		Collection: &CollectionAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient},
 		Gallery:    &GalleryAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient},
 		User:       &UserAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient, ipfsClient: ipfsClient, arweaveClient: arweaveClient, storageClient: storageClient},

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -122,6 +122,11 @@ func (api UserAPI) RemoveUserAddresses(ctx context.Context, addresses []persist.
 	return nil
 }
 
+func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authenticator) (userID persist.DBID, galleryID persist.DBID, err error) {
+	// Nothing to validate
+	return user.CreateUser(ctx, authenticator, api.repos.UserRepository, api.repos.GalleryRepository)
+}
+
 func (api UserAPI) UpdateUserInfo(ctx context.Context, username string, bio string) error {
 	// Validate
 	if err := validateFields(api.validator, validationMap{
@@ -154,6 +159,7 @@ func (api UserAPI) UpdateUserInfo(ctx context.Context, username string, bio stri
 }
 
 func (api UserAPI) GetMembershipTiers(ctx context.Context, forceRefresh bool) ([]persist.MembershipTier, error) {
+	// Nothing to validate
 	return membership.GetMembershipTiers(ctx, forceRefresh, api.repos.MembershipRepository, api.repos.UserRepository, api.repos.GalleryRepository, api.ethClient, api.ipfsClient, api.arweaveClient, api.storageClient)
 }
 

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -1,14 +1,13 @@
 package publicapi
 
 import (
-	"context"
-	"github.com/mikeydub/go-gallery/db/sqlc"
-
 	"cloud.google.com/go/storage"
+	"context"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/everFinance/goar"
 	"github.com/go-playground/validator/v10"
 	shell "github.com/ipfs/go-ipfs-api"
+	"github.com/mikeydub/go-gallery/db/sqlc"
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/event"
@@ -188,6 +187,11 @@ func (api UserAPI) GetCommunityByContractAddress(ctx context.Context, contractAd
 	}
 
 	return &community, nil
+}
+
+func (api UserAPI) Login(ctx context.Context, authenticator auth.Authenticator) (persist.DBID, error) {
+	// Nothing to validate
+	return auth.Login(ctx, authenticator)
 }
 
 func (api UserAPI) Logout(ctx context.Context) {

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -189,16 +189,6 @@ func (api UserAPI) GetCommunityByContractAddress(ctx context.Context, contractAd
 	return &community, nil
 }
 
-func (api UserAPI) Login(ctx context.Context, authenticator auth.Authenticator) (persist.DBID, error) {
-	// Nothing to validate
-	return auth.Login(ctx, authenticator)
-}
-
-func (api UserAPI) Logout(ctx context.Context) {
-	// Nothing to validate
-	auth.Logout(ctx)
-}
-
 func dispatchUserEvent(ctx context.Context, eventCode persist.EventCode, userID persist.DBID, userData persist.UserEvent) {
 	gc := util.GinContextFromContext(ctx)
 	userHandlers := event.For(gc).User

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -190,6 +190,11 @@ func (api UserAPI) GetCommunityByContractAddress(ctx context.Context, contractAd
 	return &community, nil
 }
 
+func (api UserAPI) Logout(ctx context.Context) {
+	// Nothing to validate
+	auth.Logout(ctx)
+}
+
 func dispatchUserEvent(ctx context.Context, eventCode persist.EventCode, userID persist.DBID, userData persist.UserEvent) {
 	gc := util.GinContextFromContext(ctx)
 	userHandlers := event.For(gc).User

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -29,6 +29,16 @@ type UserAPI struct {
 	storageClient *storage.Client
 }
 
+func (api UserAPI) GetLoggedInUserId(ctx context.Context) persist.DBID {
+	gc := util.GinContextFromContext(ctx)
+	return auth.GetUserIDFromCtx(gc)
+}
+
+func (api UserAPI) IsUserLoggedIn(ctx context.Context) bool {
+	gc := util.GinContextFromContext(ctx)
+	return auth.GetUserAuthedFromCtx(gc)
+}
+
 func (api UserAPI) GetUserById(ctx context.Context, userID persist.DBID) (*sqlc.User, error) {
 	// Validate
 	if err := validateFields(api.validator, validationMap{

--- a/server/handler.go
+++ b/server/handler.go
@@ -50,8 +50,7 @@ func graphqlHandlersInit(parent *gin.RouterGroup, repos *persist.Repositories, q
 }
 
 func graphqlHandler(repos *persist.Repositories, queries *sqlc.Queries, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client) gin.HandlerFunc {
-	// TODO: Resolver probably doesn't need repos or ethClient once the publicAPI is done
-	config := generated.Config{Resolvers: &graphql.Resolver{Repos: repos, EthClient: ethClient}}
+	config := generated.Config{Resolvers: &graphql.Resolver{}}
 	config.Directives.AuthRequired = graphql.AuthRequiredDirectiveHandler(ethClient)
 
 	schema := generated.NewExecutableSchema(config)

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -285,6 +285,11 @@ func Login(pCtx context.Context, authenticator Authenticator) (*model.LoginPaylo
 	return &output, nil
 }
 
+func Logout(pCtx context.Context) {
+	gc := util.GinContextFromContext(pCtx)
+	SetJWTCookie(gc, "")
+}
+
 // VerifySignatureAllMethods will verify a signature using all available methods (eth_sign and personal_sign)
 func VerifySignatureAllMethods(pSignatureStr string,
 	pNonce string,

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -275,6 +275,7 @@ func Login(pCtx context.Context, authenticator Authenticator) (persist.DBID, err
 		return "", err
 	}
 
+	SetAuthStateForCtx(gc, authResult.UserID, nil)
 	SetJWTCookie(gc, jwtTokenStr)
 
 	return authResult.UserID, nil
@@ -282,6 +283,7 @@ func Login(pCtx context.Context, authenticator Authenticator) (persist.DBID, err
 
 func Logout(pCtx context.Context) {
 	gc := util.GinContextFromContext(pCtx)
+	SetAuthStateForCtx(gc, "", ErrNoCookie)
 	SetJWTCookie(gc, "")
 }
 

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -218,6 +218,7 @@ func CreateUser(pCtx context.Context, authenticator auth.Authenticator, userRepo
 		return "", "", err
 	}
 
+	auth.SetAuthStateForCtx(gc, userID, nil)
 	auth.SetJWTCookie(gc, jwtTokenStr)
 
 	return userID, galleryID, nil


### PR DESCRIPTION
## What's new?
- Added a `logout` mutation
- Auth failures (e.g. ErrInvalidToken) will now clear the user's cookie
- Beginnings of some minor refactoring to move auth functionality into the public API instead of having GraphQL resolvers call the `auth` package directly