### PR TITLE
Add Sentry to mediaprocessing

### DIFF
--- a/indexer/core.go
+++ b/indexer/core.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/middleware"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/memstore/redis"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -22,7 +22,6 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"google.golang.org/api/option"
 )
 
 // Init initializes the indexer
@@ -47,16 +46,7 @@ func coreInit() (*gin.Engine, *indexer) {
 	initLogger()
 
 	tokenRepo, contractRepo := newRepos()
-	var s *storage.Client
-	var err error
-	if viper.GetString("ENV") != "local" {
-		s, err = storage.NewClient(context.Background())
-	} else {
-		s, err = storage.NewClient(context.Background(), option.WithCredentialsFile("./_deploy/service-key-dev.json"))
-	}
-	if err != nil {
-		panic(err)
-	}
+	s := media.NewStorageClient(context.Background(), "./_deploy/service-key-dev.json")
 	ethClient := rpc.NewEthSocketClient()
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()
@@ -120,16 +110,7 @@ func coreInitServer() *gin.Engine {
 	initLogger()
 
 	tokenRepo, contractRepo := newRepos()
-	var s *storage.Client
-	var err error
-	if viper.GetString("ENV") != "local" {
-		s, err = storage.NewClient(ctx)
-	} else {
-		s, err = storage.NewClient(ctx, option.WithCredentialsFile(storageKeyPath))
-	}
-	if err != nil {
-		panic(err)
-	}
+	s := media.NewStorageClient(ctx, storageKeyPath)
 	ethClient := rpc.NewEthSocketClient()
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()

--- a/mediaprocessing/mediaprocessing.go
+++ b/mediaprocessing/mediaprocessing.go
@@ -38,7 +38,7 @@ func coreInitServer() *gin.Engine {
 	tokenRepo := newRepos()
 	s := media.NewStorageClient(ctx, "./_deploy/service-key-dev.json")
 
-	http.DefaultClient = &http.Client{Transport: tracing.NewTracingTransport(http.DefaultTransport, false)}
+	http.DefaultClient = &http.Client{Transport: tracing.NewTracingTransport(http.DefaultTransport, false, true)}
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()
 

--- a/mediaprocessing/mediaprocessing.go
+++ b/mediaprocessing/mediaprocessing.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/middleware"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/memstore/redis"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -19,7 +19,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"google.golang.org/api/option"
 )
 
 // InitServer initializes the indexer server
@@ -37,16 +36,7 @@ func coreInitServer() *gin.Engine {
 	initLogger()
 
 	tokenRepo := newRepos()
-	var s *storage.Client
-	var err error
-	if viper.GetString("ENV") != "local" {
-		s, err = storage.NewClient(ctx)
-	} else {
-		s, err = storage.NewClient(ctx, option.WithCredentialsFile("./_deploy/service-key-dev.json"))
-	}
-	if err != nil {
-		panic(err)
-	}
+	s := media.NewStorageClient(ctx, "./_deploy/service-key-dev.json")
 
 	http.DefaultClient = &http.Client{Transport: tracing.NewTracingTransport(http.DefaultTransport, false)}
 	ipfsClient := rpc.NewIPFSShell()

--- a/mediaprocessing/process.go
+++ b/mediaprocessing/process.go
@@ -51,7 +51,7 @@ func processMedias(ctx context.Context, queue <-chan ProcessMediaInput, tokenRep
 		in := processInput
 		logger.For(nil).Infof("Processing Media: %s", in.Key)
 		wp.Submit(func() {
-			span, ctx := tracing.StartSpan(ctx, "processMedia", fmt.Sprintf("chain=%d;key=%s", processInput.Chain, processInput.Key), sentryutil.TransactionNameSafe("processMedia"))
+			span, ctx := tracing.StartSpan(ctx, "processMedia", fmt.Sprintf("processing key=%s;chain=%d", processInput.Key, processInput.Chain), sentryutil.TransactionNameSafe("processMedia"))
 
 			done := make(chan struct{})
 

--- a/mediaprocessing/process.go
+++ b/mediaprocessing/process.go
@@ -2,6 +2,7 @@ package mediaprocessing
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -14,7 +15,9 @@ import (
 	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
+	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/throttle"
+	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/mikeydub/go-gallery/util"
 )
 
@@ -42,12 +45,14 @@ func processIPFSMetadata(queue chan<- ProcessMediaInput, throttler *throttle.Loc
 	}
 }
 
-func processMedias(queue <-chan ProcessMediaInput, tokenRepo persist.TokenGalleryRepository, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, tokenBucket string, throttler *throttle.Locker) {
+func processMedias(ctx context.Context, queue <-chan ProcessMediaInput, tokenRepo persist.TokenGalleryRepository, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, tokenBucket string, throttler *throttle.Locker) {
 	wp := workerpool.New(20)
 	for processInput := range queue {
 		in := processInput
 		logger.For(nil).Infof("Processing Media: %s", in.Key)
 		wp.Submit(func() {
+			span, ctx := tracing.StartSpan(ctx, "processMedia", fmt.Sprintf("chain=%d;key=%s", processInput.Chain, processInput.Key), sentryutil.TransactionNameSafe("processMedia"))
+
 			done := make(chan struct{})
 
 			go keepAliveUntilDone(done, in.Key)
@@ -56,7 +61,7 @@ func processMedias(queue <-chan ProcessMediaInput, tokenRepo persist.TokenGaller
 			for _, token := range in.Tokens {
 				t := token
 				innerWp.Submit(func() {
-					ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+					ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
 					defer cancel()
 
 					logger.For(ctx).Infof("Processing Media: %s - Processing Token: %s-%s-%d", in.Key, t.ContractAddress, t.TokenID, in.Chain)
@@ -83,8 +88,9 @@ func processMedias(queue <-chan ProcessMediaInput, tokenRepo persist.TokenGaller
 				})
 			}
 			func() {
+				defer tracing.FinishSpan(span)
 				defer close(done)
-				defer throttler.Unlock(context.Background(), in.Key)
+				defer throttler.Unlock(ctx, in.Key)
 				innerWp.StopWait()
 				logger.For(nil).Infof("Processing Media: %s - Finished", in.Key)
 			}()

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -226,7 +226,7 @@ func Sentry(reportGinErrors bool) gin.HandlerFunc {
 
 func Tracing() gin.HandlerFunc {
 	// Trace outgoing HTTP requests
-	http.DefaultTransport = tracing.NewTracingTransport(http.DefaultTransport, true)
+	http.DefaultTransport = tracing.NewTracingTransport(http.DefaultTransport, true, false)
 	http.DefaultClient = &http.Client{Transport: http.DefaultTransport}
 
 	return func(c *gin.Context) {

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -102,7 +102,7 @@ func newLocalClient(ctx context.Context, keyPath string, scopes []string) *stora
 }
 
 func newClient(ctx context.Context, scopes []string) *storage.Client {
-	transport, err := htransport.NewTransport(ctx, tracing.NewTracingTransport(http.DefaultTransport, false), option.WithScopes(scopes...))
+	transport, err := htransport.NewTransport(ctx, tracing.NewTracingTransport(http.DefaultTransport, false, true), option.WithScopes(scopes...))
 	if err != nil {
 		panic(err)
 	}

--- a/service/tracing/http.go
+++ b/service/tracing/http.go
@@ -12,19 +12,30 @@ type tracingTransport struct {
 	http.RoundTripper
 
 	continueOnly bool
+	errorsOnly   bool
 	opts         []sentry.SpanOption
 }
 
 // NewTracingTransport creates an http transport that will trace requests via Sentry. If continueOnly is true,
 // traces will only be generated if they'd contribute to an existing parent trace (e.g. if a trace is not in progress,
-// no new trace would be started).
-func NewTracingTransport(roundTripper http.RoundTripper, continueOnly bool, spanOptions ...sentry.SpanOption) *tracingTransport {
+// no new trace would be started). It errorsOnly is true, only requests that returned an error status code (400 and above) are reported.
+func NewTracingTransport(roundTripper http.RoundTripper, continueOnly, errorsOnly bool, spanOptions ...sentry.SpanOption) *tracingTransport {
 	// If roundTripper is already a tracer, grab its underlying RoundTripper instead
 	if existingTracer, ok := roundTripper.(*tracingTransport); ok {
-		return &tracingTransport{RoundTripper: existingTracer.RoundTripper, continueOnly: continueOnly, opts: spanOptions}
+		return &tracingTransport{
+			RoundTripper: existingTracer.RoundTripper,
+			continueOnly: continueOnly,
+			opts:         spanOptions,
+			errorsOnly:   errorsOnly,
+		}
 	}
 
-	return &tracingTransport{RoundTripper: roundTripper, continueOnly: continueOnly, opts: spanOptions}
+	return &tracingTransport{
+		RoundTripper: roundTripper,
+		continueOnly: continueOnly,
+		opts:         spanOptions,
+		errorsOnly:   errorsOnly,
+	}
 }
 
 func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -36,7 +47,6 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	span, _ := StartSpan(req.Context(), "http."+strings.ToLower(req.Method), fmt.Sprintf("HTTP %s %s", req.Method, req.URL.String()), t.opts...)
-	defer FinishSpan(span)
 
 	// Send sentry-trace header in case the receiving service can continue our trace
 	req.Header.Add("sentry-trace", span.TraceID.String())
@@ -44,9 +54,13 @@ func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	response, err := t.RoundTripper.RoundTrip(req)
 
 	if err == nil {
+		if t.errorsOnly && response.StatusCode < 400 {
+			return response, err
+		}
 		AddEventDataToSpan(span, map[string]interface{}{
 			"HTTP Status Code": response.StatusCode,
 		})
+		FinishSpan(span)
 	}
 
 	return response, err


### PR DESCRIPTION
**Changes**
* Adds sentry error handling and tracing to mediaprocessing
* Figured out a way to patch GCP HTTP calls in Sentry so now we can also trace reads/writes from storage too
* Uses this gcp client in the indexer as well

Sample trace: https://sentry.io/organizations/usegallery/performance/mediaprocessing:7de37786f4054995a263339a5b12ca64/?environment=local&project=6771759&query=&statsPeriod=24h&transaction=processMedia&unselectedSeries=p100%28%29 