### PR TITLE
Debug Tools

### DIFF
--- a/debugtools/debugtools_common.go
+++ b/debugtools/debugtools_common.go
@@ -1,0 +1,26 @@
+// debugtools_common.go is always compiled and is not dependent on a build tag.
+// It contains shared code used by both debugtools_enabled.go and debugtools_disabled.go.
+
+package debugtools
+
+import (
+	"fmt"
+	"github.com/mikeydub/go-gallery/service/auth"
+	"github.com/mikeydub/go-gallery/service/persist"
+)
+
+type DebugAuthenticator struct {
+	UserID    persist.DBID
+	Addresses []persist.Address
+}
+
+func (d DebugAuthenticator) GetDescription() string {
+	return fmt.Sprintf("DebugAuthenticator(userId: %s, addresses: %v)", d.UserID, d.Addresses)
+}
+
+func NewDebugAuthenticator(userID persist.DBID, addresses []persist.Address) auth.Authenticator {
+	return DebugAuthenticator{
+		UserID:    userID,
+		Addresses: addresses,
+	}
+}

--- a/debugtools/debugtools_disabled.go
+++ b/debugtools/debugtools_disabled.go
@@ -1,0 +1,20 @@
+//go:build !debug_tools
+// +build !debug_tools
+
+// debugtools_disabled.go is compiled whenever the `debug_tools` build tag is not set.
+// It should provide production-safe alternative implementations of the code found in
+// debugtools_enabled.go.
+
+package debugtools
+
+import (
+	"context"
+	"errors"
+	"github.com/mikeydub/go-gallery/service/auth"
+)
+
+const Enabled bool = false
+
+func (d DebugAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult, error) {
+	return nil, errors.New("DebugAuthenticator only works when the 'debug_tools' build tag is set")
+}

