### PR TITLE
Support early access allowlist

### DIFF
--- a/db/migrations/000010_create_early_access_table.down.sql
+++ b/db/migrations/000010_create_early_access_table.down.sql
@@ -1,2 +1,1 @@
-DROP INDEX IF EXISTS lowercase_address;
 DROP TABLE IF EXISTS early_access;

--- a/db/migrations/000010_create_early_access_table.down.sql
+++ b/db/migrations/000010_create_early_access_table.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS lowercase_address;
+DROP TABLE IF EXISTS early_access;

--- a/db/migrations/000010_create_early_access_table.up.sql
+++ b/db/migrations/000010_create_early_access_table.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS early_access
+(
+    address varchar(255) NOT NULL PRIMARY KEY
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS lowercase_address ON early_access (lower(address));

--- a/db/migrations/000010_create_early_access_table.up.sql
+++ b/db/migrations/000010_create_early_access_table.up.sql
@@ -1,6 +1,3 @@
-CREATE TABLE IF NOT EXISTS early_access
-(
+CREATE TABLE IF NOT EXISTS early_access (
     address varchar(255) NOT NULL PRIMARY KEY
 );
-
-CREATE UNIQUE INDEX IF NOT EXISTS lowercase_address ON early_access (lower(address));

--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -6,15 +6,10 @@ import (
 	"errors"
 	"fmt"
 	gqlgen "github.com/99designs/gqlgen/graphql"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/getsentry/sentry-go"
-	goredis "github.com/go-redis/redis/v8"
 	"github.com/mikeydub/go-gallery/graphql/model"
-	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
-	"github.com/mikeydub/go-gallery/service/memstore/redis"
-	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/tracing"
 
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
@@ -27,7 +22,6 @@ import (
 	"github.com/vektah/gqlparser/v2/validator"
 	"sort"
 	"strings"
-	"time"
 )
 
 const scrubText = "<scrubbed>"
@@ -82,8 +76,7 @@ func RemapAndReportErrors(ctx context.Context, next gqlgen.Resolver) (res interf
 	return res, err
 }
 
-func AuthRequiredDirectiveHandler(earlyAccessRepo persist.EarlyAccessRepository, ethClient *ethclient.Client) func(ctx context.Context, obj interface{}, next gqlgen.Resolver) (res interface{}, err error) {
-	redisClient := redis.NewCache(redis.RequireNftsDB)
+func AuthRequiredDirectiveHandler() func(ctx context.Context, obj interface{}, next gqlgen.Resolver) (res interface{}, err error) {
 
 	return func(ctx context.Context, obj interface{}, next gqlgen.Resolver) (res interface{}, err error) {
 		gc := util.GinContextFromContext(ctx)
@@ -122,43 +115,6 @@ func AuthRequiredDirectiveHandler(earlyAccessRepo persist.EarlyAccessRepository,
 		userID := auth.GetUserIDFromCtx(gc)
 		if userID == "" {
 			panic(fmt.Errorf("userID is empty, but no auth error occurred"))
-		}
-
-		if !viper.GetBool("REQUIRE_NFTS") {
-			return next(ctx)
-		}
-
-		// If we've verified this recently, use the cached result. The real check is pretty slow (~hundreds of milliseconds).
-		cachedResult, err := redisClient.Get(ctx, userID.String())
-		if err == nil {
-			if len(cachedResult) > 0 && cachedResult[0] == 1 {
-				return next(ctx)
-			}
-		} else if err != goredis.Nil {
-			sentryutil.ReportError(ctx, err)
-			logger.For(ctx).Warnf("checking REQUIRE_NFTS in cache failed with error: %s", err)
-		}
-
-		span, ctx := tracing.StartSpan(ctx, "gql.directive", "REQUIRE_NFTS")
-		defer tracing.FinishSpan(span)
-
-		user, err := publicapi.For(ctx).User.GetUserById(ctx, userID)
-
-		if err != nil {
-			return nil, err
-		}
-
-		if hasAccess, err := auth.HasGalleryAccess(ctx, user.Addresses, earlyAccessRepo, ethClient); !hasAccess {
-			errorMsg := err.Error()
-			modelErr := model.ErrDoesNotOwnRequiredNft{Message: errorMsg}
-			return makeErrNotAuthorized(errorMsg, modelErr), nil
-		}
-
-		// Cache the REQUIRE_NFTS result for an hour
-		err = redisClient.Set(ctx, userID.String(), []byte{1}, time.Hour)
-		if err != nil {
-			sentryutil.ReportError(ctx, err)
-			logger.For(ctx).Warnf("caching REQUIRE_NFTS result failed with error: %s\n", err)
 		}
 
 		return next(ctx)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/service/auth"
-	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/spf13/viper"
@@ -61,28 +60,6 @@ func AuthRequired(userRepository persist.UserRepository, ethClient *ethclient.Cl
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, util.ErrorResponse{Error: err.Error()})
 			return
-		}
-
-		if viper.GetBool("REQUIRE_NFTS") {
-			user, err := userRepository.GetByID(c, userID)
-			if err != nil {
-				c.AbortWithStatusJSON(http.StatusInternalServerError, util.ErrorResponse{Error: err.Error()})
-				return
-			}
-			has := false
-			for _, addr := range user.Addresses {
-				allowlist := auth.GetAllowlistContracts()
-				for k, v := range allowlist {
-					if res, _ := eth.HasNFTs(c, k, v, addr, ethClient); res {
-						has = true
-						break
-					}
-				}
-			}
-			if !has {
-				c.AbortWithStatusJSON(http.StatusBadRequest, util.ErrorResponse{Error: errUserDoesNotHaveRequiredNFT{addresses: user.Addresses}.Error()})
-				return
-			}
 		}
 
 		auth.SetAuthStateForCtx(c, userID, nil)

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -36,7 +36,7 @@ func (api AuthAPI) GetAuthNonce(ctx context.Context, address persist.Address) (n
 	gc := util.GinContextFromContext(ctx)
 	authed := auth.GetUserAuthedFromCtx(gc)
 
-	return auth.GetAuthNonce(ctx, address, authed, api.repos.UserRepository, api.repos.NonceRepository, api.ethClient)
+	return auth.GetAuthNonce(ctx, address, authed, api.repos.UserRepository, api.repos.NonceRepository, api.repos.EarlyAccessRepository, api.ethClient)
 }
 
 func (api AuthAPI) Login(ctx context.Context, authenticator auth.Authenticator) (persist.DBID, error) {

--- a/server/auth.go
+++ b/server/auth.go
@@ -19,7 +19,7 @@ type authHasNFTOutput struct {
 	HasNFT bool `json:"has_nft"`
 }
 
-func getAuthPreflight(userRepository persist.UserRepository, authNonceRepository persist.NonceRepository, ethClient *ethclient.Client) gin.HandlerFunc {
+func getAuthPreflight(userRepository persist.UserRepository, authNonceRepository persist.NonceRepository, earlyAccessRepository persist.EarlyAccessRepository, ethClient *ethclient.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		input := auth.GetPreflightInput{}
@@ -31,7 +31,7 @@ func getAuthPreflight(userRepository persist.UserRepository, authNonceRepository
 
 		authed := auth.GetUserAuthedFromCtx(c)
 
-		output, err := auth.GetAuthNonceREST(c, input, authed, userRepository, authNonceRepository, ethClient)
+		output, err := auth.GetAuthNonceREST(c, input, authed, userRepository, authNonceRepository, earlyAccessRepository, ethClient)
 		if err != nil {
 			status := http.StatusInternalServerError
 			if _, ok := err.(persist.ErrNonceNotFoundForAddress); ok {

--- a/server/handler.go
+++ b/server/handler.go
@@ -48,7 +48,7 @@ func graphqlHandlersInit(parent *gin.RouterGroup, repos *persist.Repositories, q
 
 func graphqlHandler(repos *persist.Repositories, queries *sqlc.Queries, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client) gin.HandlerFunc {
 	config := generated.Config{Resolvers: &graphql.Resolver{}}
-	config.Directives.AuthRequired = graphql.AuthRequiredDirectiveHandler(ethClient)
+	config.Directives.AuthRequired = graphql.AuthRequiredDirectiveHandler(repos.EarlyAccessRepository, ethClient)
 	config.Directives.RestrictEnvironment = graphql.RestrictEnvironmentDirectiveHandler()
 
 	schema := generated.NewExecutableSchema(config)
@@ -107,7 +107,7 @@ func authHandlersInitToken(parent *gin.RouterGroup, repos *persist.Repositories,
 	authGroup := parent.Group("/auth")
 
 	// AUTH
-	authGroup.GET("/get_preflight", middleware.AuthOptional(), getAuthPreflight(repos.UserRepository, repos.NonceRepository, ethClient))
+	authGroup.GET("/get_preflight", middleware.AuthOptional(), getAuthPreflight(repos.UserRepository, repos.NonceRepository, repos.EarlyAccessRepository, ethClient))
 	authGroup.GET("/jwt_valid", middleware.AuthOptional(), auth.ValidateJWT())
 	authGroup.GET("/is_member", middleware.AuthOptional(), hasNFTs(repos.UserRepository, ethClient, membership.PremiumCards, membership.MembershipTierIDs))
 	authGroup.POST("/logout", logout())
@@ -133,7 +133,7 @@ func authHandlersInitNFT(parent *gin.RouterGroup, repos *persist.Repositories, e
 	authGroup := parent.Group("/auth")
 
 	// AUTH
-	authGroup.GET("/get_preflight", middleware.AuthOptional(), getAuthPreflight(repos.UserRepository, repos.NonceRepository, ethClient))
+	authGroup.GET("/get_preflight", middleware.AuthOptional(), getAuthPreflight(repos.UserRepository, repos.NonceRepository, repos.EarlyAccessRepository, ethClient))
 	authGroup.GET("/jwt_valid", middleware.AuthOptional(), auth.ValidateJWT())
 	authGroup.GET("/is_member", middleware.AuthOptional(), hasNFTs(repos.UserRepository, ethClient, membership.PremiumCards, membership.MembershipTierIDs))
 	authGroup.POST("/logout", logout())

--- a/server/handler.go
+++ b/server/handler.go
@@ -48,7 +48,7 @@ func graphqlHandlersInit(parent *gin.RouterGroup, repos *persist.Repositories, q
 
 func graphqlHandler(repos *persist.Repositories, queries *sqlc.Queries, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client) gin.HandlerFunc {
 	config := generated.Config{Resolvers: &graphql.Resolver{}}
-	config.Directives.AuthRequired = graphql.AuthRequiredDirectiveHandler(repos.EarlyAccessRepository, ethClient)
+	config.Directives.AuthRequired = graphql.AuthRequiredDirectiveHandler()
 	config.Directives.RestrictEnvironment = graphql.RestrictEnvironmentDirectiveHandler()
 
 	schema := generated.NewExecutableSchema(config)

--- a/server/server.go
+++ b/server/server.go
@@ -92,7 +92,6 @@ func setDefaults() {
 	viper.SetDefault("GOOGLE_APPLICATION_CREDENTIALS", "_deploy/service-key.json")
 	viper.SetDefault("CONTRACT_ADDRESSES", "0x93eC9b03a9C14a530F582aef24a21d7FC88aaC46=[0,1,2,3,4,5,6,7,8]")
 	viper.SetDefault("CONTRACT_INTERACTION_URL", "https://eth-rinkeby.alchemyapi.io/v2/_2u--i79yarLYdOT4Bgydqa0dBceVRLD")
-	viper.SetDefault("REQUIRE_NFTS", false)
 	viper.SetDefault("ADMIN_PASS", "TEST_ADMIN_PASS")
 	viper.SetDefault("MIXPANEL_TOKEN", "")
 	viper.SetDefault("MIXPANEL_API_URL", "https://api.mixpanel.com/track")

--- a/server/server.go
+++ b/server/server.go
@@ -142,6 +142,7 @@ func newRepos(db *sql.DB) *persist.Repositories {
 		CollectionEventRepository: postgres.NewCollectionEventRepository(db),
 		NftEventRepository:        postgres.NewNftEventRepository(db),
 		CommunityRepository:       postgres.NewCommunityRepository(db, redis.NewCache(2)),
+		EarlyAccessRepository:     postgres.NewEarlyAccessRepository(db),
 	}
 }
 

--- a/service/persist/early_access.go
+++ b/service/persist/early_access.go
@@ -1,0 +1,7 @@
+package persist
+
+import "context"
+
+type EarlyAccessRepository interface {
+	IsAllowedByAddresses(context.Context, []Address) (bool, error)
+}

--- a/service/persist/persist.go
+++ b/service/persist/persist.go
@@ -71,6 +71,7 @@ type Repositories struct {
 	NftEventRepository        NftEventRepository
 	CollectionEventRepository CollectionEventRepository
 	CommunityRepository       CommunityRepository
+	EarlyAccessRepository     EarlyAccessRepository
 }
 
 // GenerateID generates a application-wide unique ID

--- a/service/persist/postgres/early_access.go
+++ b/service/persist/postgres/early_access.go
@@ -1,0 +1,43 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"github.com/lib/pq"
+	"github.com/mikeydub/go-gallery/service/persist"
+	"strings"
+	"time"
+)
+
+type EarlyAccessRepository struct {
+	db                    *sql.DB
+	existsByAddressesStmt *sql.Stmt
+}
+
+func NewEarlyAccessRepository(db *sql.DB) *EarlyAccessRepository {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	existsByAddressesStmt, err := db.PrepareContext(ctx, `SELECT EXISTS(SELECT 1 FROM early_access WHERE address = ANY($1));`)
+	checkNoErr(err)
+
+	return &EarlyAccessRepository{
+		db:                    db,
+		existsByAddressesStmt: existsByAddressesStmt,
+	}
+}
+
+func (u *EarlyAccessRepository) IsAllowedByAddresses(ctx context.Context, addresses []persist.Address) (bool, error) {
+	lowerAddresses := make([]string, len(addresses))
+	for i, address := range addresses {
+		lowerAddresses[i] = strings.ToLower(address.String())
+	}
+
+	var allowed bool
+	err := u.existsByAddressesStmt.QueryRowContext(ctx, pq.Array(addresses)).Scan(&allowed)
+	if err != nil {
+		return false, err
+	}
+
+	return allowed, nil
+}


### PR DESCRIPTION
## What's new?

- Added an `early_access` database table to hold allowlisted EA addresses
- `HasAllowlistNFT()` is now `HasGalleryAccess()` and checks both membership NFTs and the `early_access` database
- We only check membership NFTs and early access addresses when _creating_ an account. We no longer confirm membership for continued access to the site (i.e. the `REQUIRE_NFTS` check was removed)

## What's left to do?

- At some point in the future, we still need to remove the REQUIRE_NFTS entry from the various environment config files in the encrypted deploy directory, but I'd rather hold off on that and avoid the possibility of merge conflicts with the multichain branch.