### PR TITLE
Add an optional collectionId parameter when updating an NFT's info

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -2326,6 +2326,10 @@ type UpdateGalleryCollectionsPayload {
 input UpdateNftInfoInput {
     nftId: DBID!
     collectorsNote: String!
+
+    # Optional (for now). Lets the backend know what collection the NFT was being edited in.
+    # Currently used to generate feedbot URLs.
+    collectionId: DBID
 }
 
 union UpdateNftInfoPayloadOrError =
@@ -10830,6 +10834,14 @@ func (ec *executionContext) unmarshalInputUpdateNftInfoInput(ctx context.Context
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("collectorsNote"))
 			it.CollectorsNote, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "collectionId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("collectionId"))
+			it.CollectionID, err = ec.unmarshalODBID2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -573,8 +573,9 @@ type UpdateGalleryCollectionsPayload struct {
 func (UpdateGalleryCollectionsPayload) IsUpdateGalleryCollectionsPayloadOrError() {}
 
 type UpdateNftInfoInput struct {
-	NftID          persist.DBID `json:"nftId"`
-	CollectorsNote string       `json:"collectorsNote"`
+	NftID          persist.DBID  `json:"nftId"`
+	CollectorsNote string        `json:"collectorsNote"`
+	CollectionID   *persist.DBID `json:"collectionId"`
 }
 
 type UpdateNftInfoPayload struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -256,7 +256,12 @@ func (r *mutationResolver) UpdateCollectionHidden(ctx context.Context, input mod
 func (r *mutationResolver) UpdateNftInfo(ctx context.Context, input model.UpdateNftInfoInput) (model.UpdateNftInfoPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
-	err := api.Nft.UpdateNftInfo(ctx, input.NftID, input.CollectorsNote)
+	collectionID := persist.DBID("")
+	if input.CollectionID != nil {
+		collectionID = *input.CollectionID
+	}
+
+	err := api.Nft.UpdateNftInfo(ctx, input.NftID, collectionID, input.CollectorsNote)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -432,6 +432,10 @@ type UpdateGalleryCollectionsPayload {
 input UpdateNftInfoInput {
     nftId: DBID!
     collectorsNote: String!
+
+    # Optional (for now). Lets the backend know what collection the NFT was being edited in.
+    # Currently used to generate feedbot URLs.
+    collectionId: DBID
 }
 
 union UpdateNftInfoPayloadOrError =

--- a/publicapi/nft.go
+++ b/publicapi/nft.go
@@ -88,7 +88,7 @@ func (api NftAPI) RefreshOpenSeaNfts(ctx context.Context, addresses string) erro
 	return nil
 }
 
-func (api NftAPI) UpdateNftInfo(ctx context.Context, nftID persist.DBID, collectorsNote string) error {
+func (api NftAPI) UpdateNftInfo(ctx context.Context, nftID persist.DBID, collectionID persist.DBID, collectorsNote string) error {
 	// Validate
 	if err := validateFields(api.validator, validationMap{
 		"nftID":          {nftID, "required"},
@@ -117,7 +117,7 @@ func (api NftAPI) UpdateNftInfo(ctx context.Context, nftID persist.DBID, collect
 	api.loaders.ClearAllCaches()
 
 	// Send event
-	nftData := persist.NftEvent{CollectorsNote: persist.NullString(collectorsNote)}
+	nftData := persist.NftEvent{CollectionID: collectionID, CollectorsNote: persist.NullString(collectorsNote)}
 	dispatchNftEvent(ctx, persist.NftCollectorsNoteAddedEvent, userID, nftID, nftData)
 
 	return nil


### PR DESCRIPTION
By supplying a collectionId, we can generate appropriate feedbot links for NFT collector's note updates!