### PR TITLE
Group follow events together

### DIFF
--- a/db/migrations/000020_add_event_time_action_index_to_feed_events.down.sql
+++ b/db/migrations/000020_add_event_time_action_index_to_feed_events.down.sql
@@ -1,2 +1,3 @@
-DROP INDEX IF EXISTS feed_events_event_time_action_idx;
+DROP INDEX IF EXISTS feed_events_event_time_action_owner_id_idx;
 CREATE INDEX IF NOT EXISTS feeds_event_timestamp_idx ON feed_events (event_time);
+CREATE INDEX IF NOT EXISTS feeds_owner_id_action_event_timestamp_idx ON feed_events (owner_id, action, event_time);

--- a/db/migrations/000020_add_event_time_action_index_to_feed_events.down.sql
+++ b/db/migrations/000020_add_event_time_action_index_to_feed_events.down.sql
@@ -1,1 +1,2 @@
 DROP INDEX IF EXISTS feed_events_event_time_action_idx;
+CREATE INDEX IF NOT EXISTS feeds_event_timestamp_idx ON feed_events (event_time);

--- a/db/migrations/000020_add_event_time_action_index_to_feed_events.down.sql
+++ b/db/migrations/000020_add_event_time_action_index_to_feed_events.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS feed_events_event_time_action_idx;

--- a/db/migrations/000020_add_event_time_action_index_to_feed_events.up.sql
+++ b/db/migrations/000020_add_event_time_action_index_to_feed_events.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS feed_events_event_time_action_idx ON feed_events (event_time, action);

--- a/db/migrations/000020_add_event_time_action_index_to_feed_events.up.sql
+++ b/db/migrations/000020_add_event_time_action_index_to_feed_events.up.sql
@@ -1,1 +1,2 @@
 CREATE INDEX IF NOT EXISTS feed_events_event_time_action_idx ON feed_events (event_time, action);
+DROP INDEX IF EXISTS feeds_event_timestamp_idx;

--- a/db/migrations/000020_add_event_time_action_index_to_feed_events.up.sql
+++ b/db/migrations/000020_add_event_time_action_index_to_feed_events.up.sql
@@ -1,2 +1,5 @@
-CREATE INDEX IF NOT EXISTS feed_events_event_time_action_idx ON feed_events (event_time, action);
+CREATE INDEX IF NOT EXISTS feed_events_event_time_action_owner_id_idx ON feed_events (event_time, action, owner_id) WHERE deleted = false;
+
+-- Remove redundant indexes
 DROP INDEX IF EXISTS feeds_event_timestamp_idx;
+DROP INDEX IF EXISTS feeds_owner_id_action_event_timestamp_idx;

--- a/db/migrations/000021_remove_old_event_tables.down.sql
+++ b/db/migrations/000021_remove_old_event_tables.down.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS user_events (
+    ID varchar(255) PRIMARY KEY,
+    USER_ID varchar(255),
+    VERSION int,
+    EVENT_CODE int,
+    CREATED_AT timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    LAST_UPDATED timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    DATA JSONB
+);
+
+CREATE INDEX IF NOT EXISTS user_id_event_code_created_at ON user_events (USER_ID, EVENT_CODE, CREATED_AT);
+
+CREATE TABLE IF NOT EXISTS nft_events (
+    ID varchar(255) PRIMARY KEY,
+    USER_ID varchar(255),
+    NFT_ID varchar(255),
+    VERSION int,
+    EVENT_CODE int,
+    CREATED_AT timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    LAST_UPDATED timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    DATA JSONB
+);
+
+CREATE INDEX IF NOT EXISTS user_id_nft_id_event_code_created_at ON nft_events (USER_ID, NFT_ID, EVENT_CODE, CREATED_AT);
+
+CREATE TABLE IF NOT EXISTS collection_events (
+    ID varchar(255) PRIMARY KEY,
+    USER_ID varchar(255),
+    COLLECTION_ID varchar(255),
+    VERSION int,
+    EVENT_CODE int,
+    CREATED_AT timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    LAST_UPDATED timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    DATA JSONB
+);
+
+CREATE INDEX IF NOT EXISTS user_id_collection_id_event_code_created_at ON collection_events (USER_ID, COLLECTION_ID, EVENT_CODE, CREATED_AT);

--- a/db/migrations/000021_remove_old_event_tables.up.sql
+++ b/db/migrations/000021_remove_old_event_tables.up.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS user_events;
+DROP TABLE IF EXISTS nft_events;
+DROP TABLE IF EXISTS collection_events;

--- a/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.down.sql
+++ b/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.down.sql
@@ -1,2 +1,1 @@
--- This downgrade will fail if there are already existing null values.
 ALTER TABLE feed_events ALTER COLUMN owner_id SET NOT NULL;

--- a/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.down.sql
+++ b/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feed_events ALTER COLUMN owner_id SET NOT NULL;

--- a/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.down.sql
+++ b/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.down.sql
@@ -1,1 +1,2 @@
+-- This downgrade will fail if there are already existing null values.
 ALTER TABLE feed_events ALTER COLUMN owner_id SET NOT NULL;

--- a/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.up.sql
+++ b/db/migrations/000022_remove_non_null_constraint_on_feed_event_owner.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feed_events ALTER COLUMN owner_id DROP NOT NULL;

--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -248,10 +248,7 @@ WITH cursors AS (
     AND event_time > (SELECT cur_after FROM cursors)
     AND event_time < (SELECT cur_before FROM cursors)
     AND fe.deleted = false AND fl.deleted = false
-
-    -- Can UNION ALL because a user can't follow themselves
     UNION ALL
-
     SELECT id FROM feed_events
     WHERE event_time > (SELECT cur_after FROM cursors)
     AND event_time < (SELECT cur_before FROM cursors)
@@ -278,10 +275,7 @@ SELECT
         WHERE event_time > (SELECT event_time FROM feed_events f WHERE f.id = $2)
         AND fe.deleted = false AND fl.deleted = false
         LIMIT 1)
-
-        -- Can UNION ALL because a user can't follow themselves
         UNION ALL
-
         (SELECT 1
         FROM feed_events
         WHERE event_time > (SELECT event_time FROM feed_events f WHERE f.id = $2)
@@ -296,10 +290,7 @@ SELECT
         WHERE event_time < (SELECT event_time FROM feed_events f WHERE f.id = $2)
         AND fe.deleted = false AND fl.deleted = false
         LIMIT 1)
-
-        -- Can UNION ALL because a user can't follow themselves
         UNION ALL
