### PR TITLE
Use indexed query when looking up tokens by wallet ID

### DIFF
--- a/db/migrations/000010_multichain.up.sql
+++ b/db/migrations/000010_multichain.up.sql
@@ -38,3 +38,5 @@ ALTER TABLE contracts ADD COLUMN IF NOT EXISTS CHAIN int;
 
 CREATE UNIQUE INDEX IF NOT EXISTS contract_address_idx ON contracts (ADDRESS,CHAIN);
 
+CREATE INDEX IF NOT EXISTS token_owned_by_wallets_idx ON tokens USING GIN (OWNED_BY_WALLETS);
+

--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -112,5 +112,8 @@ SELECT u.* FROM follows f
     WHERE f.follower = $1 AND f.deleted = false
     ORDER BY f.last_updated DESC;
 
--- name: GetTokensByWalletIdBatch :batchmany
-SELECT * FROM tokens WHERE $1 = ANY(owned_by_wallets) AND deleted = false;
+-- name: GetTokensByWalletIds :many
+SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false;
+
+-- name: GetTokensByWalletIdsBatch :batchmany
+SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false;

--- a/db/sqlc/models_gen.go
+++ b/db/sqlc/models_gen.go
@@ -198,6 +198,7 @@ type Nonce struct {
 	UserID      sql.NullString
 	Address     sql.NullString
 	Value       sql.NullString
+	Chain       sql.NullInt32
 }
 
 type Token struct {
@@ -211,7 +212,6 @@ type Token struct {
 	ContractAddress  sql.NullString
 	CollectorsNote   sql.NullString
 	Media            pgtype.JSONB
-	Chain            sql.NullInt32
 	TokenUri         sql.NullString
 	TokenType        sql.NullString
 	TokenID          sql.NullString
@@ -222,6 +222,7 @@ type Token struct {
 	BlockNumber      sql.NullInt64
 	OwnerUserID      persist.DBID
 	OwnedByWallets   persist.DBIDList
+	Chain            sql.NullInt32
 }
 
 type User struct {

--- a/docker/postgres/02_init.sql
+++ b/docker/postgres/02_init.sql
@@ -90,6 +90,7 @@ CREATE TABLE IF NOT EXISTS nonces (
     CREATED_AT timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
     USER_ID varchar(255),
     ADDRESS varchar(255),
+    CHAIN int,
     VALUE varchar(255)
 );
 
@@ -288,3 +289,5 @@ CREATE INDEX IF NOT EXISTS user_id_event_code_last_updated ON user_events (USER_
 CREATE INDEX IF NOT EXISTS user_id_nft_id_event_code_last_updated ON nft_events (USER_ID, NFT_ID, EVENT_CODE, LAST_UPDATED DESC);
 
 CREATE INDEX IF NOT EXISTS user_id_collection_id_event_code_last_updated ON collection_events (USER_ID, COLLECTION_ID, EVENT_CODE, LAST_UPDATED DESC);
+
+CREATE INDEX IF NOT EXISTS token_owned_by_wallets_idx ON tokens USING GIN (OWNED_BY_WALLETS);

--- a/graphql/dataloader/dataloaders.go
+++ b/graphql/dataloader/dataloaders.go
@@ -610,12 +610,12 @@ func loadTokensByWalletID(ctx context.Context, loaders *Loaders, q *sqlc.Queries
 		tokens := make([][]sqlc.Token, len(walletIds))
 		errors := make([]error, len(walletIds))
 
-		convertedIds := make([]interface{}, len(walletIds))
+		convertedIds := make([]persist.DBIDList, len(walletIds))
 		for i, id := range walletIds {
-			convertedIds[i] = id
+			convertedIds[i] = persist.DBIDList{id}
 		}
 
-		b := q.GetTokensByWalletIdBatch(ctx, convertedIds)
+		b := q.GetTokensByWalletIdsBatch(ctx, convertedIds)
 		defer b.Close()
 
 		b.Query(func(i int, t []sqlc.Token, err error) {


### PR DESCRIPTION
Create a GIN index on `tokens.owned_by_wallets` and use array operations to query for tokens by wallet ID (because using non-array operations like `ANY` means we won't benefit from the index). Prior to this change, looking up tokens for a wallet took about 300ms. After indexing, it takes about 10ms.