### PR TITLE
contract refreshing in multichain

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/lib/pq"
 	"github.com/mikeydub/go-gallery/service/media"
+	"github.com/mikeydub/go-gallery/service/memstore/redis"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/rpc"
@@ -83,6 +84,7 @@ func setDefaults() {
 	viper.SetDefault("POSTGRES_PASSWORD", "")
 	viper.SetDefault("POSTGRES_DB", "postgres")
 	viper.SetDefault("RPC_URL", "wss://eth-mainnet.alchemyapi.io/v2/Lxc2B4z57qtwik_KfOS0I476UUUmXT86")
+	viper.SetDefault("REDIS_URL", "localhost:6379")
 
 	viper.AutomaticEnv()
 }
@@ -183,14 +185,20 @@ func getAllNFTs(pg *sql.DB, nftsChan chan<- persist.NFT) error {
 	return nil
 }
 
+type tokenContractCombo struct {
+	contract persist.ContractGallery
+	token    persist.TokenGallery
+}
+
 func migrateNFTs(pg *sql.DB, ethClient *ethclient.Client, nfts <-chan persist.NFT) error {
 	ctx := context.Background()
 	block, err := ethClient.BlockNumber(ctx)
 	if err != nil {
 		return err
 	}
+	communityRepo := postgres.NewCommunityRepository(pg, redis.NewCache(0))
 
-	toUpsertChan := make(chan persist.TokenGallery)
+	toUpsertChan := make(chan tokenContractCombo)
 	errChan := make(chan error)
 	go func() {
 		defer close(toUpsertChan)
@@ -198,12 +206,18 @@ func migrateNFTs(pg *sql.DB, ethClient *ethclient.Client, nfts <-chan persist.NF
 		for nft := range nfts {
 			n := nft
 			f := func() {
-				toUpsert, err := nftToToken(ctx, pg, n, block)
+				token, err := nftToToken(ctx, pg, n, block)
 				if err != nil {
 					errChan <- err
 					return
 				}
-				toUpsertChan <- toUpsert
+				comm, err := communityRepo.GetByAddress(ctx, persist.NewChainAddress(token.ContractAddress, token.Chain), true)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				contract := communityToContract(comm)
+				toUpsertChan <- tokenContractCombo{contract, token}
 			}
 
 			wp.Submit(f)
@@ -214,6 +228,7 @@ func migrateNFTs(pg *sql.DB, ethClient *ethclient.Client, nfts <-chan persist.NF
 	perUpsert := 2000
 
 	tokens := make([]persist.TokenGallery, perUpsert)
+	contracts := make([]persist.ContractGallery, perUpsert)
 	i := 0
 	j := 0
 	bar := progressbar.Default(int64(perUpsert), "Prepping Upsert")
@@ -226,16 +241,22 @@ func migrateNFTs(pg *sql.DB, ethClient *ethclient.Client, nfts <-chan persist.NF
 				if err != nil {
 					return err
 				}
+				err = upsertContracts(pg, dedupeContracts(contracts))
+				if err != nil {
+					return err
+				}
 				if !ok {
 					return nil
 				}
 				tokens = make([]persist.TokenGallery, perUpsert)
+				contracts = make([]persist.ContractGallery, perUpsert)
 				i = 0
 				j++
 				bar = progressbar.Default(int64(perUpsert), fmt.Sprintf("Prepping Upsert"))
 				logrus.Infof("Upserted NFTs %d", j)
 			}
-			tokens[i] = toUpsert
+			tokens[i] = toUpsert.token
+			contracts[i] = toUpsert.contract
 			bar.Add(1)
 			i++
 		case err := <-errChan:
@@ -370,6 +391,15 @@ func nftToToken(ctx context.Context, pg *sql.DB, nft persist.NFT, block uint64) 
 	return token, nil
 }
 
+func communityToContract(community persist.Community) persist.ContractGallery {
+	return persist.ContractGallery{
+		Chain:          community.Chain,
+		Address:        community.ContractAddress,
+		Name:           community.Name,
+		CreatorAddress: community.CreatorAddress,
+	}
+}
+
 func upsertTokens(pg *sql.DB, tokens []persist.TokenGallery) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
@@ -419,6 +449,41 @@ func dedupeTokens(pTokens []persist.TokenGallery) []persist.TokenGallery {
 		seen[key] = token
 	}
 	result := make([]persist.TokenGallery, 0, len(seen))
+	for _, v := range seen {
+		result = append(result, v)
+	}
+	return result
+}
+
+func upsertContracts(pg *sql.DB, pContracts []persist.ContractGallery) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	if len(pContracts) == 0 {
+		return nil
+	}
+	sqlStr := `INSERT INTO contracts (ID,VERSION,ADDRESS,SYMBOL,NAME,CREATOR_ADDRESS,CHAIN) VALUES `
+	vals := make([]interface{}, 0, len(pContracts)*7)
+	for i, contract := range pContracts {
+		sqlStr += generateValuesPlaceholders(7, i*7)
+		vals = append(vals, persist.GenerateID(), contract.Version, contract.Address, contract.Symbol, contract.Name, contract.CreatorAddress)
+		sqlStr += ","
+	}
+	sqlStr = sqlStr[:len(sqlStr)-1]
+	sqlStr += ` ON CONFLICT (ADDRESS,CHAIN) DO UPDATE SET SYMBOL = EXCLUDED.SYMBOL,NAME = EXCLUDED.NAME,CREATOR_ADDRESS = EXCLUDED.CREATOR_ADDRESS,CHAIN = EXCLUDED.CHAIN;`
+	_, err := pg.ExecContext(ctx, sqlStr, vals...)
+	if err != nil {
+		return fmt.Errorf("error bulk upserting contracts: %v - SQL: %s -- VALS: %+v", err, sqlStr, vals)
+	}
+
+	return nil
+}
+func dedupeContracts(pContracts []persist.ContractGallery) []persist.ContractGallery {
+	seen := map[persist.Address]persist.ContractGallery{}
+	for _, contract := range pContracts {
+		seen[contract.Address] = contract
+	}
+	result := make([]persist.ContractGallery, 0, len(seen))
 	for _, v := range seen {
 		result = append(result, v)
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -138,12 +138,35 @@ func (d *Provider) UpdateTokensForUser(ctx context.Context, userID persist.DBID)
 					return
 				}
 
+				contracts := make([]ChainAgnosticContract, 0, len(tokens))
+				for _, token := range tokens {
+					contract, err := provider.GetContractByAddress(ctx, token.ContractAddress)
+					if err != nil {
+						errChan <- err
+						return
+					}
+					contracts = append(contracts, contract)
+				}
+
 				newTokens, err := tokensToTokens(ctx, tokens, chain, user, addresses)
 				if err != nil {
 					errChan <- err
 					return
 				}
-				errChan <- d.TokenRepo.BulkUpsert(ctx, newTokens)
+				newContracts, err := contractsToContracts(ctx, contracts, chain, user, addresses)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if err := d.TokenRepo.BulkUpsert(ctx, newTokens); err != nil {
+					errChan <- err
+					return
+				}
+				if err := d.ContractRepo.BulkUpsert(ctx, newContracts); err != nil {
+					errChan <- err
+					return
+				}
+				errChan <- nil
 			}(addr, chain)
 		}
 	}
@@ -220,6 +243,22 @@ func tokensToTokens(ctx context.Context, tokens []ChainAgnosticToken, chain pers
 			ExternalURL:      persist.NullString(token.ExternalURL),
 			BlockNumber:      token.BlockNumber,
 		}
+	}
+	return res, nil
+
+}
+
+func contractsToContracts(ctx context.Context, contracts []ChainAgnosticContract, chain persist.Chain, ownerUser persist.User, ownerAddresses []persist.Address) ([]persist.ContractGallery, error) {
+	res := make([]persist.ContractGallery, len(contracts))
+	for i, contract := range contracts {
+		res[i] = persist.ContractGallery{
+			Chain:          chain,
+			Address:        contract.Address,
+			Symbol:         persist.NullString(contract.Symbol),
+			Name:           persist.NullString(contract.Name),
+			CreatorAddress: contract.CreatorAddress,
+		}
+
 	}
 	return res, nil
 


### PR DESCRIPTION
Changes:

- **Added** step to migration that will get a community for each NFT and upsert the community into the contracts table
- **Added** step to the refreshing of tokens in the `multichain` package that will get the contract for each NFT and update it as well.