### PR TITLE
[GAL-486] Replace escaped null chars

### DIFF
--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -803,8 +803,12 @@ func (m TokenMetadata) Value() (driver.Value, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	return []byte(strings.ToValidUTF8(strings.ReplaceAll(string(val), "\\u0000", ""), "")), nil
+	cleaned := strings.ToValidUTF8(string(val), "")
+	// Replace literal '\\u0000' with empty string (marshal to JSON escapes each backslash)
+	cleaned = strings.ReplaceAll(cleaned, "\\\\u0000", "")
+	// Replace unicode NULL char (u+0000) i.e. '\u0000' with empty string
+	cleaned = strings.ReplaceAll(cleaned, "\\u0000", "")
+	return []byte(cleaned), nil
 }
 
 // Scan implements the database/sql Scanner interface for the AddressAtBlock type


### PR DESCRIPTION
We were receiving token metadata with the value (shortened for example): `\x05\x02\\u0000\\u0000\\u0000l\a\x04\x01`. Note that the null char is escaped: `\\u0000` which is a totally valid string.

Converting to json, this turns into: `\\x05\\x02\\\\u0000\\\\u0000\\\\u0000l\\a\\x04\\x01`. Before, we removed null chars by checking for `\\u0000`, which results in: `\\x05\\x02\\\\\\l\\a\\x04\\x01` which is no longer valid because the `\l` char is not a valid escaped string in go (in non-JSON: `\x05\x02\\\l\x04\x01`). Now we first check for `\\\\u0000` then for `\\u0000`.
