### PR TITLE
Bugfix: Fix feedbot tasks being scheduled immediately

### DIFF
--- a/service/event/cloudtask/cloudtask.go
+++ b/service/event/cloudtask/cloudtask.go
@@ -32,36 +32,30 @@ func newClient(ctx context.Context) (*gcptasks.Client, error) {
 	}
 }
 
-func createTaskForService(ctx context.Context, createdOn time.Time, eventID persist.DBID, eventCode persist.EventCode, service string, uri string) error {
+func createTaskForService(ctx context.Context, queuePath string, scheduleOn time.Time, service string, uri string, headers map[string]string, message EventMessage) error {
 	client, err := newClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	queuePath := viper.GetString("GCLOUD_FEED_TASK_QUEUE")
-	scheduleOn := createdOn.Add(time.Duration(viper.GetInt("GCLOUD_FEED_TASK_BUFFER_SECS")) * time.Second)
-
 	req := &taskspb.CreateTaskRequest{
 		Parent: queuePath,
 		Task: &taskspb.Task{
-			Name:         queuePath + "/tasks/" + eventID.String(),
+			Name:         queuePath + "/tasks/" + message.ID.String(),
 			ScheduleTime: timestamppb.New(scheduleOn),
 			MessageType: &taskspb.Task_AppEngineHttpRequest{
 				AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{
 					HttpMethod:       taskspb.HttpMethod_POST,
 					AppEngineRouting: &taskspb.AppEngineRouting{Service: service},
 					RelativeUri:      uri,
-					Headers: map[string]string{
-						"Content-type":  "application/json",
-						"Authorization": "Basic " + viper.GetString("FEEDBOT_SECRET"),
-					},
+					Headers:          headers,
 				},
 			},
 		},
 	}
 
-	body, err := json.Marshal(EventMessage{eventID, eventCode})
+	body, err := json.Marshal(message)
 	if err != nil {
 		return err
 	}
@@ -72,5 +66,16 @@ func createTaskForService(ctx context.Context, createdOn time.Time, eventID pers
 }
 
 func createTaskForFeedbot(ctx context.Context, createdOn time.Time, eventID persist.DBID, eventCode persist.EventCode) error {
-	return createTaskForService(ctx, createdOn, eventID, eventCode, "feedbot", "/tasks/feed-event")
+	queuePath := viper.GetString("GCLOUD_FEED_TASK_QUEUE")
+	buffer := viper.GetInt("GCLOUD_FEED_TASK_BUFFER_SECS")
+	scheduleOn := createdOn.Add(time.Duration(buffer) * time.Second)
+
+	headers := map[string]string{
+		"Content-type":  "application/json",
+		"Authorization": "Basic " + viper.GetString("FEEDBOT_SECRET"),
+	}
+
+	message := EventMessage{ID: eventID, EventCode: eventCode}
+
+	return createTaskForService(ctx, queuePath, scheduleOn, "feedbot", "/tasks/feed-event", headers, message)
 }

--- a/service/event/cloudtask/collection.go
+++ b/service/event/cloudtask/collection.go
@@ -16,13 +16,13 @@ func (c CollectionFeedTask) Handle(record persist.CollectionEventRecord) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	eventID, err := c.CollectionEventRepo.Add(ctx, record)
+	saved, err := c.CollectionEventRepo.Add(ctx, record)
 	if err != nil {
 		logrus.Errorf("failed to add event to collection event repo: %s", err)
 		return
 	}
 
-	err = createTaskForFeedbot(ctx, time.Time(record.CreationTime), eventID, record.Code)
+	err = createTaskForFeedbot(ctx, time.Time(saved.CreationTime), saved.ID, saved.Code)
 	if err != nil {
 		logrus.Errorf("failed to create task: %s", err)
 		return

--- a/service/event/cloudtask/nft.go
+++ b/service/event/cloudtask/nft.go
@@ -16,13 +16,13 @@ func (t NftFeedEvent) Handle(event persist.NftEventRecord) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	eventID, err := t.NftEventRepo.Add(ctx, event)
+	saved, err := t.NftEventRepo.Add(ctx, event)
 	if err != nil {
 		logrus.Errorf("failed to add event to token event repo: %s", err)
 		return
 	}
 
-	err = createTaskForFeedbot(ctx, time.Time(event.CreationTime), eventID, event.Code)
+	err = createTaskForFeedbot(ctx, time.Time(saved.CreationTime), saved.ID, saved.Code)
 	if err != nil {
 		logrus.Errorf("failed to create task: %s", err)
 		return

--- a/service/event/cloudtask/user.go
+++ b/service/event/cloudtask/user.go
@@ -16,13 +16,13 @@ func (u UserFeedTask) Handle(event persist.UserEventRecord) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	eventID, err := u.UserEventRepo.Add(ctx, event)
+	saved, err := u.UserEventRepo.Add(ctx, event)
 	if err != nil {
 		logrus.Errorf("failed to add event to user event repo: %s", err)
 		return
 	}
 
-	err = createTaskForFeedbot(ctx, time.Time(event.CreationTime), eventID, event.Code)
+	err = createTaskForFeedbot(ctx, time.Time(saved.CreationTime), saved.ID, saved.Code)
 	if err != nil {
 		logrus.Errorf("failed to create task: %s", err)
 		return

--- a/service/persist/collection_event.go
+++ b/service/persist/collection_event.go
@@ -36,7 +36,7 @@ func (c *CollectionEvent) Scan(value interface{}) error {
 }
 
 type CollectionEventRepository interface {
-	Add(context.Context, CollectionEventRecord) (DBID, error)
+	Add(context.Context, CollectionEventRecord) (*CollectionEventRecord, error)
 	Get(context.Context, DBID) (CollectionEventRecord, error)
 	GetEventsSince(context.Context, CollectionEventRecord, time.Time) ([]CollectionEventRecord, error)
 	GetEventBefore(context.Context, CollectionEventRecord) (*CollectionEventRecord, error)

--- a/service/persist/nft_event.go
+++ b/service/persist/nft_event.go
@@ -36,7 +36,7 @@ func (n *NftEvent) Scan(value interface{}) error {
 }
 
 type NftEventRepository interface {
-	Add(context.Context, NftEventRecord) (DBID, error)
+	Add(context.Context, NftEventRecord) (*NftEventRecord, error)
 	Get(context.Context, DBID) (NftEventRecord, error)
 	GetEventsSince(context.Context, NftEventRecord, time.Time) ([]NftEventRecord, error)
 	GetEventBefore(context.Context, NftEventRecord) (*NftEventRecord, error)

--- a/service/persist/user_event.go
+++ b/service/persist/user_event.go
@@ -35,7 +35,7 @@ func (u *UserEvent) Scan(value interface{}) error {
 }
 
 type UserEventRepository interface {
-	Add(context.Context, UserEventRecord) (DBID, error)
+	Add(context.Context, UserEventRecord) (*UserEventRecord, error)
 	Get(context.Context, DBID) (UserEventRecord, error)
 	GetEventsSince(context.Context, UserEventRecord, time.Time) ([]UserEventRecord, error)
 	GetEventBefore(context.Context, UserEventRecord) (*UserEventRecord, error)


### PR DESCRIPTION
Tasks were run immediately because the scheduled time used was the zeroed-out time value. Fixed by using when the event was saved to the database (plus the buffer) as the scheduled time.

Also moved some feedbot-specific things into the wrapper function. 