### PR TITLE
Don't add trace data for nil result pointers

### DIFF
--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -207,12 +207,15 @@ func FieldReporter(trace bool) func(ctx context.Context, next gqlgen.Resolver) (
 
 		res, err = next(ctx)
 
-		if span != nil && err == nil {
-			// If our result type implements the GraphQL Node pattern, add its ID to our event data
-			if node, ok := res.(interface{ ID() model.GqlID }); ok {
-				tracing.AddEventDataToSpan(span, map[string]interface{}{
-					"resolvedNodeId": node.ID(),
-				})
+		if span != nil {
+			// If we receive a non-nil result without an error, and our result type implements
+			// the GraphQL Node pattern, add its ID to our event data
+			if res != nil && err == nil {
+				if node, ok := res.(interface{ ID() model.GqlID }); ok {
+					tracing.AddEventDataToSpan(span, map[string]interface{}{
+						"resolvedNodeId": node.ID(),
+					})
+				}
 			}
 
 			tracing.FinishSpan(span)


### PR DESCRIPTION
The `viewerAdmire` field returns nil (without an error) for users who haven't admired an event. That's intentional, but it's not something that ever happened when I implemented tracing for GraphQL. I had been assuming anything that _didn't_ return an error would return a non-nil result. Since that's not the case with `viewerAdmire`, we run into a nil dereference error when trying to add the resulting node ID to our trace span.

This PR fixes that issue, and also reorders the `if` statement to close spans regardless of whether there was an error, which should have been the case all along.