### PR TITLE
Use "max" validation instead of a custom string length validator

### DIFF
--- a/service/user/user.go
+++ b/service/user/user.go
@@ -24,12 +24,6 @@ import (
 var errUserCannotRemoveAllAddresses = errors.New("user does not have enough addresses to remove")
 var errMustResolveENS = errors.New("ENS username must resolve to owner address")
 
-// UpdateUserInput is the input for the user update pipeline
-type UpdateUserInput struct {
-	UserName string `json:"username" binding:"username"`
-	BioStr   string `json:"bio" binding:"medium"`
-}
-
 // GetUserInput is the input for the user get pipeline
 type GetUserInput struct {
 	UserID   persist.DBID    `json:"user_id" form:"user_id"`

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -68,15 +67,12 @@ func RegisterCustomValidators(v *validator.Validate) {
 	v.RegisterValidation("nonce", NonceValidator)
 	v.RegisterValidation("signature", SignatureValidator)
 	v.RegisterValidation("username", UsernameValidator)
-	v.RegisterValidation("max_string_length", MaxStringLengthValidator)
 	v.RegisterValidation("sorted_asc", SortedAscValidator)
 	v.RegisterValidation("chain", ChainValidator)
-	v.RegisterAlias("medium", "max_string_length=600")
-	v.RegisterAlias("collectors_note", "max_string_length=1200")
-	v.RegisterAlias("collection_name", "max_string_length=200")
-	v.RegisterAlias("collection_note", "max_string_length=600")
-	v.RegisterAlias("token_note", "max_string_length=1200")
-	v.RegisterAlias("bio", "max_string_length=600")
+	v.RegisterAlias("collection_name", "max=200")
+	v.RegisterAlias("collection_note", "max=600")
+	v.RegisterAlias("token_note", "max=1200")
+	v.RegisterAlias("bio", "max=600")
 
 	v.RegisterStructValidation(ChainAddressValidator, persist.ChainAddress{})
 	v.RegisterStructValidation(ConnectionPaginationParamsValidator, ConnectionPaginationParams{})
@@ -171,18 +167,6 @@ var NonceValidator validator.Func = func(fl validator.FieldLevel) bool {
 		return true
 	}
 	return len(nonce) >= 10 && len(nonce) <= 150
-}
-
-// MaxStringLengthValidator validates strings with a given maximum length
-var MaxStringLengthValidator validator.Func = func(fl validator.FieldLevel) bool {
-	s := fl.Field().String()
-
-	maxLength, err := strconv.Atoi(fl.Param())
-	if err != nil {
-		panic(fmt.Errorf("error parsing MaxStringLengthValidator parameter: %s", err))
-	}
-
-	return len(s) <= maxLength
 }
 
 // UsernameValidator ensures that usernames are not reserved, are alphanumeric with the exception of underscores and periods, and do not contain consecutive periods or underscores


### PR DESCRIPTION
For some historical reason, we've been using our own custom function to validate string lengths instead of using go-validator's built-in `max` tag. Our custom function was checking the number of _bytes_ in a string, not the number of _characters_. As a result, a 598-character collector's note was rejected by the server because it contained 622 bytes, even though our limit should be 600 characters, not 600 bytes.

This PR gets rid of our "max string length" validator and uses the built-in `max` tag in its place. I also got rid of a couple of validation tags we no longer use, and a related struct that we also don't use.