### PR TITLE
Use collections table instead of collections_v2

### DIFF
--- a/db/migrations/000012_drop_collections_v2.down.sql
+++ b/db/migrations/000012_drop_collections_v2.down.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS collections_v2
+(
+    ID              varchar(255) PRIMARY KEY,
+    DELETED         boolean     NOT NULL DEFAULT false,
+    OWNER_USER_ID   varchar(255),
+    NFTS            varchar(255)[],
+    VERSION         int,
+    LAST_UPDATED    timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CREATED_AT      timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    HIDDEN          boolean     NOT NULL DEFAULT false,
+    COLLECTORS_NOTE varchar,
+    NAME            varchar(255),
+    LAYOUT          jsonb
+);

--- a/db/migrations/000012_drop_collections_v2.down.sql
+++ b/db/migrations/000012_drop_collections_v2.down.sql
@@ -12,3 +12,5 @@ CREATE TABLE IF NOT EXISTS collections_v2
     NAME            varchar(255),
     LAYOUT          jsonb
 );
+
+ALTER TABLE collections ALTER COLUMN layout TYPE json USING layout::json;

--- a/db/migrations/000012_drop_collections_v2.up.sql
+++ b/db/migrations/000012_drop_collections_v2.up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS collections_v2;

--- a/db/migrations/000012_drop_collections_v2.up.sql
+++ b/db/migrations/000012_drop_collections_v2.up.sql
@@ -1,1 +1,3 @@
 DROP TABLE IF EXISTS collections_v2;
+
+ALTER TABLE collections ALTER COLUMN layout TYPE jsonb USING layout::jsonb;

--- a/publicapi/collection.go
+++ b/publicapi/collection.go
@@ -62,7 +62,7 @@ func (api CollectionAPI) CreateCollection(ctx context.Context, galleryID persist
 		"galleryID":      {galleryID, "required"},
 		"name":           {name, "collection_name"},
 		"collectorsNote": {collectorsNote, "collection_note"},
-		"tokens":         {tokens, fmt.Sprintf("required,unique,max=%d", maxTokensPerCollection)},
+		"tokens":         {tokens, fmt.Sprintf("required,unique,min=1,max=%d", maxTokensPerCollection)},
 	}); err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (api CollectionAPI) UpdateCollectionTokens(ctx context.Context, collectionI
 	// Validate
 	if err := validateFields(api.validator, validationMap{
 		"collectionID": {collectionID, "required"},
-		"tokens":       {tokens, fmt.Sprintf("required,unique,max=%d", maxTokensPerCollection)},
+		"tokens":       {tokens, fmt.Sprintf("required,unique,min=1,max=%d", maxTokensPerCollection)},
 	}); err != nil {
 		return err
 	}

--- a/service/persist/postgres/collection_token.go
+++ b/service/persist/postgres/collection_token.go
@@ -45,45 +45,45 @@ func NewCollectionTokenRepository(db *sql.DB, galleryRepo *GalleryTokenRepositor
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	createStmt, err := db.PrepareContext(ctx, `INSERT INTO collections_v2 (ID, VERSION, NAME, COLLECTORS_NOTE, OWNER_USER_ID, LAYOUT, NFTS, HIDDEN) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING ID;`)
+	createStmt, err := db.PrepareContext(ctx, `INSERT INTO collections (ID, VERSION, NAME, COLLECTORS_NOTE, OWNER_USER_ID, LAYOUT, NFTS, HIDDEN) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING ID;`)
 	checkNoErr(err)
 
 	getByUserIDOwnerStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.COLLECTORS_NOTE,
 		c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,
 		n.ID,n.OWNER_USER_ID,n.CHAIN,n.NAME,n.DESCRIPTION,n.TOKEN_TYPE,n.TOKEN_URI,n.TOKEN_ID,n.MEDIA,n.TOKEN_METADATA,n.CONTRACT_ADDRESS,n.CREATED_AT 
-		FROM collections_v2 c, unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality) 
+		FROM collections c, unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality) 
 		JOIN tokens n ON n.ID = nft
 		WHERE c.OWNER_USER_ID = $1 AND c.DELETED = false AND n.DELETED = false ORDER BY ordinality;`)
 	checkNoErr(err)
-	getByUserIDOwnerRawStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED FROM collections_v2 c WHERE c.OWNER_USER_ID = $1 AND c.DELETED = false;`)
+	getByUserIDOwnerRawStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED FROM collections c WHERE c.OWNER_USER_ID = $1 AND c.DELETED = false;`)
 	checkNoErr(err)
 
 	getByIDOwnerStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.COLLECTORS_NOTE,
-	c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,
-	n.ID,n.OWNER_USER_ID,n.CHAIN,n.NAME,n.DESCRIPTION,n.TOKEN_TYPE,n.TOKEN_URI,n.TOKEN_ID,n.MEDIA,n.TOKEN_METADATA,n.CONTRACT_ADDRESS,n.CREATED_AT 
-	FROM collections_v2 c, unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality) 
-	JOIN tokens n ON n.ID = nft
-	WHERE c.ID = $1 AND c.DELETED = false AND n.DELETED = false ORDER BY ordinality;`)
+		c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,
+		n.ID,n.OWNER_USER_ID,n.CHAIN,n.NAME,n.DESCRIPTION,n.TOKEN_TYPE,n.TOKEN_URI,n.TOKEN_ID,n.MEDIA,n.TOKEN_METADATA,n.CONTRACT_ADDRESS,n.CREATED_AT 
+		FROM collections c, unnest(c.NFTS) WITH ORDINALITY AS u(nft, ordinality) 
+		JOIN tokens n ON n.ID = nft
+		WHERE c.ID = $1 AND c.DELETED = false AND n.DELETED = false ORDER BY ordinality;`)
 	checkNoErr(err)
 
-	getByIDOwnerRawStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED FROM collections_v2 c WHERE c.ID = $1 AND c.DELETED = false;`)
+	getByIDOwnerRawStmt, err := db.PrepareContext(ctx, `SELECT c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED FROM collections c WHERE c.ID = $1 AND c.DELETED = false;`)
 	checkNoErr(err)
 
