### PR TITLE
[GAL-397] Stop checking early access / allowlist for signups

### DIFF
--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -10,7 +10,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/util"
 )
 
 type AuthAPI struct {
@@ -38,10 +37,7 @@ func (api AuthAPI) NewNonceAuthenticator(chainAddress persist.ChainPubKey, nonce
 }
 
 func (api AuthAPI) GetAuthNonce(ctx context.Context, chainAddress persist.ChainAddress) (nonce string, userExists bool, err error) {
-	gc := util.GinContextFromContext(ctx)
-	authed := auth.GetUserAuthedFromCtx(gc)
-
-	return auth.GetAuthNonce(ctx, chainAddress, authed, api.repos.UserRepository, api.repos.NonceRepository, api.repos.WalletRepository, api.repos.EarlyAccessRepository, api.ethClient)
+	return auth.GetAuthNonce(ctx, chainAddress, api.repos.UserRepository, api.repos.NonceRepository, api.repos.WalletRepository, api.repos.EarlyAccessRepository, api.ethClient)
 }
 
 func (api AuthAPI) Login(ctx context.Context, authenticator auth.Authenticator) (persist.DBID, error) {


### PR DESCRIPTION
## What this PR does
- We no longer check for a membership NFT or an entry in the `early_access` table when a user is signing up. Any address can create an account!

## What this PR doesn't do
- This PR doesn't get rid of the `early_access` table or its associated access methods. @Robinnnnn made a comment about repurposing `early_access` for future stuff, and I think it's a good idea. We already have the table, a CLI app to add entries, methods to check it, etc. It'd be pretty easy to transform it into a general-purpose `allowlist` table with 2 columns: an address and some type to indicate what that address is allowlisted for. Let's leave the code for now and talk about whether it's worth evolving it into a new allowlist mechanism!