### PR TITLE
[GAL-429] Allow Gallery admins to sync user tokens

### DIFF
--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -452,13 +452,13 @@ func (r *mutationResolver) SetSpamPreference(ctx context.Context, input model.Se
 	return model.SetSpamPreferencePayload{Tokens: tokens}, nil
 }
 
-func (r *mutationResolver) SyncTokens(ctx context.Context, chains []persist.Chain) (model.SyncTokensPayloadOrError, error) {
+func (r *mutationResolver) SyncTokens(ctx context.Context, chains []persist.Chain, userID *persist.DBID) (model.SyncTokensPayloadOrError, error) {
 	api := publicapi.For(ctx)
 
 	if chains == nil || len(chains) == 0 {
 		chains = []persist.Chain{persist.ChainETH}
 	}
-	err := api.Token.SyncTokens(ctx, chains)
+	err := api.Token.SyncTokens(ctx, chains, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -997,7 +997,7 @@ type Mutation {
     updateTokenInfo(input: UpdateTokenInfoInput!): UpdateTokenInfoPayloadOrError @authRequired
     setSpamPreference(input: SetSpamPreferenceInput!): SetSpamPreferencePayloadOrError @authRequired
 
-    syncTokens(chains: [Chain!]): SyncTokensPayloadOrError @authRequired
+    syncTokens(chains: [Chain!], userID: DBID): SyncTokensPayloadOrError @authRequired
     refreshToken(tokenId: DBID!): RefreshTokenPayloadOrError
     refreshCollection(collectionId: DBID!): RefreshCollectionPayloadOrError
     refreshContract(contractId: DBID!): RefreshContractPayloadOrError

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -139,11 +139,37 @@ func (api TokenAPI) GetTokensByUserIDAndChain(ctx context.Context, userID persis
 	return tokens, nil
 }
 
-func (api TokenAPI) SyncTokens(ctx context.Context, chains []persist.Chain) error {
+// Short-term workaround to create admin-only functions. Should be removed when the
+// admin UI is back up and running.
+func isAdminUser(userID persist.DBID) bool {
+	switch userID {
+	case "a3ff91986625382ff776067619200efe":
+		return true
+	case "85dd971e87c9574a962af22e23e52d95":
+		return true
+	case "872b4e915dd0e2006a368b32fb6b685a":
+		return true
+	case "23LydFAYGJY03L7ZMVKIsfDzM9A":
+		return true
+	case "213enLGfyDLSd2ZX8TLMbf5qUPQ":
+		return true
+	case "217M1MtDpVQ0sZLhnH91m1AAGdq":
+		return true
+	default:
+		return false
+	}
+}
+
+func (api TokenAPI) SyncTokens(ctx context.Context, chains []persist.Chain, asUserID *persist.DBID) error {
 	// No validation to do
-	userID, err := getAuthenticatedUser(ctx)
+	authedUserID, err := getAuthenticatedUser(ctx)
 	if err != nil {
 		return err
+	}
+
+	userID := authedUserID
+	if asUserID != nil && isAdminUser(authedUserID) {
+		userID = *asUserID
 	}
 
 	if err := api.throttler.Lock(ctx, userID.String()); err != nil {


### PR DESCRIPTION
Since the Admin UI is still down, we don't have an easy way to sync a user's tokens on their behalf. This PR adds a quick workaround for that: the `syncTokens` GraphQL mutation now has an optional `userID` field to specify whose tokens should be refreshed. I added a hacky "isAdminUser" function that just checks a hardcoded list of IDs to make sure the logged-in user is a Gallery admin before allowing them to sync someone else's tokens.