### PR TITLE
Fix panic when adding nil viewerAdmire to trace data (again)

### DIFF
--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/mikeydub/go-gallery/publicapi"
+	"reflect"
 
 	gqlgen "github.com/99designs/gqlgen/graphql"
 	"github.com/getsentry/sentry-go"
@@ -209,8 +210,10 @@ func FieldReporter(trace bool) func(ctx context.Context, next gqlgen.Resolver) (
 
 		if span != nil {
 			// If we receive a non-nil result without an error, and our result type implements
-			// the GraphQL Node pattern, add its ID to our event data
-			if res != nil && err == nil {
+			// the GraphQL Node pattern, add its ID to our event data. We also have to use
+			// reflection here: the result could be a non-nil pointer to a nil interface,
+			// which would cause a panic when we try to call its ID() method.
+			if err == nil && res != nil && reflect.ValueOf(res).Kind() == reflect.Ptr && !reflect.ValueOf(res).IsNil() {
 				if node, ok := res.(interface{ ID() model.GqlID }); ok {
 					tracing.AddEventDataToSpan(span, map[string]interface{}{
 						"resolvedNodeId": node.ID(),


### PR DESCRIPTION
I thought I had fixed this issue previously, but I was wrong: an interface in golang can be non-nil and still point to a nil value. In this case, the interface is "an interface that points to a pointer to an Admire," where the interface itself is not nil, but the pointer to an Admire is. I've added reflect methods to handle this case, and have verified locally that the panic is gone.