### PR TITLE
Overwrite token if its servable

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -498,10 +498,9 @@ func tokensToNewDedupedTokens(ctx context.Context, tokens []chainTokens, contrac
 
 			ti := persist.NewTokenIdentifiers(token.ContractAddress, token.TokenID, chainToken.chain)
 
-			if seen, ok := seenTokens[ti]; ok && !seen.Media.IsServable() && token.Media.IsServable() {
-				seen.Media = token.Media
-				seenTokens[ti] = seen
-			} else if _, ok := seenTokens[ti]; !ok {
+			// If we've never seen the incoming token before, then add it. If we have the token but its not servable
+			// then we replace it entirely with the incoming token.
+			if seen, ok := seenTokens[ti]; !ok || (ok && !seen.Media.IsServable() && token.Media.IsServable()) {
 				seenTokens[ti] = persist.TokenGallery{
 					Media:                token.Media,
 					TokenType:            token.TokenType,


### PR DESCRIPTION
Previously we would only replace `Media` if the incoming token is servable. Now we replace the entire token. This is because for new tokens the indexer, on first sync, will not have the other metadata fields available yet.

truth table for all the cases:
```
seen? | seen isServable? | incoming isServable? | outcome
-- | -- | -- | --
t | t | t | do nothing
t | t | f | do nothing
t | f | t | use incoming
t | f | f | do nothing
f | t | t | use incoming
f | t | f | use incoming
f | f | t | use incoming
f | f | f | use incoming
```