### PR TITLE
refresh individual tokens and contracts

### DIFF
--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -79,6 +79,14 @@ type Node interface {
 	IsNode()
 }
 
+type RefreshContractMetadataPayloadOrError interface {
+	IsRefreshContractMetadataPayloadOrError()
+}
+
+type RefreshTokenMetadataPayloadOrError interface {
+	IsRefreshTokenMetadataPayloadOrError()
+}
+
 type RefreshTokensPayloadOrError interface {
 	IsRefreshTokensPayloadOrError()
 }
@@ -320,6 +328,8 @@ func (ErrInvalidInput) IsUpdateTokenInfoPayloadOrError()          {}
 func (ErrInvalidInput) IsAddUserWalletPayloadOrError()            {}
 func (ErrInvalidInput) IsRemoveUserWalletsPayloadOrError()        {}
 func (ErrInvalidInput) IsUpdateUserInfoPayloadOrError()           {}
+func (ErrInvalidInput) IsRefreshTokenMetadataPayloadOrError()     {}
+func (ErrInvalidInput) IsRefreshContractMetadataPayloadOrError()  {}
 func (ErrInvalidInput) IsError()                                  {}
 func (ErrInvalidInput) IsFollowUserPayloadOrError()               {}
 func (ErrInvalidInput) IsUnfollowUserPayloadOrError()             {}
@@ -513,6 +523,18 @@ type PreviewURLSet struct {
 	Large     *string `json:"large"`
 	SrcSet    *string `json:"srcSet"`
 }
