### PR TITLE
[GAL-467] Fix tezos wallet refresh sync

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -311,10 +311,12 @@ outer:
 		return err
 	}
 
-	newTokens, err := tokensToNewDedupedTokens(ctx, allTokens, addressesToContracts, allUsersNFTs, user)
+	newTokens, err := tokensToNewDedupedTokens(ctx, allTokens, addressesToContracts, user)
 	if err != nil {
 		return err
 	}
+	newTokens = addExistingMedia(ctx, newTokens, allUsersNFTs)
+
 	logger.For(ctx).Debugf("upserting %d tokens for user %s", len(newTokens), user.Username)
 	if err := p.Repos.TokenRepository.BulkUpsert(ctx, newTokens); err != nil {
 		return fmt.Errorf("error upserting tokens: %s", err)
@@ -565,7 +567,7 @@ func (d *Provider) RefreshContract(ctx context.Context, ci persist.ContractIdent
 	return nil
 }
 
-func tokensToNewDedupedTokens(ctx context.Context, tokens []chainTokens, contractAddressIDs map[string]persist.DBID, dbTokens []persist.TokenGallery, ownerUser persist.User) ([]persist.TokenGallery, error) {
+func tokensToNewDedupedTokens(ctx context.Context, tokens []chainTokens, contractAddressIDs map[string]persist.DBID, ownerUser persist.User) ([]persist.TokenGallery, error) {
 	seenTokens := make(map[persist.TokenIdentifiers]persist.TokenGallery)
 
 	seenWallets := make(map[persist.TokenIdentifiers][]persist.Wallet)
@@ -643,24 +645,32 @@ func tokensToNewDedupedTokens(ctx context.Context, tokens []chainTokens, contrac
 		}
 	}
 
-	dbSeen := make(map[persist.TokenIdentifiers]persist.TokenGallery)
-	for _, token := range dbTokens {
-		dbSeen[persist.NewTokenIdentifiers(persist.Address(token.Contract), token.TokenID, token.Chain)] = token
+	res := make([]persist.TokenGallery, len(seenTokens))
+	i := 0
+	for _, t := range seenTokens {
+		res[i] = t
+		i++
 	}
 
-	res := make([]persist.TokenGallery, 0, len(seenTokens))
-	for _, t := range seenTokens {
+	return res, nil
+}
+
+func addExistingMedia(ctx context.Context, providerTokens []persist.TokenGallery, dbTokens []persist.TokenGallery) []persist.TokenGallery {
+	savedMap := make(map[persist.TokenIdentifiers]persist.TokenGallery)
+	for _, token := range dbTokens {
+		savedMap[token.TokenIdentifiers()] = token
+	}
+	res := make([]persist.TokenGallery, len(providerTokens))
+	for i, t := range providerTokens {
 		logger.For(ctx).Debugf("token: %s", t.Name)
 		if !t.Media.IsServable() {
-			if dbToken, ok := dbSeen[persist.NewTokenIdentifiers(persist.Address(t.Contract), t.TokenID, t.Chain)]; ok && dbToken.Media.IsServable() {
-				res = append(res, dbToken)
-				continue
+			if dbToken, ok := savedMap[t.TokenIdentifiers()]; ok && dbToken.Media.IsServable() {
+				t.Media = dbToken.Media
 			}
 		}
-		res = append(res, t)
+		res[i] = t
 	}
-	return res, nil
-
+	return res
 }
 
 func contractsToNewDedupedContracts(ctx context.Context, contracts []chainContracts) ([]persist.ContractGallery, error) {

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -223,7 +223,7 @@ type Media struct {
 
 // IsServable returns true if the token's Media has enough information to serve it's assets.
 func (m Media) IsServable() bool {
-	return m.MediaURL != "" && m.MediaType != MediaTypeUnknown && m.MediaType != "" && m.MediaType != MediaTypeSyncing
+	return m.MediaURL != "" && m.MediaType.IsValid() && m.MediaType != ""
 }
 
 // NFT represents an old nft throughout the application

--- a/service/persist/token_gallery.go
+++ b/service/persist/token_gallery.go
@@ -43,6 +43,11 @@ type TokenGallery struct {
 	IsProviderMarkedSpam *bool       `json:"is_provider_marked_spam"`
 }
 
+// TokenIdentifiers returns the unique identifier for a token
+func (t TokenGallery) TokenIdentifiers() TokenIdentifiers {
+	return NewTokenIdentifiers(Address(t.Contract), t.TokenID, t.Chain)
+}
+
 // AddressAtBlock represents an address at a specific block
 type AddressAtBlock struct {
 	Address Address     `json:"address"`


### PR DESCRIPTION
**Changes**
* Fixes tezos wallet sync. Before, if we already had a token with media in the db, we would replace the provider token with the token we had in the db. This was an issue because the token still references wallets that have since been deleted. Now we only replace the `media`. 