### PR TITLE
Sanitize/validate comments

### DIFF
--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/mikeydub/go-gallery/validate"
 	"sync"
 	"time"
 
@@ -401,9 +402,13 @@ func (api InteractionAPI) CommentOnFeedEvent(ctx context.Context, feedEventID pe
 	// Validate
 	if err := validateFields(api.validator, validationMap{
 		"feedEventID": {feedEventID, "required"},
+		"comment":     {comment, "required"},
 	}); err != nil {
 		return "", err
 	}
+
+	// Sanitize
+	comment = validate.SanitizationPolicy.Sanitize(comment)
 
 	return api.repos.CommentRepository.CreateComment(ctx, feedEventID, For(ctx).User.GetLoggedInUserId(ctx), replyToID, comment)
 }

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/mikeydub/go-gallery/validate"
+	"strings"
 	"sync"
 	"time"
 
@@ -399,6 +400,10 @@ func (api InteractionAPI) GetCommentByID(ctx context.Context, commentID persist.
 }
 
 func (api InteractionAPI) CommentOnFeedEvent(ctx context.Context, feedEventID persist.DBID, replyToID *persist.DBID, comment string) (persist.DBID, error) {
+	// Trim whitespace first, so comments consisting only of whitespace will fail
+	// the "required" validation below
+	comment = strings.TrimSpace(comment)
+
 	// Validate
 	if err := validateFields(api.validator, validationMap{
 		"feedEventID": {feedEventID, "required"},


### PR DESCRIPTION
## What's new?
- Comments are now sanitized (the same way we sanitize other user-generated content)
- Empty string comments are no longer valid

Follow-up question: how should we handle empty space or trailing whitespace in comments? Should a comment that consists entirely of whitespace be rejected? Should trailing whitespace on comments be trimmed? Should leading whitespace be trimmed? cc: @kaitoo1 @Robinnnnn 