### PR TITLE
Add more indexer tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,10 +156,15 @@ jobs:
           name: "Unzip deploy file"
           command: echo "A" | unzip _deploy.zip -d _deploy
       - run:
-          name: Run integration-tests
+          name: Run backend integration-tests
           command: |
             mkdir -p /tmp/test-reports
             gotestsum --junitfile /tmp/test-reports/integration-tests.xml -- -run TestIntegrationTest ./server/... -args -chain ethereum -chainID 1
+      - run:
+          name: Run indexer integration-tests
+          command: |
+            mkdir -p /tmp/test-reports
+            gotestsum --junitfile /tmp/test-reports/indexer-integration-tests.xml -- ./indexer/...
       - store_test_results:
           path: /tmp/test-reports
   deploy:

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -65,6 +65,11 @@ func coreInit() (*gin.Engine, *indexer) {
 
 	// overrides for where the indexer starts and stops
 	startingBlock, maxBlock := getBlockRangeFromArgs()
+
+	if viper.GetString("ENV") == "production" {
+		rpcEnabled = true
+	}
+
 	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, persist.Chain(viper.GetInt("CHAIN")), events, nil, startingBlock, maxBlock)
 
 	router := gin.Default()

--- a/indexer/t__integration_test.go
+++ b/indexer/t__integration_test.go
@@ -5,13 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/storage"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/everFinance/goar"
-	shell "github.com/ipfs/go-ipfs-api"
 	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -20,15 +15,9 @@ import (
 func TestIndexLogs_Success(t *testing.T) {
 	a, db := setupTest(t)
 	i := newMockIndexer(db)
-	i.Start(configureRootContext())
 
-	a.EqualValues(100, i.lastSyncedBlock)
-	a.EqualValues(i.mostRecentBlock, i.lastSyncedBlock)
-
-	tokenRepo := postgres.NewTokenRepository(db)
-	tokens, _, err := tokenRepo.GetByWallet(context.Background(), "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5", -1, 0)
-	a.NoError(err)
-	a.Len(tokens, 4)
+	// Run the Indexer
+	i.catchUp(configureRootContext(), eventsToTopics(i.eventHashes))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()
@@ -38,79 +27,143 @@ func TestIndexLogs_Success(t *testing.T) {
 	arweaveClient := rpc.NewArweaveClient()
 	stg := newStorageClient(ctx)
 
-	uri := testBase64JSONURI(ctx, ethClient, a)
+	t.Run("it updates its state", func(t *testing.T) {
+		a.EqualValues(testBlockTo, i.lastSyncedBlock)
+		a.EqualValues(i.mostRecentBlock, i.lastSyncedBlock)
+	})
 
-	uri = testIPFSURI(uri, err, ctx, ethClient, a)
+	t.Run("it saves ERC-721s to the db", func(t *testing.T) {
+		tokens := addressHasTokens(t, a, i.tokenRepo, persist.EthereumAddress(testAddress), expectedTokensForAddress(persist.EthereumAddress(testAddress)))
+		for _, token := range tokens {
+			tokenMatchesExpected(t, a, token)
+		}
+	})
 
-	metadata := testIPFSMetadataRetrieval(ctx, uri, ipfsShell, arweaveClient, a)
+	t.Run("it saves ERC-1155s to the db", func(t *testing.T) {
+		tokens := addressHasTokens(t, a, i.tokenRepo, persist.EthereumAddress(contribAddress), expectedTokensForAddress(persist.EthereumAddress(contribAddress)))
+		for _, token := range tokens {
+			tokenMatchesExpected(t, a, token)
+		}
+	})
 
-	testPredictIPFSMediaType(ctx, metadata, a)
+	t.Run("it saves contracts to the db", func(t *testing.T) {
+		for _, address := range expectedContracts() {
+			contract := contractExistsInDB(t, a, i.contractRepo, address)
+			a.NotEmpty(contract.ID)
+			a.Equal(address, contract.Address)
+		}
+	})
 
-	testGetImageData(ctx, metadata, ipfsShell, arweaveClient, a)
+	t.Run("it can parse base64 uris", func(t *testing.T) {
+		token := tokenExistsInDB(t, a, i.tokenRepo, "0x0c2ee19b2a89943066c2dc7f1bddcc907f614033", "d9")
+		uri, err := rpc.GetTokenURI(ctx, persist.TokenTypeERC721, token.ContractAddress, token.TokenID, ethClient)
+		tokenURIHasExpectedType(t, a, err, uri, persist.URITypeBase64JSON)
+	})
 
-	testCreateImageMedia(ctx, metadata, uri, ipfsShell, arweaveClient, stg, a)
+	t.Run("it can create image media", func(t *testing.T) {
+		token := tokenExistsInDB(t, a, i.tokenRepo, "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "1")
+		uri, err := rpc.GetTokenURI(ctx, token.TokenType, token.ContractAddress, token.TokenID, ethClient)
+		tokenURIHasExpectedType(t, a, err, uri, persist.URITypeIPFS)
 
-	testCreateSVGMedia(ctx, ethClient, a, ipfsShell, arweaveClient, stg)
+		metadata, err := rpc.GetMetadataFromURI(ctx, uri, ipfsShell, arweaveClient)
+		mediaHasContent(t, a, err, metadata)
+
+		predicted, _, err := media.PredictMediaType(ctx, metadata["image"].(string))
+		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeImage, predicted)
+
+		imageData, err := rpc.GetDataFromURI(ctx, persist.TokenURI(metadata["image"].(string)), ipfsShell, arweaveClient)
+		a.NoError(err)
+		a.NotEmpty(imageData)
+
+		predicted, _ = persist.SniffMediaType(imageData)
+		mediaTypeHasExpectedType(t, a, nil, persist.MediaTypeImage, predicted)
+
+		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeImage, med.MediaType)
+		a.Empty(med.ThumbnailURL)
+		a.NotEmpty(med.MediaURL)
+
+		mediaType, _, err := media.PredictMediaType(ctx, med.MediaURL.String())
+		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeImage, mediaType)
+	})
+
+	t.Run("it can create svg media", func(t *testing.T) {
+		token := tokenExistsInDB(t, a, i.tokenRepo, "0x69c40e500b84660cb2ab09cb9614fa2387f95f64", "1")
+
+		uri, err := rpc.GetTokenURI(ctx, token.TokenType, token.ContractAddress, token.TokenID, ethClient)
+		tokenURIHasExpectedType(t, a, err, uri, persist.URITypeBase64JSON)
+
+		metadata, err := rpc.GetMetadataFromURI(ctx, uri, ipfsShell, arweaveClient)
+		mediaHasContent(t, a, err, metadata)
+
+		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeSVG, med.MediaType)
+		a.Empty(med.ThumbnailURL)
+		a.Contains(med.MediaURL.String(), "https://")
+	})
 }
 
