### PR TITLE
[GAL-422] Check if token's media is servable

### DIFF
--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -204,7 +204,7 @@ func processMedialessTokens(ctx context.Context, inputs <-chan processTokensInpu
 					tokensWithoutMedia := make([]persist.Token, 0, len(i.tokens))
 					contractsWithoutMedia := make([]persist.Contract, 0, len(i.contracts))
 					for _, token := range i.tokens {
-						if token.Media.MediaURL == "" || token.Media.MediaType == "" || token.Media.MediaType == persist.MediaTypeUnknown {
+						if !token.Media.IsServable() {
 							tokensWithoutMedia = append(tokensWithoutMedia, token)
 						}
 					}
@@ -550,7 +550,6 @@ func updateTokens(tokenRepository persist.TokenRepository, ethClient *ethclient.
 			return
 		}
 		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
-
 	}
 }
 

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -217,6 +217,11 @@ type Media struct {
 	MediaType    MediaType  `json:"media_type"`
 }
 
+// IsServable returns true if the Media's url is not empty and the MediaType isn't unknown.
+func (m Media) IsServable() bool {
+	return m.MediaURL != "" && m.MediaType != MediaTypeUnknown && m.MediaType != ""
+}
+
 // NFT represents an old nft throughout the application
 type NFT struct {
 	Version         NullInt32       `json:"version"` // schema version for this model

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -217,7 +217,7 @@ type Media struct {
 	MediaType    MediaType  `json:"media_type"`
 }
 
-// IsServable returns true if the Media's url is not empty and the MediaType isn't unknown.
+// IsServable returns true if the token's Media has enough information to serve it's assets.
 func (m Media) IsServable() bool {
 	return m.MediaURL != "" && m.MediaType != MediaTypeUnknown && m.MediaType != ""
 }


### PR DESCRIPTION
### Changes
Updates the dedupe logic when combining separate providers:
* Add `IsServable` method to the `Media` type. It seems that we can generalize on the fact that a token's media is servable if it has a media type and it has a media URL. Only types of `unknown` and `""` are missing a `media_url`
```
postgres=# select media->>'media_type' media_type, media->>'media_url' != '' has_url, count(*) count from tokens group by 1, 2;
 media_type | has_url | count
------------+---------+--------
 audio      | t       |   2953
 json       | t       |      1
 svg        | t       |  16431
 animation  | t       |    901
 unknown    | t       |  31228
 html       | t       |  35120
 video      | t       |  55509
 text       | t       |    785
 unknown    |         |   5673
 gif        | t       |  34164
            |         |  58903
 image      | t       | 308467
(12 rows)
```
* Use `IsServable` to determine which provider to use for the token

### How did I test?
Pointed my local backend to the prod indexer API and ran "Refresh wallet" on `noise_dao`.

Prior to the change, noise dao's NFTs looked like:
```
postgres=# select media->>'media_type' media_type, deleted, count(*) count from tokens where owner_user_id = '2CmnkzXTHkxlJTfhOVUIkjJqHI1' group by 1,2 order by 2,1;
 media_type | deleted | count
------------+---------+-------
            | f       |   415
 audio      | f       |   325
 gif        | f       |     1
 html       | f       |    82
 image      | f       |    81
 svg        | f       |     5
 unknown    | f       |     3
 video      | f       |   144
 audio      | t       |     1
 image      | t       |    38
 svg        | t       |     1
 video      | t       |     2
(12 rows)
```

After running a sync, their NFTs looks like:
```
 media_type | deleted | count
------------+---------+-------
            | f       |     7
 audio      | f       |   430
 gif        | f       |     1
 html       | f       |   204
 image      | f       |   120
 svg        | f       |     6
 unknown    | f       |    21
 video      | f       |   301
 audio      | t       |     1
 image      | t       |    38
 svg        | t       |     1
 video      | t       |     2
(12 rows)
```

For `dcinvestor`, before:
```
postgres=# select media->>'media_type' media_type, deleted, count(*) count from tokens where owner_user_id = '3369d75dc3f482f8cf7213b03670112f' group by 1,2 order by 2,1;
 media_type | deleted | count
------------+---------+-------
 gif        | f       |    65
 html       | f       |   104
 image      | f       |   408
 svg        | f       |    12
 unknown    | f       |    23
 video      | f       |   116
 image      | t       |    28
(7 rows)
```
and after:
```
postgres=# select media->>'media_type' media_type, deleted, count(*) count from tokens where owner_user_id = '3369d75dc3f482f8cf7213b03670112f' group by 1,2 order by 2,1;
 media_type | deleted | count
------------+---------+-------
            | f       |   374
 animation  | f       |     3
 gif        | f       |    84
 html       | f       |    99
 image      | f       |   468
 svg        | f       |    50
 unknown    | f       |    42
 video      | f       |   175
 image      | t       |    30
(9 rows)
```

It looks like dcinvestor hasn't ran a sync since early July, but the extra `unknown`s look like a bunch of spam nfts. Inspecting his Gallery after the refresh though looks identical to before the refresh. Also running a refresh on my Gallery fixed tokens that were previously broken.