### PR TITLE
no autogenerated IDs to prevent empty ID edge cases

### DIFF
--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -411,6 +411,10 @@ func nftToToken(ctx context.Context, pg *sql.DB, nft persist.NFT, contractID per
 	if err != nil && err != sql.ErrNoRows {
 		return persist.TokenGallery{}, err
 	}
+	ownedByWallets := []persist.Wallet{}
+	if walletID != "" {
+		ownedByWallets = append(ownedByWallets, persist.Wallet{ID: walletID})
+	}
 
 	token := persist.TokenGallery{
 		ID:               nft.ID,
@@ -422,7 +426,7 @@ func nftToToken(ctx context.Context, pg *sql.DB, nft persist.NFT, contractID per
 		OwnershipHistory: []persist.AddressAtBlock{},
 		CollectorsNote:   nft.CollectorsNote,
 		Chain:            persist.ChainETH,
-		OwnedByWallets:   []persist.Wallet{{ID: walletID}},
+		OwnedByWallets:   ownedByWallets,
 		TokenURI:         persist.TokenURI(nft.TokenMetadataURL),
 		TokenID:          nft.OpenseaTokenID,
 		OwnerUserID:      ownerUserID,

--- a/service/persist/persist.go
+++ b/service/persist/persist.go
@@ -101,9 +101,6 @@ func (d *DBID) Scan(i interface{}) error {
 
 // Value implements the database/sql driver Valuer interface for the DBID type
 func (d DBID) Value() (driver.Value, error) {
-	if d.String() == "" {
-		return GenerateID().String(), nil
-	}
 	return d.String(), nil
 }
 

--- a/service/persist/postgres/token.go
+++ b/service/persist/postgres/token.go
@@ -124,7 +124,7 @@ func (t *TokenRepository) CreateBulk(pCtx context.Context, pTokens []persist.Tok
 	vals := make([]interface{}, 0, len(pTokens)*15)
 	for i, token := range pTokens {
 		insertSQL += generateValuesPlaceholders(15, i*15) + ","
-		vals = append(vals, token.ID, token.Media, token.TokenType, token.Chain, token.Name, token.Description, token.TokenID, token.TokenURI, token.Quantity, token.OwnerAddress, pq.Array(token.OwnershipHistory), token.TokenMetadata, token.ContractAddress, token.ExternalURL, token.BlockNumber, token.Version)
+		vals = append(vals, persist.GenerateID(), token.Media, token.TokenType, token.Chain, token.Name, token.Description, token.TokenID, token.TokenURI, token.Quantity, token.OwnerAddress, pq.Array(token.OwnershipHistory), token.TokenMetadata, token.ContractAddress, token.ExternalURL, token.BlockNumber, token.Version)
 	}
 	insertSQL = insertSQL[:len(insertSQL)-1]
 	insertSQL += " RETURNING ID"
@@ -156,7 +156,7 @@ func (t *TokenRepository) CreateBulk(pCtx context.Context, pTokens []persist.Tok
 func (t *TokenRepository) Create(pCtx context.Context, pToken persist.Token) (persist.DBID, error) {
 
 	var id persist.DBID
-	err := t.createStmt.QueryRowContext(pCtx, pToken.ID, pToken.Version, pToken.Media, pToken.TokenMetadata, pToken.TokenType, pToken.TokenID, pToken.Chain, pToken.Name, pToken.Description, pToken.ExternalURL, pToken.BlockNumber, pToken.TokenURI, pToken.Quantity, pToken.OwnerAddress, pq.Array(pToken.OwnershipHistory), pToken.ContractAddress).Scan(&id)
+	err := t.createStmt.QueryRowContext(pCtx, persist.GenerateID(), pToken.Version, pToken.Media, pToken.TokenMetadata, pToken.TokenType, pToken.TokenID, pToken.Chain, pToken.Name, pToken.Description, pToken.ExternalURL, pToken.BlockNumber, pToken.TokenURI, pToken.Quantity, pToken.OwnerAddress, pq.Array(pToken.OwnershipHistory), pToken.ContractAddress).Scan(&id)
 	if err != nil {
 		return "", err
 	}

--- a/service/persist/postgres/token_gallery.go
+++ b/service/persist/postgres/token_gallery.go
@@ -146,7 +146,7 @@ func (t *TokenGalleryRepository) CreateBulk(pCtx context.Context, pTokens []pers
 	vals := make([]interface{}, 0, len(pTokens)*18)
 	for i, token := range pTokens {
 		insertSQL += generateValuesPlaceholders(18, i*18) + ","
-		vals = append(vals, token.ID, token.CollectorsNote, token.Media, token.TokenType, token.Chain, token.Name, token.Description, token.TokenID, token.TokenURI, token.Quantity, token.OwnerUserID, token.OwnedByWallets, pq.Array(token.OwnershipHistory), token.TokenMetadata, token.Contract, token.ExternalURL, token.BlockNumber, token.Version)
+		vals = append(vals, persist.GenerateID(), token.CollectorsNote, token.Media, token.TokenType, token.Chain, token.Name, token.Description, token.TokenID, token.TokenURI, token.Quantity, token.OwnerUserID, token.OwnedByWallets, pq.Array(token.OwnershipHistory), token.TokenMetadata, token.Contract, token.ExternalURL, token.BlockNumber, token.Version)
 	}
 	insertSQL = insertSQL[:len(insertSQL)-1]
 	insertSQL += " RETURNING ID"
@@ -178,7 +178,7 @@ func (t *TokenGalleryRepository) CreateBulk(pCtx context.Context, pTokens []pers
 func (t *TokenGalleryRepository) Create(pCtx context.Context, pToken persist.TokenGallery) (persist.DBID, error) {
 
 	var id persist.DBID
-	err := t.createStmt.QueryRowContext(pCtx, pToken.ID, pToken.Version, pToken.CollectorsNote, pToken.Media, pToken.TokenMetadata, pToken.TokenType, pToken.TokenID, pToken.Chain, pToken.Name, pToken.Description, pToken.ExternalURL, pToken.BlockNumber, pToken.TokenURI, pToken.Quantity, pToken.OwnerUserID, pToken.OwnedByWallets, pq.Array(pToken.OwnershipHistory), pToken.Contract).Scan(&id)
+	err := t.createStmt.QueryRowContext(pCtx, persist.GenerateID(), pToken.Version, pToken.CollectorsNote, pToken.Media, pToken.TokenMetadata, pToken.TokenType, pToken.TokenID, pToken.Chain, pToken.Name, pToken.Description, pToken.ExternalURL, pToken.BlockNumber, pToken.TokenURI, pToken.Quantity, pToken.OwnerUserID, pToken.OwnedByWallets, pq.Array(pToken.OwnershipHistory), pToken.Contract).Scan(&id)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Change:

- **Removed** `GenerateID()` from the `(DBID).Value()` function so that it only returns the string version of the DBID rather than automatically generating a new ID when it is empty. Generating the ID when the current DBID is empty leads to some unexpected effects that are hard to track down because there is nothing explicit about the `driver.Valuer` interface that would require the DBID to not be empty.
- **Changed** token persist funcs to explicitly generate IDs instead of relying on auto-generation.

I went through each insert/create func in the persist package to make sure they all explicitly generated IDs and the only ones that I found that didn't were two of the unused token funcs in both `token` and `token_gallery`.