### PR TITLE
Indexer - Always close channel

### DIFF
--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -615,7 +615,7 @@ func processRefreshes(idxr *indexer, storageClient *storage.Client) gin.HandlerF
 						logs := idxr.fetchLogs(ctx, b, events)
 						transfers := filterTransfers(ctx, message, logsToTransfers(ctx, logs))
 						transfersAtBlock := transfersToTransfersAtBlock(transfers)
-						batchTransfers(ctx, transferCh, transfersAtBlock)
+						transferCh <- transfersAtBlock
 						close(transferCh)
 					}()
 					go idxr.processAllTransfers(sentryutil.NewSentryHubContext(ctx), transferCh, enabledPlugins)


### PR DESCRIPTION
Fixes edge case where the Indexer would get blocked when there are no logs because the transfers channel is never closed. Also removes the `batchTransfers` method because each plugin buffers its own messages