-func testCreateSVGMedia(ctx context.Context, ethClient *ethclient.Client, a *assert.Assertions, ipfsShell *shell.Shell, arweaveClient *goar.Client, stg *storage.Client) {
-	svgURI, err := rpc.GetTokenURI(ctx, persist.TokenTypeERC721, "0x69c40e500b84660cb2ab09cb9614fa2387f95f64", "1", ethClient)
+func tokenExistsInDB(t *testing.T, a *assert.Assertions, tokenRepo persist.TokenRepository, address persist.EthereumAddress, tokenID persist.TokenID) persist.Token {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tokens, err := tokenRepo.GetByTokenIdentifiers(ctx, tokenID, address, 0, -1)
 	a.NoError(err)
-	a.Equal(svgURI.Type(), persist.URITypeBase64JSON)
-	svgMetadata, err := rpc.GetMetadataFromURI(ctx, svgURI, ipfsShell, arweaveClient)
-	a.NoError(err)
-	a.NotEmpty(svgMetadata["image"])
-	image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-	med, err := media.MakePreviewsForMetadata(ctx, svgMetadata, "0x69c40e500b84660cb2ab09cb9614fa2387f95f64", "1", svgURI, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
-	a.NoError(err)
-	a.Equal(persist.MediaTypeSVG, med.MediaType)
-	a.Empty(med.ThumbnailURL)
-	a.Contains(med.MediaURL.String(), "https://")
+	a.Len(tokens, 1)
+	return tokens[0]
 }
 
-func testCreateImageMedia(ctx context.Context, metadata persist.TokenMetadata, uri persist.TokenURI, ipfsShell *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, a *assert.Assertions) {
-	image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-	med, err := media.MakePreviewsForMetadata(ctx, metadata, "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "1", uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+func contractExistsInDB(t *testing.T, a *assert.Assertions, contractRepo persist.ContractRepository, address persist.EthereumAddress) persist.Contract {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	contract, err := contractRepo.GetByAddress(ctx, address)
 	a.NoError(err)
-	a.Equal(persist.MediaTypeImage, med.MediaType)
-	a.Empty(med.ThumbnailURL)
-	a.NotEmpty(med.MediaURL)
-	mediaType, _, err := media.PredictMediaType(ctx, med.MediaURL.String())
-	a.NoError(err)
-	a.Equal(persist.MediaTypeImage, mediaType)
+	return contract
 }
 
-func testGetImageData(ctx context.Context, metadata persist.TokenMetadata, ipfsShell *shell.Shell, arweaveClient *goar.Client, a *assert.Assertions) {
-	imageData, err := rpc.GetDataFromURI(ctx, persist.TokenURI(metadata["image"].(string)), ipfsShell, arweaveClient)
+func addressHasTokens(t *testing.T, a *assert.Assertions, tokenRepo persist.TokenRepository, address persist.EthereumAddress, expected int) []persist.Token {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	tokens, _, err := tokenRepo.GetByWallet(ctx, address, -1, 0)
 	a.NoError(err)
-	a.NotEmpty(imageData)
-	mediaType, _ := persist.SniffMediaType(imageData)
-	a.Equal(persist.MediaTypeImage, mediaType)
+	a.Len(tokens, expected)
+	return tokens
 }
 
-func testPredictIPFSMediaType(ctx context.Context, metadata persist.TokenMetadata, a *assert.Assertions) {
-	predicted, _, err := media.PredictMediaType(ctx, metadata["image"].(string))
+func tokenURIHasExpectedType(t *testing.T, a *assert.Assertions, err error, uri persist.TokenURI, expectedType persist.URIType) {
+	t.Helper()
 	a.NoError(err)
-	a.Equal(predicted, persist.MediaTypeImage)
+	a.Equal(expectedType, uri.Type())
 }
 
-func testIPFSMetadataRetrieval(ctx context.Context, uri persist.TokenURI, ipfsShell *shell.Shell, arweaveClient *goar.Client, a *assert.Assertions) persist.TokenMetadata {
-	metadata, err := rpc.GetMetadataFromURI(ctx, uri, ipfsShell, arweaveClient)
+func mediaHasContent(t *testing.T, a *assert.Assertions, err error, metadata persist.TokenMetadata) {
+	t.Helper()
 	a.NoError(err)
 	a.NotEmpty(metadata["image"])
-	return metadata
 }
 
-func testIPFSURI(uri persist.TokenURI, err error, ctx context.Context, ethClient *ethclient.Client, a *assert.Assertions) persist.TokenURI {
-	uri, err = rpc.GetTokenURI(ctx, persist.TokenTypeERC721, "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "0", ethClient)
+func mediaTypeHasExpectedType(t *testing.T, a *assert.Assertions, err error, expected, actual persist.MediaType) {
+	t.Helper()
 	a.NoError(err)
-	a.Equal(uri.Type(), persist.URITypeIPFS)
-	return uri
+	a.Equal(expected, actual)
 }
 
-func testBase64JSONURI(ctx context.Context, ethClient *ethclient.Client, a *assert.Assertions) persist.TokenURI {
-	uri, err := rpc.GetTokenURI(ctx, persist.TokenTypeERC721, "0x0c2ee19b2a89943066c2dc7f1bddcc907f614033", "d9", ethClient)
-	a.NoError(err)
-	a.Equal(uri.Type(), persist.URITypeBase64JSON)
-	return uri
+func tokenMatchesExpected(t *testing.T, a *assert.Assertions, actual persist.Token) {
+	t.Helper()
+	id := persist.NewTokenIdentifiers(persist.Address(actual.ContractAddress), actual.TokenID, actual.Chain)
+	expected, ok := expectedResults[id]
+	if !ok {
+		t.Fatalf("tokenID=%s not in expected results", id)
+	}
+	a.NotEmpty(actual.ID)
+	a.Equal(expected.BlockNumber, actual.BlockNumber)
+	a.Equal(expected.OwnerAddress, actual.OwnerAddress)
+	a.Equal(expected.ContractAddress, actual.ContractAddress)
+	a.Equal(expected.TokenType, actual.TokenType)
+	a.Equal(expected.TokenID, actual.TokenID)
+	a.Equal(expected.Quantity, actual.Quantity)
 }

--- a/indexer/t__utils_test.go
+++ b/indexer/t__utils_test.go
@@ -24,7 +24,7 @@ var (
 	testBlockFrom  = 0
 	testBlockTo    = 100
 	testAddress    = "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"
-	contribAddress = "0xda3845b44736b57e05ee80fc011a52a9c777423a" // Jarrel's address with a contributer card in it
+	contribAddress = "0xda3845b44736b57e05ee80fc011a52a9c777423a" // Jarrel's address with a contributor card in it
 )
 
 var allLogs = func() []types.Log {

--- a/indexer/t__utils_test.go
+++ b/indexer/t__utils_test.go
@@ -13,11 +13,28 @@ import (
 	"github.com/mikeydub/go-gallery/docker"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
+	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/ory/dockertest"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/option"
 )
+
+var (
+	testBlockFrom  = 0
+	testBlockTo    = 100
+	testAddress    = "0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"
+	contribAddress = "0xda3845b44736b57e05ee80fc011a52a9c777423a" // Jarrel's address with a contributer card in it
+)
+
+var allLogs = func() []types.Log {
+	logs := htmlLogs
+	logs = append(logs, ipfsLogs...)
+	logs = append(logs, customHandlerLogs...)
+	logs = append(logs, svgLogs...)
+	logs = append(logs, erc1155Logs...)
+	return logs
+}()
 
 func setupTest(t *testing.T) (*assert.Assertions, *sql.DB) {
 	fi, err := util.FindFile("_local/app-local-indexer-server.yaml", 4)
@@ -46,45 +63,17 @@ func setupTest(t *testing.T) (*assert.Assertions, *sql.DB) {
 	return assert.New(t), db
 }
 
-var htmlLogs = []types.Log{{
-	Address:     common.HexToAddress("0x0c2ee19b2a89943066c2dc7f1bddcc907f614033"),
-	Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), common.HexToHash("0x0000000000000000000000009a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"), common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000d9")},
-	Data:        []byte{},
-	BlockNumber: 1,
-}, {
-	Address:     common.HexToAddress("0x059edd72cd353df5106d2b9cc5ab83a52287ac3a"),
-	Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), common.HexToHash("0x0000000000000000000000009a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")},
-	Data:        []byte{},
-	BlockNumber: 1,
-}}
-var ipfsLogs = []types.Log{{
-	Address:     common.HexToAddress("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"),
-	Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), common.HexToHash("0x0000000000000000000000009a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")},
-	Data:        []byte{},
-	BlockNumber: 2,
-}}
-
-var customHandlerLogs = []types.Log{{
-	Address:     common.HexToAddress("0xd4e4078ca3495de5b1d4db434bebc5a986197782"),
-	Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), common.HexToHash("0x0000000000000000000000009a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")},
-	Data:        []byte{},
-	BlockNumber: 22,
-}}
-var svgLogs = []types.Log{{Address: common.HexToAddress("0x69c40e500b84660cb2ab09cb9614fa2387f95f64"),
-	Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"), common.HexToHash("0x0000000000000000000000009a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"), common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")},
-	Data:        []byte{},
-	BlockNumber: 3,
-}}
-
-var allLogs = append(append(append(append(htmlLogs, ipfsLogs...), customHandlerLogs...), svgLogs...))
-
 func newMockIndexer(db *sql.DB) *indexer {
-	start := uint64(0)
-	end := uint64(100)
-	i := newIndexer(nil, nil, nil, nil, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), persist.ChainETH, []eventHash{transferBatchEventHash, transferEventHash, transferSingleEventHash}, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
+	start := uint64(testBlockFrom)
+	end := uint64(testBlockTo)
+
+	rpcEnabled = true
+	ethClient := rpc.NewEthSocketClient()
+
+	i := newIndexer(ethClient, nil, nil, nil, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), persist.ChainETH, []eventHash{transferBatchEventHash, transferEventHash, transferSingleEventHash}, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
 		transferAgainLogs := []types.Log{{
 			Address:     common.HexToAddress("0x0c2ee19b2a89943066c2dc7f1bddcc907f614033"),
-			Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash("0x0000000000000000000000009a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5"), common.HexToHash("0x0000000000000000000000008914496dc01efcc49a2fa340331fb90969b6f1d2"), common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000d9")},
+			Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash(testAddress), common.HexToHash("0x0000000000000000000000008914496dc01efcc49a2fa340331fb90969b6f1d2"), common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000d9")},
 			Data:        []byte{},
 			BlockNumber: 51,
 		}}
@@ -92,7 +81,6 @@ func newMockIndexer(db *sql.DB) *indexer {
 			return allLogs, nil
 		}
 		return transferAgainLogs, nil
-
 	}, &start, &end)
 	return i
 }
