### PR TITLE
Use username for follow input

### DIFF
--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -364,8 +364,8 @@ func (r *mutationResolver) Logout(ctx context.Context) (*model.LogoutPayload, er
 	return output, nil
 }
 
-func (r *mutationResolver) FollowUser(ctx context.Context, userID persist.DBID) (model.FollowUserPayloadOrError, error) {
-	err := publicapi.For(ctx).User.FollowUser(ctx, userID)
+func (r *mutationResolver) FollowUser(ctx context.Context, username string) (model.FollowUserPayloadOrError, error) {
+	err := publicapi.For(ctx).User.FollowUser(ctx, username)
 
 	if err != nil {
 		return nil, err
@@ -378,8 +378,8 @@ func (r *mutationResolver) FollowUser(ctx context.Context, userID persist.DBID) 
 	return output, err
 }
 
-func (r *mutationResolver) UnfollowUser(ctx context.Context, userID persist.DBID) (model.UnfollowUserPayloadOrError, error) {
-	err := publicapi.For(ctx).User.UnfollowUser(ctx, userID)
+func (r *mutationResolver) UnfollowUser(ctx context.Context, username string) (model.UnfollowUserPayloadOrError, error) {
+	err := publicapi.For(ctx).User.UnfollowUser(ctx, username)
 
 	if err != nil {
 		return nil, err

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -645,6 +645,6 @@ type Mutation {
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
     logout: LogoutPayload
 
-    followUser(userId: DBID!): FollowUserPayloadOrError @authRequired
-    unfollowUser(userId: DBID!): UnfollowUserPayloadOrError @authRequired
+    followUser(username: String!): FollowUserPayloadOrError @authRequired
+    unfollowUser(username: String!): UnfollowUserPayloadOrError @authRequired
 }

--- a/service/persist/user_event.go
+++ b/service/persist/user_event.go
@@ -18,9 +18,9 @@ type UserEventRecord struct {
 }
 
 type UserEvent struct {
-	Username   string     `json:"username"`
-	Bio        NullString `json:"bio"`
-	FolloweeID DBID       `json:"followee_id"`
+	Username     string     `json:"username"`
+	Bio          NullString `json:"bio"`
+	FolloweeName string     `json:"followee_name"`
 }
 
 func (u UserEvent) Value() (driver.Value, error) {


### PR DESCRIPTION
**Changes**
This PR updates the follow mutations to use `username` instead of the `userID` as the input type. I noticed that the `userByUsername` query uses `username` and thought it'd be good to keep the API consistent. 

This is also helpful for the feedbot, since it can use the `username` added to the event context to make the followee URL without needing to fetch more data. 