### PR TITLE
Add asUsername parameter to GraphQL debug auth

### DIFF
--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -292,6 +292,7 @@ type CreateUserPayload struct {
 func (CreateUserPayload) IsCreateUserPayloadOrError() {}
 
 type DebugAuth struct {
+	AsUsername     *string                 `json:"asUsername"`
 	UserID         *persist.DBID           `json:"userId"`
 	ChainAddresses []*persist.ChainAddress `json:"chainAddresses"`
 }

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -98,6 +98,47 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 	return nil, false
 }
 
+func createDebugAuthenticator(ctx context.Context, debugParams model.DebugAuth) (auth.Authenticator, error) {
+	if debugParams.AsUsername == nil {
+		if debugParams.ChainAddresses == nil {
+			return nil, fmt.Errorf("debug auth failed: either asUsername or chainAddresses must be specified")
+		}
+
+		userID := persist.DBID("")
+		if debugParams.UserID != nil {
+			userID = *debugParams.UserID
+		}
+
+		return debugtools.NewDebugAuthenticator(userID, chainAddressPointersToChainAddresses(debugParams.ChainAddresses)), nil
+	}
+
+	if debugParams.UserID != nil || debugParams.ChainAddresses != nil {
+		return nil, fmt.Errorf("debug auth failed: asUsername parameter cannot be used in conjunction with userId or chainAddresses parameters")
+	}
+
+	username := *debugParams.AsUsername
+	if username == "" {
+		return nil, fmt.Errorf("debug auth failed: asUsername parameter cannot be empty")
+	}
+
+	user, err := publicapi.For(ctx).User.GetUserByUsername(ctx, username)
+	if err != nil {
+		return nil, fmt.Errorf("debug auth failed for user '%s': %w", username, err)
+	}
+
+	wallets, err := publicapi.For(ctx).Wallet.GetWalletsByUserID(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("debug auth failed for user '%s': %w", username, err)
+	}
+
+	var addresses []persist.ChainAddress
+	for _, wallet := range wallets {
+		addresses = append(addresses, persist.NewChainAddress(wallet.Address, persist.Chain(wallet.Chain.Int32)))
+	}
+
+	return debugtools.NewDebugAuthenticator(user.ID, addresses), nil
+}
+
 // authMechanismToAuthenticator takes a GraphQL AuthMechanism and returns an Authenticator that can be used for auth
 func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.AuthMechanism) (auth.Authenticator, error) {
 
@@ -105,45 +146,7 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 
 	if debugtools.Enabled {
 		if viper.GetString("ENV") == "local" && m.Debug != nil {
-
-			if m.Debug.AsUsername == nil {
-				if m.Debug.ChainAddresses == nil {
-					return nil, fmt.Errorf("debug auth failed: either asUsername or chainAddresses must be specified")
-				}
-
-				userID := persist.DBID("")
-				if m.Debug.UserID != nil {
-					userID = *m.Debug.UserID
-				}
-
-				return debugtools.NewDebugAuthenticator(userID, chainAddressPointersToChainAddresses(m.Debug.ChainAddresses)), nil
-			}
-
-			if m.Debug.UserID != nil || m.Debug.ChainAddresses != nil {
-				return nil, fmt.Errorf("debug auth failed: asUsername parameter cannot be used in conjunction with userId or chainAddresses parameters")
-			}
-
-			username := *m.Debug.AsUsername
-			if username == "" {
-				return nil, fmt.Errorf("debug auth failed: asUsername parameter cannot be empty")
-			}
-
-			user, err := publicapi.For(ctx).User.GetUserByUsername(ctx, username)
-			if err != nil {
-				return nil, fmt.Errorf("debug auth failed for user '%s': %w", username, err)
-			}
-
-			wallets, err := publicapi.For(ctx).Wallet.GetWalletsByUserID(ctx, user.ID)
-			if err != nil {
-				return nil, fmt.Errorf("debug auth failed for user '%s': %w", username, err)
-			}
-
-			var addresses []persist.ChainAddress
-			for _, wallet := range wallets {
-				addresses = append(addresses, persist.NewChainAddress(wallet.Address, persist.Chain(wallet.Chain.Int32)))
-			}
-
-			return debugtools.NewDebugAuthenticator(user.ID, addresses), nil
+			return createDebugAuthenticator(ctx, *m.Debug)
 		}
 	}
 

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -99,6 +99,10 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 }
 
 func createDebugAuthenticator(ctx context.Context, debugParams model.DebugAuth) (auth.Authenticator, error) {
+	if !debugtools.Enabled || viper.GetString("ENV") != "local" {
+		return nil, fmt.Errorf("debug auth is only allowed in local environments with debugtools enabled")
+	}
+
 	if debugParams.AsUsername == nil {
 		if debugParams.ChainAddresses == nil {
 			return nil, fmt.Errorf("debug auth failed: either asUsername or chainAddresses must be specified")

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -732,11 +732,23 @@ input EoaAuth {
     signature: String! @scrub
 }
 
-# DebugAuth always succeeds and returns the supplied userId and addresses.
-# Only available for local development.
+# DebugAuth is a local-only authentication mechanism for testing and debugging.
+# It creates an authenticator that will return the supplied userId and chainAddresses as if they had been
+# successfully authenticated. For existing users, the asUsername parameter may be supplied as a convenience
+# method to look up and return their userId and chainAddresses.
 input DebugAuth @restrictEnvironment(allowed: ["local"]){
+    # Convenience method to authenticate as an existing user.
+    # Cannot be used in conjunction with the userId and chainAddresses parameters.
+    asUsername: String
+
+    # The userId that will be returned from the resulting authenticator.
+    # May be omitted or blank to indicate that there is no user associated with the supplied chainAddresses.
+    # Cannot be used in conjunction with the asUsername parameter.
     userId: DBID
-    chainAddresses:[ChainAddressInput!]!
+
+    # The chainAddresses that will be returned from the resulting authenticator.
+    # Cannot be used in conjunction with the asUsername parameter.
+    chainAddresses:[ChainAddressInput!]
 }
 
 input GnosisSafeAuth {


### PR DESCRIPTION
When debugging user issues, I usually log in as that user locally (via debug auth) and see if I can reproduce the issue. Historically, that means looking up their userID and their addresses in the database and then supplying those to a debug authenticator.

This PR adds the `asUsername` parameter as a convenience method to log in as a given user without needing to look up their ID and addresses manually.