### PR TITLE
Don't delete an NFT if the same user still owns the same NFT in a different wallet

### DIFF
--- a/service/persist/postgres/collection_nft.go
+++ b/service/persist/postgres/collection_nft.go
@@ -450,33 +450,16 @@ func (c *CollectionRepository) ClaimNFTs(pCtx context.Context, pUserID persist.D
 	defer tx.Rollback()
 
 	deleteManyStmt := tx.StmtContext(pCtx, c.deleteNFTsStmt)
-	deleteStmt := tx.StmtContext(pCtx, c.deleteNFTStmt)
 	removeFromCollStmt := tx.StmtContext(pCtx, c.removeNFTFromCollectionsStmt)
-	updateOwnerStmt := tx.StmtContext(pCtx, c.updateOwnerAddressStmt)
 
 	nftsToRemoveIDs := make([]persist.DBID, 0, len(removing))
 
 	for removeID, removeOpenseaID := range removing {
 		remove := true
-		for id, openseaID := range newOpenseaIDs {
+		for _, openseaID := range newOpenseaIDs {
 			if removeOpenseaID == openseaID {
 				remove = false
-
-				var newAddress persist.NullString
-				err := c.getOwnerAddressStmt.QueryRowContext(pCtx, id).Scan(&newAddress)
-				if err != nil {
-					return err
-				}
-
-				_, err = deleteStmt.ExecContext(pCtx, id)
-				if err != nil {
-					return err
-				}
-
-				_, err = updateOwnerStmt.ExecContext(pCtx, newAddress, removeID)
-				if err != nil {
-					return err
-				}
+				break
 			}
 		}
 		if remove {


### PR DESCRIPTION
This is a fix for an issue one of our users was running into. When doing an Opensea refresh, it's possible for the user to have multiple copies of the same NFT spread throughout their wallets. Historically, we've tried to keep the old IDs (since they're potentially used in collections), but update them with the new owner_addresses. Unfortunately, this strategy can fail when working with multiple copies of an NFT distributed among different wallets, as we might attempt to map the same new address to multiple old versions of the NFT, and that violates a uniqueness constraint in our database.

As a fix, @bennycio and @Robinnnnn and I decided not to delete the old versions of the NFT at all. If the user brings in new copies of the same NFT, we'll keep the old ones and the new ones. This potentially allows the user to have more copies of the NFT than they should, but we'll also be implementing a follow-up PR to deduplicate these on the frontend.