### PR TITLE
[GAL-563] Layout default + limit tweaks

### DIFF
--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -777,6 +777,11 @@ func galleryToModel(ctx context.Context, gallery db.Gallery) *model.Gallery {
 
 func layoutToModel(ctx context.Context, layout persist.TokenLayout, version int) *model.CollectionLayout {
 	if version == 0 {
+		// Some older collections predate configurable columns; the default back then was 3
+		if layout.Columns == 0 {
+			layout.Columns = 3
+		}
+
 		// Treat the original collection as a single section.
 		return &model.CollectionLayout{
 			Sections: []*int{util.IntToPointer(0)},

--- a/service/persist/collection.go
+++ b/service/persist/collection.go
@@ -12,7 +12,7 @@ const (
 	maxColumns          = 10
 	defaultColumns      = 3
 	maxWhitespace       = 1000
-	maxTokensPerSection = 500
+	maxTokensPerSection = 1000
 )
 
 // CollectionDB is the struct that represents a collection of tokens in the database


### PR DESCRIPTION
## What's new?
- Default 0-column layouts to 3 columns
  - Old collections that predate multi-column have been returning `0` columns instead of the original default of `3`. This leads to a confusing situation when editing a gallery: the column count is set to 0 and none of the tokens show up. Viewing a collection works better; the frontend appears to enforce a minimum of at least 1 column, so these collections are visible, but they're using a 1-column layout when they had previously been using a 3-column layout.

- `maxTokensPerSection` is now 1000 instead of 500
  - A few collections that predate multi-section have more than 500 tokens in them. When trying to convert those collections to sectional layouts, we encounter an error because a 641-token collection can't fit into a 500-token section. I've bumped the `maxTokensPerSection` up to 1000 to match `maxTokensPerCollection`. (cc @jarrel-b -- any problems you foresee with this approach?)