### PR TITLE
[GAL-380] Update feed schema to handle deleted collections and tokens

### DIFF
--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -525,6 +525,35 @@ type FeedEvent implements Node {
     hasViewerAdmiredEvent: Boolean @goField(forceResolver: true)
 }
 
+# FeedCollection represents a snapshot of a collection at a point in time.
+# Therefore, it's properties and its assets (i.e. its tokens) in the collection
+# may be stale and could no longer be owned by the user.
+type FeedCollection implements Node {
+    id: ID!
+    dbid: DBID!
+    deleted: Boolean
+    version: Int
+    name: String
+    collectorsNote: String
+    gallery: Gallery @goField(forceResolver: true)
+    layout: CollectionLayout
+    hidden: Boolean
+    tokens: [FeedToken] @goField(forceResolver: true)
+}
+
+# FeedToken represents a snapshot of a token at a point in time.
+# It's properties may be out of date and are no longer accurate.
+type FeedToken implements Node
+@goEmbedHelper
+@goGqlId(fields: ["tokenId", "collectionId"]) {
+    id: ID!
+    dbid: DBID!
+    deleted: Boolean
+    token: Token
+    collection: FeedCollection
+    tokenSettings: CollectionTokenSettings @goField(forceResolver: true)
+}
+
 type UserCreatedFeedEventData implements FeedEventData {
     eventTime: Time
     owner: GalleryUser @goField(forceResolver: true)
@@ -543,6 +572,7 @@ type CollectorsNoteAddedToTokenFeedEventData implements FeedEventData {
     owner: GalleryUser @goField(forceResolver: true)
     action: Action
     token: CollectionToken @goField(forceResolver: true)
+    feedToken: FeedToken @goField(forceResolver: true)
     newCollectorsNote: String
 }
 
@@ -552,6 +582,8 @@ type CollectionCreatedFeedEventData implements FeedEventData @goEmbedHelper {
     action: Action
     collection: Collection @goField(forceResolver: true)
     newTokens: [CollectionToken] @goField(forceResolver: true)
+    newFeedTokens: [FeedToken] @goField(forceResolver: true)
+    feedCollection: FeedCollection @goField(forceResolver: true)
 }
 
 type CollectorsNoteAddedToCollectionFeedEventData implements FeedEventData {
@@ -560,6 +592,7 @@ type CollectorsNoteAddedToCollectionFeedEventData implements FeedEventData {
     action: Action
     collection: Collection @goField(forceResolver: true)
     newCollectorsNote: String
+    feedCollection: FeedCollection @goField(forceResolver: true)
 }
 
 type TokensAddedToCollectionFeedEventData implements FeedEventData @goEmbedHelper {
@@ -569,6 +602,8 @@ type TokensAddedToCollectionFeedEventData implements FeedEventData @goEmbedHelpe
     action: Action
     newTokens: [CollectionToken] @goField(forceResolver: true)
     isPreFeed: Boolean
+    newFeedTokens: [FeedToken] @goField(forceResolver: true)
+    feedCollection: FeedCollection @goField(forceResolver: true)
 }
 
 type ErrUnknownAction implements Error {


### PR DESCRIPTION
This is a proposal of a schema to handle the cases where a token is no longer owned by a user or a collection has been deleted. The idea is that these types may or may not be `deleted`. In the case where they are `deleted`, we won't link to it if it's a deleted collection. If it is a token, I'm thinking we can either :
* not resolve to anything
* resolve to showing stale data (the token as it was before it got deleted)
* resolve to the current owner in Gallery (there could be multiple owners if users haven't synced and if it was transferred frequently, but we can decided based on the block number)
* longterm - refresh that token and resolve to the universal page

Considerations:
* May need to do something similar for when we have multi-gallery support when users can delete galleries if that is something we choose to display on the feed
