### PR TITLE
append with capacity set not length

### DIFF
--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -148,7 +148,7 @@ func (d *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentif
 }
 
 func (d *Provider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/nfts/get?contract_address=%s&token_id=%s&address=%s&limit=1", d.indexerBaseURL, tokenIdentifiers.ContractAddress, tokenIdentifiers.TokenID, ownerAddress), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/nfts/get?contract_address=%s&token_id=%s&address=%s", d.indexerBaseURL, tokenIdentifiers.ContractAddress, tokenIdentifiers.TokenID, ownerAddress), nil)
 	if err != nil {
 		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, err
 	}
@@ -572,7 +572,7 @@ func tokensToChainAgnostic(tokens []persist.Token) []multichain.ChainAgnosticTok
 }
 
 func contractsToChainAgnostic(contracts []persist.Contract) []multichain.ChainAgnosticContract {
-	result := make([]multichain.ChainAgnosticContract, len(contracts))
+	result := make([]multichain.ChainAgnosticContract, 0, len(contracts))
 	for _, contract := range contracts {
 		result = append(result, contractToChainAgnostic(contract))
 	}


### PR DESCRIPTION
Changes:

- **Changed** the conversion from indexer contracts to agnostic contracts to use capacity instead of length because otherwise `append` does nothing causing contracts to get updated with empty data