-
         (SELECT 1
         FROM feed_events
         WHERE event_time < (SELECT event_time FROM feed_events f WHERE f.id = $2)
@@ -314,6 +305,9 @@ SELECT * FROM feed_events WHERE id = $1 AND deleted = false;
 
 -- name: CreateFeedEvent :one
 INSERT INTO feed_events (id, owner_id, action, data, event_time, event_ids) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *;
+
+-- name: CreateFeedEventNoOwner :one
+INSERT INTO feed_events (id, action, data, event_time, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING *;
 
 -- name: GetLastFeedEvent :one
 SELECT * FROM feed_events

--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -261,7 +261,8 @@ WITH cursors AS (
         ELSE 0 END pos
     FROM edges
 )
-SELECT * FROM feed_events WHERE id = ANY(SELECT id FROM edges)
+SELECT * FROM feed_events
+    WHERE id = ANY(SELECT id FROM edges)
     ORDER BY event_time ASC
     LIMIT $2 OFFSET (SELECT pos FROM offsets);
 

--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -306,9 +306,6 @@ SELECT * FROM feed_events WHERE id = $1 AND deleted = false;
 -- name: CreateFeedEvent :one
 INSERT INTO feed_events (id, owner_id, action, data, event_time, event_ids) VALUES ($1, $2, $3, $4, $5, $6) RETURNING *;
 
--- name: CreateFeedEventNoOwner :one
-INSERT INTO feed_events (id, action, data, event_time, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING *;
-
 -- name: GetLastFeedEvent :one
 SELECT * FROM feed_events
     WHERE owner_id = $1 AND action = $2 AND event_time < $3 AND deleted = false

--- a/db/queries/query.sql
+++ b/db/queries/query.sql
@@ -173,8 +173,8 @@ WITH RECURSIVE activity AS (
     SELECT * FROM events WHERE events.id = $1 AND deleted = false
     UNION
     SELECT e.* FROM events e, activity a
-    WHERE e.subject_id = a.subject_id
-        AND e.action = a.action
+    WHERE e.action = a.action
+        AND e.subject_id = a.subject_id
         AND e.created_at < a.created_at
         AND e.created_at >= a.created_at - make_interval(secs => $2)
         AND e.deleted = false

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -570,6 +570,8 @@ WITH cursors AS (
     WHERE event_time > (SELECT cur_after FROM cursors)
     AND event_time < (SELECT cur_before FROM cursors)
     AND deleted = false
+    -- Remove when frontend can support this type
+    AND action != 'UserFollowedByUsers'
 ), offsets AS (
     SELECT
         CASE WHEN NOT $4::bool AND count(id) - $1::int > 0
@@ -1164,12 +1166,8 @@ WITH cursors AS (
     AND event_time > (SELECT cur_after FROM cursors)
     AND event_time < (SELECT cur_before FROM cursors)
     AND fe.deleted = false AND fl.deleted = false
-    UNION ALL
-    SELECT id FROM feed_events
-    WHERE event_time > (SELECT cur_after FROM cursors)
-    AND event_time < (SELECT cur_before FROM cursors)
-    AND action = 'UserFollowedByUsers' AND (data -> 'user_follower_ids') ?| array(SELECT followee FROM follows WHERE deleted = false AND follower = $1)
-    AND deleted = false
+    -- Remove when frontend can support this type
+    AND fe.action != 'UserFollowedByUsers'
 ), offsets AS (
     SELECT
         CASE WHEN NOT $5::bool AND count(id) - $2::int > 0

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -1177,7 +1177,8 @@ WITH cursors AS (
         ELSE 0 END pos
     FROM edges
 )
-SELECT id, version, owner_id, action, data, event_time, event_ids, deleted, last_updated, created_at FROM feed_events WHERE id = ANY(SELECT id FROM edges)
+SELECT id, version, owner_id, action, data, event_time, event_ids, deleted, last_updated, created_at FROM feed_events
+    WHERE id = ANY(SELECT id FROM edges)
     ORDER BY event_time ASC
     LIMIT $2 OFFSET (SELECT pos FROM offsets)
 `

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -1175,8 +1175,7 @@ WITH cursors AS (
         ELSE 0 END pos
     FROM edges
 )
-SELECT id, version, owner_id, action, data, event_time, event_ids, deleted, last_updated, created_at FROM feed_events
-    WHERE id = ANY(SELECT id FROM edges)
+SELECT id, version, owner_id, action, data, event_time, event_ids, deleted, last_updated, created_at FROM feed_events WHERE id = ANY(SELECT id FROM edges)
     ORDER BY event_time ASC
     LIMIT $2 OFFSET (SELECT pos FROM offsets)
 `

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -1164,10 +1164,7 @@ WITH cursors AS (
     AND event_time > (SELECT cur_after FROM cursors)
     AND event_time < (SELECT cur_before FROM cursors)
     AND fe.deleted = false AND fl.deleted = false
-
-    -- Can UNION ALL because a user can't follow themselves
     UNION ALL
-
     SELECT id FROM feed_events
     WHERE event_time > (SELECT cur_after FROM cursors)
     AND event_time < (SELECT cur_before FROM cursors)

--- a/db/sqlc/models_gen.go
+++ b/db/sqlc/models_gen.go
@@ -48,18 +48,6 @@ type Collection struct {
 	Layout         TokenLayout
 }
 
-type CollectionEvent struct {
-	ID           persist.DBID
-	UserID       sql.NullString
-	CollectionID sql.NullString
-	Version      sql.NullInt32
-	EventCode    sql.NullInt32
-	CreatedAt    time.Time
-	LastUpdated  time.Time
-	Data         pgtype.JSONB
-	Sent         sql.NullBool
-}
-
 type Contract struct {
 	ID             persist.DBID
 	Deleted        bool
@@ -167,18 +155,6 @@ type Membership struct {
 	Owners      persist.TokenHolderList
 }
 
-type NftEvent struct {
-	ID          persist.DBID
-	UserID      sql.NullString
-	NftID       sql.NullString
-	Version     sql.NullInt32
-	EventCode   sql.NullInt32
-	CreatedAt   time.Time
-	LastUpdated time.Time
-	Data        pgtype.JSONB
-	Sent        sql.NullBool
-}
-
 type Nonce struct {
 	ID          persist.DBID
 	Deleted     bool
@@ -225,17 +201,6 @@ type User struct {
 	UsernameIdempotent sql.NullString
 	Wallets            persist.WalletList
 	Bio                sql.NullString
-}
-
-type UserEvent struct {
-	ID          persist.DBID
-	UserID      sql.NullString
-	Version     sql.NullInt32
-	EventCode   sql.NullInt32
-	CreatedAt   time.Time
-	LastUpdated time.Time
-	Data        pgtype.JSONB
-	Sent        sql.NullBool
 }
 
 type Wallet struct {

--- a/db/sqlc/models_gen.go
+++ b/db/sqlc/models_gen.go
@@ -99,7 +99,7 @@ type Feature struct {
 type FeedEvent struct {
 	ID          persist.DBID
 	Version     int32
-	OwnerID     persist.DBID
+	OwnerID     sql.NullString
 	Action      persist.Action
 	Data        persist.FeedEventData
 	EventTime   time.Time

--- a/db/sqlc/query.sql.go
+++ b/db/sqlc/query.sql.go
@@ -60,7 +60,7 @@ INSERT INTO feed_events (id, owner_id, action, data, event_time, event_ids) VALU
 
 type CreateFeedEventParams struct {
 	ID        persist.DBID
-	OwnerID   persist.DBID
+	OwnerID   sql.NullString
 	Action    persist.Action
 	Data      persist.FeedEventData
 	EventTime time.Time
@@ -71,42 +71,6 @@ func (q *Queries) CreateFeedEvent(ctx context.Context, arg CreateFeedEventParams
 	row := q.db.QueryRow(ctx, createFeedEvent,
 		arg.ID,
 		arg.OwnerID,
-		arg.Action,
-		arg.Data,
-		arg.EventTime,
-		arg.EventIds,
-	)
-	var i FeedEvent
-	err := row.Scan(
-		&i.ID,
-		&i.Version,
-		&i.OwnerID,
-		&i.Action,
-		&i.Data,
-		&i.EventTime,
-		&i.EventIds,
-		&i.Deleted,
-		&i.LastUpdated,
-		&i.CreatedAt,
-	)
-	return i, err
-}
-
-const createFeedEventNoOwner = `-- name: CreateFeedEventNoOwner :one
-INSERT INTO feed_events (id, action, data, event_time, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING id, version, owner_id, action, data, event_time, event_ids, deleted, last_updated, created_at
-`
-
-type CreateFeedEventNoOwnerParams struct {
-	ID        persist.DBID
-	Action    persist.Action
-	Data      persist.FeedEventData
-	EventTime time.Time
-	EventIds  persist.DBIDList
-}
-
-func (q *Queries) CreateFeedEventNoOwner(ctx context.Context, arg CreateFeedEventNoOwnerParams) (FeedEvent, error) {
-	row := q.db.QueryRow(ctx, createFeedEventNoOwner,
-		arg.ID,
 		arg.Action,
 		arg.Data,
 		arg.EventTime,
@@ -530,7 +494,7 @@ SELECT id, version, owner_id, action, data, event_time, event_ids, deleted, last
 `
 
 type GetLastFeedEventParams struct {
-	OwnerID   persist.DBID
+	OwnerID   sql.NullString
 	Action    persist.Action
 	EventTime time.Time
 }
@@ -561,7 +525,7 @@ SELECT id, version, owner_id, action, data, event_time, event_ids, deleted, last
 `
 
 type GetLastFeedEventForCollectionParams struct {
-	OwnerID      persist.DBID
+	OwnerID      sql.NullString
 	Action       persist.Action
 	EventTime    time.Time
 	CollectionID string
@@ -598,7 +562,7 @@ SELECT id, version, owner_id, action, data, event_time, event_ids, deleted, last
 `
 
 type GetLastFeedEventForTokenParams struct {
-	OwnerID   persist.DBID
+	OwnerID   sql.NullString
 	Action    persist.Action
 	EventTime time.Time
 	TokenID   string

--- a/db/sqlc/query.sql.go
+++ b/db/sqlc/query.sql.go
@@ -351,8 +351,8 @@ WITH RECURSIVE activity AS (
     SELECT id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at FROM events WHERE events.id = $1 AND deleted = false
     UNION
     SELECT e.id, e.version, e.actor_id, e.resource_type_id, e.subject_id, e.user_id, e.token_id, e.collection_id, e.action, e.data, e.deleted, e.last_updated, e.created_at FROM events e, activity a
-    WHERE e.subject_id = a.subject_id
-        AND e.action = a.action
+    WHERE e.action = a.action
+        AND e.subject_id = a.subject_id
         AND e.created_at < a.created_at
         AND e.created_at >= a.created_at - make_interval(secs => $2)
         AND e.deleted = false

--- a/feed/event.go
+++ b/feed/event.go
@@ -45,6 +45,10 @@ func (b *EventBuilder) NewEvent(ctx context.Context, message task.FeedMessage) (
 	case persist.ActionUserCreated:
 		return b.createUserCreatedEvent(ctx, event)
 	case persist.ActionUserFollowedUsers:
+		// Store both event types for now until the frontend supports UserFollowedByUsers
+		if _, err := b.createUserFollowedUsersEvent(ctx, event); err != nil {
+			return nil, err
+		}
 		return b.createrUserFollowedByUsersEvent(ctx, event)
 	case persist.ActionCollectorsNoteAddedToToken:
 		return b.createCollectorsNoteAddedToTokenEvent(ctx, event)

--- a/feed/event.go
+++ b/feed/event.go
@@ -83,7 +83,7 @@ func (b *EventBuilder) createUserCreatedEvent(ctx context.Context, event sqlc.Ev
 
 	return b.feedRepo.Add(ctx, sqlc.FeedEvent{
 		ID:        persist.GenerateID(),
-		OwnerID:   event.ActorID,
+		OwnerID:   persist.DBIDToNullString(&event.ActorID),
 		Action:    event.Action,
 		EventTime: event.CreatedAt,
 		Data:      persist.FeedEventData{UserBio: event.Data.UserBio},
@@ -124,7 +124,7 @@ func (b *EventBuilder) createUserFollowedUsersEvent(ctx context.Context, event s
 
 	return b.feedRepo.Add(ctx, sqlc.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.DBIDToNullString(&event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			UserFollowedIDs:  followedIDs,
@@ -209,7 +209,7 @@ func (b *EventBuilder) createCollectorsNoteAddedToTokenEvent(ctx context.Context
 
 	return b.feedRepo.Add(ctx, sqlc.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.DBIDToNullString(&event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			TokenID:                event.SubjectID,
@@ -236,7 +236,7 @@ func (b *EventBuilder) createCollectionCreatedEvent(ctx context.Context, event s
 
 	return b.feedRepo.Add(ctx, sqlc.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.DBIDToNullString(&event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			CollectionID:                event.SubjectID,
@@ -274,7 +274,7 @@ func (b *EventBuilder) createCollectorsNoteAddedToCollectionEvent(ctx context.Co
 
 	return b.feedRepo.Add(ctx, sqlc.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.DBIDToNullString(&event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			CollectionID:                event.SubjectID,
@@ -332,7 +332,7 @@ func (b *EventBuilder) createTokensAddedToCollectionEvent(ctx context.Context, e
 
 	return b.feedRepo.Add(ctx, sqlc.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.DBIDToNullString(&event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			CollectionID:          event.SubjectID,

--- a/feed/event.go
+++ b/feed/event.go
@@ -156,7 +156,7 @@ func (b *EventBuilder) createrUserFollowedByUsersEvent(ctx context.Context, even
 
 	for _, event := range events {
 		if !event.Data.UserRefollowed {
-			followerIDs = append(followerIDs, event.SubjectID)
+			followerIDs = append(followerIDs, event.ActorID)
 			followedBack = append(followedBack, event.Data.UserFollowedBack)
 			eventIDs = append(eventIDs, event.ID)
 		}
@@ -167,12 +167,12 @@ func (b *EventBuilder) createrUserFollowedByUsersEvent(ctx context.Context, even
 	}
 
 	return b.feedRepo.Add(ctx, sqlc.FeedEvent{
-		ID:      persist.GenerateID(),
-		OwnerID: event.SubjectID,
-		Action:  persist.ActionUserFollowedByUsers,
+		ID:     persist.GenerateID(),
+		Action: persist.ActionUserFollowedByUsers,
 		Data: persist.FeedEventData{
 			UserFollowerIDs:  followerIDs,
 			UserFollowedBack: followedBack,
+			UserFollowedIDs:  []persist.DBID{event.SubjectID},
 		},
 		EventTime: event.CreatedAt,
 		EventIds:  eventIDs,

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -56,6 +56,7 @@ type ResolverRoot interface {
 	TokensAddedToCollectionFeedEventData() TokensAddedToCollectionFeedEventDataResolver
 	UnfollowUserPayload() UnfollowUserPayloadResolver
 	UserCreatedFeedEventData() UserCreatedFeedEventDataResolver
+	UserFollowedByUsersFeedEventData() UserFollowedByUsersFeedEventDataResolver
 	UserFollowedUsersFeedEventData() UserFollowedUsersFeedEventDataResolver
 	Viewer() ViewerResolver
 	Wallet() WalletResolver
@@ -500,6 +501,13 @@ type ComplexityRoot struct {
 		Owner     func(childComplexity int) int
 	}
 
+	UserFollowedByUsersFeedEventData struct {
+		Action     func(childComplexity int) int
+		EventTime  func(childComplexity int) int
+		FollowedBy func(childComplexity int) int
+		Owner      func(childComplexity int) int
+	}
+
 	UserFollowedUsersFeedEventData struct {
 		Action    func(childComplexity int) int
 		EventTime func(childComplexity int) int
@@ -646,6 +654,9 @@ type UnfollowUserPayloadResolver interface {
 }
 type UserCreatedFeedEventDataResolver interface {
 	Owner(ctx context.Context, obj *model.UserCreatedFeedEventData) (*model.GalleryUser, error)
+}
+type UserFollowedByUsersFeedEventDataResolver interface {
+	Owner(ctx context.Context, obj *model.UserFollowedByUsersFeedEventData) (*model.GalleryUser, error)
 }
 type UserFollowedUsersFeedEventDataResolver interface {
 	Owner(ctx context.Context, obj *model.UserFollowedUsersFeedEventData) (*model.GalleryUser, error)
@@ -2431,6 +2442,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.UserCreatedFeedEventData.Owner(childComplexity), true
 
+	case "UserFollowedByUsersFeedEventData.action":
+		if e.complexity.UserFollowedByUsersFeedEventData.Action == nil {
+			break
+		}
+
+		return e.complexity.UserFollowedByUsersFeedEventData.Action(childComplexity), true
+
+	case "UserFollowedByUsersFeedEventData.eventTime":
+		if e.complexity.UserFollowedByUsersFeedEventData.EventTime == nil {
+			break
+		}
+
+		return e.complexity.UserFollowedByUsersFeedEventData.EventTime(childComplexity), true
+
+	case "UserFollowedByUsersFeedEventData.followedBy":
+		if e.complexity.UserFollowedByUsersFeedEventData.FollowedBy == nil {
+			break
+		}
+
+		return e.complexity.UserFollowedByUsersFeedEventData.FollowedBy(childComplexity), true
+
+	case "UserFollowedByUsersFeedEventData.owner":
+		if e.complexity.UserFollowedByUsersFeedEventData.Owner == nil {
+			break
+		}
+
+		return e.complexity.UserFollowedByUsersFeedEventData.Owner(childComplexity), true
+
 	case "UserFollowedUsersFeedEventData.action":
 		if e.complexity.UserFollowedUsersFeedEventData.Action == nil {
 			break
@@ -3062,6 +3101,13 @@ type UserFollowedUsersFeedEventData implements FeedEventData {
     followed: [FollowInfo]
 }
 
+type UserFollowedByUsersFeedEventData implements FeedEventData {
+    eventTime: Time
+    owner: GalleryUser @goField(forceResolver: true)
+    action: Action
+    followedBy: [FollowInfo]
+}
+
 type CollectorsNoteAddedToTokenFeedEventData implements FeedEventData {
     eventTime: Time
     owner: GalleryUser @goField(forceResolver: true)
@@ -3144,6 +3190,7 @@ type Query {
     generalAllowlist: [ChainAddress!]
     galleryOfTheWeekWinners: [GalleryUser!]
     globalFeed(before: String, after: String, first: Int, last: Int): FeedConnection
+    # Remove when frontend uses feed field on Viewer
     feedEventById(id: DBID!): FeedEventByIdOrError
 }
 
@@ -12115,6 +12162,134 @@ func (ec *executionContext) _UserCreatedFeedEventData_action(ctx context.Context
 	return ec.marshalOAction2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐAction(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _UserFollowedByUsersFeedEventData_eventTime(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedByUsersFeedEventData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UserFollowedByUsersFeedEventData",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EventTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UserFollowedByUsersFeedEventData_owner(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedByUsersFeedEventData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UserFollowedByUsersFeedEventData",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.UserFollowedByUsersFeedEventData().Owner(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.GalleryUser)
+	fc.Result = res
+	return ec.marshalOGalleryUser2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UserFollowedByUsersFeedEventData_action(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedByUsersFeedEventData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UserFollowedByUsersFeedEventData",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Action, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*persist.Action)
+	fc.Result = res
+	return ec.marshalOAction2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐAction(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UserFollowedByUsersFeedEventData_followedBy(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedByUsersFeedEventData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UserFollowedByUsersFeedEventData",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FollowedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.FollowInfo)
+	fc.Result = res
+	return ec.marshalOFollowInfo2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFollowInfo(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _UserFollowedUsersFeedEventData_eventTime(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedUsersFeedEventData) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -14984,6 +15159,13 @@ func (ec *executionContext) _FeedEventData(ctx context.Context, sel ast.Selectio
 			return graphql.Null
 		}
 		return ec._UserFollowedUsersFeedEventData(ctx, sel, obj)
+	case model.UserFollowedByUsersFeedEventData:
+		return ec._UserFollowedByUsersFeedEventData(ctx, sel, &obj)
+	case *model.UserFollowedByUsersFeedEventData:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._UserFollowedByUsersFeedEventData(ctx, sel, obj)
 	case model.CollectorsNoteAddedToTokenFeedEventData:
 		return ec._CollectorsNoteAddedToTokenFeedEventData(ctx, sel, &obj)
 	case *model.CollectorsNoteAddedToTokenFeedEventData:
@@ -19508,6 +19690,65 @@ func (ec *executionContext) _UserCreatedFeedEventData(ctx context.Context, sel a
 		case "action":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._UserCreatedFeedEventData_action(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var userFollowedByUsersFeedEventDataImplementors = []string{"UserFollowedByUsersFeedEventData", "FeedEventData"}
+
+func (ec *executionContext) _UserFollowedByUsersFeedEventData(ctx context.Context, sel ast.SelectionSet, obj *model.UserFollowedByUsersFeedEventData) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, userFollowedByUsersFeedEventDataImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UserFollowedByUsersFeedEventData")
+		case "eventTime":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._UserFollowedByUsersFeedEventData_eventTime(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "owner":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserFollowedByUsersFeedEventData_owner(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "action":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._UserFollowedByUsersFeedEventData_action(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "followedBy":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._UserFollowedByUsersFeedEventData_followedBy(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -505,7 +505,6 @@ type ComplexityRoot struct {
 		Action       func(childComplexity int) int
 		EventTime    func(childComplexity int) int
 		FollowedBy   func(childComplexity int) int
-		Owner        func(childComplexity int) int
 		UserFollowed func(childComplexity int) int
 	}
 
@@ -2464,13 +2463,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.UserFollowedByUsersFeedEventData.FollowedBy(childComplexity), true
 
-	case "UserFollowedByUsersFeedEventData.owner":
-		if e.complexity.UserFollowedByUsersFeedEventData.Owner == nil {
-			break
-		}
-
-		return e.complexity.UserFollowedByUsersFeedEventData.Owner(childComplexity), true
-
 	case "UserFollowedByUsersFeedEventData.userFollowed":
 		if e.complexity.UserFollowedByUsersFeedEventData.UserFollowed == nil {
 			break
@@ -3086,7 +3078,6 @@ type FollowInfo {
 
 interface FeedEventData {
     eventTime: Time
-    owner: GalleryUser
     action: Action
 }
 
@@ -3111,7 +3102,6 @@ type UserFollowedUsersFeedEventData implements FeedEventData {
 
 type UserFollowedByUsersFeedEventData implements FeedEventData {
     eventTime: Time
-    owner: GalleryUser
     userFollowed: GalleryUser @goField(forceResolver: true)
     action: Action
     followedBy: [FollowInfo]
@@ -12202,38 +12192,6 @@ func (ec *executionContext) _UserFollowedByUsersFeedEventData_eventTime(ctx cont
 	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _UserFollowedByUsersFeedEventData_owner(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedByUsersFeedEventData) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "UserFollowedByUsersFeedEventData",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Owner, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.GalleryUser)
-	fc.Result = res
-	return ec.marshalOGalleryUser2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryUser(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _UserFollowedByUsersFeedEventData_userFollowed(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedByUsersFeedEventData) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -19758,13 +19716,6 @@ func (ec *executionContext) _UserFollowedByUsersFeedEventData(ctx context.Contex
 		case "eventTime":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._UserFollowedByUsersFeedEventData_eventTime(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "owner":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._UserFollowedByUsersFeedEventData_owner(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -502,10 +502,11 @@ type ComplexityRoot struct {
 	}
 
 	UserFollowedByUsersFeedEventData struct {
-		Action     func(childComplexity int) int
-		EventTime  func(childComplexity int) int
-		FollowedBy func(childComplexity int) int
-		Owner      func(childComplexity int) int
+		Action       func(childComplexity int) int
+		EventTime    func(childComplexity int) int
+		FollowedBy   func(childComplexity int) int
+		Owner        func(childComplexity int) int
+		UserFollowed func(childComplexity int) int
 	}
 
 	UserFollowedUsersFeedEventData struct {
@@ -656,7 +657,7 @@ type UserCreatedFeedEventDataResolver interface {
 	Owner(ctx context.Context, obj *model.UserCreatedFeedEventData) (*model.GalleryUser, error)
 }
 type UserFollowedByUsersFeedEventDataResolver interface {
-	Owner(ctx context.Context, obj *model.UserFollowedByUsersFeedEventData) (*model.GalleryUser, error)
+	UserFollowed(ctx context.Context, obj *model.UserFollowedByUsersFeedEventData) (*model.GalleryUser, error)
 }
 type UserFollowedUsersFeedEventDataResolver interface {
 	Owner(ctx context.Context, obj *model.UserFollowedUsersFeedEventData) (*model.GalleryUser, error)
@@ -2470,6 +2471,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.UserFollowedByUsersFeedEventData.Owner(childComplexity), true
 
+	case "UserFollowedByUsersFeedEventData.userFollowed":
+		if e.complexity.UserFollowedByUsersFeedEventData.UserFollowed == nil {
+			break
+		}
+
+		return e.complexity.UserFollowedByUsersFeedEventData.UserFollowed(childComplexity), true
+
 	case "UserFollowedUsersFeedEventData.action":
 		if e.complexity.UserFollowedUsersFeedEventData.Action == nil {
 			break
@@ -3103,7 +3111,8 @@ type UserFollowedUsersFeedEventData implements FeedEventData {
 
 type UserFollowedByUsersFeedEventData implements FeedEventData {
     eventTime: Time
-    owner: GalleryUser @goField(forceResolver: true)
+    owner: GalleryUser
+    userFollowed: GalleryUser @goField(forceResolver: true)
     action: Action
     followedBy: [FollowInfo]
 }
@@ -3190,7 +3199,6 @@ type Query {
     generalAllowlist: [ChainAddress!]
     galleryOfTheWeekWinners: [GalleryUser!]
     globalFeed(before: String, after: String, first: Int, last: Int): FeedConnection
-    # Remove when frontend uses feed field on Viewer
     feedEventById(id: DBID!): FeedEventByIdOrError
 }
 
@@ -12205,6 +12213,38 @@ func (ec *executionContext) _UserFollowedByUsersFeedEventData_owner(ctx context.
 		Object:     "UserFollowedByUsersFeedEventData",
 		Field:      field,
 		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Owner, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.GalleryUser)
+	fc.Result = res
+	return ec.marshalOGalleryUser2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _UserFollowedByUsersFeedEventData_userFollowed(ctx context.Context, field graphql.CollectedField, obj *model.UserFollowedByUsersFeedEventData) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "UserFollowedByUsersFeedEventData",
+		Field:      field,
+		Args:       nil,
 		IsMethod:   true,
 		IsResolver: true,
 	}
@@ -12212,7 +12252,7 @@ func (ec *executionContext) _UserFollowedByUsersFeedEventData_owner(ctx context.
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.UserFollowedByUsersFeedEventData().Owner(rctx, obj)
+		return ec.resolvers.UserFollowedByUsersFeedEventData().UserFollowed(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -19723,6 +19763,13 @@ func (ec *executionContext) _UserFollowedByUsersFeedEventData(ctx context.Contex
 			out.Values[i] = innerFunc(ctx)
 
 		case "owner":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._UserFollowedByUsersFeedEventData_owner(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "userFollowed":
 			field := field
 
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
@@ -19731,7 +19778,7 @@ func (ec *executionContext) _UserFollowedByUsersFeedEventData(ctx context.Contex
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._UserFollowedByUsersFeedEventData_owner(ctx, field, obj)
+				res = ec._UserFollowedByUsersFeedEventData_userFollowed(ctx, field, obj)
 				return res
 			}
 

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -794,10 +794,11 @@ type UserCreatedFeedEventData struct {
 func (UserCreatedFeedEventData) IsFeedEventData() {}
 
 type UserFollowedByUsersFeedEventData struct {
-	EventTime  *time.Time      `json:"eventTime"`
-	Owner      *GalleryUser    `json:"owner"`
-	Action     *persist.Action `json:"action"`
-	FollowedBy []*FollowInfo   `json:"followedBy"`
+	EventTime    *time.Time      `json:"eventTime"`
+	Owner        *GalleryUser    `json:"owner"`
+	UserFollowed *GalleryUser    `json:"userFollowed"`
+	Action       *persist.Action `json:"action"`
+	FollowedBy   []*FollowInfo   `json:"followedBy"`
 }
 
 func (UserFollowedByUsersFeedEventData) IsFeedEventData() {}

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -793,6 +793,15 @@ type UserCreatedFeedEventData struct {
 
 func (UserCreatedFeedEventData) IsFeedEventData() {}
 
+type UserFollowedByUsersFeedEventData struct {
+	EventTime  *time.Time      `json:"eventTime"`
+	Owner      *GalleryUser    `json:"owner"`
+	Action     *persist.Action `json:"action"`
+	FollowedBy []*FollowInfo   `json:"followedBy"`
+}
+
+func (UserFollowedByUsersFeedEventData) IsFeedEventData() {}
+
 type UserFollowedUsersFeedEventData struct {
 	EventTime *time.Time      `json:"eventTime"`
 	Owner     *GalleryUser    `json:"owner"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -795,7 +795,6 @@ func (UserCreatedFeedEventData) IsFeedEventData() {}
 
 type UserFollowedByUsersFeedEventData struct {
 	EventTime    *time.Time      `json:"eventTime"`
-	Owner        *GalleryUser    `json:"owner"`
 	UserFollowed *GalleryUser    `json:"userFollowed"`
 	Action       *persist.Action `json:"action"`
 	FollowedBy   []*FollowInfo   `json:"followedBy"`

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -641,6 +641,10 @@ func (r *userCreatedFeedEventDataResolver) Owner(ctx context.Context, obj *model
 	return resolveGalleryUserByUserID(ctx, obj.Owner.Dbid)
 }
 
+func (r *userFollowedByUsersFeedEventDataResolver) Owner(ctx context.Context, obj *model.UserFollowedByUsersFeedEventData) (*model.GalleryUser, error) {
+	return resolveGalleryUserByUserID(ctx, obj.Owner.Dbid)
+}
+
 func (r *userFollowedUsersFeedEventDataResolver) Owner(ctx context.Context, obj *model.UserFollowedUsersFeedEventData) (*model.GalleryUser, error) {
 	return resolveGalleryUserByUserID(ctx, obj.Owner.Dbid)
 }
@@ -754,6 +758,11 @@ func (r *Resolver) UserCreatedFeedEventData() generated.UserCreatedFeedEventData
 	return &userCreatedFeedEventDataResolver{r}
 }
 
+// UserFollowedByUsersFeedEventData returns generated.UserFollowedByUsersFeedEventDataResolver implementation.
+func (r *Resolver) UserFollowedByUsersFeedEventData() generated.UserFollowedByUsersFeedEventDataResolver {
+	return &userFollowedByUsersFeedEventDataResolver{r}
+}
+
 // UserFollowedUsersFeedEventData returns generated.UserFollowedUsersFeedEventDataResolver implementation.
 func (r *Resolver) UserFollowedUsersFeedEventData() generated.UserFollowedUsersFeedEventDataResolver {
 	return &userFollowedUsersFeedEventDataResolver{r}
@@ -788,6 +797,7 @@ type tokenHolderResolver struct{ *Resolver }
 type tokensAddedToCollectionFeedEventDataResolver struct{ *Resolver }
 type unfollowUserPayloadResolver struct{ *Resolver }
 type userCreatedFeedEventDataResolver struct{ *Resolver }
+type userFollowedByUsersFeedEventDataResolver struct{ *Resolver }
 type userFollowedUsersFeedEventDataResolver struct{ *Resolver }
 type viewerResolver struct{ *Resolver }
 type walletResolver struct{ *Resolver }

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -641,8 +641,8 @@ func (r *userCreatedFeedEventDataResolver) Owner(ctx context.Context, obj *model
 	return resolveGalleryUserByUserID(ctx, obj.Owner.Dbid)
 }
 
-func (r *userFollowedByUsersFeedEventDataResolver) Owner(ctx context.Context, obj *model.UserFollowedByUsersFeedEventData) (*model.GalleryUser, error) {
-	return resolveGalleryUserByUserID(ctx, obj.Owner.Dbid)
+func (r *userFollowedByUsersFeedEventDataResolver) UserFollowed(ctx context.Context, obj *model.UserFollowedByUsersFeedEventData) (*model.GalleryUser, error) {
+	return resolveGalleryUserByUserID(ctx, obj.UserFollowed.Dbid)
 }
 
 func (r *userFollowedUsersFeedEventDataResolver) Owner(ctx context.Context, obj *model.UserFollowedUsersFeedEventData) (*model.GalleryUser, error) {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -604,8 +604,11 @@ func eventToUserFollowedByUsersFeedEventData(event *sqlc.FeedEvent) model.FeedEv
 	}
 
 	return model.UserFollowedByUsersFeedEventData{
-		EventTime:  &event.EventTime,
-		Owner:      &model.GalleryUser{Dbid: event.OwnerID}, // remaining fields handled by dedicated resolver
+		EventTime: &event.EventTime,
+		Owner:     nil, // no owner for this event type
+		UserFollowed: &model.GalleryUser{
+			Dbid: event.Data.UserFollowedIDs[0], // remaining fields handled by dedicated resolver
+		},
 		Action:     &event.Action,
 		FollowedBy: followedBy,
 	}

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -604,13 +604,11 @@ func eventToUserFollowedByUsersFeedEventData(event *sqlc.FeedEvent) model.FeedEv
 	}
 
 	return model.UserFollowedByUsersFeedEventData{
-		EventTime: &event.EventTime,
-		Owner:     nil, // no owner for this event type
-		UserFollowed: &model.GalleryUser{
-			Dbid: event.Data.UserFollowedIDs[0], // remaining fields handled by dedicated resolver
-		},
-		Action:     &event.Action,
-		FollowedBy: followedBy,
+		EventTime:    &event.EventTime,
+		Owner:        nil,                                                     // no owner for this event type
+		UserFollowed: &model.GalleryUser{Dbid: event.Data.UserFollowedIDs[0]}, // remaining fields handled by dedicated resolver
+		Action:       &event.Action,
+		FollowedBy:   followedBy,
 	}
 }
 

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -570,7 +570,7 @@ func feedEventToDataModel(event *sqlc.FeedEvent) (model.FeedEventData, error) {
 func eventToUserCreatedFeedEventData(event *sqlc.FeedEvent) model.FeedEventData {
 	return model.UserCreatedFeedEventData{
 		EventTime: &event.EventTime,
-		Owner:     &model.GalleryUser{Dbid: event.OwnerID}, // remaining fields handled by dedicated resolver
+		Owner:     &model.GalleryUser{Dbid: persist.DBID(event.OwnerID.String)}, // remaining fields handled by dedicated resolver
 		Action:    &event.Action,
 	}
 }
@@ -587,7 +587,7 @@ func eventToUserFollowedUsersFeedEventData(event *sqlc.FeedEvent) model.FeedEven
 
 	return model.UserFollowedUsersFeedEventData{
 		EventTime: &event.EventTime,
-		Owner:     &model.GalleryUser{Dbid: event.OwnerID}, // remaining fields handled by dedicated resolver
+		Owner:     &model.GalleryUser{Dbid: persist.DBID(event.OwnerID.String)}, // remaining fields handled by dedicated resolver
 		Action:    &event.Action,
 		Followed:  followed,
 	}
@@ -614,7 +614,7 @@ func eventToUserFollowedByUsersFeedEventData(event *sqlc.FeedEvent) model.FeedEv
 func eventToCollectorsNoteAddedToTokenFeedEventData(event *sqlc.FeedEvent) model.FeedEventData {
 	return model.CollectorsNoteAddedToTokenFeedEventData{
 		EventTime: &event.EventTime,
-		Owner:     &model.GalleryUser{Dbid: event.OwnerID}, // remaining fields handled by dedicated resolver
+		Owner:     &model.GalleryUser{Dbid: persist.DBID(event.OwnerID.String)}, // remaining fields handled by dedicated resolver
 		Token: &model.CollectionToken{
 			Token:      &model.Token{Dbid: event.Data.TokenID},                // remaining fields handled by dedicated resolver
 			Collection: &model.Collection{Dbid: event.Data.TokenCollectionID}, // remaining fields handled by dedicated resolver
@@ -627,8 +627,8 @@ func eventToCollectorsNoteAddedToTokenFeedEventData(event *sqlc.FeedEvent) model
 func eventToCollectionCreatedFeedEventData(event *sqlc.FeedEvent) model.FeedEventData {
 	return model.CollectionCreatedFeedEventData{
 		EventTime:  &event.EventTime,
-		Owner:      &model.GalleryUser{Dbid: event.OwnerID},          // remaining fields handled by dedicated resolver
-		Collection: &model.Collection{Dbid: event.Data.CollectionID}, // remaining fields handled by dedicated resolver
+		Owner:      &model.GalleryUser{Dbid: persist.DBID(event.OwnerID.String)}, // remaining fields handled by dedicated resolver
+		Collection: &model.Collection{Dbid: event.Data.CollectionID},             // remaining fields handled by dedicated resolver
 		Action:     &event.Action,
 		NewTokens:  nil, // handled by dedicated resolver
 		HelperCollectionCreatedFeedEventDataData: model.HelperCollectionCreatedFeedEventDataData{
@@ -640,8 +640,8 @@ func eventToCollectionCreatedFeedEventData(event *sqlc.FeedEvent) model.FeedEven
 func eventToCollectorsNoteAddedToCollectionFeedEventData(event *sqlc.FeedEvent) model.FeedEventData {
 	return model.CollectorsNoteAddedToCollectionFeedEventData{
 		EventTime:         &event.EventTime,
-		Owner:             &model.GalleryUser{Dbid: event.OwnerID},          // remaining fields handled by dedicated resolver
-		Collection:        &model.Collection{Dbid: event.Data.CollectionID}, // remaining fields handled by dedicated resolver
+		Owner:             &model.GalleryUser{Dbid: persist.DBID(event.OwnerID.String)}, // remaining fields handled by dedicated resolver
+		Collection:        &model.Collection{Dbid: event.Data.CollectionID},             // remaining fields handled by dedicated resolver
 		Action:            &event.Action,
 		NewCollectorsNote: util.StringToPointer(event.Data.CollectionNewCollectorsNote),
 	}
@@ -650,8 +650,8 @@ func eventToCollectorsNoteAddedToCollectionFeedEventData(event *sqlc.FeedEvent) 
 func eventToTokensAddedToCollectionFeedEventData(event *sqlc.FeedEvent) model.FeedEventData {
 	return model.TokensAddedToCollectionFeedEventData{
 		EventTime:  &event.EventTime,
-		Owner:      &model.GalleryUser{Dbid: event.OwnerID},          // remaining fields handled by dedicated resolver
-		Collection: &model.Collection{Dbid: event.Data.CollectionID}, // remaining fields handled by dedicated resolver
+		Owner:      &model.GalleryUser{Dbid: persist.DBID(event.OwnerID.String)}, // remaining fields handled by dedicated resolver
+		Collection: &model.Collection{Dbid: event.Data.CollectionID},             // remaining fields handled by dedicated resolver
 		Action:     &event.Action,
 		NewTokens:  nil, // handled by dedicated resolver
 		IsPreFeed:  util.BoolToPointer(event.Data.CollectionIsPreFeed),

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -605,7 +605,6 @@ func eventToUserFollowedByUsersFeedEventData(event *sqlc.FeedEvent) model.FeedEv
 
 	return model.UserFollowedByUsersFeedEventData{
 		EventTime:    &event.EventTime,
-		Owner:        nil,                                                     // no owner for this event type
 		UserFollowed: &model.GalleryUser{Dbid: event.Data.UserFollowedIDs[0]}, // remaining fields handled by dedicated resolver
 		Action:       &event.Action,
 		FollowedBy:   followedBy,

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -408,7 +408,8 @@ type UserFollowedUsersFeedEventData implements FeedEventData {
 
 type UserFollowedByUsersFeedEventData implements FeedEventData {
     eventTime: Time
-    owner: GalleryUser @goField(forceResolver: true)
+    owner: GalleryUser
+    userFollowed: GalleryUser @goField(forceResolver: true)
     action: Action
     followedBy: [FollowInfo]
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -383,7 +383,6 @@ type FollowInfo {
 
 interface FeedEventData {
     eventTime: Time
-    owner: GalleryUser
     action: Action
 }
 
@@ -408,7 +407,6 @@ type UserFollowedUsersFeedEventData implements FeedEventData {
 
 type UserFollowedByUsersFeedEventData implements FeedEventData {
     eventTime: Time
-    owner: GalleryUser  # always null for this event
     userFollowed: GalleryUser @goField(forceResolver: true)
     action: Action
     followedBy: [FollowInfo]

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -408,7 +408,7 @@ type UserFollowedUsersFeedEventData implements FeedEventData {
 
 type UserFollowedByUsersFeedEventData implements FeedEventData {
     eventTime: Time
-    owner: GalleryUser
+    owner: GalleryUser  # always null for this event
     userFollowed: GalleryUser @goField(forceResolver: true)
     action: Action
     followedBy: [FollowInfo]

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -406,6 +406,13 @@ type UserFollowedUsersFeedEventData implements FeedEventData {
     followed: [FollowInfo]
 }
 
+type UserFollowedByUsersFeedEventData implements FeedEventData {
+    eventTime: Time
+    owner: GalleryUser @goField(forceResolver: true)
+    action: Action
+    followedBy: [FollowInfo]
+}
+
 type CollectorsNoteAddedToTokenFeedEventData implements FeedEventData {
     eventTime: Time
     owner: GalleryUser @goField(forceResolver: true)

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -13,6 +13,7 @@ const (
 	ResourceTypeCollection
 	ActionUserCreated                     Action = "UserCreated"
 	ActionUserFollowedUsers               Action = "UserFollowedUsers"
+	ActionUserFollowedByUsers             Action = "UserFollowedByUsers"
 	ActionCollectorsNoteAddedToToken      Action = "CollectorsNoteAddedToToken"
 	ActionCollectionCreated               Action = "CollectionCreated"
 	ActionCollectorsNoteAddedToCollection Action = "CollectorsNoteAddedToCollection"
@@ -32,6 +33,7 @@ type EventData struct {
 type FeedEventData struct {
 	UserBio                     string   `json:"user_bio"`
 	UserFollowedIDs             DBIDList `json:"user_followed_ids"`
+	UserFollowerIDs             DBIDList `json:"user_follower_ids"`
 	UserFollowedBack            []bool   `json:"user_followed_back"`
 	TokenID                     DBID     `json:"token_id"`
 	TokenCollectionID           DBID     `json:"token_collection_id"`

--- a/service/persist/persist.go
+++ b/service/persist/persist.go
@@ -1,6 +1,7 @@
 package persist
 
 import (
+	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -326,4 +327,12 @@ func ContainsDBID(pSrc []DBID, pID DBID) bool {
 		}
 	}
 	return false
+}
+
+// DBIDToNullString converts a DBID to a sql.NullString
+func DBIDToNullString(v *DBID) sql.NullString {
+	if v == nil {
+		return sql.NullString{Valid: false}
+	}
+	return sql.NullString{String: v.String(), Valid: true}
 }

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -66,9 +66,9 @@ func (r *EventRepository) AddCollectionEvent(ctx context.Context, event sqlc.Eve
 	return &event, err
 }
 
-// WindowActiveForActor checks if there are more recent events with the same actor and action as the provided event.
-func (r *EventRepository) WindowActiveForActor(ctx context.Context, event sqlc.Event) (bool, error) {
-	return r.Queries.IsWindowActive(ctx, sqlc.IsWindowActiveParams{
+// WindowActiveForActorAction checks if there are more recent events with the same actor and action as the provided event.
+func (r *EventRepository) WindowActiveForActorAction(ctx context.Context, event sqlc.Event) (bool, error) {
+	return r.Queries.IsWindowActiveForActorAction(ctx, sqlc.IsWindowActiveForActorActionParams{
 		ActorID:     event.ActorID,
 		Action:      event.Action,
 		WindowStart: event.CreatedAt,
@@ -76,10 +76,10 @@ func (r *EventRepository) WindowActiveForActor(ctx context.Context, event sqlc.E
 	})
 }
 
-// WindowActiveForActorAndSubject checks if there are more recent events with the same actor and action applied to a specific subject such as
+// WindowActiveForActorActionSubject checks if there are more recent events with the same actor and action applied to a specific subject such as
 // for a particular collection or token.
-func (r *EventRepository) WindowActiveForActorAndSubject(ctx context.Context, event sqlc.Event) (bool, error) {
-	return r.Queries.IsWindowActiveWithSubject(ctx, sqlc.IsWindowActiveWithSubjectParams{
+func (r *EventRepository) WindowActiveForActorActionSubject(ctx context.Context, event sqlc.Event) (bool, error) {
+	return r.Queries.IsWindowActiveForActorActionSubject(ctx, sqlc.IsWindowActiveForActorActionSubjectParams{
 		ActorID:     event.ActorID,
 		Action:      event.Action,
 		SubjectID:   event.SubjectID,
@@ -88,18 +88,28 @@ func (r *EventRepository) WindowActiveForActorAndSubject(ctx context.Context, ev
 	})
 }
 
-// EventsInWindowForActor returns events with the same actor and action that belong to the same window of activity as the given eventID.
-func (r *EventRepository) EventsInWindowForActor(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
-	return r.Queries.GetEventsInWindowForActor(ctx, sqlc.GetEventsInWindowForActorParams{
+// WindowActiveForActionSubject checks if there are more recent events with the same action and subject as the provided event.
+func (r *EventRepository) WindowActiveForActionSubject(ctx context.Context, event sqlc.Event) (bool, error) {
+	return r.Queries.IsWindowActiveForActionSubject(ctx, sqlc.IsWindowActiveForActionSubjectParams{
+		Action:      event.Action,
+		SubjectID:   event.SubjectID,
+		WindowStart: event.CreatedAt,
+		WindowEnd:   event.CreatedAt.Add(time.Duration(viper.GetInt("FEED_WINDOW_SIZE")) * time.Second),
+	})
+}
+
+// EventsInWindowForActorAction returns events with the same actor and action that belong to the same window of activity as the given eventID.
+func (r *EventRepository) EventsInWindowForActorAction(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
+	return r.Queries.GetEventsInWindowForActorAction(ctx, sqlc.GetEventsInWindowForActorActionParams{
 		ID:   eventID,
 		Secs: float64(windowSeconds),
 	})
 }
 
-// EventsInWindowForSubject returns events with the same subject and action that belong to the same window of activity as the given eventID
+// EventsInWindowForActionSubject returns events with the same subject and action that belong to the same window of activity as the given eventID
 // regardless of the actor.
-func (r *EventRepository) EventsInWindowForSubject(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
-	return r.Queries.GetEventsInWindowForSubject(ctx, sqlc.GetEventsInWindowForSubjectParams{
+func (r *EventRepository) EventsInWindowForActionSubject(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
+	return r.Queries.GetEventsInWindowForActionSubject(ctx, sqlc.GetEventsInWindowForActionSubjectParams{
 		ID:   eventID,
 		Secs: float64(windowSeconds),
 	})

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -66,8 +66,8 @@ func (r *EventRepository) AddCollectionEvent(ctx context.Context, event sqlc.Eve
 	return &event, err
 }
 
-// WindowActive checks if there are more recent events with an action that matches the provided event.
-func (r *EventRepository) WindowActive(ctx context.Context, event sqlc.Event) (bool, error) {
+// WindowActiveForActor checks if there are more recent events with the same actor and action as the provided event.
+func (r *EventRepository) WindowActiveForActor(ctx context.Context, event sqlc.Event) (bool, error) {
 	return r.Queries.IsWindowActive(ctx, sqlc.IsWindowActiveParams{
 		ActorID:     event.ActorID,
 		Action:      event.Action,
@@ -76,9 +76,9 @@ func (r *EventRepository) WindowActive(ctx context.Context, event sqlc.Event) (b
 	})
 }
 
-// WindowActiveForSubject checks if there are more recent events with an action on a specific resource such as
-// as a collection or a token.
-func (r *EventRepository) WindowActiveForSubject(ctx context.Context, event sqlc.Event) (bool, error) {
+// WindowActiveForActorAndSubject checks if there are more recent events with the same actor and action applied to a specific subject such as
+// for a particular collection or token.
+func (r *EventRepository) WindowActiveForActorAndSubject(ctx context.Context, event sqlc.Event) (bool, error) {
 	return r.Queries.IsWindowActiveWithSubject(ctx, sqlc.IsWindowActiveWithSubjectParams{
 		ActorID:     event.ActorID,
 		Action:      event.Action,
@@ -88,9 +88,18 @@ func (r *EventRepository) WindowActiveForSubject(ctx context.Context, event sqlc
 	})
 }
 
-// EventsInWindow returns events belonging to the same window of activity as the given eventID.
-func (r *EventRepository) EventsInWindow(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
-	return r.Queries.GetEventsInWindow(ctx, sqlc.GetEventsInWindowParams{
+// EventsInWindowForActor returns events with the same actor and action that belong to the same window of activity as the given eventID.
+func (r *EventRepository) EventsInWindowForActor(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
+	return r.Queries.GetEventsInWindowForActor(ctx, sqlc.GetEventsInWindowForActorParams{
+		ID:   eventID,
+		Secs: float64(windowSeconds),
+	})
+}
+
+// EventsInWindowForSubject returns events with the same subject and action that belong to the same window of activity as the given eventID
+// irregardless of the actor.
+func (r *EventRepository) EventsInWindowForSubject(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
+	return r.Queries.GetEventsInWindowForSubject(ctx, sqlc.GetEventsInWindowForSubjectParams{
 		ID:   eventID,
 		Secs: float64(windowSeconds),
 	})

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -97,7 +97,7 @@ func (r *EventRepository) EventsInWindowForActor(ctx context.Context, eventID pe
 }
 
 // EventsInWindowForSubject returns events with the same subject and action that belong to the same window of activity as the given eventID
-// irregardless of the actor.
+// regardless of the actor.
 func (r *EventRepository) EventsInWindowForSubject(ctx context.Context, eventID persist.DBID, windowSeconds int) ([]sqlc.Event, error) {
 	return r.Queries.GetEventsInWindowForSubject(ctx, sqlc.GetEventsInWindowForSubjectParams{
 		ID:   eventID,

--- a/service/persist/postgres/feed.go
+++ b/service/persist/postgres/feed.go
@@ -15,6 +15,17 @@ type FeedRepository struct {
 }
 
 func (r *FeedRepository) Add(ctx context.Context, event sqlc.FeedEvent) (*sqlc.FeedEvent, error) {
+	if event.OwnerID == "" {
+		evt, err := r.Queries.CreateFeedEventNoOwner(ctx, sqlc.CreateFeedEventNoOwnerParams{
+			ID:        persist.GenerateID(),
+			Action:    event.Action,
+			Data:      event.Data,
+			EventTime: event.EventTime,
+			EventIds:  event.EventIds,
+		})
+		return &evt, err
+	}
+
 	evt, err := r.Queries.CreateFeedEvent(ctx, sqlc.CreateFeedEventParams{
 		ID:        persist.GenerateID(),
 		OwnerID:   event.OwnerID,

--- a/service/persist/postgres/feed.go
+++ b/service/persist/postgres/feed.go
@@ -15,17 +15,6 @@ type FeedRepository struct {
 }
 
 func (r *FeedRepository) Add(ctx context.Context, event sqlc.FeedEvent) (*sqlc.FeedEvent, error) {
-	if event.OwnerID == "" {
-		evt, err := r.Queries.CreateFeedEventNoOwner(ctx, sqlc.CreateFeedEventNoOwnerParams{
-			ID:        persist.GenerateID(),
-			Action:    event.Action,
-			Data:      event.Data,
-			EventTime: event.EventTime,
-			EventIds:  event.EventIds,
-		})
-		return &evt, err
-	}
-
 	evt, err := r.Queries.CreateFeedEvent(ctx, sqlc.CreateFeedEventParams{
 		ID:        persist.GenerateID(),
 		OwnerID:   event.OwnerID,
@@ -41,7 +30,7 @@ func (r *FeedRepository) Add(ctx context.Context, event sqlc.FeedEvent) (*sqlc.F
 // LastEventFrom returns the most recent event which occurred before `event`.
 func (r *FeedRepository) LastEventFrom(ctx context.Context, event sqlc.Event) (*sqlc.FeedEvent, error) {
 	evt, err := r.Queries.GetLastFeedEvent(ctx, sqlc.GetLastFeedEventParams{
-		OwnerID:   event.ActorID,
+		OwnerID:   persist.DBIDToNullString(&event.ActorID),
 		Action:    event.Action,
 		EventTime: event.CreatedAt,
 	})
@@ -56,7 +45,7 @@ func (r *FeedRepository) LastEventFrom(ctx context.Context, event sqlc.Event) (*
 // LastTokenEventFromEvent returns the most recent token event which occured before `event`.
 func (r *FeedRepository) LastTokenEventFromEvent(ctx context.Context, event sqlc.Event) (*sqlc.FeedEvent, error) {
 	evt, err := r.Queries.GetLastFeedEventForToken(ctx, sqlc.GetLastFeedEventForTokenParams{
-		OwnerID:   event.ActorID,
+		OwnerID:   persist.DBIDToNullString(&event.ActorID),
 		Action:    event.Action,
 		TokenID:   string(event.SubjectID),
 		EventTime: event.CreatedAt,
@@ -77,7 +66,7 @@ func (r *FeedRepository) LastCollectionEventFromEvent(ctx context.Context, event
 // LastCollectionEvent returns the most recent collection event for the given owner, action, and collection that occurred before time `since`.
 func (r *FeedRepository) LastCollectionEvent(ctx context.Context, ownerID persist.DBID, action persist.Action, collectionID persist.DBID, since time.Time) (*sqlc.FeedEvent, error) {
 	evt, err := r.Queries.GetLastFeedEventForCollection(ctx, sqlc.GetLastFeedEventForCollectionParams{
-		OwnerID:      ownerID,
+		OwnerID:      persist.DBIDToNullString(&ownerID),
 		Action:       action,
 		CollectionID: string(collectionID),
 		EventTime:    since,

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -76,8 +76,6 @@ overrides:
     go_type: "int"
 
   # Feed Events
-  - column: "feed_events.owner_id"
-    go_type: "github.com/mikeydub/go-gallery/service/persist.DBID"
   - column: "feed_events.action"
     go_type: "github.com/mikeydub/go-gallery/service/persist.Action"
   - column: "feed_events.event_ids"


### PR DESCRIPTION
Adds the `UserFollowedByUsers` feed event type which groups user events that followed the same user together. 

The feed writes the new event alongside the existing `UserFollowedUsers` event temporarily so the frontend has some data to work with. Then will follow up to stop generating `UserFollowedUsers` events and instead display the new `UserFollowedByUsers` in the feed once the frontend supports it.

This PR also removes the `owner` as a required field from the `FeedEventData` interface since there's not really a notion of a single `owner` for events of this type. Maybe was a bit overzealous in thinking of the interface, but luckily the frontend queries already specify `owner` per event type so no changes should be needed on that side. 

Also removed the old event tables while I'm at it, and renamed some existing feed functions to better reflect what they filter on.

Updated the docs on Notion as well: https://www.notion.so/gallery-so/Event-Design-eaf7607654024d54894cb19741904280