### PR TITLE
Sort by newest first when returning tokens for a user or wallet

### DIFF
--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -113,20 +113,24 @@ SELECT u.* FROM follows f
     ORDER BY f.last_updated DESC;
 
 -- name: GetTokensByWalletIds :many
-SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false;
+SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false
+    ORDER BY tokens.created_at DESC;
 
 -- name: GetTokensByWalletIdsBatch :batchmany
-SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false;
+SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false
+    ORDER BY tokens.created_at DESC;
 
 -- name: GetTokensByUserId :many
 SELECT tokens.* FROM tokens, users
     WHERE tokens.owner_user_id = $1 AND users.id = $1
       AND tokens.owned_by_wallets && users.wallets
-      AND tokens.deleted = false AND users.deleted = false;
+      AND tokens.deleted = false AND users.deleted = false
+    ORDER BY tokens.created_at DESC;
 
 -- name: GetTokensByUserIdBatch :batchmany
 SELECT tokens.* FROM tokens, users
     WHERE tokens.owner_user_id = $1 AND users.id = $1
       AND tokens.owned_by_wallets && users.wallets
-      AND tokens.deleted = false AND users.deleted = false;
+      AND tokens.deleted = false AND users.deleted = false
+    ORDER BY tokens.created_at DESC;
 


### PR DESCRIPTION
## What's new?

In the pre-multichain world, we returned a list of NFTs per wallet without any explicit sorting, but the returned NFTs seemed to be mostly sorted anyway (probably due to the way Postgres stores rows). This is no longer the case in the post-multichain world, so this PR adds explicit sorting when querying for a wallet's tokens or a user's tokens.