--- a/debugtools/debugtools_enabled.go
+++ b/debugtools/debugtools_enabled.go
@@ -1,0 +1,38 @@
+//go:build debug_tools
+// +build debug_tools
+
+// debugtools_enabled.go is only compiled when the `debug_tools` build tag is set.
+// Anything that should be debug-only can be added here. Additionally, because the
+// 'Enabled' bool is a const, code in other files that is conditional on Enabled
+// will also be compiled out of builds.
+
+package debugtools
+
+import (
+	"context"
+	"errors"
+	"github.com/mikeydub/go-gallery/service/auth"
+	"github.com/spf13/viper"
+)
+
+const Enabled bool = true
+
+func init() {
+	// An additional safeguard against running debug tools in production
+	if viper.GetString("ENV") == "production" {
+		panic(errors.New("debug tools may not be enabled in a production environment"))
+	}
+}
+
+func (d DebugAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult, error) {
+	if viper.GetString("ENV") != "local" {
+		return nil, errors.New("DebugAuthenticator may only be used in a local environment")
+	}
+
+	authResult := auth.AuthResult{
+		Addresses: d.Addresses,
+		UserID:    d.UserID,
+	}
+
+	return &authResult, nil
+}

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -2430,8 +2430,16 @@ type ErrDoesNotOwnRequiredNFT implements Error {
 }
 
 input AuthMechanism {
+    debugAuth: DebugAuth
     ethereumEoa: EthereumEoaAuth
     gnosisSafe: GnosisSafeAuth
+}
+
+# DebugAuth always succeeds and returns the supplied userId and addresses.
+# Only available for local development.
+input DebugAuth @restrictEnvironment(allowed: ["local"]){
+    userId: DBID
+    addresses: [Address!]!
 }
 
 input EthereumEoaAuth {
@@ -10376,6 +10384,36 @@ func (ec *executionContext) unmarshalInputAuthMechanism(ctx context.Context, obj
 
 	for k, v := range asMap {
 		switch k {
+		case "debugAuth":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("debugAuth"))
+			directive0 := func(ctx context.Context) (interface{}, error) {
+				return ec.unmarshalODebugAuth2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐDebugAuth(ctx, v)
+			}
+			directive1 := func(ctx context.Context) (interface{}, error) {
+				allowed, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"local"})
+				if err != nil {
+					return nil, err
+				}
+				if ec.directives.RestrictEnvironment == nil {
+					return nil, errors.New("directive restrictEnvironment is not implemented")
+				}
+				return ec.directives.RestrictEnvironment(ctx, obj, directive0, allowed)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*model.DebugAuth); ok {
+				it.DebugAuth = data
+			} else if tmp == nil {
+				it.DebugAuth = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *github.com/mikeydub/go-gallery/graphql/model.DebugAuth`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "ethereumEoa":
 			var err error
 
@@ -10477,6 +10515,81 @@ func (ec *executionContext) unmarshalInputCreateCollectionInput(ctx context.Cont
 			it.Layout, err = ec.unmarshalNCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayoutInput(ctx, v)
 			if err != nil {
 				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputDebugAuth(ctx context.Context, obj interface{}) (model.DebugAuth, error) {
+	var it model.DebugAuth
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "userId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userId"))
+			directive0 := func(ctx context.Context) (interface{}, error) {
+				return ec.unmarshalODBID2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, v)
+			}
+			directive1 := func(ctx context.Context) (interface{}, error) {
+				allowed, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"local"})
+				if err != nil {
+					return nil, err
+				}
+				if ec.directives.RestrictEnvironment == nil {
+					return nil, errors.New("directive restrictEnvironment is not implemented")
+				}
+				return ec.directives.RestrictEnvironment(ctx, obj, directive0, allowed)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*persist.DBID); ok {
+				it.UserID = data
+			} else if tmp == nil {
+				it.UserID = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *github.com/mikeydub/go-gallery/service/persist.DBID`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+		case "addresses":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("addresses"))
+			directive0 := func(ctx context.Context) (interface{}, error) {
+				return ec.unmarshalNAddress2ᚕgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐAddressᚄ(ctx, v)
+			}
+			directive1 := func(ctx context.Context) (interface{}, error) {
+				allowed, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"local"})
+				if err != nil {
+					return nil, err
+				}
+				if ec.directives.RestrictEnvironment == nil {
+					return nil, errors.New("directive restrictEnvironment is not implemented")
+				}
+				return ec.directives.RestrictEnvironment(ctx, obj, directive0, allowed)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.([]persist.Address); ok {
+				it.Addresses = data
+			} else if tmp == nil {
+				it.Addresses = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be []github.com/mikeydub/go-gallery/service/persist.Address`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
 			}
 		}
 	}
@@ -15685,6 +15798,14 @@ func (ec *executionContext) marshalODBID2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalle
 	}
 	res := graphql.MarshalString(string(*v))
 	return res
+}
+
+func (ec *executionContext) unmarshalODebugAuth2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐDebugAuth(ctx context.Context, v interface{}) (*model.DebugAuth, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputDebugAuth(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalODeleteCollectionPayloadOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐDeleteCollectionPayloadOrError(ctx context.Context, sel ast.SelectionSet, v model.DeleteCollectionPayloadOrError) graphql.Marshaler {

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -51,7 +51,8 @@ type ResolverRoot interface {
 }
 
 type DirectiveRoot struct {
-	AuthRequired func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	AuthRequired        func(ctx context.Context, obj interface{}, next graphql.Resolver) (res interface{}, err error)
+	RestrictEnvironment func(ctx context.Context, obj interface{}, next graphql.Resolver, allowed []string) (res interface{}, err error)
 }
 
 type ComplexityRoot struct {
@@ -1909,6 +1910,11 @@ directive @authRequired on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 # other sensitive data)
 directive @scrub on INPUT_FIELD_DEFINITION
 
+# Use @restrictEnvironment to choose which values of the ENV environment variable the annotated field/object
+# should be usable in (case-insensitive). Example: @restrictEnvironment(allowed:["local", "development"]) would
+# allow a field in "local" and "development" environments but not in "production"
+directive @restrictEnvironment(allowed:[String!]!) on INPUT_FIELD_DEFINITION | INPUT_OBJECT | FIELD_DEFINITION | OBJECT
+
 # All types that implement Node must have a unique GqlID set in their "id" field. For types with
 # a "dbid" field, it's assumed that we can synthesize a unique ID from the type name and the dbid,
 # so those types will automatically have an ID function generated for them (which gqlgen will find
@@ -2503,6 +2509,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) dir_restrictEnvironment_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 []string
+	if tmp, ok := rawArgs["allowed"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allowed"))
+		arg0, err = ec.unmarshalNString2ᚕstringᚄ(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["allowed"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_addUserAddress_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -132,6 +132,7 @@ func (AudioMedia) IsMediaSubtype() {}
 func (AudioMedia) IsMedia()        {}
 
 type AuthMechanism struct {
+	DebugAuth   *DebugAuth       `json:"debugAuth"`
 	EthereumEoa *EthereumEoaAuth `json:"ethereumEoa"`
 	GnosisSafe  *GnosisSafeAuth  `json:"gnosisSafe"`
 }
@@ -215,6 +216,11 @@ type CreateUserPayload struct {
 }
 
 func (CreateUserPayload) IsCreateUserPayloadOrError() {}
+
+type DebugAuth struct {
+	UserID    *persist.DBID     `json:"userId"`
+	Addresses []persist.Address `json:"addresses"`
+}
 
 type DeleteCollectionPayload struct {
 	Gallery *Gallery `json:"gallery"`

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -536,8 +536,16 @@ type ErrDoesNotOwnRequiredNFT implements Error {
 }
 
 input AuthMechanism {
+    debugAuth: DebugAuth
     ethereumEoa: EthereumEoaAuth
     gnosisSafe: GnosisSafeAuth
+}
+
+# DebugAuth always succeeds and returns the supplied userId and addresses.
+# Only available for local development.
+input DebugAuth @restrictEnvironment(allowed: ["local"]){
+    userId: DBID
+    addresses: [Address!]!
 }
 
 input EthereumEoaAuth {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -16,6 +16,11 @@ directive @authRequired on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 # other sensitive data)
 directive @scrub on INPUT_FIELD_DEFINITION
 
+# Use @restrictEnvironment to choose which values of the ENV environment variable the annotated field/object
+# should be usable in (case-insensitive). Example: @restrictEnvironment(allowed:["local", "development"]) would
+# allow a field in "local" and "development" environments but not in "production"
+directive @restrictEnvironment(allowed:[String!]!) on INPUT_FIELD_DEFINITION | INPUT_OBJECT | FIELD_DEFINITION | OBJECT
+
 # All types that implement Node must have a unique GqlID set in their "id" field. For types with
 # a "dbid" field, it's assumed that we can synthesize a unique ID from the type name and the dbid,
 # so those types will automatically have an ID function generated for them (which gqlgen will find

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,10 +1,9 @@
 package server
 
 import (
+	"cloud.google.com/go/storage"
 	"context"
 	"fmt"
-
-	"cloud.google.com/go/storage"
 	gqlgen "github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
@@ -52,6 +51,7 @@ func graphqlHandlersInit(parent *gin.RouterGroup, repos *persist.Repositories, q
 func graphqlHandler(repos *persist.Repositories, queries *sqlc.Queries, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client) gin.HandlerFunc {
 	config := generated.Config{Resolvers: &graphql.Resolver{}}
 	config.Directives.AuthRequired = graphql.AuthRequiredDirectiveHandler(ethClient)
+	config.Directives.RestrictEnvironment = graphql.RestrictEnvironmentDirectiveHandler()
 
 	schema := generated.NewExecutableSchema(config)
 	h := handler.NewDefaultServer(schema)


### PR DESCRIPTION
## What's new?
This PR adds two things:

1. A `DebugAuthenticator` type that can be used to bypass authentication and impersonate any user or address
2. One trillion safeguards to stop a `DebugAuthenticator` from ever being usable in production

### Why?
One really cool thing about using `Authenticators` for auth is that we have a very modular auth system. Anything that requires authentication accepts an `Authenticator` type, and we can use that to allow auth from all sorts of sources (nonce-based, OAuth, other integrations) anywhere we want to verify ownership of a user account or an address.

This is _also_ very handy for local debugging. A `DebugAuthenticator` can be used to impersonate any user or validate any address for the sake of testing/debugging from the perspective of the given user. This is great for investigating issues that are happening to specific users, or for seeing what would happen if a particular user disconnected a wallet, etc.

### Sounds cool! And also scary. How do we make sure this is only usable locally?
I've implemented a bunch of safeguards to make sure a `DebugAuthenticator` can only be used in a `local` environment.

1. Our GraphQL schema now supports a `restrictEnvironment` directive. Any attempt to use a field annotated with `restrictEnvironment` will throw an error if the current environment is not in the directive's `allowed` parameters. In the case of `DebugAuthenticator`, it looks like this:

```
# DebugAuth always succeeds and returns the supplied userId and addresses.
# Only available for local development.
input DebugAuth @restrictEnvironment(allowed: ["local"]){
    userId: DBID
    addresses: [Address!]!
}
```

2. Once the GraphQL resolvers receive a `DebugAuth` input, they'll only map it to a `DebugAuthenticator` object if `debugtools.Enabled` is true and we're in a `local` environment:

```
if debugtools.Enabled {
    if viper.GetString("ENV") == "local" && m.DebugAuth != nil {
        userID := persist.DBID("")
        if m.DebugAuth.UserID != nil {
            userID = *m.DebugAuth.UserID
        }
        return debugtools.NewDebugAuthenticator(userID, m.DebugAuth.Addresses), nil
    }
}
```

3. `debugtools.Enabled` is part of a new compilation-based `debugtools` package. Unlike the other safeguards, which are all runtime checks, `debugtools` uses a golang build tag to choose which file to compile: either `debugtools_enabled.go` or `debugtools_disabled.go`. Only a build compiled with the `-tags debug_tools`* flag will contain a working implementation of a `DebugAuthenticator`, meaning that even if our production environment were somehow returning `ENV="local"`, the version of `DebugAuthenticator` returned by `debugtools` would still throw an error.

\* - Also worth noting: the `debug_tools` build tag is something I made up, so it only exists in builds where we explicitly set it. 

4. After all that, the working version of a `DebugAuthenticator` will still check the environment before returning successfully:

```
if viper.GetString("ENV") != "local" {
    return nil, errors.New("DebugAuthenticator may only be used in a local environment")
}

authResult := auth.AuthResult{
    Addresses: d.Addresses,
    UserID:    d.UserID,
}

return &authResult, nil
```
