### PR TITLE
[GAL-284] Add unique index to users.username_idempotent

### DIFF
--- a/db/migrations/000022_add_username_idempotent_index.down.sql
+++ b/db/migrations/000022_add_username_idempotent_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS users_username_idempotent_idx;

--- a/db/migrations/000022_add_username_idempotent_index.up.sql
+++ b/db/migrations/000022_add_username_idempotent_index.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX users_username_idempotent_idx ON users (username_idempotent) WHERE deleted = false;


### PR DESCRIPTION
Now that we've removed all duplicate usernames from the database, we can enforce uniqueness on the `username_idempotent` column to make sure we don't end up with duplicates in the future.