### PR TITLE
More comment/admire tweaks

### DIFF
--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -438,6 +438,20 @@ type ErrAddressOwnedByUser struct {
 func (ErrAddressOwnedByUser) IsAddUserWalletPayloadOrError() {}
 func (ErrAddressOwnedByUser) IsError()                       {}
 
+type ErrAdmireAlreadyExists struct {
+	Message string `json:"message"`
+}
+
+func (ErrAdmireAlreadyExists) IsError()                         {}
+func (ErrAdmireAlreadyExists) IsAdmireFeedEventPayloadOrError() {}
+
+type ErrAdmireNotFound struct {
+	Message string `json:"message"`
+}
+
+func (ErrAdmireNotFound) IsError()                      {}
+func (ErrAdmireNotFound) IsRemoveAdmirePayloadOrError() {}
+
 type ErrAuthenticationFailed struct {
 	Message string `json:"message"`
 }
@@ -461,6 +475,13 @@ func (ErrCollectionNotFound) IsError()                          {}
 func (ErrCollectionNotFound) IsCollectionByIDOrError()          {}
 func (ErrCollectionNotFound) IsCollectionTokenByIDOrError()     {}
 func (ErrCollectionNotFound) IsDeleteCollectionPayloadOrError() {}
+
+type ErrCommentNotFound struct {
+	Message string `json:"message"`
+}
+
+func (ErrCommentNotFound) IsError()                       {}
+func (ErrCommentNotFound) IsRemoveCommentPayloadOrError() {}
 
 type ErrCommunityNotFound struct {
 	Message string `json:"message"`
@@ -626,6 +647,7 @@ type FeedEvent struct {
 	Admires               *FeedEventAdmiresConnection      `json:"admires"`
 	Comments              *FeedEventCommentsConnection     `json:"comments"`
 	Interactions          *FeedEventInteractionsConnection `json:"interactions"`
+	ViewerAdmire          *Admire                          `json:"viewerAdmire"`
 	HasViewerAdmiredEvent *bool                            `json:"hasViewerAdmiredEvent"`
 }
 

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -85,6 +85,12 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 		mappedErr = model.ErrCommunityNotFound{Message: message}
 	case persist.ErrAddressOwnedByUser:
 		mappedErr = model.ErrAddressOwnedByUser{Message: message}
+	case persist.ErrAdmireNotFound:
+		mappedErr = model.ErrAdmireNotFound{Message: message}
+	case persist.ErrAdmireAlreadyExists:
+		mappedErr = model.ErrAdmireAlreadyExists{Message: message}
+	case persist.ErrCommentNotFound:
+		mappedErr = model.ErrCommentNotFound{Message: message}
 	case publicapi.ErrTokenRefreshFailed:
 		mappedErr = model.ErrSyncFailed{Message: message}
 	case publicapi.ErrInvalidInput:

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -522,6 +522,10 @@ type FeedEvent implements Node {
     # If typeFilter is omitted, all interaction types will be queried.
     interactions(before: String, after: String, first: Int, last: Int, typeFilter:[InteractionType!]): FeedEventInteractionsConnection @goField(forceResolver: true)
 
+    viewerAdmire: Admire @goField(forceResolver: true)
+
+    # TODO: This is just here while we migrate the frontend over to viewerAdmire.
+    # Remove this in the near future.
     hasViewerAdmiredEvent: Boolean @goField(forceResolver: true)
 }
 
@@ -893,6 +897,18 @@ type ErrSyncFailed implements Error {
     message: String!
 }
 
+type ErrAdmireNotFound implements Error {
+    message: String!
+}
+
+type ErrAdmireAlreadyExists implements Error {
+    message: String!
+}
+
+type ErrCommentNotFound implements Error {
+    message: String!
+}
+
 input AuthMechanism {
     eoa: EoaAuth
     gnosisSafe: GnosisSafeAuth
@@ -1000,12 +1016,14 @@ union AdmireFeedEventPayloadOrError =
   | ErrAuthenticationFailed
   | ErrFeedEventNotFound
   | ErrInvalidInput
+  | ErrAdmireAlreadyExists
 
 union RemoveAdmirePayloadOrError =
     RemoveAdmirePayload
   | ErrAuthenticationFailed
   | ErrFeedEventNotFound
   | ErrInvalidInput
+  | ErrAdmireNotFound
 
 union CommentOnFeedEventPayloadOrError =
     CommentOnFeedEventPayload
@@ -1018,6 +1036,7 @@ union RemoveCommentPayloadOrError =
   | ErrAuthenticationFailed
   | ErrFeedEventNotFound
   | ErrInvalidInput
+  | ErrCommentNotFound
 
 type AdmireFeedEventPayload {
     viewer: Viewer
@@ -1078,7 +1097,7 @@ type Mutation {
     followUser(userId: DBID!): FollowUserPayloadOrError @authRequired
     unfollowUser(userId: DBID!): UnfollowUserPayloadOrError @authRequired
     admireFeedEvent(feedEventId: DBID!): AdmireFeedEventPayloadOrError @authRequired
-    removeAdmire(feedEventId: DBID!): RemoveAdmirePayloadOrError @authRequired
+    removeAdmire(admireId: DBID!): RemoveAdmirePayloadOrError @authRequired
     commentOnFeedEvent(feedEventId: DBID!, replyToID: DBID, comment: String!): CommentOnFeedEventPayloadOrError @authRequired
     removeComment(commentId: DBID!): RemoveCommentPayloadOrError @authRequired
 }

--- a/service/persist/admire.go
+++ b/service/persist/admire.go
@@ -26,5 +26,15 @@ type ErrAdmireNotFound struct {
 }
 
 func (e ErrAdmireNotFound) Error() string {
-	return fmt.Sprintf("admire not found by AdmireID: %s, ActorID: %s, FeedEventID: %s", e.AdmireID, e.ActorID, e.FeedEventID)
+	return fmt.Sprintf("admire not found | AdmireID: %s, ActorID: %s, FeedEventID: %s", e.AdmireID, e.ActorID, e.FeedEventID)
+}
+
+type ErrAdmireAlreadyExists struct {
+	AdmireID    DBID
+	ActorID     DBID
+	FeedEventID DBID
+}
+
+func (e ErrAdmireAlreadyExists) Error() string {
+	return fmt.Sprintf("admire already exists | AdmireID: %s, ActorID: %s, FeedEventID: %s", e.AdmireID, e.ActorID, e.FeedEventID)
 }


### PR DESCRIPTION
## What's new?
- Replaced `hasViewerAdmiredEvent` with `viewerAdmire`, the latter of which returns an `Admire` type instead of a bool. As it turns out, having the `admire` is more useful than just knowing it exists.
- `hasViewerAdmiredEvent` is still present -- for now -- so we don't break existing clients. It always returns false and should be removed once a new frontend without it has been deployed for a while.
- Adding/removing comments and admires will now return appropriate error types for handled errors: `ErrAdmireNotFound`, `ErrAdmireAlreadyExists`, and `ErrCommentNotFound`. These previously returned unhandled errors that weren't in our schema.
- The `removeAdmire`mutation takes an admireID again, instead of a userID + feedEventID (which I switched it to briefly before we settled on this latest design)