### PR TITLE
[GAL-131] REQUIRE_NFTS speedup / Redis tracing / Tracing tweaks

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -54,7 +54,7 @@ func CoreInit(pqClient *sql.DB, pgx *pgxpool.Pool) *gin.Engine {
 		validate.RegisterCustomValidators(v)
 	}
 
-	if err := redis.ClearCache(); err != nil {
+	if err := redis.ClearCache(redis.GalleriesDB); err != nil {
 		panic(err)
 	}
 	return handlersInit(router, newRepos(pqClient), sqlc.New(pgx), newEthClient(), rpc.NewIPFSShell(), rpc.NewArweaveClient(), newStorageClient())

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"context"
-	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 )
@@ -16,13 +15,6 @@ func NewContextWithFields(parent context.Context, fields logrus.Fields) context.
 	return context.WithValue(parent, loggerContextKey, For(parent).WithFields(fields))
 }
 
-func NewContextWithSpan(parent context.Context, span *sentry.Span) context.Context {
-	return NewContextWithFields(parent, logrus.Fields{
-		"spanId":       span.SpanID,
-		"parentSpanId": span.ParentSpanID,
-	})
-}
-
 func SetLoggerOptions(optionsFunc func(logger *logrus.Logger)) {
 	optionsFunc(defaultLogger)
 }
