### PR TITLE
Fix for updating token collector's notes

### DIFF
--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -353,8 +353,8 @@ func resolveWalletsByUserID(ctx context.Context, userID persist.DBID) ([]*model.
 
 	output := make([]*model.Wallet, 0, len(wallets))
 
-	for _, address := range wallets {
-		output = append(output, walletToModelSqlc(ctx, address))
+	for _, wallet := range wallets {
+		output = append(output, walletToModelSqlc(ctx, wallet))
 	}
 
 	return output, nil

--- a/service/persist/postgres/token_gallery.go
+++ b/service/persist/postgres/token_gallery.go
@@ -434,20 +434,16 @@ func (t *TokenGalleryRepository) UpdateByIDUnsafe(pCtx context.Context, pID pers
 
 // UpdateByID updates a token by its ID
 func (t *TokenGalleryRepository) UpdateByID(pCtx context.Context, pID persist.DBID, pUserID persist.DBID, pUpdate interface{}) error {
-	var addresses []persist.Wallet
-	err := t.getUserWalletsStmt.QueryRowContext(pCtx, pUserID).Scan(pq.Array(&addresses))
-	if err != nil {
-		return err
-	}
-
 	var res sql.Result
+	var err error
+
 	switch pUpdate.(type) {
 	case persist.TokenUpdateInfoInput:
 		update := pUpdate.(persist.TokenUpdateInfoInput)
-		res, err = t.updateInfoStmt.ExecContext(pCtx, update.CollectorsNote, update.LastUpdated, pID, pq.Array(addresses))
+		res, err = t.updateInfoStmt.ExecContext(pCtx, update.CollectorsNote, update.LastUpdated, pID, pUserID)
 	case persist.TokenUpdateMediaInput:
 		update := pUpdate.(persist.TokenUpdateMediaInput)
-		res, err = t.updateMediaStmt.ExecContext(pCtx, update.Media, update.TokenURI, update.Metadata, update.LastUpdated, pID, pq.Array(addresses))
+		res, err = t.updateMediaStmt.ExecContext(pCtx, update.Media, update.TokenURI, update.Metadata, update.LastUpdated, pID, pUserID)
 	default:
 		return fmt.Errorf("unsupported update type: %T", pUpdate)
 	}


### PR DESCRIPTION
SQL queries for updating tokens expect `owner_user_id`, but the code paths using these queries were passing an array of wallets. Now they're passing a user ID, and updating collector's notes works again.