-	updateInfoStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET COLLECTORS_NOTE = $1, NAME = $2, LAST_UPDATED = $3 WHERE ID = $4 AND OWNER_USER_ID = $5;`)
+	updateInfoStmt, err := db.PrepareContext(ctx, `UPDATE collections SET COLLECTORS_NOTE = $1, NAME = $2, LAST_UPDATED = $3 WHERE ID = $4 AND OWNER_USER_ID = $5;`)
 	checkNoErr(err)
-	updateInfoUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET COLLECTORS_NOTE = $1, NAME = $2, LAST_UPDATED = $3 WHERE ID = $4;`)
-	checkNoErr(err)
-
-	updateHiddenStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET HIDDEN = $1, LAST_UPDATED = $2 WHERE ID = $3 AND OWNER_USER_ID = $4;`)
+	updateInfoUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE collections SET COLLECTORS_NOTE = $1, NAME = $2, LAST_UPDATED = $3 WHERE ID = $4;`)
 	checkNoErr(err)
 
-	updateHiddenUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET HIDDEN = $1, LAST_UPDATED = $2 WHERE ID = $3;`)
+	updateHiddenStmt, err := db.PrepareContext(ctx, `UPDATE collections SET HIDDEN = $1, LAST_UPDATED = $2 WHERE ID = $3 AND OWNER_USER_ID = $4;`)
 	checkNoErr(err)
 
-	updateNFTsStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET NFTS = $1, LAYOUT = $2, LAST_UPDATED = $3 WHERE ID = $4 AND OWNER_USER_ID = $5;`)
+	updateHiddenUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE collections SET HIDDEN = $1, LAST_UPDATED = $2 WHERE ID = $3;`)
 	checkNoErr(err)
 
-	updateNFTsUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET NFTS = $1, LAYOUT = $2, LAST_UPDATED = $3 WHERE ID = $4;`)
+	updateNFTsStmt, err := db.PrepareContext(ctx, `UPDATE collections SET NFTS = $1, LAYOUT = $2, LAST_UPDATED = $3 WHERE ID = $4 AND OWNER_USER_ID = $5;`)
+	checkNoErr(err)
+
+	updateNFTsUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE collections SET NFTS = $1, LAYOUT = $2, LAST_UPDATED = $3 WHERE ID = $4;`)
 	checkNoErr(err)
 
 	nftsToRemoveStmt, err := db.PrepareContext(ctx, `SELECT ID FROM tokens WHERE OWNER_USER_ID = $1 AND ID <> ALL($2);`)
@@ -92,16 +92,16 @@ func NewCollectionTokenRepository(db *sql.DB, galleryRepo *GalleryTokenRepositor
 	deleteNFTsStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET DELETED = true WHERE ID = ANY($1)`)
 	checkNoErr(err)
 
-	removeNFTFromCollectionsStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET NFTS = array_remove(NFTS, $1) WHERE OWNER_USER_ID = $2;`)
+	removeNFTFromCollectionsStmt, err := db.PrepareContext(ctx, `UPDATE collections SET NFTS = array_remove(NFTS, $1) WHERE OWNER_USER_ID = $2;`)
 	checkNoErr(err)
 
 	getNFTsForAddressStmt, err := db.PrepareContext(ctx, `SELECT ID FROM tokens WHERE OWNER_USER_ID = $1;`)
 	checkNoErr(err)
 
-	deleteCollectionStmt, err := db.PrepareContext(ctx, `UPDATE collections_v2 SET DELETED = true WHERE ID = $1 AND OWNER_USER_ID = $2;`)
+	deleteCollectionStmt, err := db.PrepareContext(ctx, `UPDATE collections SET DELETED = true WHERE ID = $1 AND OWNER_USER_ID = $2;`)
 	checkNoErr(err)
 
-	getUserWalletsStmt, err := db.PrepareContext(ctx, `SELECT w.ID FROM users u, unnest(u.WALLETS) WITH ORDINALITY AS d(wallet, wallet_ord) LEFT JOIN wallets w on w.ID = wallet WHERE u.ID = $1;`)
+	getUserWalletsStmt, err := db.PrepareContext(ctx, `SELECT wallets FROM users WHERE ID = $1;`)
 	checkNoErr(err)
 
 	checkOwnNFTsStmt, err := db.PrepareContext(ctx, `SELECT COUNT(*) FROM tokens WHERE OWNER_USER_ID = $1 AND ID = ANY($2);`)
@@ -448,19 +448,19 @@ func (c *CollectionTokenRepository) Delete(pCtx context.Context, pID persist.DBI
 	return c.galleryRepo.RefreshCache(pCtx, pUserID)
 }
 
-func ensureTokensOwnedByUser(pCtx context.Context, c *CollectionTokenRepository, pUserID persist.DBID, nfts []persist.DBID) error {
-	var addresses []persist.EthereumAddress
-	err := c.getUserWalletsStmt.QueryRowContext(pCtx, pUserID).Scan(pq.Array(&addresses))
-	if err != nil {
-		return err
-	}
+func ensureTokensOwnedByUser(pCtx context.Context, c *CollectionTokenRepository, pUserID persist.DBID, tokens []persist.DBID) error {
+	//var addresses []persist.EthereumAddress
+	//err := c.getUserWalletsStmt.QueryRowContext(pCtx, pUserID).Scan(pq.Array(&addresses))
+	//if err != nil {
+	//	return err
+	//}
 
 	var ct int64
-	err = c.checkOwnNFTsStmt.QueryRowContext(pCtx, pq.Array(addresses), pq.Array(nfts)).Scan(&ct)
+	err := c.checkOwnNFTsStmt.QueryRowContext(pCtx, pUserID, pq.Array(tokens)).Scan(&ct)
 	if err != nil {
 		return err
 	}
-	if ct != int64(len(nfts)) {
+	if ct != int64(len(tokens)) {
 		return errNotOwnedByUser
 	}
 	return nil

--- a/service/persist/postgres/gallery_token.go
+++ b/service/persist/postgres/gallery_token.go
@@ -57,7 +57,7 @@ func NewGalleryTokenRepository(db *sql.DB, gCache memstore.Cache) *GalleryTokenR
 	c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,
 	n.ID,n.OWNER_USER_ID,n.CHAIN,n.NAME,n.DESCRIPTION,n.TOKEN_TYPE,n.TOKEN_URI,n.TOKEN_ID,n.MEDIA,n.TOKEN_METADATA,n.CONTRACT_ADDRESS,n.CREATED_AT 
 	FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord)
-	LEFT JOIN collections_v2 c ON c.ID = coll AND c.DELETED = false
+	LEFT JOIN collections c ON c.ID = coll AND c.DELETED = false
 	LEFT JOIN LATERAL (SELECT n.*,nft,nft_ord FROM tokens n, unnest(c.NFTS) WITH ORDINALITY AS x(nft, nft_ord)) n ON n.ID = n.nft
 	WHERE g.OWNER_USER_ID = $1 AND g.DELETED = false ORDER BY coll_ord,n.nft_ord;`)
 	checkNoErr(err)
@@ -66,7 +66,7 @@ func NewGalleryTokenRepository(db *sql.DB, gCache memstore.Cache) *GalleryTokenR
 	c.ID,c.OWNER_USER_ID,c.NAME,c.VERSION,c.DELETED,c.COLLECTORS_NOTE,c.LAYOUT,c.HIDDEN,c.CREATED_AT,c.LAST_UPDATED,
 	n.ID,n.OWNER_USER_ID,n.CHAIN,n.NAME,n.DESCRIPTION,n.TOKEN_TYPE,n.TOKEN_URI,n.TOKEN_ID,n.MEDIA,n.TOKEN_METADATA,n.CONTRACT_ADDRESS,n.CREATED_AT
 	FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord)
