### PR TITLE
Stable sort order for tokens (again)

### DIFF
--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -114,23 +114,23 @@ SELECT u.* FROM follows f
 
 -- name: GetTokensByWalletIds :many
 SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false
-    ORDER BY tokens.created_at DESC;
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC;
 
 -- name: GetTokensByWalletIdsBatch :batchmany
 SELECT * FROM tokens WHERE owned_by_wallets && $1 AND deleted = false
-    ORDER BY tokens.created_at DESC;
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC;
 
 -- name: GetTokensByUserId :many
 SELECT tokens.* FROM tokens, users
     WHERE tokens.owner_user_id = $1 AND users.id = $1
       AND tokens.owned_by_wallets && users.wallets
       AND tokens.deleted = false AND users.deleted = false
-    ORDER BY tokens.created_at DESC;
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC;
 
 -- name: GetTokensByUserIdBatch :batchmany
 SELECT tokens.* FROM tokens, users
     WHERE tokens.owner_user_id = $1 AND users.id = $1
       AND tokens.owned_by_wallets && users.wallets
       AND tokens.deleted = false AND users.deleted = false
-    ORDER BY tokens.created_at DESC;
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC;
 

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -699,7 +699,7 @@ SELECT tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last
     WHERE tokens.owner_user_id = $1 AND users.id = $1
       AND tokens.owned_by_wallets && users.wallets
       AND tokens.deleted = false AND users.deleted = false
-    ORDER BY tokens.created_at DESC
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC
 `
 
 type GetTokensByUserIdBatchBatchResults struct {
@@ -770,7 +770,7 @@ func (b *GetTokensByUserIdBatchBatchResults) Close() error {
 
 const getTokensByWalletIdsBatch = `-- name: GetTokensByWalletIdsBatch :batchmany
 SELECT id, deleted, version, created_at, last_updated, name, description, collectors_note, media, token_uri, token_type, token_id, quantity, ownership_history, token_metadata, external_url, block_number, owner_user_id, owned_by_wallets, chain, contract FROM tokens WHERE owned_by_wallets && $1 AND deleted = false
-    ORDER BY tokens.created_at DESC
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC
 `
 
 type GetTokensByWalletIdsBatchBatchResults struct {

--- a/db/sqlc/query.sql.go
+++ b/db/sqlc/query.sql.go
@@ -301,7 +301,7 @@ SELECT tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last
     WHERE tokens.owner_user_id = $1 AND users.id = $1
       AND tokens.owned_by_wallets && users.wallets
       AND tokens.deleted = false AND users.deleted = false
-    ORDER BY tokens.created_at DESC
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC
 `
 
 func (q *Queries) GetTokensByUserId(ctx context.Context, ownerUserID persist.DBID) ([]Token, error) {
@@ -348,7 +348,7 @@ func (q *Queries) GetTokensByUserId(ctx context.Context, ownerUserID persist.DBI
 
 const getTokensByWalletIds = `-- name: GetTokensByWalletIds :many
 SELECT id, deleted, version, created_at, last_updated, name, description, collectors_note, media, token_uri, token_type, token_id, quantity, ownership_history, token_metadata, external_url, block_number, owner_user_id, owned_by_wallets, chain, contract FROM tokens WHERE owned_by_wallets && $1 AND deleted = false
-    ORDER BY tokens.created_at DESC
+    ORDER BY tokens.created_at DESC, tokens.name DESC, tokens.id DESC
 `
 
 func (q *Queries) GetTokensByWalletIds(ctx context.Context, ownedByWallets persist.DBIDList) ([]Token, error) {


### PR DESCRIPTION
## What's new?

My previous token sorting PR sorted tokens by creation time. Upon testing that against dev, I found that it's not uncommon for several tokens from the same collection to have been created at the same time. Since it'd be cool to show tokens in a stable sort order by default, I've updated the criteria to sort by: `creationTime`, then `name`, then `tokenID`.

Soooo now we'll show the newest stuff first, and if tokens were created at the same time we'll sort them by name (since tokens created at the same time often have names like `My Cool Token #14`, `My Cool Token #15`, etc), and if they have identical names, we'll sort them by ID too.