### PR TITLE
[GAL-484] Update tokenprocessing base to bullseye

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,11 +45,11 @@ services:
       - "8080:80"
     volumes:
       - ${PWD}/docker/nginx/nginx.local.conf:/etc/nginx/nginx.conf
-  # Uncomment if you want to run mediaprocessing locally as a container
-  # mediaprocessing:
+  # Uncomment if you want to run tokenprocessing locally as a container
+  # tokenprocessing:
   #   build:
   #     context: "."
-  #     dockerfile: "docker/mediaprocessing/Dockerfile"
+  #     dockerfile: "docker/tokenprocessing/Dockerfile"
   #   ports:
   #     - "6500:6500"
   #   volumes:

--- a/docker/tokenprocessing/Dockerfile
+++ b/docker/tokenprocessing/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.16-buster
+FROM golang:1.16-bullseye
 
 RUN apt-get update && apt-get install -y \
     ffmpeg \


### PR DESCRIPTION
There is a bug in `ffmpeg v4.1.x`, which is the latest available version on the buster distro, upgrading to bullseye fixed the issue.