### PR TITLE
Sentry error reporting tweaks

### DIFF
--- a/service/sentry/sentry.go
+++ b/service/sentry/sentry.go
@@ -123,11 +123,7 @@ func UpdateErrorFingerprints(event *sentry.Event, hint *sentry.EventHint) *sentr
 		return event
 	}
 
-	// This is a hacky way to do this -- we'd rather check the actual type than a string, but
-	// the errors.errorString type isn't exported and we'd really like a way to separate those
-	// errors on Sentry. It's not very useful to group every error created with errors.New().
-	exceptionType := fmt.Sprintf("%T", hint.OriginalException)
-	if exceptionType == "*errors.errorString" {
+	if isErrErrorString(hint.OriginalException) {
 		event.Fingerprint = []string{"{{ default }}", hint.OriginalException.Error()}
 	}
 
@@ -138,8 +134,13 @@ func UpdateErrorFingerprints(event *sentry.Event, hint *sentry.EventHint) *sentr
 func UpdateLogErrorEvent(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 	if wrapped, ok := hint.OriginalException.(logger.LoggedError); ok {
 		if wrapped.Err != nil {
-			// Group first by the LoggedError type and further group by the actual wrapped error.
-			event.Fingerprint = []string{"{{ type }}", fmt.Sprintf("%T", wrapped.Err)}
+			if isErrErrorString(wrapped.Err) {
+				// Group by the actual error string so those errors are better categorized on Sentry.
+				event.Fingerprint = []string{"{{ type }}", wrapped.Err.Error()}
+			} else {
+				// Group first by the LoggedError type and further group by the actual wrapped error.
+				event.Fingerprint = []string{"{{ type }}", fmt.Sprintf("%T", wrapped.Err)}
+			}
 			mostRecent := len(event.Exception) - 1
 			event.Exception[mostRecent].Type = reflect.TypeOf(wrapped.Err).String()
 
@@ -341,4 +342,14 @@ func TransactionNameSafe(name string) sentry.SpanOption {
 
 		sentry.TransactionName(name)(s)
 	}
+}
+
+// This is a hacky way to do this -- we'd rather check the actual type than a string, but
+// the errors.errorString type isn't exported and we'd really like a way to separate those
+// errors on Sentry. It's not very useful to group every error created with errors.New().
+func isErrErrorString(err error) bool {
+	if fmt.Sprintf("%T", err) == "*errors.errorString" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
**Changes**
* Updates the sentry logger to properly handle the generic `errors.errorString` so that they are grouped separately 