### PR TITLE
Use lowercase addresses when querying early_access table

### DIFF
--- a/service/persist/postgres/early_access.go
+++ b/service/persist/postgres/early_access.go
@@ -34,7 +34,7 @@ func (u *EarlyAccessRepository) IsAllowedByAddresses(ctx context.Context, addres
 	}
 
 	var allowed bool
-	err := u.existsByAddressesStmt.QueryRowContext(ctx, pq.Array(addresses)).Scan(&allowed)
+	err := u.existsByAddressesStmt.QueryRowContext(ctx, pq.Array(lowerAddresses)).Scan(&allowed)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Dumb mistake. Created a list of lowercase addresses and then used the original list in the SQL query instead.