### PR TITLE
[GAL-141] Add Live Render

### DIFF
--- a/db/migrations/000020_add_token_settings_to_collections.down.sql
+++ b/db/migrations/000020_add_token_settings_to_collections.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE collections DROP COLUMN IF EXISTS token_settings;

--- a/db/migrations/000020_add_token_settings_to_collections.up.sql
+++ b/db/migrations/000020_add_token_settings_to_collections.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE collections ADD COLUMN IF NOT EXISTS token_settings jsonb;

--- a/db/sqlc/batch.go
+++ b/db/sqlc/batch.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getCollectionByIdBatch = `-- name: GetCollectionByIdBatch :batchone
-SELECT id, deleted, owner_user_id, nfts, version, last_updated, created_at, hidden, collectors_note, name, layout FROM collections WHERE id = $1 AND deleted = false
+SELECT id, deleted, owner_user_id, nfts, version, last_updated, created_at, hidden, collectors_note, name, layout, token_settings FROM collections WHERE id = $1 AND deleted = false
 `
 
 type GetCollectionByIdBatchBatchResults struct {
@@ -49,6 +49,7 @@ func (b *GetCollectionByIdBatchBatchResults) QueryRow(f func(int, Collection, er
 			&i.CollectorsNote,
 			&i.Name,
 			&i.Layout,
+			&i.TokenSettings,
 		)
 		if err != nil && (err.Error() == "no result" || err.Error() == "batch already closed") {
 			break
@@ -65,7 +66,7 @@ func (b *GetCollectionByIdBatchBatchResults) Close() error {
 }
 
 const getCollectionsByGalleryIdBatch = `-- name: GetCollectionsByGalleryIdBatch :batchmany
-SELECT c.id, c.deleted, c.owner_user_id, c.nfts, c.version, c.last_updated, c.created_at, c.hidden, c.collectors_note, c.name, c.layout FROM galleries g, unnest(g.collections)
+SELECT c.id, c.deleted, c.owner_user_id, c.nfts, c.version, c.last_updated, c.created_at, c.hidden, c.collectors_note, c.name, c.layout, c.token_settings FROM galleries g, unnest(g.collections)
     WITH ORDINALITY AS x(coll_id, coll_ord)
     INNER JOIN collections c ON c.id = x.coll_id
     WHERE g.id = $1 AND g.deleted = false AND c.deleted = false ORDER BY x.coll_ord
@@ -110,6 +111,7 @@ func (b *GetCollectionsByGalleryIdBatchBatchResults) Query(f func(int, []Collect
 				&i.CollectorsNote,
 				&i.Name,
 				&i.Layout,
+				&i.TokenSettings,
 			); err != nil {
 				break
 			}

--- a/db/sqlc/models_gen.go
+++ b/db/sqlc/models_gen.go
@@ -46,6 +46,7 @@ type Collection struct {
 	CollectorsNote sql.NullString
 	Name           sql.NullString
 	Layout         TokenLayout
+	TokenSettings  map[persist.DBID]persist.CollectionTokenSettings
 }
 
 type CollectionEvent struct {

--- a/db/sqlc/query.sql.go
+++ b/db/sqlc/query.sql.go
@@ -175,7 +175,7 @@ func (q *Queries) CreateUserEvent(ctx context.Context, arg CreateUserEventParams
 }
 
 const getCollectionById = `-- name: GetCollectionById :one
-SELECT id, deleted, owner_user_id, nfts, version, last_updated, created_at, hidden, collectors_note, name, layout FROM collections WHERE id = $1 AND deleted = false
+SELECT id, deleted, owner_user_id, nfts, version, last_updated, created_at, hidden, collectors_note, name, layout, token_settings FROM collections WHERE id = $1 AND deleted = false
 `
 
 func (q *Queries) GetCollectionById(ctx context.Context, id persist.DBID) (Collection, error) {
@@ -193,12 +193,13 @@ func (q *Queries) GetCollectionById(ctx context.Context, id persist.DBID) (Colle
 		&i.CollectorsNote,
 		&i.Name,
 		&i.Layout,
+		&i.TokenSettings,
 	)
 	return i, err
 }
 
 const getCollectionsByGalleryId = `-- name: GetCollectionsByGalleryId :many
-SELECT c.id, c.deleted, c.owner_user_id, c.nfts, c.version, c.last_updated, c.created_at, c.hidden, c.collectors_note, c.name, c.layout FROM galleries g, unnest(g.collections)
+SELECT c.id, c.deleted, c.owner_user_id, c.nfts, c.version, c.last_updated, c.created_at, c.hidden, c.collectors_note, c.name, c.layout, c.token_settings FROM galleries g, unnest(g.collections)
     WITH ORDINALITY AS x(coll_id, coll_ord)
     INNER JOIN collections c ON c.id = x.coll_id
     WHERE g.id = $1 AND g.deleted = false AND c.deleted = false ORDER BY x.coll_ord
@@ -225,6 +226,7 @@ func (q *Queries) GetCollectionsByGalleryId(ctx context.Context, id persist.DBID
 			&i.CollectorsNote,
 			&i.Name,
 			&i.Layout,
+			&i.TokenSettings,
 		); err != nil {
 			return nil, err
 		}

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -117,6 +117,7 @@ type ComplexityRoot struct {
 	CollectionToken struct {
 		Collection func(childComplexity int) int
 		ID         func(childComplexity int) int
+		RenderLive func(childComplexity int) int
 		Token      func(childComplexity int) int
 	}
 
@@ -871,6 +872,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CollectionToken.ID(childComplexity), true
+
+	case "CollectionToken.renderLive":
+		if e.complexity.CollectionToken.RenderLive == nil {
+			break
+		}
+
+		return e.complexity.CollectionToken.RenderLive(childComplexity), true
 
 	case "CollectionToken.token":
 		if e.complexity.CollectionToken.Token == nil {
@@ -2929,6 +2937,7 @@ type CollectionToken implements Node
     id: ID!
     token: Token
     collection: Collection
+    renderLive: Boolean
 }
 
 type CollectionLayout {
@@ -3163,12 +3172,18 @@ input CollectionLayoutInput {
     whitespace: [Int!]!
 }
 
+input CollectionTokenSettingsInput {
+    tokenId: DBID!
+    renderLive: Boolean!
+}
+
 input CreateCollectionInput {
     galleryId: DBID!
     name: String!
     collectorsNote: String!
     tokens: [DBID!]!
     layout: CollectionLayoutInput!
+    tokenSettings: [CollectionTokenSettingsInput!]!
 }
 
 union CreateCollectionPayloadOrError =
@@ -3194,6 +3209,7 @@ input UpdateCollectionInfoInput {
     collectionId: DBID!
     name: String!
     collectorsNote: String!
+    tokenSettings: [CollectionTokenSettingsInput!]!
 }
 
 union UpdateCollectionInfoPayloadOrError =
@@ -5010,6 +5026,38 @@ func (ec *executionContext) _CollectionToken_collection(ctx context.Context, fie
 	res := resTmp.(*model.Collection)
 	fc.Result = res
 	return ec.marshalOCollection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _CollectionToken_renderLive(ctx context.Context, field graphql.CollectedField, obj *model.CollectionToken) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "CollectionToken",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RenderLive, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CollectorsNoteAddedToCollectionFeedEventData_eventTime(ctx context.Context, field graphql.CollectedField, obj *model.CollectorsNoteAddedToCollectionFeedEventData) (ret graphql.Marshaler) {
@@ -14229,6 +14277,37 @@ func (ec *executionContext) unmarshalInputCollectionLayoutInput(ctx context.Cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCollectionTokenSettingsInput(ctx context.Context, obj interface{}) (model.CollectionTokenSettingsInput, error) {
+	var it model.CollectionTokenSettingsInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	for k, v := range asMap {
+		switch k {
+		case "tokenId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tokenId"))
+			it.TokenID, err = ec.unmarshalNDBID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "renderLive":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("renderLive"))
+			it.RenderLive, err = ec.unmarshalNBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateCollectionInput(ctx context.Context, obj interface{}) (model.CreateCollectionInput, error) {
 	var it model.CreateCollectionInput
 	asMap := map[string]interface{}{}
@@ -14275,6 +14354,14 @@ func (ec *executionContext) unmarshalInputCreateCollectionInput(ctx context.Cont
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("layout"))
 			it.Layout, err = ec.unmarshalNCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayoutInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "tokenSettings":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tokenSettings"))
+			it.TokenSettings, err = ec.unmarshalNCollectionTokenSettingsInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionTokenSettingsInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -14518,6 +14605,14 @@ func (ec *executionContext) unmarshalInputUpdateCollectionInfoInput(ctx context.
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("collectorsNote"))
 			it.CollectorsNote, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "tokenSettings":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("tokenSettings"))
+			it.TokenSettings, err = ec.unmarshalNCollectionTokenSettingsInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionTokenSettingsInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -16404,6 +16499,13 @@ func (ec *executionContext) _CollectionToken(ctx context.Context, sel ast.Select
 		case "collection":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._CollectionToken_collection(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "renderLive":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._CollectionToken_renderLive(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)
@@ -20522,6 +20624,28 @@ func (ec *executionContext) unmarshalNChainAddressInput2ᚖgithubᚗcomᚋmikeyd
 
 func (ec *executionContext) unmarshalNCollectionLayoutInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionLayoutInput(ctx context.Context, v interface{}) (*model.CollectionLayoutInput, error) {
 	res, err := ec.unmarshalInputCollectionLayoutInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNCollectionTokenSettingsInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionTokenSettingsInputᚄ(ctx context.Context, v interface{}) ([]*model.CollectionTokenSettingsInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]*model.CollectionTokenSettingsInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNCollectionTokenSettingsInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionTokenSettingsInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNCollectionTokenSettingsInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCollectionTokenSettingsInput(ctx context.Context, v interface{}) (*model.CollectionTokenSettingsInput, error) {
+	res, err := ec.unmarshalInputCollectionTokenSettingsInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -217,13 +217,17 @@ type CollectionLayoutInput struct {
 
 type CollectionToken struct {
 	HelperCollectionTokenData
-	Token      *Token      `json:"token"`
-	Collection *Collection `json:"collection"`
-	RenderLive *bool       `json:"renderLive"`
+	Token         *Token                   `json:"token"`
+	Collection    *Collection              `json:"collection"`
+	TokenSettings *CollectionTokenSettings `json:"tokenSettings"`
 }
 
 func (CollectionToken) IsNode()                       {}
 func (CollectionToken) IsCollectionTokenByIDOrError() {}
+
+type CollectionTokenSettings struct {
+	RenderLive *bool `json:"renderLive"`
+}
 
 type CollectionTokenSettingsInput struct {
 	TokenID    persist.DBID `json:"tokenId"`
@@ -744,10 +748,9 @@ type UpdateCollectionHiddenPayload struct {
 func (UpdateCollectionHiddenPayload) IsUpdateCollectionHiddenPayloadOrError() {}
 
 type UpdateCollectionInfoInput struct {
-	CollectionID   persist.DBID                    `json:"collectionId"`
-	Name           string                          `json:"name"`
-	CollectorsNote string                          `json:"collectorsNote"`
-	TokenSettings  []*CollectionTokenSettingsInput `json:"tokenSettings"`
+	CollectionID   persist.DBID `json:"collectionId"`
+	Name           string       `json:"name"`
+	CollectorsNote string       `json:"collectorsNote"`
 }
 
 type UpdateCollectionInfoPayload struct {
@@ -757,9 +760,10 @@ type UpdateCollectionInfoPayload struct {
 func (UpdateCollectionInfoPayload) IsUpdateCollectionInfoPayloadOrError() {}
 
 type UpdateCollectionTokensInput struct {
-	CollectionID persist.DBID           `json:"collectionId"`
-	Tokens       []persist.DBID         `json:"tokens"`
-	Layout       *CollectionLayoutInput `json:"layout"`
+	CollectionID  persist.DBID                    `json:"collectionId"`
+	Tokens        []persist.DBID                  `json:"tokens"`
+	Layout        *CollectionLayoutInput          `json:"layout"`
+	TokenSettings []*CollectionTokenSettingsInput `json:"tokenSettings"`
 }
 
 type UpdateCollectionTokensPayload struct {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -219,10 +219,16 @@ type CollectionToken struct {
 	HelperCollectionTokenData
 	Token      *Token      `json:"token"`
 	Collection *Collection `json:"collection"`
+	RenderLive *bool       `json:"renderLive"`
 }
 
 func (CollectionToken) IsNode()                       {}
 func (CollectionToken) IsCollectionTokenByIDOrError() {}
+
+type CollectionTokenSettingsInput struct {
+	TokenID    persist.DBID `json:"tokenId"`
+	RenderLive bool         `json:"renderLive"`
+}
 
 type CollectorsNoteAddedToCollectionFeedEventData struct {
 	EventTime         *time.Time      `json:"eventTime"`
@@ -270,11 +276,12 @@ type Contract struct {
 func (Contract) IsNode() {}
 
 type CreateCollectionInput struct {
-	GalleryID      persist.DBID           `json:"galleryId"`
-	Name           string                 `json:"name"`
-	CollectorsNote string                 `json:"collectorsNote"`
-	Tokens         []persist.DBID         `json:"tokens"`
-	Layout         *CollectionLayoutInput `json:"layout"`
+	GalleryID      persist.DBID                    `json:"galleryId"`
+	Name           string                          `json:"name"`
+	CollectorsNote string                          `json:"collectorsNote"`
+	Tokens         []persist.DBID                  `json:"tokens"`
+	Layout         *CollectionLayoutInput          `json:"layout"`
+	TokenSettings  []*CollectionTokenSettingsInput `json:"tokenSettings"`
 }
 
 type CreateCollectionPayload struct {
@@ -737,9 +744,10 @@ type UpdateCollectionHiddenPayload struct {
 func (UpdateCollectionHiddenPayload) IsUpdateCollectionHiddenPayloadOrError() {}
 
 type UpdateCollectionInfoInput struct {
-	CollectionID   persist.DBID `json:"collectionId"`
-	Name           string       `json:"name"`
-	CollectorsNote string       `json:"collectorsNote"`
+	CollectionID   persist.DBID                    `json:"collectionId"`
+	Name           string                          `json:"name"`
+	CollectorsNote string                          `json:"collectorsNote"`
+	TokenSettings  []*CollectionTokenSettingsInput `json:"tokenSettings"`
 }
 
 type UpdateCollectionInfoPayload struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -38,8 +38,9 @@ func (r *collectionResolver) Tokens(ctx context.Context, obj *model.Collection) 
 				TokenId:      token.ID,
 				CollectionId: obj.Dbid,
 			},
-			Token:      tokenToModel(ctx, token),
-			Collection: obj,
+			Token:         tokenToModel(ctx, token),
+			Collection:    obj,
+			TokenSettings: nil, // handled by dedicated resolver
 		}
 	}
 
@@ -56,6 +57,10 @@ func (r *collectionCreatedFeedEventDataResolver) Collection(ctx context.Context,
 
 func (r *collectionCreatedFeedEventDataResolver) NewTokens(ctx context.Context, obj *model.CollectionCreatedFeedEventData) ([]*model.CollectionToken, error) {
 	return resolveNewTokensByEventID(ctx, obj.FeedEventId)
+}
+
+func (r *collectionTokenResolver) TokenSettings(ctx context.Context, obj *model.CollectionToken) (*model.CollectionTokenSettings, error) {
+	return resolveTokenSettingsByIDs(ctx, obj.TokenId, obj.CollectionId)
 }
 
 func (r *collectorsNoteAddedToCollectionFeedEventDataResolver) Owner(ctx context.Context, obj *model.CollectorsNoteAddedToCollectionFeedEventData) (*model.GalleryUser, error) {
@@ -202,7 +207,12 @@ func (r *mutationResolver) CreateCollection(ctx context.Context, input model.Cre
 		Whitespace: input.Layout.Whitespace,
 	}
 
-	collection, err := api.Collection.CreateCollection(ctx, input.GalleryID, input.Name, input.CollectorsNote, input.Tokens, layout, input.TokenSettings)
+	settings := make(map[persist.DBID]persist.CollectionTokenSettings)
+	for _, tokenSetting := range input.TokenSettings {
+		settings[tokenSetting.TokenID] = persist.CollectionTokenSettings{RenderLive: tokenSetting.RenderLive}
+	}
+
+	collection, err := api.Collection.CreateCollection(ctx, input.GalleryID, input.Name, input.CollectorsNote, input.Tokens, layout, settings)
 
 	if err != nil {
 		return nil, err
@@ -273,7 +283,12 @@ func (r *mutationResolver) UpdateCollectionTokens(ctx context.Context, input mod
 		Whitespace: input.Layout.Whitespace,
 	}
 
-	err := api.Collection.UpdateCollectionTokens(ctx, input.CollectionID, input.Tokens, layout)
+	settings := make(map[persist.DBID]persist.CollectionTokenSettings)
+	for _, tokenSetting := range input.TokenSettings {
+		settings[tokenSetting.TokenID] = persist.CollectionTokenSettings{RenderLive: tokenSetting.RenderLive}
+	}
+
+	err := api.Collection.UpdateCollectionTokens(ctx, input.CollectionID, input.Tokens, layout, settings)
 	if err != nil {
 		return nil, err
 	}
@@ -697,6 +712,11 @@ func (r *Resolver) CollectionCreatedFeedEventData() generated.CollectionCreatedF
 	return &collectionCreatedFeedEventDataResolver{r}
 }
 
+// CollectionToken returns generated.CollectionTokenResolver implementation.
+func (r *Resolver) CollectionToken() generated.CollectionTokenResolver {
+	return &collectionTokenResolver{r}
+}
+
 // CollectorsNoteAddedToCollectionFeedEventData returns generated.CollectorsNoteAddedToCollectionFeedEventDataResolver implementation.
 func (r *Resolver) CollectorsNoteAddedToCollectionFeedEventData() generated.CollectorsNoteAddedToCollectionFeedEventDataResolver {
 	return &collectorsNoteAddedToCollectionFeedEventDataResolver{r}
@@ -777,6 +797,7 @@ func (r *Resolver) ChainAddressInput() generated.ChainAddressInputResolver {
 
 type collectionResolver struct{ *Resolver }
 type collectionCreatedFeedEventDataResolver struct{ *Resolver }
+type collectionTokenResolver struct{ *Resolver }
 type collectorsNoteAddedToCollectionFeedEventDataResolver struct{ *Resolver }
 type collectorsNoteAddedToTokenFeedEventDataResolver struct{ *Resolver }
 type feedConnectionResolver struct{ *Resolver }

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -202,7 +202,7 @@ func (r *mutationResolver) CreateCollection(ctx context.Context, input model.Cre
 		Whitespace: input.Layout.Whitespace,
 	}
 
-	collection, err := api.Collection.CreateCollection(ctx, input.GalleryID, input.Name, input.CollectorsNote, input.Tokens, layout)
+	collection, err := api.Collection.CreateCollection(ctx, input.GalleryID, input.Name, input.CollectorsNote, input.Tokens, layout, input.TokenSettings)
 
 	if err != nil {
 		return nil, err

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -262,12 +262,16 @@ type CollectionToken implements Node
     id: ID!
     token: Token
     collection: Collection
-    renderLive: Boolean
+    tokenSettings: CollectionTokenSettings @goField(forceResolver: true)
 }
 
 type CollectionLayout {
     columns: Int
     whitespace: [Int]
+}
+
+type CollectionTokenSettings {
+    renderLive: Boolean
 }
 
 type Collection implements Node {
@@ -534,7 +538,6 @@ input UpdateCollectionInfoInput {
     collectionId: DBID!
     name: String!
     collectorsNote: String!
-    tokenSettings: [CollectionTokenSettingsInput!]!
 }
 
 union UpdateCollectionInfoPayloadOrError =
@@ -550,6 +553,7 @@ input UpdateCollectionTokensInput {
     collectionId: DBID!
     tokens: [DBID!]!
     layout: CollectionLayoutInput!
+    tokenSettings: [CollectionTokenSettingsInput!]!
 }
 
 union UpdateCollectionTokensPayloadOrError =

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -262,6 +262,7 @@ type CollectionToken implements Node
     id: ID!
     token: Token
     collection: Collection
+    renderLive: Boolean
 }
 
 type CollectionLayout {
@@ -496,12 +497,18 @@ input CollectionLayoutInput {
     whitespace: [Int!]!
 }
 
+input CollectionTokenSettingsInput {
+    tokenId: DBID!
+    renderLive: Boolean!
+}
+
 input CreateCollectionInput {
     galleryId: DBID!
     name: String!
     collectorsNote: String!
     tokens: [DBID!]!
     layout: CollectionLayoutInput!
+    tokenSettings: [CollectionTokenSettingsInput!]!
 }
 
 union CreateCollectionPayloadOrError =
@@ -527,6 +534,7 @@ input UpdateCollectionInfoInput {
     collectionId: DBID!
     name: String!
     collectorsNote: String!
+    tokenSettings: [CollectionTokenSettingsInput!]!
 }
 
 union UpdateCollectionInfoPayloadOrError =

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -25,6 +25,8 @@ overrides:
     go_type: "github.com/mikeydub/go-gallery/service/persist.DBIDList"
   - column: "collections.layout"
     go_type: { "type": "TokenLayout" } # Required format when the type is in the same package as the generated code
+  - column: "collections.token_settings"
+    go_type: { "type": "map[persist.DBID]persist.CollectionTokenSettings" }
 
   # Nfts
   - column: "nfts.contract"


### PR DESCRIPTION
**Changes**
* `createCollection` and `updateCollection` mutations now supports `tokenSettings` to enable live rendering of a token in a collection

* `CollectionToken` now has an added field, `tokenSettings`, which contains collection-specific configurations for that token. 

**Considerations**
* The frontend is required to provide the settings for each token in the collection. Will also need to coordinate the deploys to prod closely because `tokenSettings` is a required field for both mutations

* The settings are stored as a map in the db which makes looking up a token's settings convenient, but also means that collections can't display more than one instance of a token for the time being