### PR TITLE
[GAL-281] [GAL-271] Improved CreateUser flow

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -341,7 +341,7 @@ type ComplexityRoot struct {
 	Mutation struct {
 		AddUserWallet            func(childComplexity int, chainAddress persist.ChainAddress, authMechanism model.AuthMechanism) int
 		CreateCollection         func(childComplexity int, input model.CreateCollectionInput) int
-		CreateUser               func(childComplexity int, authMechanism model.AuthMechanism, username string) int
+		CreateUser               func(childComplexity int, authMechanism model.AuthMechanism, username string, bio *string) int
 		DeleteCollection         func(childComplexity int, collectionID persist.DBID) int
 		FollowUser               func(childComplexity int, userID persist.DBID) int
 		GetAuthNonce             func(childComplexity int, chainAddress persist.ChainAddress) int
@@ -605,7 +605,7 @@ type MutationResolver interface {
 	RefreshToken(ctx context.Context, tokenID persist.DBID) (model.RefreshTokenPayloadOrError, error)
 	RefreshContract(ctx context.Context, contractID persist.DBID) (model.RefreshContractPayloadOrError, error)
 	GetAuthNonce(ctx context.Context, chainAddress persist.ChainAddress) (model.GetAuthNoncePayloadOrError, error)
-	CreateUser(ctx context.Context, authMechanism model.AuthMechanism, username string) (model.CreateUserPayloadOrError, error)
+	CreateUser(ctx context.Context, authMechanism model.AuthMechanism, username string, bio *string) (model.CreateUserPayloadOrError, error)
 	Login(ctx context.Context, authMechanism model.AuthMechanism) (model.LoginPayloadOrError, error)
 	Logout(ctx context.Context) (*model.LogoutPayload, error)
 	FollowUser(ctx context.Context, userID persist.DBID) (model.FollowUserPayloadOrError, error)
@@ -1641,7 +1641,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CreateUser(childComplexity, args["authMechanism"].(model.AuthMechanism), args["username"].(string)), true
+		return e.complexity.Mutation.CreateUser(childComplexity, args["authMechanism"].(model.AuthMechanism), args["username"].(string), args["bio"].(*string)), true
 
 	case "Mutation.deleteCollection":
 		if e.complexity.Mutation.DeleteCollection == nil {
@@ -3493,7 +3493,7 @@ type Mutation {
 
     getAuthNonce(chainAddress: ChainAddressInput!): GetAuthNoncePayloadOrError
 
-    createUser(authMechanism: AuthMechanism!, username: String!): CreateUserPayloadOrError
+    createUser(authMechanism: AuthMechanism!, username: String!, bio:String): CreateUserPayloadOrError
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
     logout: LogoutPayload
 
@@ -3583,6 +3583,15 @@ func (ec *executionContext) field_Mutation_createUser_args(ctx context.Context, 
 		}
 	}
 	args["username"] = arg1
+	var arg2 *string
+	if tmp, ok := rawArgs["bio"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("bio"))
+		arg2, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["bio"] = arg2
 	return args, nil
 }
 
@@ -9199,7 +9208,7 @@ func (ec *executionContext) _Mutation_createUser(ctx context.Context, field grap
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CreateUser(rctx, args["authMechanism"].(model.AuthMechanism), args["username"].(string))
+		return ec.resolvers.Mutation().CreateUser(rctx, args["authMechanism"].(model.AuthMechanism), args["username"].(string), args["bio"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -382,6 +382,7 @@ func (ErrInvalidInput) IsUpdateUserInfoPayloadOrError()           {}
 func (ErrInvalidInput) IsRefreshTokenPayloadOrError()             {}
 func (ErrInvalidInput) IsRefreshContractPayloadOrError()          {}
 func (ErrInvalidInput) IsError()                                  {}
+func (ErrInvalidInput) IsCreateUserPayloadOrError()               {}
 func (ErrInvalidInput) IsFollowUserPayloadOrError()               {}
 func (ErrInvalidInput) IsUnfollowUserPayloadOrError()             {}
 
@@ -447,9 +448,8 @@ type ErrUserAlreadyExists struct {
 	Message string `json:"message"`
 }
 
-func (ErrUserAlreadyExists) IsUpdateUserInfoPayloadOrError() {}
-func (ErrUserAlreadyExists) IsError()                        {}
-func (ErrUserAlreadyExists) IsCreateUserPayloadOrError()     {}
+func (ErrUserAlreadyExists) IsError()                    {}
+func (ErrUserAlreadyExists) IsCreateUserPayloadOrError() {}
 
 type ErrUserNotFound struct {
 	Message string `json:"message"`
@@ -461,6 +461,14 @@ func (ErrUserNotFound) IsError()                      {}
 func (ErrUserNotFound) IsLoginPayloadOrError()        {}
 func (ErrUserNotFound) IsFollowUserPayloadOrError()   {}
 func (ErrUserNotFound) IsUnfollowUserPayloadOrError() {}
+
+type ErrUsernameNotAvailable struct {
+	Message string `json:"message"`
+}
+
+func (ErrUsernameNotAvailable) IsUpdateUserInfoPayloadOrError() {}
+func (ErrUsernameNotAvailable) IsError()                        {}
+func (ErrUsernameNotAvailable) IsCreateUserPayloadOrError()     {}
 
 type FeedConnection struct {
 	HelperFeedConnectionData

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -407,13 +407,18 @@ func (r *mutationResolver) GetAuthNonce(ctx context.Context, chainAddress persis
 	return output, nil
 }
 
-func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.AuthMechanism, username string) (model.CreateUserPayloadOrError, error) {
+func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.AuthMechanism, username string, bio *string) (model.CreateUserPayloadOrError, error) {
 	authenticator, err := r.authMechanismToAuthenticator(ctx, authMechanism)
 	if err != nil {
 		return nil, err
 	}
 
-	userID, galleryID, err := publicapi.For(ctx).User.CreateUser(ctx, authenticator, username)
+	bioStr := ""
+	if bio != nil {
+		bioStr = *bio
+	}
+
+	userID, galleryID, err := publicapi.For(ctx).User.CreateUser(ctx, authenticator, username, bioStr)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -407,13 +407,13 @@ func (r *mutationResolver) GetAuthNonce(ctx context.Context, chainAddress persis
 	return output, nil
 }
 
-func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.AuthMechanism) (model.CreateUserPayloadOrError, error) {
+func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.AuthMechanism, username string) (model.CreateUserPayloadOrError, error) {
 	authenticator, err := r.authMechanismToAuthenticator(ctx, authMechanism)
 	if err != nil {
 		return nil, err
 	}
 
-	userID, galleryID, err := publicapi.For(ctx).User.CreateUser(ctx, authenticator)
+	userID, galleryID, err := publicapi.For(ctx).User.CreateUser(ctx, authenticator, username)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -70,6 +70,8 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 		mappedErr = model.ErrUserNotFound{Message: message}
 	case persist.ErrUserAlreadyExists:
 		mappedErr = model.ErrUserAlreadyExists{Message: message}
+	case persist.ErrUsernameNotAvailable:
+		mappedErr = model.ErrUsernameNotAvailable{Message: message}
 	case persist.ErrCollectionNotFoundByID:
 		mappedErr = model.ErrCollectionNotFound{Message: message}
 	case persist.ErrTokenNotFoundByID:

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -826,7 +826,7 @@ type Mutation {
 
     getAuthNonce(chainAddress: ChainAddressInput!): GetAuthNoncePayloadOrError
 
-    createUser(authMechanism: AuthMechanism!, username: String!): CreateUserPayloadOrError
+    createUser(authMechanism: AuthMechanism!, username: String!, bio:String): CreateUserPayloadOrError
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
     logout: LogoutPayload
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -627,8 +627,8 @@ input UpdateUserInfoInput {
 union UpdateUserInfoPayloadOrError =
     UpdateUserInfoPayload
     | ErrNotAuthorized
+    | ErrUsernameNotAvailable
     | ErrInvalidInput
-    | ErrUserAlreadyExists
 
 type UpdateUserInfoPayload {
     viewer: Viewer
@@ -673,6 +673,10 @@ type ErrAuthenticationFailed implements Error {
 }
 
 type ErrUserAlreadyExists implements Error {
+    message: String!
+}
+
+type ErrUsernameNotAvailable implements Error {
     message: String!
 }
 
@@ -762,9 +766,11 @@ type LogoutPayload {
 
 union CreateUserPayloadOrError =
     CreateUserPayload
-    | ErrUserAlreadyExists
     | ErrAuthenticationFailed
     | ErrDoesNotOwnRequiredToken
+    | ErrUserAlreadyExists
+    | ErrUsernameNotAvailable
+    | ErrInvalidInput
 
 type CreateUserPayload {
     userId: DBID
@@ -820,7 +826,7 @@ type Mutation {
 
     getAuthNonce(chainAddress: ChainAddressInput!): GetAuthNoncePayloadOrError
 
-    createUser(authMechanism: AuthMechanism!): CreateUserPayloadOrError
+    createUser(authMechanism: AuthMechanism!, username: String!): CreateUserPayloadOrError
     login(authMechanism: AuthMechanism!): LoginPayloadOrError
     logout: LogoutPayload
 

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -118,15 +118,16 @@ func (api UserAPI) RemoveWalletsFromUser(ctx context.Context, walletIDs []persis
 	return nil
 }
 
-func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authenticator, username string) (userID persist.DBID, galleryID persist.DBID, err error) {
+func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authenticator, username string, bio string) (userID persist.DBID, galleryID persist.DBID, err error) {
 	// Validate
 	if err := validateFields(api.validator, validationMap{
 		"username": {username, "required,username"},
+		"bio":      {bio, "bio"},
 	}); err != nil {
 		return "", "", err
 	}
 
-	return user.CreateUser(ctx, authenticator, username, api.repos.UserRepository, api.repos.GalleryRepository)
+	return user.CreateUser(ctx, authenticator, username, bio, api.repos.UserRepository, api.repos.GalleryRepository)
 }
 
 func (api UserAPI) UpdateUserInfo(ctx context.Context, username string, bio string) error {

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -118,9 +118,15 @@ func (api UserAPI) RemoveWalletsFromUser(ctx context.Context, walletIDs []persis
 	return nil
 }
 
-func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authenticator) (userID persist.DBID, galleryID persist.DBID, err error) {
-	// Nothing to validate
-	return user.CreateUser(ctx, authenticator, api.repos.UserRepository, api.repos.GalleryRepository)
+func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authenticator, username string) (userID persist.DBID, galleryID persist.DBID, err error) {
+	// Validate
+	if err := validateFields(api.validator, validationMap{
+		"username": {username, "required,username"},
+	}); err != nil {
+		return "", "", err
+	}
+
+	return user.CreateUser(ctx, authenticator, username, api.repos.UserRepository, api.repos.GalleryRepository)
 }
 
 func (api UserAPI) UpdateUserInfo(ctx context.Context, username string, bio string) error {

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -156,33 +156,73 @@ func (u *UserRepository) UpdateByID(pCtx context.Context, pID persist.DBID, pUpd
 
 }
 
+func (u *UserRepository) createWalletWithTx(ctx context.Context, tx *sql.Tx, chainAddress persist.ChainAddress, walletType persist.WalletType) (persist.DBID, error) {
+	// Do we already have a wallet with this ChainAddress?
+	var walletID persist.DBID
+	if err := tx.StmtContext(ctx, u.getWalletIDStmt).QueryRowContext(ctx, chainAddress.Address(), chainAddress.Chain()).Scan(&walletID); err != nil && err != sql.ErrNoRows {
+		return "", err
+	}
+
+	if walletID != "" {
+		// If we do have a wallet with this ChainAddress, does it belong to a user?
+		var user persist.User
+		err := tx.StmtContext(ctx, u.getByWalletIDStmt).QueryRowContext(ctx, walletID).Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, &user.Bio, &user.CreationTime, &user.LastUpdated)
+		if err != nil && err != sql.ErrNoRows {
+			return "", err
+		}
+
+		// If the wallet belongs to a user, its address can't be used to create a new wallet. Return an error.
+		if user.ID != "" {
+			return "", persist.ErrAddressOwnedByUser{ChainAddress: chainAddress, OwnerID: user.ID}
+		}
+
+		// If the wallet exists but doesn't belong to anyone, it should be deleted.
+		if _, err := tx.StmtContext(ctx, u.deleteWalletStmt).ExecContext(ctx, walletID); err != nil {
+			return "", err
+		}
+	}
+
+	newWalletID := persist.GenerateID()
+	// At this point, we know there's no existing wallet in the database with this ChainAddress, so let's make a new one!
+	if _, err := tx.StmtContext(ctx, u.createWalletStmt).ExecContext(ctx, newWalletID, chainAddress.Address(), chainAddress.Chain(), walletType); err != nil {
+		return "", err
+	}
+
+	return newWalletID, nil
+}
+
 // Create creates a new user
 func (u *UserRepository) Create(pCtx context.Context, pUser persist.CreateUserInput) (persist.DBID, error) {
-	var walletID persist.DBID
-	var id persist.DBID
+	tx, err := u.db.BeginTx(pCtx, nil)
+	if err != nil {
+		return "", err
+	}
 
-	// TODO: Wrap all of this in a transaction
-	_, err := u.GetByUsername(pCtx, pUser.Username)
+	defer tx.Rollback()
+
+	var user persist.User
+	err = tx.StmtContext(pCtx, u.getByUsernameStmt).QueryRowContext(pCtx, strings.ToLower(pUser.Username)).Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, pq.Array(&user.Wallets), &user.Bio, &user.CreationTime, &user.LastUpdated)
 	if err == nil {
 		return "", persist.ErrUsernameNotAvailable{Username: pUser.Username}
 	}
 
-	var notFoundErr persist.ErrUserNotFound
-	if !errors.As(err, &notFoundErr) {
+	// If there are no rows returned, the username isn't taken yet
+	if err != sql.ErrNoRows {
 		return "", err
 	}
 
-	_, err = u.createWalletStmt.ExecContext(pCtx, persist.GenerateID(), pUser.ChainAddress.Address(), pUser.ChainAddress.Chain(), pUser.WalletType)
-	if err != nil {
-		return "", fmt.Errorf("failed to create wallet: %w", err)
-	}
-	err = u.getWalletIDStmt.QueryRowContext(pCtx, pUser.ChainAddress.Address(), pUser.ChainAddress.Chain()).Scan(&walletID)
+	walletID, err := u.createWalletWithTx(pCtx, tx, pUser.ChainAddress, pUser.WalletType)
 	if err != nil {
 		return "", err
 	}
 
-	err = u.createStmt.QueryRowContext(pCtx, persist.GenerateID(), pUser.Username, strings.ToLower(pUser.Username), pUser.Bio, []persist.DBID{walletID}).Scan(&id)
+	var id persist.DBID
+	err = tx.StmtContext(pCtx, u.createStmt).QueryRowContext(pCtx, persist.GenerateID(), pUser.Username, strings.ToLower(pUser.Username), pUser.Bio, []persist.DBID{walletID}).Scan(&id)
 	if err != nil {
+		return "", err
+	}
+
+	if err := tx.Commit(); err != nil {
 		return "", err
 	}
 
@@ -271,39 +311,13 @@ func (u *UserRepository) AddWallet(pCtx context.Context, pUserID persist.DBID, p
 
 	defer tx.Rollback()
 
-	// Do we already have a wallet with this ChainAddress?
-	var walletID persist.DBID
-	if err := tx.StmtContext(pCtx, u.getWalletIDStmt).QueryRowContext(pCtx, pChainAddress.Address(), pChainAddress.Chain()).Scan(&walletID); err != nil && err != sql.ErrNoRows {
-		return err
-	}
-
-	if walletID != "" {
-		// If we do have a wallet with this ChainAddress, does it belong to a user?
-		var user persist.User
-		err := tx.StmtContext(pCtx, u.getByWalletIDStmt).QueryRowContext(pCtx, walletID).Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, &user.Bio, &user.CreationTime, &user.LastUpdated)
-		if err != nil && err != sql.ErrNoRows {
-			return err
-		}
-
-		// If the wallet belongs to a user, its address can't be used to create a new wallet. Return an error.
-		if user.ID != "" {
-			return persist.ErrAddressOwnedByUser{ChainAddress: pChainAddress, OwnerID: user.ID}
-		}
-
-		// If the wallet exists but doesn't belong to anyone, it should be deleted.
-		if _, err := tx.StmtContext(pCtx, u.deleteWalletStmt).ExecContext(pCtx, walletID); err != nil {
-			return err
-		}
-	}
-
-	newWalletID := persist.GenerateID()
-	// At this point, we know there's no existing wallet in the database with this ChainAddress, so let's make a new one!
-	if _, err := tx.StmtContext(pCtx, u.createWalletStmt).ExecContext(pCtx, newWalletID, pChainAddress.Address(), pChainAddress.Chain(), pWalletType); err != nil {
+	walletID, err := u.createWalletWithTx(pCtx, tx, pChainAddress, pWalletType)
+	if err != nil {
 		return err
 	}
 
 	// Add the new wallet to the user
-	if _, err := tx.StmtContext(pCtx, u.addWalletStmt).ExecContext(pCtx, newWalletID, pUserID); err != nil {
+	if _, err := tx.StmtContext(pCtx, u.addWalletStmt).ExecContext(pCtx, walletID, pUserID); err != nil {
 		return err
 	}
 

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -44,7 +44,7 @@ func NewUserRepository(db *sql.DB) *UserRepository {
 	updateInfoStmt, err := db.PrepareContext(ctx, `UPDATE users SET USERNAME = $2, USERNAME_IDEMPOTENT = $3, LAST_UPDATED = $4, BIO = $5 WHERE ID = $1;`)
 	checkNoErr(err)
 
-	createStmt, err := db.PrepareContext(ctx, `INSERT INTO users (ID, USERNAME, USERNAME_IDEMPOTENT, WALLETS) VALUES ($1, $2, $3, $4) RETURNING ID;`)
+	createStmt, err := db.PrepareContext(ctx, `INSERT INTO users (ID, USERNAME, USERNAME_IDEMPOTENT, BIO, WALLETS) VALUES ($1, $2, $3, $4, $5) RETURNING ID;`)
 	checkNoErr(err)
 
 	getByIDStmt, err := db.PrepareContext(ctx, `SELECT ID,DELETED,VERSION,USERNAME,USERNAME_IDEMPOTENT,BIO,WALLETS,CREATED_AT,LAST_UPDATED FROM users WHERE ID = $1 AND DELETED = false;`)
@@ -181,7 +181,7 @@ func (u *UserRepository) Create(pCtx context.Context, pUser persist.CreateUserIn
 		return "", err
 	}
 
-	err = u.createStmt.QueryRowContext(pCtx, persist.GenerateID(), pUser.Username, strings.ToLower(pUser.Username), []persist.DBID{walletID}).Scan(&id)
+	err = u.createStmt.QueryRowContext(pCtx, persist.GenerateID(), pUser.Username, strings.ToLower(pUser.Username), pUser.Bio, []persist.DBID{walletID}).Scan(&id)
 	if err != nil {
 		return "", err
 	}

--- a/service/persist/user.go
+++ b/service/persist/user.go
@@ -27,6 +27,7 @@ type UserUpdateInfoInput struct {
 }
 
 type CreateUserInput struct {
+	Username     string
 	ChainAddress ChainAddress
 	WalletType   WalletType
 }
@@ -69,6 +70,14 @@ type ErrUserAlreadyExists struct {
 
 func (e ErrUserAlreadyExists) Error() string {
 	return fmt.Sprintf("user already exists: username: %s, address: %s, authenticator: %s", e.Username, e.ChainAddress, e.Authenticator)
+}
+
+type ErrUsernameNotAvailable struct {
+	Username string
+}
+
+func (e ErrUsernameNotAvailable) Error() string {
+	return fmt.Sprintf("username not available: %s", e.Username)
 }
 
 type ErrAddressOwnedByUser struct {

--- a/service/persist/user.go
+++ b/service/persist/user.go
@@ -28,6 +28,7 @@ type UserUpdateInfoInput struct {
 
 type CreateUserInput struct {
 	Username     string
+	Bio          string
 	ChainAddress ChainAddress
 	WalletType   WalletType
 }

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -90,7 +90,7 @@ type MergeUsersInput struct {
 }
 
 // CreateUser creates a new user
-func CreateUser(pCtx context.Context, authenticator auth.Authenticator, username string, userRepo persist.UserRepository,
+func CreateUser(pCtx context.Context, authenticator auth.Authenticator, username string, bio string, userRepo persist.UserRepository,
 	galleryRepo persist.GalleryRepository) (userID persist.DBID, galleryID persist.DBID, err error) {
 	gc := util.GinContextFromContext(pCtx)
 
@@ -112,6 +112,7 @@ func CreateUser(pCtx context.Context, authenticator auth.Authenticator, username
 
 	user := persist.CreateUserInput{
 		Username:     username,
+		Bio:          bio,
 		ChainAddress: wallet.ChainAddress,
 		WalletType:   wallet.WalletType,
 	}

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -90,7 +90,7 @@ type MergeUsersInput struct {
 }
 
 // CreateUser creates a new user
-func CreateUser(pCtx context.Context, authenticator auth.Authenticator, userRepo persist.UserRepository,
+func CreateUser(pCtx context.Context, authenticator auth.Authenticator, username string, userRepo persist.UserRepository,
 	galleryRepo persist.GalleryRepository) (userID persist.DBID, galleryID persist.DBID, err error) {
 	gc := util.GinContextFromContext(pCtx)
 
@@ -111,6 +111,7 @@ func CreateUser(pCtx context.Context, authenticator auth.Authenticator, userRepo
 	wallet := authResult.Addresses[0]
 
 	user := persist.CreateUserInput{
+		Username:     username,
 		ChainAddress: wallet.ChainAddress,
 		WalletType:   wallet.WalletType,
 	}


### PR DESCRIPTION
## What's new?

- The `CreateUser` mutation now requires a username to be specified. Prior to this, we'd create an account and _then_ allow the user to pick a username, leading to all sorts of scenarios where a user can take actions on our site but doesn't have a username.

- `CreateUser` also takes an optional `bio` field, since we still ask for a bio during the initial sign-up flow. If omitted, the bio will be an empty string as usual.

- Bug fix: `CreateUser` now succeeds when using an address owned by a deleted wallet or a deleted user. Previously, user creation would fail if a previous (but now deleted) wallet or user had used the same address.