### PR TITLE
wrap error correctly [GAL-431]

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -246,9 +246,9 @@ outer:
 		case err := <-errChan:
 			if err, ok := err.(errWithPriority); ok {
 				if err.priority == 0 {
-					return err.err
+					return err
 				}
-				logger.For(ctx).Errorf("error updating fallback media for user %s: %s", user.Username, err.err)
+				logger.For(ctx).Errorf("error updating fallback media for user %s: %w", user.Username, err)
 			} else {
 				return err
 			}
@@ -674,7 +674,7 @@ func (e ErrChainNotFound) Error() string {
 }
 
 func (e errWithPriority) Error() string {
-	return e.err.Error()
+	return fmt.Sprintf("error with priority %d: %s", e.priority, e.err)
 }
 
 func dedupeWallets(wallets []persist.Wallet) []persist.Wallet {


### PR DESCRIPTION
Changes:

- **Changed** `errWithPriority` to wrap error rather than assume the error is not nil and call its `Error()` func. This seems to be the cause of the panic at https://sentry.io/organizations/usegallery/issues/3534892888/?end=2022-08-27T03%3A59%3A59&project=6262886&query=is%3Aunresolved&start=2022-08-26T04%3A00%3A00

