### PR TITLE
fixes for dave corp [GAL-485]

### DIFF
--- a/service/media/media.go
+++ b/service/media/media.go
@@ -114,6 +114,8 @@ func MakePreviewsForMetadata(pCtx context.Context, metadata persist.TokenMetadat
 
 	imgURL, vURL := FindImageAndAnimationURLs(pCtx, tokenID, contractAddress, metadata, turi, animationKeywords, imageKeywords, name, true)
 
+	logger.For(pCtx).Infof("imgURL: %s, vURL: %s", imgURL, vURL)
+
 	imgAsURI := persist.TokenURI(imgURL)
 	videoAsURI := persist.TokenURI(vURL)
 
@@ -310,7 +312,7 @@ func getHTMLMedia(pCtx context.Context, name, tokenBucket string, storageClient 
 
 func remapPaths(mediaURL string) string {
 	switch persist.TokenURI(mediaURL).Type() {
-	case persist.URITypeIPFS:
+	case persist.URITypeIPFS, persist.URITypeIPFSAPI, persist.URITypeIPFSGateway:
 		path := util.GetIPFSPath(mediaURL, false)
 		return fmt.Sprintf("%s/ipfs/%s", viper.GetString("IPFS_URL"), path)
 	case persist.URITypeArweave:
@@ -749,7 +751,7 @@ func PredictMediaType(pCtx context.Context, url string) (persist.MediaType, stri
 		return persist.MediaTypeSVG, "image/svg", int64(len(asURI.String())), nil
 	case persist.URITypeBase64BMP:
 		return persist.MediaTypeBase64BMP, "image/bmp", int64(len(asURI.String())), nil
-	case persist.URITypeHTTP, persist.URITypeIPFSAPI:
+	case persist.URITypeHTTP, persist.URITypeIPFSAPI, persist.URITypeIPFSGateway:
 		req, err := http.NewRequestWithContext(pCtx, "GET", url, nil)
 		if err != nil {
 			return persist.MediaTypeUnknown, "", 0, err

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -252,7 +252,7 @@ func GetDataFromURI(ctx context.Context, turi persist.TokenURI, ipfsClient *shel
 		}
 
 		return util.RemoveBOM(decoded), nil
-	case persist.URITypeIPFS:
+	case persist.URITypeIPFS, persist.URITypeIPFSGateway:
 		path := util.GetIPFSPath(asString, true)
 
 		bs, err := GetIPFSData(ctx, ipfsClient, path)
@@ -269,7 +269,7 @@ func GetDataFromURI(ctx context.Context, turi persist.TokenURI, ipfsClient *shel
 			return nil, err
 		}
 		return util.RemoveBOM(bs), nil
-	case persist.URITypeHTTP, persist.URITypeIPFSGateway:
+	case persist.URITypeHTTP:
 
 		req, err := http.NewRequestWithContext(ctx, "GET", asString, nil)
 		if err != nil {
@@ -355,7 +355,7 @@ func GetDataFromURIAsReader(ctx context.Context, turi persist.TokenURI, ipfsClie
 		buf := bytes.NewBuffer(util.RemoveBOM(decoded))
 
 		return util.NewFileHeaderReader(buf)
-	case persist.URITypeIPFS:
+	case persist.URITypeIPFS, persist.URITypeIPFSGateway:
 		path := util.GetIPFSPath(asString, true)
 
 		resp, err := GetIPFSResponse(ctx, ipfsClient, path)
@@ -373,7 +373,7 @@ func GetDataFromURIAsReader(ctx context.Context, turi persist.TokenURI, ipfsClie
 		}
 		buf := bytes.NewBuffer(util.RemoveBOM(bs))
 		return util.NewFileHeaderReader(buf)
-	case persist.URITypeHTTP, persist.URITypeIPFSGateway:
+	case persist.URITypeHTTP:
 
 		req, err := http.NewRequestWithContext(ctx, "GET", asString, nil)
 		if err != nil {
@@ -460,12 +460,9 @@ func DecodeMetadataFromURI(ctx context.Context, turi persist.TokenURI, into *per
 		}
 		into = &persist.TokenMetadata{"image": string(decoded)}
 		return nil
-	case persist.URITypeIPFS:
-		path := strings.ReplaceAll(asString, "ipfs://", "")
-		path = strings.ReplaceAll(path, "ipfs/", "")
-		path = strings.Split(path, "?")[0]
+	case persist.URITypeIPFS, persist.URITypeIPFSGateway:
 
-		bs, err := GetIPFSData(ctx, ipfsClient, path)
+		bs, err := GetIPFSData(ctx, ipfsClient, util.GetIPFSPath(asString, false))
 		if err != nil {
 			return err
 		}
@@ -478,7 +475,7 @@ func DecodeMetadataFromURI(ctx context.Context, turi persist.TokenURI, into *per
 			return err
 		}
 		return json.Unmarshal(result, into)
-	case persist.URITypeHTTP, persist.URITypeIPFSGateway:
+	case persist.URITypeHTTP:
 
 		req, err := http.NewRequestWithContext(ctx, "GET", asString, nil)
 		if err != nil {

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -296,8 +296,20 @@ func IntToPointerSlice(s []int) []*int {
 
 // GetIPFSPath takes an IPFS URL in any form and returns just the path
 func GetIPFSPath(initial string, withoutQuery bool) string {
-	path := strings.ReplaceAll(initial, "ipfs://", "")
+
+	path := strings.TrimSpace(initial)
+	if strings.HasPrefix(initial, "http") {
+		path = strings.TrimPrefix(path, "https://")
+		path = strings.TrimPrefix(path, "http://")
+		indexOfPath := strings.Index(path, "/")
+		if indexOfPath > 0 {
+			path = path[indexOfPath:]
+		}
+	} else if strings.HasPrefix(initial, "ipfs://") {
+		path = strings.ReplaceAll(initial, "ipfs://", "")
+	}
 	path = strings.ReplaceAll(path, "ipfs/", "")
+	path = strings.TrimPrefix(path, "/")
 	if withoutQuery {
 		path = strings.Split(path, "?")[0]
 		path = strings.TrimSuffix(path, "/")


### PR DESCRIPTION
Changes:

- **Changed** media grabbing to use the correctly mapped ipfs URLs for gateways so that we don't run into broken gateways. For example, `ipfs.infura.io` does not work anymore but some NFTs still use it. We should not rely on those API's being up when we can use the IPFS path with our own gateway and better guarantee success