### PR TITLE
Fix sending same errors multiple times to Sentry

### DIFF
--- a/indexer/core.go
+++ b/indexer/core.go
@@ -196,7 +196,7 @@ func initLogger() {
 
 // configureRootContext configures the main context from which other contexts are derived.
 func configureRootContext() context.Context {
-	ctx := logger.NewContextWithFields(context.Background(), logrus.Fields{})
+	ctx := logger.NewContextWithLogger(context.Background(), logrus.Fields{}, logrus.New())
 	logger.For(ctx).Logger.SetReportCaller(true)
 	logger.For(ctx).Logger.AddHook(sentryutil.SentryLoggerHook)
 	return sentry.SetHubOnContext(ctx, sentry.CurrentHub())

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -14,8 +14,18 @@ const loggerContextKey = "logger.logger"
 var defaultLogger = logrus.New()
 var defaultEntry = logrus.NewEntry(defaultLogger)
 
+// NewContextWithFields returns a new context with a log entry derived from the default logger.
 func NewContextWithFields(parent context.Context, fields logrus.Fields) context.Context {
 	return context.WithValue(parent, loggerContextKey, For(parent).WithFields(fields))
+}
+
+// NewContextWithLogger returns a new context with a log entry derived from the input logger. This is useful
+// when needing to configure the logger with options that differ from the default logger.
+func NewContextWithLogger(parent context.Context, fields logrus.Fields, logger *logrus.Logger) context.Context {
+	if logger == nil {
+		return NewContextWithFields(parent, fields)
+	}
+	return context.WithValue(parent, loggerContextKey, logger.WithFields(fields))
 }
 
 func SetLoggerOptions(optionsFunc func(logger *logrus.Logger)) {


### PR DESCRIPTION
**Changes**
* Fixes bug where an error for the indexer-api is sent several times because of the sentry middleware, the error logger, and the sentry log hook