### PR TITLE
Init pgx client once

### DIFF
--- a/feed/event.go
+++ b/feed/event.go
@@ -3,6 +3,7 @@ package feed
 import (
 	"context"
 
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/mikeydub/go-gallery/db/sqlc"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -16,8 +17,8 @@ type EventBuilder struct {
 	feedRepo  *postgres.FeedRepository
 }
 
-func NewEventBuilder() *EventBuilder {
-	queries := sqlc.New(postgres.NewPgxClient())
+func NewEventBuilder(pgx *pgxpool.Pool) *EventBuilder {
+	queries := sqlc.New(pgx)
 	return &EventBuilder{
 		eventRepo: &postgres.EventRepository{Queries: queries},
 		feedRepo:  &postgres.FeedRepository{Queries: queries},

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/mikeydub/go-gallery/middleware"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -18,11 +20,11 @@ func Init() {
 	initLogger()
 	initSentry()
 
-	router := coreInit()
+	router := coreInit(postgres.NewPgxClient())
 	http.Handle("/", router)
 }
 
-func coreInit() *gin.Engine {
+func coreInit(pgx *pgxpool.Pool) *gin.Engine {
 	logger.For(nil).Info("initializing server...")
 
 	router := gin.Default()
@@ -32,7 +34,7 @@ func coreInit() *gin.Engine {
 		gin.SetMode(gin.DebugMode)
 	}
 
-	return handlersInit(router)
+	return handlersInit(router, pgx)
 }
 
 func setDefaults() {

--- a/feed/handler.go
+++ b/feed/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/spf13/viper"
 )
 
@@ -32,8 +33,8 @@ func taskRequired() gin.HandlerFunc {
 	}
 }
 
-func handlersInit(router *gin.Engine) *gin.Engine {
+func handlersInit(router *gin.Engine, pgx *pgxpool.Pool) *gin.Engine {
 	router.GET("/ping", ping())
-	router.POST("/tasks/feed-event", taskRequired(), handleEvent())
+	router.POST("/tasks/feed-event", taskRequired(), handleEvent(pgx))
 	return router
 }

--- a/feed/server.go
+++ b/feed/server.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
 )
 
-func handleEvent() gin.HandlerFunc {
+func handleEvent(pgx *pgxpool.Pool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		message := task.FeedMessage{}
 
@@ -21,7 +22,7 @@ func handleEvent() gin.HandlerFunc {
 			return
 		}
 
-		builder := NewEventBuilder()
+		builder := NewEventBuilder(pgx)
 		event, err := builder.NewEvent(c.Request.Context(), message)
 
 		if err != nil {


### PR DESCRIPTION
**Changes**
* Noticed half the response time for handling messages is spent creating a connection pool to the db because it is done per request, changed it so the connection is made once at startup (like we do in the backend)