### PR TITLE
UpdateUserInfo now returns ErrUserAlreadyExists when username is taken

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -2365,6 +2365,7 @@ union UpdateUserInfoPayloadOrError =
     UpdateUserInfoPayload
     | ErrNotAuthorized
     | ErrInvalidInput
+    | ErrUserAlreadyExists
 
 type UpdateUserInfoPayload {
     viewer: Viewer
@@ -11749,6 +11750,13 @@ func (ec *executionContext) _UpdateUserInfoPayloadOrError(ctx context.Context, s
 			return graphql.Null
 		}
 		return ec._ErrInvalidInput(ctx, sel, obj)
+	case model.ErrUserAlreadyExists:
+		return ec._ErrUserAlreadyExists(ctx, sel, &obj)
+	case *model.ErrUserAlreadyExists:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ErrUserAlreadyExists(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -12635,7 +12643,7 @@ func (ec *executionContext) _ErrNotAuthorized(ctx context.Context, sel ast.Selec
 	return out
 }
 
-var errUserAlreadyExistsImplementors = []string{"ErrUserAlreadyExists", "Error", "CreateUserPayloadOrError"}
+var errUserAlreadyExistsImplementors = []string{"ErrUserAlreadyExists", "UpdateUserInfoPayloadOrError", "Error", "CreateUserPayloadOrError"}
 
 func (ec *executionContext) _ErrUserAlreadyExists(ctx context.Context, sel ast.SelectionSet, obj *model.ErrUserAlreadyExists) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, errUserAlreadyExistsImplementors)

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -327,8 +327,9 @@ type ErrUserAlreadyExists struct {
 	Message string `json:"message"`
 }
 
-func (ErrUserAlreadyExists) IsError()                    {}
-func (ErrUserAlreadyExists) IsCreateUserPayloadOrError() {}
+func (ErrUserAlreadyExists) IsUpdateUserInfoPayloadOrError() {}
+func (ErrUserAlreadyExists) IsError()                        {}
+func (ErrUserAlreadyExists) IsCreateUserPayloadOrError()     {}
 
 type ErrUserNotFound struct {
 	Message string `json:"message"`

--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/mikeydub/go-gallery/publicapi"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 
 	gqlgen "github.com/99designs/gqlgen/graphql"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -38,6 +39,12 @@ func RemapErrors(ctx context.Context, next gqlgen.Resolver) (res interface{}, er
 
 	fc := gqlgen.GetFieldContext(ctx)
 	typeName := fc.Field.Field.Definition.Type.NamedType
+
+	// Unwrap any gqlerror.Error wrappers to get the underlying error type
+	var gqlErr *gqlerror.Error
+	for errors.As(err, &gqlErr) {
+		err = gqlErr.Unwrap()
+	}
 
 	// If a resolver returns an error that can be mapped to that resolver's expected GQL type,
 	// remap it and return the appropriate GQL model instead of an error. This is common for

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
-	userservice "github.com/mikeydub/go-gallery/service/user"
 	"github.com/mikeydub/go-gallery/util"
 )
 
@@ -56,7 +55,7 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 		mappedErr = model.ErrDoesNotOwnRequiredNft{Message: message}
 	case persist.ErrUserNotFound:
 		mappedErr = model.ErrUserNotFound{Message: message}
-	case userservice.ErrUserAlreadyExists:
+	case persist.ErrUserAlreadyExists:
 		mappedErr = model.ErrUserAlreadyExists{Message: message}
 	case persist.ErrCollectionNotFoundByID:
 		mappedErr = model.ErrCollectionNotFound{Message: message}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -471,6 +471,7 @@ union UpdateUserInfoPayloadOrError =
     UpdateUserInfoPayload
     | ErrNotAuthorized
     | ErrInvalidInput
+    | ErrUserAlreadyExists
 
 type UpdateUserInfoPayload {
     viewer: Viewer

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -94,7 +94,7 @@ func (u *UserRepository) UpdateByID(pCtx context.Context, pID persist.DBID, pUpd
 		update := pUpdate.(persist.UserUpdateInfoInput)
 		aUser, _ := u.GetByUsername(pCtx, update.Username.String())
 		if aUser.ID != "" && aUser.ID != pID {
-			return fmt.Errorf("username %s already exists", update.Username.String())
+			return persist.ErrUserAlreadyExists{Username: update.Username.String()}
 		}
 		res, err := u.updateInfoStmt.ExecContext(pCtx, pID, update.Username, strings.ToLower(update.UsernameIdempotent.String()), update.LastUpdated, update.Bio)
 		if err != nil {

--- a/service/persist/user.go
+++ b/service/persist/user.go
@@ -51,3 +51,13 @@ type ErrUserNotFound struct {
 func (e ErrUserNotFound) Error() string {
 	return fmt.Sprintf("user not found: address: %s, ID: %s, username: %s, authenticator: %s", e.Address, e.UserID, e.Username, e.Authenticator)
 }
+
+type ErrUserAlreadyExists struct {
+	Address       Address
+	Authenticator string
+	Username      string
+}
+
+func (e ErrUserAlreadyExists) Error() string {
+	return fmt.Sprintf("user already exists: username: %s, address: %s, authenticator: %s", e.Username, e.Address, e.Authenticator)
+}

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -99,7 +99,7 @@ func CreateUserToken(pCtx context.Context, pInput AddUserAddressesInput, userRep
 		return CreateUserOutput{}, auth.ErrNonceNotFound{Address: pInput.Address}
 	}
 	if id != "" {
-		return CreateUserOutput{}, ErrUserAlreadyExists{Address: pInput.Address}
+		return CreateUserOutput{}, persist.ErrUserAlreadyExists{Address: pInput.Address}
 	}
 
 	if pInput.WalletType != auth.WalletTypeEOA {
@@ -187,7 +187,7 @@ func CreateUser(pCtx context.Context, authenticator auth.Authenticator, userRepo
 	}
 
 	if authResult.UserID != "" {
-		return "", "", ErrUserAlreadyExists{Authenticator: authenticator.GetDescription()}
+		return "", "", persist.ErrUserAlreadyExists{Authenticator: authenticator.GetDescription()}
 	}
 
 	// TODO: This currently takes the first authenticated address returned by the authenticator and creates
@@ -492,15 +492,6 @@ func ensureMediaContent(pCtx context.Context, pAddress persist.Address, tokenRep
 	}
 	return nil
 
-}
-
-type ErrUserAlreadyExists struct {
-	Address       persist.Address
-	Authenticator string
-}
-
-func (e ErrUserAlreadyExists) Error() string {
-	return fmt.Sprintf("user already exists: address: %s, authenticator: %s", e.Address, e.Authenticator)
 }
 
 type ErrAddressOwnedByUser struct {


### PR DESCRIPTION
## What's new?

The GraphQL schema has been updated to include `ErrUserAlreadyExists` as a possible return type for the `UpdateUserInfo` mutation.