### PR TITLE
use different time marshalling

### DIFF
--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -380,15 +380,15 @@ func parseTime(bytes []byte, idx int, err error) (time.Time, int, error) {
 	}
 
 	t := time.Time{}
-	err = t.UnmarshalJSON(timeSlice[1 : timeLen+1])
+	err = t.UnmarshalBinary(timeSlice[1 : timeLen+1])
 	if err != nil {
 		return time.Time{}, 0, err
 	}
-	return t, len(timeSlice[1 : timeLen+1]), nil
+	return t, len(timeSlice[1:timeLen+1]) + 1, nil
 }
 
 func marshallTimeBytes(t time.Time, id persist.DBID) ([]byte, error) {
-	timeBytes, err := t.MarshalJSON()
+	timeBytes, err := t.MarshalBinary()
 	if err != nil {
 		return nil, err
 	}

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gammazero/workerpool"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/throttle"
 	"github.com/mikeydub/go-gallery/validate"
@@ -100,7 +101,8 @@ func (api TokenAPI) GetTokensByContractIdPaginate(ctx context.Context, contractI
 
 	queryFunc := func(params boolTimeIDPagingParams) ([]interface{}, error) {
 
-		tokens, err := api.loaders.TokensByContractIDWithPagination.Load(db.GetTokensByContractIdBatchPaginateParams{
+		logger.For(ctx).Infof("GetTokensByContractIdPaginate: %+v", params)
+		tokens, err := api.queries.GetTokensByContractIdPaginate(ctx, db.GetTokensByContractIdPaginateParams{
 			Contract:           contractID,
 			Limit:              params.Limit,
 			CurBeforeUniversal: params.CursorBeforeBool,

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -379,6 +379,10 @@ func FindImageAndAnimationURLs(ctx context.Context, tokenID persist.TokenID, con
 
 }
 
+func FindNameAndDescription(ctx context.Context, metadata persist.TokenMetadata) (name string, description string) {
+	return util.GetValueFromMapUnsafe(metadata, "name", util.DefaultSearchDepth).(string), util.GetValueFromMapUnsafe(metadata, "description", util.DefaultSearchDepth).(string)
+}
+
 func predictTrueURLs(ctx context.Context, curImg, curV string) (string, string) {
 	imgMediaType, _, _, err := PredictMediaType(ctx, curImg)
 	if err != nil {

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -126,6 +126,16 @@ func processToken(c context.Context, key string, t persist.TokenGallery, contrac
 	logger.For(ctx).Infof("Processing Media: %s - Processing Token: %s-%s-%d", key, contractAddress, t.TokenID, t.Chain)
 	image, animation := media.KeywordsForChain(t.Chain, imageKeywords, animationKeywords)
 
+	name, description := media.FindNameAndDescription(ctx, t.TokenMetadata)
+
+	if name == "" {
+		name = t.Name.String()
+	}
+
+	if description == "" {
+		description = t.Description.String()
+	}
+
 	totalTimeOfMedia := time.Now()
 	med, err := media.MakePreviewsForMetadata(ctx, t.TokenMetadata, contractAddress, persist.TokenID(t.TokenID.String()), t.TokenURI, t.Chain, ipfsClient, arweaveClient, stg, tokenBucket, image, animation)
 	if err != nil {
@@ -140,8 +150,8 @@ func processToken(c context.Context, key string, t persist.TokenGallery, contrac
 		Media:       med,
 		Metadata:    t.TokenMetadata,
 		TokenURI:    t.TokenURI,
-		Name:        persist.NullString(t.Name),
-		Description: persist.NullString(t.Description),
+		Name:        persist.NullString(name),
+		Description: persist.NullString(description),
 		LastUpdated: persist.LastUpdatedTime{},
 	}
 	totalUpdateTime := time.Now()


### PR DESCRIPTION
Changes:

- **Changed** time marshaling to use JSON instead of binary (binary was causing some bad utf8 characters to appear but JSON will always be valid utf8)
- **Changed** token processing to also update name and description because previously the tokens would just keep the name and description they have when being updated which is often empty.