+
+type RefreshContractMetadataPayload struct {
+	Contract *Contract `json:"contract"`
+}
+
+func (RefreshContractMetadataPayload) IsRefreshContractMetadataPayloadOrError() {}
+
+type RefreshTokenMetadataPayload struct {
+	Token *Token `json:"token"`
+}
+
+func (RefreshTokenMetadataPayload) IsRefreshTokenMetadataPayloadOrError() {}
 
 type RefreshTokensPayload struct {
 	Viewer *Viewer `json:"viewer"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -79,20 +79,20 @@ type Node interface {
 	IsNode()
 }
 
-type RefreshContractMetadataPayloadOrError interface {
-	IsRefreshContractMetadataPayloadOrError()
+type RefreshContractPayloadOrError interface {
+	IsRefreshContractPayloadOrError()
 }
 
-type RefreshTokenMetadataPayloadOrError interface {
-	IsRefreshTokenMetadataPayloadOrError()
-}
-
-type RefreshTokensPayloadOrError interface {
-	IsRefreshTokensPayloadOrError()
+type RefreshTokenPayloadOrError interface {
+	IsRefreshTokenPayloadOrError()
 }
 
 type RemoveUserWalletsPayloadOrError interface {
 	IsRemoveUserWalletsPayloadOrError()
+}
+
+type SyncTokensPayloadOrError interface {
+	IsSyncTokensPayloadOrError()
 }
 
 type TokenByIDOrError interface {
@@ -328,8 +328,8 @@ func (ErrInvalidInput) IsUpdateTokenInfoPayloadOrError()          {}
 func (ErrInvalidInput) IsAddUserWalletPayloadOrError()            {}
 func (ErrInvalidInput) IsRemoveUserWalletsPayloadOrError()        {}
 func (ErrInvalidInput) IsUpdateUserInfoPayloadOrError()           {}
-func (ErrInvalidInput) IsRefreshTokenMetadataPayloadOrError()     {}
-func (ErrInvalidInput) IsRefreshContractMetadataPayloadOrError()  {}
+func (ErrInvalidInput) IsRefreshTokenPayloadOrError()             {}
+func (ErrInvalidInput) IsRefreshContractPayloadOrError()          {}
 func (ErrInvalidInput) IsError()                                  {}
 func (ErrInvalidInput) IsFollowUserPayloadOrError()               {}
 func (ErrInvalidInput) IsUnfollowUserPayloadOrError()             {}
@@ -364,15 +364,17 @@ func (ErrNotAuthorized) IsUpdateTokenInfoPayloadOrError()          {}
 func (ErrNotAuthorized) IsAddUserWalletPayloadOrError()            {}
 func (ErrNotAuthorized) IsRemoveUserWalletsPayloadOrError()        {}
 func (ErrNotAuthorized) IsUpdateUserInfoPayloadOrError()           {}
-func (ErrNotAuthorized) IsRefreshTokensPayloadOrError()            {}
+func (ErrNotAuthorized) IsSyncTokensPayloadOrError()               {}
 func (ErrNotAuthorized) IsError()                                  {}
 
 type ErrOpenSeaRefreshFailed struct {
 	Message string `json:"message"`
 }
 
-func (ErrOpenSeaRefreshFailed) IsRefreshTokensPayloadOrError() {}
-func (ErrOpenSeaRefreshFailed) IsError()                       {}
+func (ErrOpenSeaRefreshFailed) IsSyncTokensPayloadOrError()      {}
+func (ErrOpenSeaRefreshFailed) IsRefreshTokenPayloadOrError()    {}
+func (ErrOpenSeaRefreshFailed) IsRefreshContractPayloadOrError() {}
+func (ErrOpenSeaRefreshFailed) IsError()                         {}
 
 type ErrTokenNotFound struct {
 	Message string `json:"message"`
@@ -524,29 +526,29 @@ type PreviewURLSet struct {
 	SrcSet    *string `json:"srcSet"`
 }
 
-type RefreshContractMetadataPayload struct {
+type RefreshContractPayload struct {
 	Contract *Contract `json:"contract"`
 }
 
-func (RefreshContractMetadataPayload) IsRefreshContractMetadataPayloadOrError() {}
+func (RefreshContractPayload) IsRefreshContractPayloadOrError() {}
 
-type RefreshTokenMetadataPayload struct {
+type RefreshTokenPayload struct {
 	Token *Token `json:"token"`
 }
 
-func (RefreshTokenMetadataPayload) IsRefreshTokenMetadataPayloadOrError() {}
-
-type RefreshTokensPayload struct {
-	Viewer *Viewer `json:"viewer"`
-}
-
-func (RefreshTokensPayload) IsRefreshTokensPayloadOrError() {}
+func (RefreshTokenPayload) IsRefreshTokenPayloadOrError() {}
 
 type RemoveUserWalletsPayload struct {
 	Viewer *Viewer `json:"viewer"`
 }
 
 func (RemoveUserWalletsPayload) IsRemoveUserWalletsPayloadOrError() {}
+
+type SyncTokensPayload struct {
+	Viewer *Viewer `json:"viewer"`
+}
+
+func (SyncTokensPayload) IsSyncTokensPayloadOrError() {}
 
 type TextMedia struct {
 	PreviewURLs      *PreviewURLSet `json:"previewURLs"`

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -88,23 +88,23 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
-	"RefreshContractMetadataPayloadOrError": func(object interface{}) (interface{}, bool) {
-		obj, ok := object.(RefreshContractMetadataPayloadOrError)
+	"RefreshContractPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(RefreshContractPayloadOrError)
 		return obj, ok
 	},
 
-	"RefreshTokenMetadataPayloadOrError": func(object interface{}) (interface{}, bool) {
-		obj, ok := object.(RefreshTokenMetadataPayloadOrError)
-		return obj, ok
-	},
-
-	"RefreshTokensPayloadOrError": func(object interface{}) (interface{}, bool) {
-		obj, ok := object.(RefreshTokensPayloadOrError)
+	"RefreshTokenPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(RefreshTokenPayloadOrError)
 		return obj, ok
 	},
 
 	"RemoveUserWalletsPayloadOrError": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(RemoveUserWalletsPayloadOrError)
+		return obj, ok
+	},
+
+	"SyncTokensPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(SyncTokensPayloadOrError)
 		return obj, ok
 	},
 

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -88,6 +88,16 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
+	"RefreshContractMetadataPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(RefreshContractMetadataPayloadOrError)
+		return obj, ok
+	},
+
+	"RefreshTokenMetadataPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(RefreshTokenMetadataPayloadOrError)
+		return obj, ok
+	},
+
 	"RefreshTokensPayloadOrError": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(RefreshTokensPayloadOrError)
 		return obj, ok

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -298,13 +298,53 @@ func (r *mutationResolver) UpdateTokenInfo(ctx context.Context, input model.Upda
 func (r *mutationResolver) RefreshTokens(ctx context.Context) (model.RefreshTokensPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
-	err := api.Token.RefreshTokens(ctx)
+	err := api.Token.RefreshTokensForUser(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	output := &model.RefreshTokensPayload{
 		Viewer: resolveViewer(ctx),
+	}
+
+	return output, nil
+}
+
+func (r *mutationResolver) RefreshTokenMetadata(ctx context.Context, tokenID persist.DBID) (model.RefreshTokenMetadataPayloadOrError, error) {
+	api := publicapi.For(ctx)
+
+	err := api.Token.RefreshToken(ctx, tokenID)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := resolveTokenByTokenID(ctx, tokenID)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &model.RefreshTokenMetadataPayload{
+		Token: token,
+	}
+
+	return output, nil
+}
+
+func (r *mutationResolver) RefreshContractMetadata(ctx context.Context, contractID persist.DBID) (model.RefreshContractMetadataPayloadOrError, error) {
+	api := publicapi.For(ctx)
+
+	err := api.Contract.RefreshContract(ctx, contractID)
+	if err != nil {
+		return nil, err
+	}
+
+	contract, err := resolveContractByContractID(ctx, contractID)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &model.RefreshContractMetadataPayload{
+		Contract: contract,
 	}
 
 	return output, nil

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -295,22 +295,22 @@ func (r *mutationResolver) UpdateTokenInfo(ctx context.Context, input model.Upda
 	return output, nil
 }
 
-func (r *mutationResolver) RefreshTokens(ctx context.Context) (model.RefreshTokensPayloadOrError, error) {
+func (r *mutationResolver) SyncTokens(ctx context.Context) (model.SyncTokensPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
-	err := api.Token.RefreshTokensForUser(ctx)
+	err := api.Token.SyncTokens(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	output := &model.RefreshTokensPayload{
+	output := &model.SyncTokensPayload{
 		Viewer: resolveViewer(ctx),
 	}
 
 	return output, nil
 }
 
-func (r *mutationResolver) RefreshTokenMetadata(ctx context.Context, tokenID persist.DBID) (model.RefreshTokenMetadataPayloadOrError, error) {
+func (r *mutationResolver) RefreshToken(ctx context.Context, tokenID persist.DBID) (model.RefreshTokenPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
 	err := api.Token.RefreshToken(ctx, tokenID)
@@ -323,14 +323,14 @@ func (r *mutationResolver) RefreshTokenMetadata(ctx context.Context, tokenID per
 		return nil, err
 	}
 
-	output := &model.RefreshTokenMetadataPayload{
+	output := &model.RefreshTokenPayload{
 		Token: token,
 	}
 
 	return output, nil
 }
 
-func (r *mutationResolver) RefreshContractMetadata(ctx context.Context, contractID persist.DBID) (model.RefreshContractMetadataPayloadOrError, error) {
+func (r *mutationResolver) RefreshContract(ctx context.Context, contractID persist.DBID) (model.RefreshContractPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
 	err := api.Contract.RefreshContract(ctx, contractID)
@@ -343,7 +343,7 @@ func (r *mutationResolver) RefreshContractMetadata(ctx context.Context, contract
 		return nil, err
 	}
 
-	output := &model.RefreshContractMetadataPayload{
+	output := &model.RefreshContractPayload{
 		Contract: contract,
 	}
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -530,6 +530,24 @@ type RefreshTokensPayload {
     viewer: Viewer
 }
 
+union RefreshTokenMetadataPayloadOrError =
+    RefreshTokenMetadataPayload
+  | ErrInvalidInput
+  | ErrOpenSeaRefreshFailed
+
+type RefreshTokenMetadataPayload {
+    token: Token
+}
+
+union RefreshContractMetadataPayloadOrError =
+    RefreshContractMetadataPayload
+  | ErrInvalidInput
+  | ErrOpenSeaRefreshFailed
+
+type RefreshContractMetadataPayload {
+    contract: Contract
+}
+
 type AuthNonce {
     nonce: String
     userExists: Boolean
@@ -684,6 +702,8 @@ type Mutation {
     updateTokenInfo(input: UpdateTokenInfoInput!): UpdateTokenInfoPayloadOrError @authRequired
 
     refreshTokens: RefreshTokensPayloadOrError @authRequired
+    refreshTokenMetadata(tokenID: DBID!): RefreshTokenMetadataPayloadOrError
+    refreshContractMetadata(contractID: DBID!): RefreshContractMetadataPayloadOrError
 
     getAuthNonce(chainAddress: ChainAddressInput!): GetAuthNoncePayloadOrError
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -521,30 +521,30 @@ type UpdateUserInfoPayload {
     viewer: Viewer
 }
 
-union RefreshTokensPayloadOrError =
-    RefreshTokensPayload
+union SyncTokensPayloadOrError =
+    SyncTokensPayload
     | ErrNotAuthorized
     | ErrOpenSeaRefreshFailed
 
-type RefreshTokensPayload {
+type SyncTokensPayload {
     viewer: Viewer
 }
 
-union RefreshTokenMetadataPayloadOrError =
-    RefreshTokenMetadataPayload
+union RefreshTokenPayloadOrError =
+    RefreshTokenPayload
   | ErrInvalidInput
   | ErrOpenSeaRefreshFailed
 
-type RefreshTokenMetadataPayload {
+type RefreshTokenPayload {
     token: Token
 }
 
-union RefreshContractMetadataPayloadOrError =
-    RefreshContractMetadataPayload
+union RefreshContractPayloadOrError =
+    RefreshContractPayload
   | ErrInvalidInput
   | ErrOpenSeaRefreshFailed
 
-type RefreshContractMetadataPayload {
+type RefreshContractPayload {
     contract: Contract
 }
 
@@ -701,9 +701,9 @@ type Mutation {
     # Token Mutations
     updateTokenInfo(input: UpdateTokenInfoInput!): UpdateTokenInfoPayloadOrError @authRequired
 
-    refreshTokens: RefreshTokensPayloadOrError @authRequired
-    refreshTokenMetadata(tokenID: DBID!): RefreshTokenMetadataPayloadOrError
-    refreshContractMetadata(contractID: DBID!): RefreshContractMetadataPayloadOrError
+    syncTokens: SyncTokensPayloadOrError @authRequired
+    refreshToken(tokenId: DBID!): RefreshTokenPayloadOrError
+    refreshContract(contractId: DBID!): RefreshContractPayloadOrError
 
     getAuthNonce(chainAddress: ChainAddressInput!): GetAuthNoncePayloadOrError
 

--- a/indexer/contracts.go
+++ b/indexer/contracts.go
@@ -1,8 +1,95 @@
 package indexer
 
-import "github.com/mikeydub/go-gallery/service/persist"
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/gin-gonic/gin"
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/service/rpc"
+	"github.com/mikeydub/go-gallery/util"
+)
 
 // GetContractOutput is the response for getting a single smart contract
 type GetContractOutput struct {
 	Contract persist.Contract `json:"contract"`
+}
+
+// GetContractInput is the input to the Get Contract endpoint
+type GetContractInput struct {
+	Address persist.EthereumAddress `form:"address,required"`
+}
+
+// UpdateContractMediaInput is used to refresh metadata for a given contract
+type UpdateContractMediaInput struct {
+	Address persist.EthereumAddress `json:"address,required"`
+}
+
+func getContract(contractsRepo persist.ContractRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input GetContractInput
+		if err := c.ShouldBindQuery(&input); err != nil {
+			err = util.ErrInvalidInput{Reason: fmt.Sprintf("must specify 'address' field: %v", err)}
+			util.ErrResponse(c, http.StatusBadRequest, err)
+			return
+		}
+
+		contract, err := contractsRepo.GetByAddress(c, input.Address)
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, GetContractOutput{Contract: contract})
+	}
+}
+
+func updateContractMedia(contractsRepo persist.ContractRepository, ethClient *ethclient.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input UpdateContractMediaInput
+		if err := c.ShouldBindJSON(&input); err != nil {
+			err = util.ErrInvalidInput{Reason: fmt.Sprintf("must specify 'address' field: %v", err)}
+			util.ErrResponse(c, http.StatusBadRequest, err)
+			return
+		}
+
+		newMetadata, err := rpc.GetTokenContractMetadata(c, input.Address, ethClient)
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+
+		latestBlock, err := ethClient.BlockNumber(c)
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+
+		up := persist.ContractUpdateInput{
+			Name:        persist.NullString(newMetadata.Name),
+			Symbol:      persist.NullString(newMetadata.Symbol),
+			LatestBlock: persist.BlockNumber(latestBlock),
+		}
+
+		timedContext, cancel := context.WithTimeout(c, time.Second*10)
+		defer cancel()
+
+		creator, err := rpc.GetContractCreator(timedContext, input.Address, ethClient)
+		if err != nil {
+			logger.For(c).Errorf("error finding creator address: %v", err)
+		} else {
+			up.CreatorAddress = creator
+		}
+
+		if err := contractsRepo.UpdateByAddress(c, input.Address, up); err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
+	}
 }

--- a/indexer/handler.go
+++ b/indexer/handler.go
@@ -17,12 +17,14 @@ func handlersInit(router *gin.Engine, i *indexer, tokenRepository persist.TokenR
 
 func handlersInitServer(router *gin.Engine, tokenRepository persist.TokenRepository, contractRepository persist.ContractRepository, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client) *gin.Engine {
 
-	mediaGroup := router.Group("/media")
-	mediaGroup.POST("/update", updateMedia(tokenRepository, ethClient, ipfsClient, arweaveClient, storageClient))
-
 	nftsGroup := router.Group("/nfts")
+	nftsGroup.POST("/refresh", updateTokenMedia(tokenRepository, ethClient, ipfsClient, arweaveClient, storageClient))
 	nftsGroup.POST("/validate", validateWalletsNFTs(tokenRepository, contractRepository, ethClient, ipfsClient, arweaveClient, storageClient))
 	nftsGroup.GET("/get", getTokens(tokenRepository, ipfsClient, ethClient))
+
+	contractsGroup := router.Group("/contracts")
+	contractsGroup.GET("/get", getContract(contractRepository))
+	contractsGroup.POST("/refresh", updateContractMedia(contractRepository, ethClient))
 
 	return router
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1055,7 +1055,9 @@ func fillContractFields(ethClient *ethclient.Client, contractAddress persist.Eth
 		Address:     contractAddress,
 		LatestBlock: lastSyncedBlock,
 	}
-	cMetadata, err := rpc.GetTokenContractMetadata(contractAddress, ethClient)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	cMetadata, err := rpc.GetTokenContractMetadata(ctx, contractAddress, ethClient)
 	if err != nil {
 		// TODO figure out what type of error this is
 		logrus.WithError(err).WithField("address", contractAddress).Error("error getting contract metadata")

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -97,14 +97,14 @@ func (api TokenAPI) GetTokensByUserID(ctx context.Context, userID persist.DBID) 
 	return tokens, nil
 }
 
-func (api TokenAPI) RefreshTokensForUser(ctx context.Context) error {
+func (api TokenAPI) SyncTokens(ctx context.Context) error {
 	// No validation to do
 	userID, err := getAuthenticatedUser(ctx)
 	if err != nil {
 		return err
 	}
 
-	err = api.multichainProvider.UpdateTokensForUser(ctx, userID)
+	err = api.multichainProvider.SyncTokens(ctx, userID)
 	if err != nil {
 		// Wrap all OpenSea sync failures in a generic type that can be returned to the frontend as an expected error type
 		return ErrTokenRefreshFailed{Message: err.Error()}

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -97,7 +97,7 @@ func (api TokenAPI) GetTokensByUserID(ctx context.Context, userID persist.DBID) 
 	return tokens, nil
 }
 
-func (api TokenAPI) RefreshTokens(ctx context.Context) error {
+func (api TokenAPI) RefreshTokensForUser(ctx context.Context) error {
 	// No validation to do
 	userID, err := getAuthenticatedUser(ctx)
 	if err != nil {
@@ -107,6 +107,32 @@ func (api TokenAPI) RefreshTokens(ctx context.Context) error {
 	err = api.multichainProvider.UpdateTokensForUser(ctx, userID)
 	if err != nil {
 		// Wrap all OpenSea sync failures in a generic type that can be returned to the frontend as an expected error type
+		return ErrTokenRefreshFailed{Message: err.Error()}
+	}
+
+	api.loaders.ClearAllCaches()
+
+	return nil
+}
+
+func (api TokenAPI) RefreshToken(ctx context.Context, tokenDBID persist.DBID) error {
+	if err := validateFields(api.validator, validationMap{
+		"tokenID": {tokenDBID, "required"},
+	}); err != nil {
+		return err
+	}
+
+	token, err := api.loaders.TokenByTokenID.Load(tokenDBID)
+	if err != nil {
+		return err
+	}
+	contract, err := api.loaders.ContractByContractId.Load(token.Contract)
+	if err != nil {
+		return err
+	}
+
+	err = api.multichainProvider.RefreshToken(ctx, persist.NewTokenIdentifiers(contract.Address, persist.TokenID(token.TokenID.String), persist.Chain(contract.Chain.Int32)))
+	if err != nil {
 		return ErrTokenRefreshFailed{Message: err.Error()}
 	}
 

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -63,7 +63,7 @@ func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Ad
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {
@@ -94,7 +94,7 @@ func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddre
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {
@@ -124,7 +124,7 @@ func (d *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentif
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {
@@ -154,7 +154,7 @@ func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Addres
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {
@@ -195,7 +195,7 @@ func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnostic
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {
@@ -232,7 +232,7 @@ func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Addr
 
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {
@@ -244,7 +244,7 @@ func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Addr
 	return nil
 }
 
-// RefreshContract refreshses the metadata for a contract
+// RefreshContract refreshes the metadata for a contract
 func (d *Provider) RefreshContract(ctx context.Context, addr persist.Address) error {
 	input := indexer.UpdateContractMediaInput{
 		Address: persist.EthereumAddress(persist.ChainETH.NormalizeAddress(addr)),
@@ -267,7 +267,7 @@ func (d *Provider) RefreshContract(ctx context.Context, addr persist.Address) er
 
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {
@@ -300,7 +300,7 @@ func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.A
 
 	defer res.Body.Close()
 
-	if res.StatusCode >= 299 || res.StatusCode < 200 {
+	if res.StatusCode != 200 {
 		errResp := util.ErrorResponse{}
 		err = json.NewDecoder(res.Body).Decode(&errResp)
 		if err != nil {

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -53,7 +53,7 @@ func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.Blockchain
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Ethereum Blockchain
 func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address) ([]multichain.ChainAgnosticToken, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/tokens?address=%s&limit=-1", d.indexerBaseURL, addr), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/nfts?address=%s", d.indexerBaseURL, addr), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddre
 }
 
 // GetTokensByTokenIdentifiers retrieves tokens for a token identifiers on the Ethereum Blockchain
-func (d *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers persist.TokenIdentifiers) ([]multichain.ChainAgnosticToken, error) {
+func (d *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers) ([]multichain.ChainAgnosticToken, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/nfts/get?contract_address=%s&token_id=%s&limit=-1", d.indexerBaseURL, tokenIdentifiers.ContractAddress, tokenIdentifiers.TokenID), nil)
 	if err != nil {
 		return nil, err
@@ -172,11 +172,46 @@ func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Addres
 
 }
 
+// RefreshToken refreshes the metadata for a given token.
+func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) error {
+
+	input := indexer.UpdateTokenMediaInput{
+		TokenID:         ti.TokenID,
+		ContractAddress: persist.EthereumAddress(persist.ChainETH.NormalizeAddress(ti.ContractAddress)),
+		UpdateAll:       true,
+	}
+
+	m, err := json.Marshal(input)
+
+	buf := bytes.NewBuffer(m)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/nfts/refresh", d.indexerBaseURL), buf)
+	if err != nil {
+		return err
+	}
+	res, err := d.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 299 || res.StatusCode < 200 {
+		errResp := util.ErrorResponse{}
+		err = json.NewDecoder(res.Body).Decode(&errResp)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("unexpected status: %s | err: %s ", res.Status, errResp.Error)
+	}
+
+	return nil
+}
+
 // UpdateMediaForWallet updates media for the tokens owned by a wallet on the Ethereum Blockchain
 func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 
-	input := indexer.UpdateMediaInput{
-		OwnerAddress: persist.EthereumAddress(wallet.String()),
+	input := indexer.UpdateTokenMediaInput{
+		OwnerAddress: persist.EthereumAddress(persist.ChainETH.NormalizeAddress(wallet)),
 		UpdateAll:    all,
 	}
 
@@ -185,7 +220,42 @@ func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Addr
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/update", d.indexerBaseURL), bytes.NewReader(asJSON))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/nfts/refresh", d.indexerBaseURL), bytes.NewReader(asJSON))
+	if err != nil {
+		return err
+	}
+
+	res, err := d.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode >= 299 || res.StatusCode < 200 {
+		errResp := util.ErrorResponse{}
+		err = json.NewDecoder(res.Body).Decode(&errResp)
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("unexpected status: %s | err: %s ", res.Status, errResp.Error)
+	}
+
+	return nil
+}
+
+// RefreshContract refreshses the metadata for a contract
+func (d *Provider) RefreshContract(ctx context.Context, addr persist.Address) error {
+	input := indexer.UpdateContractMediaInput{
+		Address: persist.EthereumAddress(persist.ChainETH.NormalizeAddress(addr)),
+	}
+
+	asJSON, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/contracts/refresh", d.indexerBaseURL), bytes.NewReader(asJSON))
 	if err != nil {
 		return err
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -61,6 +61,12 @@ type ChainAgnosticContract struct {
 	LatestBlock persist.BlockNumber `json:"latest_block"`
 }
 
+// ChainAgnosticIdentifiers identify tokens despite their chain
+type ChainAgnosticIdentifiers struct {
+	ContractAddress persist.Address `json:"contract_address"`
+	TokenID         persist.TokenID `json:"token_id"`
+}
+
 // ErrChainNotFound is an error that occurs when a chain provider for a given chain is not registered in the MultichainProvider
 type ErrChainNotFound struct {
 	Chain persist.Chain
@@ -87,8 +93,10 @@ type ChainProvider interface {
 	GetBlockchainInfo(context.Context) (BlockchainInfo, error)
 	GetTokensByWalletAddress(context.Context, persist.Address) ([]ChainAgnosticToken, []ChainAgnosticContract, error)
 	GetTokensByContractAddress(context.Context, persist.Address) ([]ChainAgnosticToken, ChainAgnosticContract, error)
-	GetTokensByTokenIdentifiers(context.Context, persist.TokenIdentifiers) ([]ChainAgnosticToken, []ChainAgnosticContract, error)
+	GetTokensByTokenIdentifiers(context.Context, ChainAgnosticIdentifiers) ([]ChainAgnosticToken, []ChainAgnosticContract, error)
 	GetContractByAddress(context.Context, persist.Address) (ChainAgnosticContract, error)
+	RefreshToken(context.Context, ChainAgnosticIdentifiers) error
+	RefreshContract(context.Context, persist.Address) error
 	// bool is whether or not to update all media content, including the tokens that already have media content
 	UpdateMediaForWallet(context.Context, persist.Address, bool) error
 	// do we want to return the tokens we validate?

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -245,6 +245,24 @@ func (d *Provider) VerifySignature(ctx context.Context, pSig string, pNonce stri
 	return provider.VerifySignature(ctx, pChainAddress.Address(), pWalletType, pNonce, pSig)
 }
 
+// RefreshToken refreshes a token on the given chain using the chain provider for that chain
+func (d *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers) error {
+	provider, ok := d.Chains[ti.Chain]
+	if !ok {
+		return ErrChainNotFound{Chain: ti.Chain}
+	}
+	return provider.RefreshToken(ctx, ChainAgnosticIdentifiers{ContractAddress: ti.ContractAddress, TokenID: ti.TokenID})
+}
+
+// RefreshContract refreshes a contract on the given chain using the chain provider for that chain
+func (d *Provider) RefreshContract(ctx context.Context, ci persist.ContractIdentifiers) error {
+	provider, ok := d.Chains[ci.Chain]
+	if !ok {
+		return ErrChainNotFound{Chain: ci.Chain}
+	}
+	return provider.RefreshContract(ctx, ci.ContractAddress)
+}
+
 func tokensToTokens(ctx context.Context, chaintokens []chainTokens, contractAddressIDs map[string]persist.DBID, ownerUser persist.User) ([]persist.TokenGallery, error) {
 	res := make([]persist.TokenGallery, 0, len(chaintokens))
 	seenWallets := make(map[persist.TokenIdentifiers][]persist.Wallet)

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -128,9 +128,9 @@ func NewMultiChainDataRetriever(ctx context.Context, tokenRepo persist.TokenGall
 	}
 }
 
-// UpdateTokensForUser updates the media for all tokens for a user
+// SyncTokens updates the media for all tokens for a user
 // TODO consider updating contracts as well
-func (d *Provider) UpdateTokensForUser(ctx context.Context, userID persist.DBID) error {
+func (d *Provider) SyncTokens(ctx context.Context, userID persist.DBID) error {
 	user, err := d.UserRepo.GetByID(ctx, userID)
 	if err != nil {
 		return err

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -184,7 +184,7 @@ func (p *Provider) GetTokensByContractAddress(ctx context.Context, address persi
 }
 
 // GetTokensByTokenIdentifiers returns a list of tokens for a list of token identifiers
-func (p *Provider) GetTokensByTokenIdentifiers(ctx context.Context, ti persist.TokenIdentifiers) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (p *Provider) GetTokensByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	assetsChan := make(chan assetsReceieved)
 	go func() {
 		defer close(assetsChan)
@@ -566,6 +566,16 @@ func contractToContract(ctx context.Context, openseaContract Contract, ethClient
 		CreatorAddress: persist.Address(openseaContract.Collection.PayoutAddress),
 		LatestBlock:    persist.BlockNumber(block),
 	}, nil
+}
+
+// RefreshToken refreshes the metadata for a given token.
+func (p *Provider) RefreshToken(context.Context, multichain.ChainAgnosticIdentifiers) error {
+	return nil
+}
+
+// RefreshContract refreshses the metadata for a contract
+func (p *Provider) RefreshContract(context.Context, persist.Address) error {
+	return nil
 }
 
 // VerifySignature will verify a signature using all available methods (eth_sign and personal_sign)

--- a/service/persist/contract.go
+++ b/service/persist/contract.go
@@ -23,9 +23,19 @@ type Contract struct {
 	LatestBlock BlockNumber `json:"latest_block"`
 }
 
+// ContractUpdateInput is the input for updating contract metadata fields
+type ContractUpdateInput struct {
+	Symbol         NullString      `json:"symbol"`
+	Name           NullString      `json:"name"`
+	CreatorAddress EthereumAddress `json:"creator_address"`
+
+	LatestBlock BlockNumber `json:"latest_block"`
+}
+
 // ContractRepository represents a repository for interacting with persisted contracts
 type ContractRepository interface {
 	GetByAddress(context.Context, EthereumAddress) (Contract, error)
+	UpdateByAddress(context.Context, EthereumAddress, ContractUpdateInput) error
 	UpsertByAddress(context.Context, EthereumAddress, Contract) error
 	BulkUpsert(context.Context, []Contract) error
 }

--- a/service/persist/postgres/contract.go
+++ b/service/persist/postgres/contract.go
@@ -28,7 +28,7 @@ func NewContractRepository(db *sql.DB) *ContractRepository {
 	upsertByAddressStmt, err := db.PrepareContext(ctx, `INSERT INTO contracts (ID,VERSION,ADDRESS,SYMBOL,NAME,LATEST_BLOCK,CREATOR_ADDRESS) VALUES ($1,$2,$3,$4,$5,$6,$7) ON CONFLICT (ADDRESS) DO UPDATE SET VERSION = $2,ADDRESS = $3,SYMBOL = $4,NAME = $5,LATEST_BLOCK = $6,CREATOR_ADDRESS = $7;`)
 	checkNoErr(err)
 
-	updateByAddressStmt, err := db.PrepareContext(ctx, `UPDATE contracts SET NAME = $2, SYMBOL = $3, CREATOR_ADDRESS = $4, LATEST_BLOCK = $5 WHERE ADDRESS = $1;`)
+	updateByAddressStmt, err := db.PrepareContext(ctx, `UPDATE contracts SET NAME = $2, SYMBOL = $3, CREATOR_ADDRESS = $4, LATEST_BLOCK = $5, LAST_UPDATED = $6 WHERE ADDRESS = $1;`)
 	checkNoErr(err)
 
 	return &ContractRepository{db: db, getByAddressStmt: getByAddressStmt, upsertByAddressStmt: upsertByAddressStmt, updateByAddressStmt: updateByAddressStmt}
@@ -80,7 +80,7 @@ func (c *ContractRepository) BulkUpsert(pCtx context.Context, pContracts []persi
 
 // UpdateByAddress updates the given contract's metadata fields by its address field.
 func (c *ContractRepository) UpdateByAddress(ctx context.Context, addr persist.EthereumAddress, up persist.ContractUpdateInput) error {
-	if _, err := c.updateByAddressStmt.ExecContext(ctx, addr, up.Name, up.Symbol, up.CreatorAddress, up.LatestBlock); err != nil {
+	if _, err := c.updateByAddressStmt.ExecContext(ctx, addr, up.Name, up.Symbol, up.CreatorAddress, up.LatestBlock, persist.LastUpdatedTime{}); err != nil {
 		return err
 	}
 	return nil

--- a/service/persist/token_gallery.go
+++ b/service/persist/token_gallery.go
@@ -54,6 +54,12 @@ type TokenIdentifiers struct {
 	Chain           Chain   `json:"chain"`
 }
 
+// ContractIdentifiers represents a unique identifier for a contract
+type ContractIdentifiers struct {
+	ContractAddress Address `json:"contract_address"`
+	Chain           Chain   `json:"chain"`
+}
+
 // TokenInCollection represents a token within a collection
 type TokenInCollection struct {
 	ID           DBID         `json:"id" binding:"required"`
@@ -162,6 +168,14 @@ func (t *TokenIdentifiers) Scan(i interface{}) error {
 		Chain:           Chain(chain),
 	}
 	return nil
+}
+
+// NewContractIdentifiers creates a new contract identifiers
+func NewContractIdentifiers(pContractAddress Address, pChain Chain) ContractIdentifiers {
+	return ContractIdentifiers{
+		ContractAddress: pContractAddress,
+		Chain:           pChain,
+	}
 }
 
 // Scan implements the database/sql Scanner interface for the AddressAtBlock type

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -96,15 +96,13 @@ func NewArweaveClient() *goar.Client {
 }
 
 // GetTokenContractMetadata returns the metadata for a given contract (without URI)
-func GetTokenContractMetadata(address persist.EthereumAddress, ethClient *ethclient.Client) (*TokenContractMetadata, error) {
+func GetTokenContractMetadata(ctx context.Context, address persist.EthereumAddress, ethClient *ethclient.Client) (*TokenContractMetadata, error) {
 	contract := address.Address()
 	instance, err := contracts.NewIERC721MetadataCaller(contract, ethClient)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
 	name, err := instance.Name(&bind.CallOpts{
 		Context: ctx,
 	})

--- a/util/response.go
+++ b/util/response.go
@@ -18,7 +18,7 @@ type SuccessResponse struct {
 
 // ErrInvalidInput is an error response for an invalid input
 type ErrInvalidInput struct {
-	Reason string
+	Reason string `json:"reason"`
 }
 
 func (e ErrInvalidInput) Error() string {


### PR DESCRIPTION
Changes:

- **Added** endpoint to indexer for refreshing contracts manually
- **Added** two functions to the `ChainProvider` interface for refreshing individual tokens and contracts as well as implemented those functions for the opensea and indexer chain providers.

Considerations:

- We need the frontend to call these functions somewhere so they probably need to have their own graph QL endpoints, so we will follow this PR up with another PR for graph QL endpoints.
- Should the refreshing of tokens and contracts be combined into one `ChainProvider` function where the contract for a given token is refreshed when a token is refreshed. We could do this at the graphQL level as well if we wanted to and have one "refresh" endpoint that refreshes the contract for a token and the token. I also imagine that there could be a refresh button on individual NFT pages for refreshing tokens and also a button on community pages for refreshing a contract. 