### PR TITLE
syncing media

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -451,6 +451,13 @@ type ComplexityRoot struct {
 		Viewer func(childComplexity int) int
 	}
 
+	SyncingMedia struct {
+		ContentRenderURL func(childComplexity int) int
+		MediaType        func(childComplexity int) int
+		MediaURL         func(childComplexity int) int
+		PreviewURLs      func(childComplexity int) int
+	}
+
 	TextMedia struct {
 		ContentRenderURL func(childComplexity int) int
 		MediaType        func(childComplexity int) int
@@ -2294,6 +2301,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SyncTokensPayload.Viewer(childComplexity), true
 
+	case "SyncingMedia.contentRenderURL":
+		if e.complexity.SyncingMedia.ContentRenderURL == nil {
+			break
+		}
+
+		return e.complexity.SyncingMedia.ContentRenderURL(childComplexity), true
+
+	case "SyncingMedia.mediaType":
+		if e.complexity.SyncingMedia.MediaType == nil {
+			break
+		}
+
+		return e.complexity.SyncingMedia.MediaType(childComplexity), true
+
+	case "SyncingMedia.mediaURL":
+		if e.complexity.SyncingMedia.MediaURL == nil {
+			break
+		}
+
+		return e.complexity.SyncingMedia.MediaURL(childComplexity), true
+
+	case "SyncingMedia.previewURLs":
+		if e.complexity.SyncingMedia.PreviewURLs == nil {
+			break
+		}
+
+		return e.complexity.SyncingMedia.PreviewURLs(childComplexity), true
+
 	case "TextMedia.contentRenderURL":
 		if e.complexity.TextMedia.ContentRenderURL == nil {
 			break
@@ -2996,6 +3031,7 @@ union MediaSubtype =
     | JsonMedia
     | GltfMedia
     | UnknownMedia
+    | SyncingMedia
     | InvalidMedia
 
 type PreviewURLSet {
@@ -3091,6 +3127,14 @@ type UnknownMedia implements Media {
     mediaType: String
 
     contentRenderURL: String
+}
+
+type SyncingMedia implements Media {
+  previewURLs: PreviewURLSet
+  mediaURL: String
+  mediaType: String
+
+  contentRenderURL: String
 }
 
 type InvalidMedia implements Media {
@@ -11597,6 +11641,134 @@ func (ec *executionContext) _SyncTokensPayload_viewer(ctx context.Context, field
 	return ec.marshalOViewer2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐViewer(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _SyncingMedia_previewURLs(ctx context.Context, field graphql.CollectedField, obj *model.SyncingMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "SyncingMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PreviewURLs, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.PreviewURLSet)
+	fc.Result = res
+	return ec.marshalOPreviewURLSet2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPreviewURLSet(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _SyncingMedia_mediaURL(ctx context.Context, field graphql.CollectedField, obj *model.SyncingMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "SyncingMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MediaURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _SyncingMedia_mediaType(ctx context.Context, field graphql.CollectedField, obj *model.SyncingMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "SyncingMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MediaType, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _SyncingMedia_contentRenderURL(ctx context.Context, field graphql.CollectedField, obj *model.SyncingMedia) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "SyncingMedia",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContentRenderURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _TextMedia_previewURLs(ctx context.Context, field graphql.CollectedField, obj *model.TextMedia) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -16590,6 +16762,13 @@ func (ec *executionContext) _Media(ctx context.Context, sel ast.SelectionSet, ob
 			return graphql.Null
 		}
 		return ec._UnknownMedia(ctx, sel, obj)
+	case model.SyncingMedia:
+		return ec._SyncingMedia(ctx, sel, &obj)
+	case *model.SyncingMedia:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._SyncingMedia(ctx, sel, obj)
 	case model.InvalidMedia:
 		return ec._InvalidMedia(ctx, sel, &obj)
 	case *model.InvalidMedia:
@@ -16662,6 +16841,13 @@ func (ec *executionContext) _MediaSubtype(ctx context.Context, sel ast.Selection
 			return graphql.Null
 		}
 		return ec._UnknownMedia(ctx, sel, obj)
+	case model.SyncingMedia:
+		return ec._SyncingMedia(ctx, sel, &obj)
+	case *model.SyncingMedia:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._SyncingMedia(ctx, sel, obj)
 	case model.InvalidMedia:
 		return ec._InvalidMedia(ctx, sel, &obj)
 	case *model.InvalidMedia:
@@ -20489,6 +20675,55 @@ func (ec *executionContext) _SyncTokensPayload(ctx context.Context, sel ast.Sele
 		case "viewer":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._SyncTokensPayload_viewer(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var syncingMediaImplementors = []string{"SyncingMedia", "MediaSubtype", "Media"}
+
+func (ec *executionContext) _SyncingMedia(ctx context.Context, sel ast.SelectionSet, obj *model.SyncingMedia) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, syncingMediaImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SyncingMedia")
+		case "previewURLs":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._SyncingMedia_previewURLs(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "mediaURL":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._SyncingMedia_mediaURL(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "mediaType":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._SyncingMedia_mediaType(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+		case "contentRenderURL":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._SyncingMedia_contentRenderURL(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -714,6 +714,16 @@ type SyncTokensPayload struct {
 
 func (SyncTokensPayload) IsSyncTokensPayloadOrError() {}
 
+type SyncingMedia struct {
+	PreviewURLs      *PreviewURLSet `json:"previewURLs"`
+	MediaURL         *string        `json:"mediaURL"`
+	MediaType        *string        `json:"mediaType"`
+	ContentRenderURL *string        `json:"contentRenderURL"`
+}
+
+func (SyncingMedia) IsMediaSubtype() {}
+func (SyncingMedia) IsMedia()        {}
+
 type TextMedia struct {
 	PreviewURLs      *PreviewURLSet `json:"previewURLs"`
 	MediaURL         *string        `json:"mediaURL"`

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1038,8 +1038,12 @@ func getMediaForToken(ctx context.Context, token sqlc.Token) model.MediaSubtype 
 		return getJsonMedia(ctx, med)
 	case persist.MediaTypeText, persist.MediaTypeBase64Text:
 		return getTextMedia(ctx, med)
-	default:
+	case persist.MediaTypeUnknown:
 		return getUnknownMedia(ctx, med)
+	case persist.MediaTypeSyncing:
+		return getSyncingMedia(ctx, med)
+	default:
+		return getInvalidMedia(ctx, med)
 	}
 
 }
@@ -1147,6 +1151,15 @@ func getGltfMedia(ctx context.Context, media persist.Media) model.GltfMedia {
 
 func getUnknownMedia(ctx context.Context, media persist.Media) model.UnknownMedia {
 	return model.UnknownMedia{
+		PreviewURLs:      getPreviewUrls(ctx, media),
+		MediaURL:         util.StringToPointer(media.MediaURL.String()),
+		MediaType:        (*string)(&media.MediaType),
+		ContentRenderURL: (*string)(&media.MediaURL),
+	}
+}
+
+func getSyncingMedia(ctx context.Context, media persist.Media) model.SyncingMedia {
+	return model.SyncingMedia{
 		PreviewURLs:      getPreviewUrls(ctx, media),
 		MediaURL:         util.StringToPointer(media.MediaURL.String()),
 		MediaType:        (*string)(&media.MediaType),

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -106,6 +106,7 @@ union MediaSubtype =
     | JsonMedia
     | GltfMedia
     | UnknownMedia
+    | SyncingMedia
     | InvalidMedia
 
 type PreviewURLSet {
@@ -201,6 +202,14 @@ type UnknownMedia implements Media {
     mediaType: String
 
     contentRenderURL: String
+}
+
+type SyncingMedia implements Media {
+  previewURLs: PreviewURLSet
+  mediaURL: String
+  mediaType: String
+
+  contentRenderURL: String
 }
 
 type InvalidMedia implements Media {

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -440,7 +440,9 @@ func (d *Provider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzkt
 }
 
 func (d *Provider) makeTempMedia(agnosticMetadata persist.TokenMetadata, name string) persist.Media {
-	med := persist.Media{}
+	med := persist.Media{
+		MediaType: persist.MediaTypeSyncing,
+	}
 	img, anim := media.FindImageAndAnimationURLs(agnosticMetadata, "", tezAnimationKeywords, tezImageKeywords, name)
 	if persist.TokenURI(anim).Type() == persist.URITypeIPFS {
 		removedIPFS := strings.Replace(anim, "ipfs://", "", 1)

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -54,6 +54,9 @@ const (
 	MediaTypeInvalid MediaType = "invalid"
 	// MediaTypeUnknown represents an unknown media type
 	MediaTypeUnknown MediaType = "unknown"
+	// MediaTypeSyncing represents a syncing media
+	// This will be an empty string representing we do not know yet what media type this is.
+	MediaTypeSyncing MediaType = ""
 )
 
 const (


### PR DESCRIPTION
Changes:

- **Added** `SyncingMedia` to the graphQL schema
- **Added** MediaTypeSyncing that will be returned when an NFT is still syncing
- **Added** resolvers for this media type
- **Updated** default case for graphQL media resolving to invalid instead of unknown. Unknown is a case we want to handle and expect to occur, invalid is a case where something is going wrong.