### PR TITLE
Filter out disconnected wallets' tokens in collections

### DIFF
--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -53,16 +53,18 @@ SELECT * FROM tokens WHERE id = $1 AND deleted = false;
 SELECT * FROM tokens WHERE id = $1 AND deleted = false;
 
 -- name: GetTokensByCollectionId :many
-SELECT t.* FROM collections c, unnest(c.nfts)
+SELECT t.* FROM users u, collections c, unnest(c.nfts)
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
-    WHERE c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
+    WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
+    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
 
 -- name: GetTokensByCollectionIdBatch :batchmany
-SELECT t.* FROM collections c, unnest(c.nfts)
+SELECT t.* FROM users u, collections c, unnest(c.nfts)
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
-    WHERE c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
+    WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
+    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
 
 -- name: GetMembershipByMembershipId :one
 SELECT * FROM membership WHERE id = $1 AND deleted = false;

--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -57,14 +57,14 @@ SELECT t.* FROM users u, collections c, unnest(c.nfts)
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
     WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
-    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
+    AND c.id = $1 AND u.deleted = false AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
 
 -- name: GetTokensByCollectionIdBatch :batchmany
 SELECT t.* FROM users u, collections c, unnest(c.nfts)
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
     WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
-    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
+    AND c.id = $1 AND u.deleted = false AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord;
 
 -- name: GetMembershipByMembershipId :one
 SELECT * FROM membership WHERE id = $1 AND deleted = false;

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -626,7 +626,7 @@ SELECT t.id, t.deleted, t.version, t.created_at, t.last_updated, t.name, t.descr
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
     WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
-    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
+    AND c.id = $1 AND u.deleted = false AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
 `
 
 type GetTokensByCollectionIdBatchBatchResults struct {

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -622,10 +622,11 @@ func (b *GetTokenByIdBatchBatchResults) Close() error {
 }
 
 const getTokensByCollectionIdBatch = `-- name: GetTokensByCollectionIdBatch :batchmany
-SELECT t.id, t.deleted, t.version, t.created_at, t.last_updated, t.name, t.description, t.collectors_note, t.media, t.token_uri, t.token_type, t.token_id, t.quantity, t.ownership_history, t.token_metadata, t.external_url, t.block_number, t.owner_user_id, t.owned_by_wallets, t.chain, t.contract FROM collections c, unnest(c.nfts)
+SELECT t.id, t.deleted, t.version, t.created_at, t.last_updated, t.name, t.description, t.collectors_note, t.media, t.token_uri, t.token_type, t.token_id, t.quantity, t.ownership_history, t.token_metadata, t.external_url, t.block_number, t.owner_user_id, t.owned_by_wallets, t.chain, t.contract FROM users u, collections c, unnest(c.nfts)
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
-    WHERE c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
+    WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
+    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
 `
 
 type GetTokensByCollectionIdBatchBatchResults struct {

--- a/db/sqlc/query.sql.go
+++ b/db/sqlc/query.sql.go
@@ -252,7 +252,7 @@ SELECT t.id, t.deleted, t.version, t.created_at, t.last_updated, t.name, t.descr
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
     WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
-    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
+    AND c.id = $1 AND u.deleted = false AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
 `
 
 func (q *Queries) GetTokensByCollectionId(ctx context.Context, id persist.DBID) ([]Token, error) {

--- a/db/sqlc/query.sql.go
+++ b/db/sqlc/query.sql.go
@@ -248,10 +248,11 @@ func (q *Queries) GetTokenById(ctx context.Context, id persist.DBID) (Token, err
 }
 
 const getTokensByCollectionId = `-- name: GetTokensByCollectionId :many
-SELECT t.id, t.deleted, t.version, t.created_at, t.last_updated, t.name, t.description, t.collectors_note, t.media, t.token_uri, t.token_type, t.token_id, t.quantity, t.ownership_history, t.token_metadata, t.external_url, t.block_number, t.owner_user_id, t.owned_by_wallets, t.chain, t.contract FROM collections c, unnest(c.nfts)
+SELECT t.id, t.deleted, t.version, t.created_at, t.last_updated, t.name, t.description, t.collectors_note, t.media, t.token_uri, t.token_type, t.token_id, t.quantity, t.ownership_history, t.token_metadata, t.external_url, t.block_number, t.owner_user_id, t.owned_by_wallets, t.chain, t.contract FROM users u, collections c, unnest(c.nfts)
     WITH ORDINALITY AS x(nft_id, nft_ord)
     INNER JOIN tokens t ON t.id = x.nft_id
-    WHERE c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
+    WHERE u.id = t.owner_user_id AND t.owned_by_wallets && u.wallets
+    AND c.id = $1 AND c.deleted = false AND t.deleted = false ORDER BY x.nft_ord
 `
 
 func (q *Queries) GetTokensByCollectionId(ctx context.Context, id persist.DBID) ([]Token, error) {


### PR DESCRIPTION
Prior to this change, disconnecting a wallet from a user's account would still allow tokens from that wallet to be displayed in the user's collections. The tokens would only disappear after an Opensea refresh.

This PR updates the "tokens by collection ID" query to only include tokens in wallets owned by the collection owner. The upshot is that disconnecting a wallet will immediately remove the affected tokens from the user's collections, which is consistent with the way the sidebar works (sidebar tokens disappear immediately after a wallet is disconnected).