@@ -107,4 +95,151 @@ func newStorageClient(ctx context.Context) *storage.Client {
 		panic(err)
 	}
 	return stg
+}
+
+var htmlLogs = []types.Log{
+	{
+		Address: common.HexToAddress("0x0c2ee19b2a89943066c2dc7f1bddcc907f614033"),
+		Topics: []common.Hash{
+			common.HexToHash(string(transferEventHash)),
+			common.HexToHash(persist.ZeroAddress.String()),
+			common.HexToHash(testAddress),
+			common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000d9"),
+		},
+		BlockNumber: 1,
+	},
+	{
+		Address: common.HexToAddress("0x059edd72cd353df5106d2b9cc5ab83a52287ac3a"),
+		Topics: []common.Hash{
+			common.HexToHash(string(transferEventHash)),
+			common.HexToHash(persist.ZeroAddress.String()),
+			common.HexToHash(testAddress),
+			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+		},
+		BlockNumber: 1,
+	},
+}
+var ipfsLogs = []types.Log{
+	{
+		Address: common.HexToAddress("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"),
+		Topics: []common.Hash{common.HexToHash(
+			string(transferEventHash)),
+			common.HexToHash(persist.ZeroAddress.String()),
+			common.HexToHash(testAddress),
+			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+		},
+		BlockNumber: 2,
+	},
+}
+var customHandlerLogs = []types.Log{
+	{
+		Address: common.HexToAddress("0xd4e4078ca3495de5b1d4db434bebc5a986197782"),
+		Topics: []common.Hash{
+			common.HexToHash(string(transferEventHash)),
+			common.HexToHash(persist.ZeroAddress.String()),
+			common.HexToHash(testAddress),
+			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+		},
+		BlockNumber: 22,
+	},
+}
+var svgLogs = []types.Log{
+	{
+		Address: common.HexToAddress("0x69c40e500b84660cb2ab09cb9614fa2387f95f64"),
+		Topics: []common.Hash{
+			common.HexToHash(string(transferEventHash)),
+			common.HexToHash(persist.ZeroAddress.String()),
+			common.HexToHash(testAddress),
+			common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+		},
+		BlockNumber: 3,
+	},
+}
+var erc1155Logs = []types.Log{
+	{
+		Address: common.HexToAddress("0xe01569ca9b39e55bc7c0dfa09f05fa15cb4c7698"),
+		Topics: []common.Hash{
+			common.HexToHash(string(transferSingleEventHash)),
+			common.HexToHash(persist.ZeroAddress.String()),
+			common.HexToHash(persist.ZeroAddress.String()),
+			common.HexToHash(contribAddress),
+		},
+		Data:        common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"),
+		BlockNumber: 5,
+	},
+}
+
+type expectedTokenResults map[persist.TokenIdentifiers]persist.Token
+
+var expectedResults expectedTokenResults = expectedTokenResults{
+	persist.NewTokenIdentifiers("0x059edd72cd353df5106d2b9cc5ab83a52287ac3a", "1", 0): {
+		BlockNumber:     1,
+		OwnerAddress:    persist.EthereumAddress(testAddress),
+		ContractAddress: persist.EthereumAddress("0x059edd72cd353df5106d2b9cc5ab83a52287ac3a"),
+		TokenType:       persist.TokenTypeERC721,
+		TokenID:         "1",
+		Quantity:        "1",
+	},
+	persist.NewTokenIdentifiers("0x69c40e500b84660cb2ab09cb9614fa2387f95f64", "1", 0): persist.Token{
+		BlockNumber:     3,
+		OwnerAddress:    persist.EthereumAddress(testAddress),
+		ContractAddress: persist.EthereumAddress("0x69c40e500b84660cb2ab09cb9614fa2387f95f64"),
+		TokenType:       persist.TokenTypeERC721,
+		TokenID:         "1",
+		Quantity:        "1",
+	},
+	persist.NewTokenIdentifiers("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", "1", 0): persist.Token{
+		BlockNumber:     2,
+		OwnerAddress:    persist.EthereumAddress(testAddress),
+		ContractAddress: persist.EthereumAddress("0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d"),
+		TokenType:       persist.TokenTypeERC721,
+		TokenID:         "1",
+		Quantity:        "1",
+	},
+	persist.NewTokenIdentifiers("0xd4e4078ca3495de5b1d4db434bebc5a986197782", "1", 0): persist.Token{
+		BlockNumber:     22,
+		OwnerAddress:    persist.EthereumAddress(testAddress),
+		ContractAddress: persist.EthereumAddress("0xd4e4078ca3495de5b1d4db434bebc5a986197782"),
+		TokenType:       persist.TokenTypeERC721,
+		TokenID:         "1",
+		Quantity:        "1",
+	},
+	persist.NewTokenIdentifiers("0x0c2ee19b2a89943066c2dc7f1bddcc907f614033", "d9", 0): persist.Token{
+		BlockNumber:     51,
+		OwnerAddress:    persist.EthereumAddress("0x8914496dc01efcc49a2fa340331fb90969b6f1d2"),
+		ContractAddress: persist.EthereumAddress("0x0c2ee19b2a89943066c2dc7f1bddcc907f614033"),
+		TokenType:       persist.TokenTypeERC721,
+		TokenID:         "d9",
+		Quantity:        "1",
+	},
+	persist.NewTokenIdentifiers("0xe01569ca9b39e55bc7c0dfa09f05fa15cb4c7698", "0", 0): persist.Token{
+		BlockNumber:     5,
+		OwnerAddress:    persist.EthereumAddress(contribAddress),
+		ContractAddress: persist.EthereumAddress("0xe01569ca9b39e55bc7c0dfa09f05fa15cb4c7698"),
+		TokenType:       persist.TokenTypeERC1155,
+		TokenID:         "0",
+		Quantity:        "1",
+	},
+}
+
+func expectedTokensForAddress(address persist.EthereumAddress) int {
+	count := 0
+	for _, token := range expectedResults {
+		if token.OwnerAddress == address {
+			count++
+		}
+	}
+	return count
+}
+
+func expectedContracts() []persist.EthereumAddress {
+	contracts := make([]persist.EthereumAddress, 0, len(expectedResults))
+	seen := map[persist.EthereumAddress]struct{}{}
+	for _, token := range expectedResults {
+		if _, ok := seen[token.ContractAddress]; !ok {
+			seen[token.ContractAddress] = struct{}{}
+			contracts = append(contracts, token.ContractAddress)
+		}
+	}
+	return contracts
 }


### PR DESCRIPTION
**Changes**
* Added more tests (contracts, erc1155s, checking specific fields in db) and also refactored the tests a bit
* Refactored the indexer to make it easier to test, namely moving `rpcEnabled` to a global var and splitting the indexer `Start` method into `catchUp` and `waitForBlocks`  methods