### PR TITLE
Add gRPC tracing

### DIFF
--- a/service/event/cloudtask/cloudtask.go
+++ b/service/event/cloudtask/cloudtask.go
@@ -25,8 +25,11 @@ type EventMessage struct {
 
 func newClient(ctx context.Context) (*gcptasks.Client, error) {
 	trace := tracing.NewTracingInterceptor(true)
-	dopt := grpc.WithUnaryInterceptor(trace.UnaryInterceptor)
-	copts := []option.ClientOption{option.WithGRPCDialOption(dopt)}
+
+	copts := []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithUnaryInterceptor(trace.UnaryInterceptor)),
+		option.WithGRPCDialOption(grpc.WithTimeout(time.Duration(2) * time.Second)),
+	}
 
 	if viper.GetString("ENV") == "local" {
 		copts = append(

--- a/service/event/cloudtask/cloudtask.go
+++ b/service/event/cloudtask/cloudtask.go
@@ -2,15 +2,19 @@ package cloudtask
 
 import (
 	"context"
+	"fmt"
+
 	"encoding/json"
 	"time"
 
 	gcptasks "cloud.google.com/go/cloudtasks/apiv2"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/spf13/viper"
 	"google.golang.org/api/option"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -20,62 +24,63 @@ type EventMessage struct {
 }
 
 func newClient(ctx context.Context) (*gcptasks.Client, error) {
-	if viper.GetString("ENV") != "local" {
-		return gcptasks.NewClient(ctx)
-	} else {
-		conn, err := grpc.Dial(viper.GetString("TASK_QUEUE_HOST"), grpc.WithInsecure())
-		if err != nil {
-			return nil, err
-		}
-		clientOpt := option.WithGRPCConn(conn)
-		return gcptasks.NewClient(ctx, clientOpt)
+	trace := tracing.NewTracingInterceptor(true)
+	dopt := grpc.WithUnaryInterceptor(trace.UnaryInterceptor)
+	copts := []option.ClientOption{option.WithGRPCDialOption(dopt)}
+
+	if viper.GetString("ENV") == "local" {
+		copts = append(
+			copts,
+			option.WithEndpoint(viper.GetString("TASK_QUEUE_HOST")),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+			option.WithoutAuthentication(),
+		)
 	}
+
+	return gcptasks.NewClient(ctx, copts...)
 }
 
-func createTaskForService(ctx context.Context, queuePath string, scheduleOn time.Time, service string, uri string, headers map[string]string, message EventMessage) error {
+func submitTask(ctx context.Context, client *gcptasks.Client, queue string, task *taskspb.Task, messageBody []byte) error {
+	req := &taskspb.CreateTaskRequest{Parent: queue, Task: task}
+	req.Task.GetAppEngineHttpRequest().Body = messageBody
+	_, err := client.CreateTask(ctx, req)
+	return err
+}
+
+func createTaskForFeedbot(ctx context.Context, createdOn time.Time, eventID persist.DBID, eventCode persist.EventCode) error {
+	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForFeedbot")
+	defer tracing.FinishSpan(span)
+
+	tracing.AddEventDataToSpan(span, map[string]interface{}{
+		"Event ID":   eventID,
+		"Event Code": eventCode,
+	})
+
 	client, err := newClient(ctx)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	req := &taskspb.CreateTaskRequest{
-		Parent: queuePath,
-		Task: &taskspb.Task{
-			Name:         queuePath + "/tasks/" + message.ID.String(),
-			ScheduleTime: timestamppb.New(scheduleOn),
-			MessageType: &taskspb.Task_AppEngineHttpRequest{
-				AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{
-					HttpMethod:       taskspb.HttpMethod_POST,
-					AppEngineRouting: &taskspb.AppEngineRouting{Service: service},
-					RelativeUri:      uri,
-					Headers:          headers,
+	queue := viper.GetString("GCLOUD_FEED_TASK_QUEUE")
+	task := &taskspb.Task{
+		Name:         fmt.Sprintf("%s/tasks/%s", queue, eventID.String()),
+		ScheduleTime: timestamppb.New(createdOn.Add(time.Duration(viper.GetInt("GCLOUD_FEED_TASK_BUFFER_SECS")) * time.Second)),
+		MessageType: &taskspb.Task_AppEngineHttpRequest{
+			AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{
+				HttpMethod:       taskspb.HttpMethod_POST,
+				AppEngineRouting: &taskspb.AppEngineRouting{Service: "feedbot"},
+				RelativeUri:      "/tasks/feed-event",
+				Headers: map[string]string{
+					"Content-type":  "application/json",
+					"Authorization": "Basic " + viper.GetString("FEEDBOT_SECRET"),
+					"sentry-trace":  span.TraceID.String(),
 				},
 			},
 		},
 	}
 
-	body, err := json.Marshal(message)
-	if err != nil {
-		return err
-	}
+	body, _ := json.Marshal(EventMessage{ID: eventID, EventCode: eventCode})
 
-	req.Task.GetAppEngineHttpRequest().Body = body
-	_, err = client.CreateTask(ctx, req)
-	return err
-}
-
-func createTaskForFeedbot(ctx context.Context, createdOn time.Time, eventID persist.DBID, eventCode persist.EventCode) error {
-	queuePath := viper.GetString("GCLOUD_FEED_TASK_QUEUE")
-	buffer := viper.GetInt("GCLOUD_FEED_TASK_BUFFER_SECS")
-	scheduleOn := createdOn.Add(time.Duration(buffer) * time.Second)
-
-	headers := map[string]string{
-		"Content-type":  "application/json",
-		"Authorization": "Basic " + viper.GetString("FEEDBOT_SECRET"),
-	}
-
-	message := EventMessage{ID: eventID, EventCode: eventCode}
-
-	return createTaskForService(ctx, queuePath, scheduleOn, "feedbot", "/tasks/feed-event", headers, message)
+	return submitTask(ctx, client, queue, task, body)
 }

--- a/service/event/cloudtask/collection.go
+++ b/service/event/cloudtask/collection.go
@@ -2,11 +2,12 @@ package cloudtask
 
 import (
 	"context"
-	"github.com/mikeydub/go-gallery/service/logger"
 	"time"
 
+	"github.com/mikeydub/go-gallery/service/logger"
+	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
+
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/sentry"
 )
 
 type CollectionFeedTask struct {
@@ -15,9 +16,6 @@ type CollectionFeedTask struct {
 
 func (c CollectionFeedTask) Handle(ctx context.Context, record persist.CollectionEventRecord) {
 	hub := sentryutil.SentryHubFromContext(ctx)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	saved, err := c.CollectionEventRepo.Add(ctx, record)
 	if err != nil {

--- a/service/event/cloudtask/nft.go
+++ b/service/event/cloudtask/nft.go
@@ -2,11 +2,12 @@ package cloudtask
 
 import (
 	"context"
-	"github.com/mikeydub/go-gallery/service/logger"
 	"time"
 
+	"github.com/mikeydub/go-gallery/service/logger"
+	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
+
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/sentry"
 )
 
 type NftFeedEvent struct {
@@ -15,9 +16,6 @@ type NftFeedEvent struct {
 
 func (t NftFeedEvent) Handle(ctx context.Context, event persist.NftEventRecord) {
 	hub := sentryutil.SentryHubFromContext(ctx)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	saved, err := t.NftEventRepo.Add(ctx, event)
 	if err != nil {

--- a/service/event/cloudtask/user.go
+++ b/service/event/cloudtask/user.go
@@ -17,9 +17,6 @@ type UserFeedTask struct {
 func (u UserFeedTask) Handle(ctx context.Context, event persist.UserEventRecord) {
 	hub := sentryutil.SentryHubFromContext(ctx)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	saved, err := u.UserEventRepo.Add(ctx, event)
 	if err != nil {
 		logger.For(ctx).Errorf("failed to add event to user event repo: %s", err)

--- a/service/event/collection.go
+++ b/service/event/collection.go
@@ -2,8 +2,8 @@ package event
 
 import (
 	"context"
+
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/sentry"
 )
 
 type CollectionDispatcher struct {
@@ -15,15 +15,11 @@ func (c CollectionDispatcher) Handle(eventCode persist.EventCode, handler Collec
 }
 
 func (c CollectionDispatcher) Dispatch(ctx context.Context, event persist.CollectionEventRecord) {
-	currentHub := sentryutil.SentryHubFromContext(ctx)
-
-	go func(hubCtx context.Context) {
-		if handlers, ok := c.Handlers[event.Code]; ok {
-			for _, handler := range handlers {
-				handler.Handle(hubCtx, event)
-			}
+	if handlers, ok := c.Handlers[event.Code]; ok {
+		for _, handler := range handlers {
+			handler.Handle(ctx, event)
 		}
-	}(sentryutil.NewSentryHubContext(ctx, currentHub))
+	}
 }
 
 type CollectionEventHandler interface {

--- a/service/event/nft.go
+++ b/service/event/nft.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/sentry"
 )
 
 type NftDispatcher struct {
@@ -16,15 +15,11 @@ func (c NftDispatcher) Handle(eventCode persist.EventCode, handler NftEventHandl
 }
 
 func (c NftDispatcher) Dispatch(ctx context.Context, event persist.NftEventRecord) {
-	currentHub := sentryutil.SentryHubFromContext(ctx)
-
-	go func(hubCtx context.Context) {
-		if handlers, ok := c.Handlers[event.Code]; ok {
-			for _, handler := range handlers {
-				handler.Handle(hubCtx, event)
-			}
+	if handlers, ok := c.Handlers[event.Code]; ok {
+		for _, handler := range handlers {
+			handler.Handle(ctx, event)
 		}
-	}(sentryutil.NewSentryHubContext(ctx, currentHub))
+	}
 }
 
 type NftEventHandler interface {

--- a/service/event/user.go
+++ b/service/event/user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/sentry"
 )
 
 type UserDispatcher struct {
@@ -16,15 +15,11 @@ func (c UserDispatcher) Handle(eventCode persist.EventCode, handler UserEventHan
 }
 
 func (c UserDispatcher) Dispatch(ctx context.Context, event persist.UserEventRecord) {
-	currentHub := sentryutil.SentryHubFromContext(ctx)
-
-	go func(hubCtx context.Context) {
-		if handlers, ok := c.Handlers[event.Code]; ok {
-			for _, handler := range handlers {
-				handler.Handle(hubCtx, event)
-			}
+	if handlers, ok := c.Handlers[event.Code]; ok {
+		for _, handler := range handlers {
+			handler.Handle(ctx, event)
 		}
-	}(sentryutil.NewSentryHubContext(ctx, currentHub))
+	}
 }
 
 type UserEventHandler interface {

--- a/service/tracing/grpc.go
+++ b/service/tracing/grpc.go
@@ -1,0 +1,54 @@
+package tracing
+
+import (
+	"context"
+
+	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
+
+	"github.com/getsentry/sentry-go"
+	"google.golang.org/grpc"
+)
+
+type TracingInterceptor struct {
+	continueOnly bool
+}
+
+func (t TracingInterceptor) UnaryInterceptor(ctx context.Context, method string, req interface{}, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	if t.continueOnly {
+		transaction := sentry.TransactionFromContext(ctx)
+		if transaction == nil {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+	}
+
+	span, ctx := StartSpan(ctx, "grpc.call", method, sentry.TransactionName(method))
+	defer FinishSpan(span)
+
+	err := invoker(ctx, method, req, reply, cc, opts...)
+
+	if taskReq, ok := req.(*taskspb.CreateTaskRequest); ok {
+		AddEventDataToSpan(span, map[string]interface{}{
+			"Queue":     taskReq.Parent,
+			"Task Name": taskReq.Task.Name,
+		})
+
+		if appReq, ok := taskReq.Task.MessageType.(*taskspb.Task_AppEngineHttpRequest); ok {
+			if _, ok := appReq.AppEngineHttpRequest.Headers["Authorization"]; ok {
+				appReq.AppEngineHttpRequest.Headers["Authorization"] = "[filtered]"
+			}
+
+			AddEventDataToSpan(span, map[string]interface{}{
+				"HTTP Method":  appReq.AppEngineHttpRequest.HttpMethod,
+				"Relative URI": appReq.AppEngineHttpRequest.RelativeUri,
+				"Headers":      appReq.AppEngineHttpRequest.Headers,
+				"Body":         appReq.AppEngineHttpRequest.GetBody(),
+			})
+		}
+	}
+
+	return err
+}
+
+func NewTracingInterceptor(continueOnly bool) TracingInterceptor {
+	return TracingInterceptor{continueOnly: continueOnly}
+}

--- a/service/tracing/grpc.go
+++ b/service/tracing/grpc.go
@@ -41,7 +41,7 @@ func (t TracingInterceptor) UnaryInterceptor(ctx context.Context, method string,
 				"HTTP Method":  appReq.AppEngineHttpRequest.HttpMethod,
 				"Relative URI": appReq.AppEngineHttpRequest.RelativeUri,
 				"Headers":      appReq.AppEngineHttpRequest.Headers,
-				"Body":         appReq.AppEngineHttpRequest.GetBody(),
+				"Body":         string(appReq.AppEngineHttpRequest.GetBody()),
 			})
 		}
 	}


### PR DESCRIPTION
This PR adds gRPC tracing so that we can [trace requests to Cloud Tasks](https://sentry.io/organizations/usegallery/performance/gallery-backend:6ecaf0abafa94e19bfb9d995a5e98aa6/?environment=local&project=6262886&query=transaction.duration%3A%3C15m+http.method%3APOST&showTransactions=recent&statsPeriod=1h&transaction=POST+%2Fglry%2Fgraphql%2Fquery+%28useUpdateUserMutation%29&unselectedSeries=p100%28%29) and also helps pave the way for tracing requests in the feedbot.

One biggish change is that the event handlers no longer run in a separate goroutine, but I think it's a good tradeoff so that the trace is added to the current transaction. It'd require creating a new context since gin closes the context after the response is sent and being able to add the parent span to the new context. Sentry doesn't export this function atm: https://github.com/getsentry/sentry-go/blob/master/tracing.go#L598 which would let us grab the most recent span. 

This should be ok since it doesn't take long at all (< 10ms) and we can keep an eye on it now that it's being traced. I also added a default 2 second timeout so that it doesn't hang forever.

edit: oh just noticed there is a ContinueFromTrace that should work https://github.com/getsentry/sentry-go/blob/master/tracing.go#L557