-	LEFT JOIN collections_v2 c ON c.ID = coll AND c.DELETED = false
+	LEFT JOIN collections c ON c.ID = coll AND c.DELETED = false
 	LEFT JOIN LATERAL (SELECT n.*,nft,nft_ord FROM tokens n, unnest(c.NFTS) WITH ORDINALITY AS x(nft, nft_ord)) n ON n.ID = n.nft
 	WHERE g.ID = $1 AND g.DELETED = false ORDER BY coll_ord,n.nft_ord;`)
 	checkNoErr(err)
@@ -77,19 +77,19 @@ func NewGalleryTokenRepository(db *sql.DB, gCache memstore.Cache) *GalleryTokenR
 	getByIDRawStmt, err := db.PrepareContext(ctx, `SELECT g.ID,g.VERSION,g.OWNER_USER_ID,g.CREATED_AT,g.LAST_UPDATED FROM galleries g WHERE g.ID = $1 AND g.DELETED = false;`)
 	checkNoErr(err)
 
-	checkOwnCollectionsStmt, err := db.PrepareContext(ctx, `SELECT COUNT(*) FROM collections_v2 WHERE ID = ANY($1) AND OWNER_USER_ID = $2;`)
+	checkOwnCollectionsStmt, err := db.PrepareContext(ctx, `SELECT COUNT(*) FROM collections WHERE ID = ANY($1) AND OWNER_USER_ID = $2;`)
 	checkNoErr(err)
 
-	countAllCollectionsStmt, err := db.PrepareContext(ctx, `SELECT COUNT(*) FROM collections_v2 WHERE OWNER_USER_ID = $1 AND DELETED = false;`)
+	countAllCollectionsStmt, err := db.PrepareContext(ctx, `SELECT COUNT(*) FROM collections WHERE OWNER_USER_ID = $1 AND DELETED = false;`)
 	checkNoErr(err)
 
-	countCollsStmt, err := db.PrepareContext(ctx, `SELECT COUNT(c.ID) FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord) LEFT JOIN collections_v2 c ON c.ID = coll WHERE g.ID = $1 AND c.DELETED = false and g.DELETED = false;`)
+	countCollsStmt, err := db.PrepareContext(ctx, `SELECT COUNT(c.ID) FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord) LEFT JOIN collections c ON c.ID = coll WHERE g.ID = $1 AND c.DELETED = false and g.DELETED = false;`)
 	checkNoErr(err)
 
-	getCollectionsStmt, err := db.PrepareContext(ctx, `SELECT ID FROM collections_v2 WHERE OWNER_USER_ID = $1 AND DELETED = false;`)
+	getCollectionsStmt, err := db.PrepareContext(ctx, `SELECT ID FROM collections WHERE OWNER_USER_ID = $1 AND DELETED = false;`)
 	checkNoErr(err)
 
-	getGalleryCollectionsStmt, err := db.PrepareContext(ctx, `SELECT array_agg(c.ID) FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord) LEFT JOIN collections_v2 c ON c.ID = coll WHERE g.ID = $1 AND c.DELETED = false and g.DELETED = false GROUP BY coll_ord ORDER BY coll_ord;`)
+	getGalleryCollectionsStmt, err := db.PrepareContext(ctx, `SELECT array_agg(c.ID) FROM galleries g, unnest(g.COLLECTIONS) WITH ORDINALITY AS u(coll, coll_ord) LEFT JOIN collections c ON c.ID = coll WHERE g.ID = $1 AND c.DELETED = false and g.DELETED = false GROUP BY coll_ord ORDER BY coll_ord;`)
 	checkNoErr(err)
 
 	return &GalleryTokenRepository{db: db, createStmt: createStmt, updateStmt: updateStmt, updateUnsafeStmt: updateUnsafeStmt, addCollectionsStmt: addCollectionsStmt, getByUserIDStmt: getByUserIDStmt, getByIDStmt: getByIDStmt, galleriesCache: gCache, checkOwnCollectionsStmt: checkOwnCollectionsStmt, countAllCollectionsStmt: countAllCollectionsStmt, countCollsStmt: countCollsStmt, getCollectionsStmt: getCollectionsStmt, getGalleryCollectionsStmt: getGalleryCollectionsStmt, getByUserIDRawStmt: getByUserIDRawStmt, getByIDRawStmt: getByIDRawStmt}

--- a/service/persist/user.go
+++ b/service/persist/user.go
@@ -57,7 +57,7 @@ type ErrUserNotFound struct {
 }
 
 func (e ErrUserNotFound) Error() string {
-	return fmt.Sprintf("user not found: address: %s, ID: %s, walletID: %s,username: %s, authenticator: %s", e.ChainAddress, e.WalletID, e.UserID, e.Username, e.Authenticator)
+	return fmt.Sprintf("user not found: address: %s, ID: %s, walletID: %s, username: %s, authenticator: %s", e.ChainAddress, e.UserID, e.WalletID, e.Username, e.Authenticator)
 }
 
 type ErrUserAlreadyExists struct {


### PR DESCRIPTION
Most `tokens` queries were using the `collections_v2` table, but we're not actually using that for anything, so this commit drops it and uses `collections` in queries instead. Fixes all sorts of issues we were having with collections (since they were being created in one table and queried from another).