@@ -31,7 +23,7 @@ func For(ctx context.Context) *logrus.Entry {
 	if ctx == nil {
 		return defaultEntry
 	}
-	
+
 	// If ctx is a *gin.Context, get the underlying request context
 	if gc, ok := ctx.(*gin.Context); ok {
 		ctx = gc.Request.Context()

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/mikeydub/go-gallery/service/logger"
-	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
+	"github.com/mikeydub/go-gallery/service/tracing"
 	"io"
 	"math/big"
 	"net"
@@ -34,7 +34,7 @@ import (
 var keepAliveTimeout = 600 * time.Second
 var client = &http.Client{
 	Timeout: time.Second * 30,
-	Transport: sentryutil.NewTracingTransport(&http.Transport{
+	Transport: tracing.NewTracingTransport(&http.Transport{
 		Dial: (&net.Dialer{
 			KeepAlive: keepAliveTimeout,
 		}).Dial,

--- a/service/tracing/http.go
+++ b/service/tracing/http.go
@@ -1,0 +1,49 @@
+package tracing
+
+import (
+	"fmt"
+	"github.com/getsentry/sentry-go"
+	"net/http"
+	"strings"
+)
+
+type tracingTransport struct {
+	http.RoundTripper
+
+	continueOnly bool
+}
+
+// NewTracingTransport creates an http transport that will trace requests via Sentry. If continueOnly is true,
+// traces will only be generated if they'd contribute to an existing parent trace (e.g. if a trace is not in progress,
+// no new trace would be started).
+func NewTracingTransport(roundTripper http.RoundTripper, continueOnly bool) *tracingTransport {
+	// If roundTripper is already a tracer, grab its underlying RoundTripper instead
+	if existingTracer, ok := roundTripper.(*tracingTransport); ok {
+		return &tracingTransport{RoundTripper: existingTracer.RoundTripper, continueOnly: continueOnly}
+	}
+
+	return &tracingTransport{RoundTripper: roundTripper, continueOnly: continueOnly}
+}
+
+func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.continueOnly {
+		transaction := sentry.TransactionFromContext(req.Context())
+		if transaction == nil {
+			return t.RoundTripper.RoundTrip(req)
+		}
+	}
+
+	span, _ := StartSpan(req.Context(), "http."+strings.ToLower(req.Method), fmt.Sprintf("HTTP %s %s", req.Method, req.URL.String()))
+	defer FinishSpan(span)
+
+	// Send sentry-trace header in case the receiving service can continue our trace
+	req.Header.Add("sentry-trace", span.TraceID.String())
+
+	response, err := t.RoundTripper.RoundTrip(req)
+
+	AddEventDataToSpan(span, map[string]interface{}{
+		"HTTP Status Code": response.StatusCode,
+	})
+
+	return response, err
+}

--- a/service/tracing/redis.go
+++ b/service/tracing/redis.go
@@ -1,0 +1,198 @@
+package tracing
+
+// Redis tracing hook, based on the OpenTelemetry hook here:
+// https://github.com/go-redis/redis/blob/v8.0.0-beta.5/redisext/otel.go
+
+import (
+	"context"
+	"fmt"
+	"github.com/getsentry/sentry-go"
+	"github.com/go-redis/redis/v8"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+func NewRedisHook(db int, dbName string, continueOnly bool) redis.Hook {
+	return redisHook{
+		db:           db,
+		dbName:       dbName,
+		continueOnly: continueOnly,
+	}
+}
+
+type redisHook struct {
+	db           int
+	dbName       string
+	continueOnly bool
+}
+
+var _ redis.Hook = redisHook{}
+
+type spanContextKey struct{}
+
+func (r redisHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+	if r.continueOnly {
+		transaction := sentry.TransactionFromContext(ctx)
+		if transaction == nil {
+			return ctx, nil
+		}
+	}
+
+	cmdBytes := make([]byte, 0, 32)
+	cmdString := string(appendCmd(cmdBytes, cmd))
+
+	span, ctx := StartSpan(ctx, "redis."+strings.ToLower(cmd.FullName()), r.dbName)
+
+	AddEventDataToSpan(span, map[string]interface{}{
+		"Redis Cmd": cmdString,
+		"Redis DB":  r.db,
+	})
+
+	ctx = context.WithValue(span.Context(), spanContextKey{}, span)
+
+	return ctx, nil
+}
+
+func (redisHook) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
+	if span, ok := ctx.Value(spanContextKey{}).(*sentry.Span); ok {
+		if err := cmd.Err(); err != nil {
+			AddEventDataToSpan(span, map[string]interface{}{
+				"Redis Error": err,
+			})
+		}
+
+		FinishSpan(span)
+	}
+
+	return nil
+}
+
+func (r redisHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+	if r.continueOnly {
+		transaction := sentry.TransactionFromContext(ctx)
+		if transaction == nil {
+			return ctx, nil
+		}
+	}
+
+	span, ctx := StartSpan(ctx, "redis.pipeline", r.dbName)
+
+	AddEventDataToSpan(span, map[string]interface{}{
+		"Redis Pipeline Num Cmds": len(cmds),
+		"Redis DB":                r.db,
+	})
+
+	ctx = context.WithValue(span.Context(), spanContextKey{}, span)
+
+	return ctx, nil
+}
+
+func (redisHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
+	if span, ok := ctx.Value(spanContextKey{}).(*sentry.Span); ok {
+		FinishSpan(span)
+	}
+
+	return nil
+}
+
+func appendCmd(b []byte, cmd redis.Cmder) []byte {
+	const lengthLimitPerArg = 64
+	isSetCmd := cmd.Name() == "set"
+
+	for i, arg := range cmd.Args() {
+		if i > 0 {
+			b = append(b, ' ')
+		}
+
+		start := len(b)
+		b = appendArg(b, arg)
+		argLength := len(b) - start
+
+		// The third element of a set command is the payload string
+		if isSetCmd && i == 2 {
+			b = append(b[:start], fmt.Sprintf("[scrubbed payload: %d bytes]", argLength)...)
+		} else if argLength > lengthLimitPerArg {
+			b = append(b[:start+lengthLimitPerArg], "..."...)
+		}
+	}
+
+	return b
+}
+
+// --------------------------------------------------------------------------------------------------------
+// Code below this point was copied from the redis/internal namespace, which the OpenTelemetry hook can
+// use (because it's part of the redis package) but we can't (because we're an external caller).
+// --------------------------------------------------------------------------------------------------------
+
+func appendArg(b []byte, v interface{}) []byte {
+	switch v := v.(type) {
+	case nil:
+		return append(b, "<nil>"...)
+	case string:
+		return appendUTF8String(b, v)
+	case []byte:
+		return appendUTF8String(b, string(v))
+	case int:
+		return strconv.AppendInt(b, int64(v), 10)
+	case int8:
+		return strconv.AppendInt(b, int64(v), 10)
+	case int16:
+		return strconv.AppendInt(b, int64(v), 10)
+	case int32:
+		return strconv.AppendInt(b, int64(v), 10)
+	case int64:
+		return strconv.AppendInt(b, v, 10)
+	case uint:
+		return strconv.AppendUint(b, uint64(v), 10)
+	case uint8:
+		return strconv.AppendUint(b, uint64(v), 10)
+	case uint16:
+		return strconv.AppendUint(b, uint64(v), 10)
+	case uint32:
+		return strconv.AppendUint(b, uint64(v), 10)
+	case uint64:
+		return strconv.AppendUint(b, v, 10)
+	case float32:
+		return strconv.AppendFloat(b, float64(v), 'f', -1, 64)
+	case float64:
+		return strconv.AppendFloat(b, v, 'f', -1, 64)
+	case bool:
+		if v {
+			return append(b, "true"...)
+		}
+		return append(b, "false"...)
+	case time.Time:
+		return v.AppendFormat(b, time.RFC3339Nano)
+	default:
+		return append(b, fmt.Sprint(v)...)
+	}
+}
+
+func appendUTF8String(b []byte, s string) []byte {
+	for _, r := range s {
+		b = appendRune(b, r)
+	}
+	return b
+}
+
+func appendRune(b []byte, r rune) []byte {
+	if r < utf8.RuneSelf {
+		switch c := byte(r); c {
+		case '\n':
+			return append(b, "\\n"...)
+		case '\r':
+			return append(b, "\\r"...)
+		default:
+			return append(b, c)
+		}
+	}
+
+	l := len(b)
+	b = append(b, make([]byte, utf8.UTFMax)...)
+	n := utf8.EncodeRune(b[l:l+utf8.UTFMax], r)
+	b = b[:l+n]
+
+	return b
+}

--- a/service/tracing/tracing.go
+++ b/service/tracing/tracing.go
@@ -1,0 +1,44 @@
+package tracing
+
+import (
+	"context"
+	"github.com/getsentry/sentry-go"
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/sirupsen/logrus"
+)
+
+func StartSpan(ctx context.Context, operation string, description string, options ...sentry.SpanOption) (*sentry.Span, context.Context) {
+	// TODO: Consider checking for a transaction, seeing if this trace should be sampled, and returning a nil span if not.
+	// Trace functionality in other methods can check for nil to see if trace data should be added.
+	span := sentry.StartSpan(ctx, operation, options...)
+	ctx = logger.NewContextWithFields(span.Context(), logrus.Fields{
+		"spanId":       span.SpanID,
+		"parentSpanId": span.ParentSpanID,
+	})
+
+	span.Description = description
+
+	return span, ctx
+}
+
+func FinishSpan(span *sentry.Span) {
+	if span == nil {
+		return
+	}
+
+	span.Finish()
+}
+
+func AddEventDataToSpan(span *sentry.Span, eventData map[string]interface{}) {
+	if span == nil {
+		return
+	}
+
+	if span.Data == nil {
+		span.Data = make(map[string]interface{})
+	}
+
+	for k, v := range eventData {
+		span.Data[k] = v
+	}
+}


### PR DESCRIPTION
# What's new?

## REQUIRE_NFTS
- We require a Gallery membership card to sign up or log in, but we _also_ require a membership card for any action that requires membership. In the GraphQL era, we're checking a user's auth status as part of any logged-in request, which means we run the REQUIRE_NFTS check every time a logged-in user does anything on our site.

- REQUIRE_NFTS fires off a call to Alchemy to see whether a user has one of our membership NFTs. This means that every time a logged-in user does anything, they have to wait for a round trip HTTP request from our servers to Alchemy. This often takes some ~400-500ms to complete.

- This PR addresses the issue by caching the result of that Alchemy call in Redis with a 1-hour expiration time. As long as a user has one of our membership cards when we check with Alchemy, they can keep using the site for the next hour without the need for another Alchemy round-trip. The 1-hour window was my guess at a good starting value; we can make this shorter or longer, but one round trip per hour seems okay to me.

## Redis Tracing
- Given the tracing PR I just finished, it should come as no surprise that I implemented Redis tracing while working on this REQUIRE_NFTS improvement. Nothing too crazy here: I took the OpenTelemetry tracing hook from the `go-redis` repository and customized it for our purposes.

## Tracing Tweaks
- I didn't want to make a `tracing` package in my original tracing PR because it didn't seem necessary, but with the addition of the Redis tracing hook, it made sense to create a new package. HTTP and Redis tracing implementations both live in the `tracing` package now, and I added a few utility methods (like `StartSpan` and `FinishSpan`) to make tracing easier.

## Auth Tweaks
- Also worth noting that I did some very minor refactoring in the `auth` package to make the "does user have required NFT" checking more reusable.
