### PR TITLE
Comment and Admire Notification Fixups

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -354,52 +354,6 @@ func (q *Queries) CreateFeedEvent(ctx context.Context, arg CreateFeedEventParams
 	return i, err
 }
 
-const createFeedEventEvent = `-- name: CreateFeedEventEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, feed_event_id, subject_id, data) VALUES ($1, $2, $3, $4, $5, $5, $6) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id
-`
-
-type CreateFeedEventEventParams struct {
-	ID             persist.DBID
-	ActorID        persist.DBID
-	Action         persist.Action
-	ResourceTypeID persist.ResourceType
-	FeedEventID    persist.DBID
-	Data           persist.EventData
-}
-
-func (q *Queries) CreateFeedEventEvent(ctx context.Context, arg CreateFeedEventEventParams) (Event, error) {
-	row := q.db.QueryRow(ctx, createFeedEventEvent,
-		arg.ID,
-		arg.ActorID,
-		arg.Action,
-		arg.ResourceTypeID,
-		arg.FeedEventID,
-		arg.Data,
-	)
-	var i Event
-	err := row.Scan(
-		&i.ID,
-		&i.Version,
-		&i.ActorID,
-		&i.ResourceTypeID,
-		&i.SubjectID,
-		&i.UserID,
-		&i.TokenID,
-		&i.CollectionID,
-		&i.Action,
-		&i.Data,
-		&i.Deleted,
-		&i.LastUpdated,
-		&i.CreatedAt,
-		&i.GalleryID,
-		&i.CommentID,
-		&i.AdmireID,
-		&i.FeedEventID,
-		&i.ExternalID,
-	)
-	return i, err
-}
-
 const createFollowNotification = `-- name: CreateFollowNotification :one
 INSERT INTO notifications (id, owner_id, action, data, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount
 `

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -270,9 +270,6 @@ INSERT INTO events (id, actor_id, action, resource_type_id, gallery_id, subject_
 -- name: CreateAdmireEvent :one
 INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, subject_id, data) VALUES ($1, $2, $3, $4, $5, $6, $5, $7) RETURNING *;
 
--- name: CreateFeedEventEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, feed_event_id, subject_id, data) VALUES ($1, $2, $3, $4, $5, $5, $6) RETURNING *;
-
 -- name: CreateCommentEvent :one
 INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, subject_id, data) VALUES ($1, $2, $3, $4, $5, $6, $5, $7) RETURNING *;
 

--- a/event/event.go
+++ b/event/event.go
@@ -153,12 +153,6 @@ func (h notificationHandler) findOwnerForNotificationFromEvent(event db.Event) (
 			return "", err
 		}
 		return gallery.OwnerUserID, nil
-	case persist.ResourceTypeFeedEvent:
-		feedEvent, err := h.dataloaders.FeedEventByFeedEventID.Load(event.FeedEventID)
-		if err != nil {
-			return "", err
-		}
-		return feedEvent.OwnerID, nil
 	case persist.ResourceTypeComment:
 		feedEvent, err := h.dataloaders.FeedEventByFeedEventID.Load(event.FeedEventID)
 		if err != nil {

--- a/event/event.go
+++ b/event/event.go
@@ -159,6 +159,18 @@ func (h notificationHandler) findOwnerForNotificationFromEvent(event db.Event) (
 			return "", err
 		}
 		return feedEvent.OwnerID, nil
+	case persist.ResourceTypeComment:
+		feedEvent, err := h.dataloaders.FeedEventByFeedEventID.Load(event.FeedEventID)
+		if err != nil {
+			return "", err
+		}
+		return feedEvent.OwnerID, nil
+	case persist.ResourceTypeAdmire:
+		feedEvent, err := h.dataloaders.FeedEventByFeedEventID.Load(event.FeedEventID)
+		if err != nil {
+			return "", err
+		}
+		return feedEvent.OwnerID, nil
 	case persist.ResourceTypeUser:
 		return event.UserID, nil
 	}

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -380,7 +380,7 @@ func (api InteractionAPI) AdmireFeedEvent(ctx context.Context, feedEventID persi
 
 	err = dispatchEvent(ctx, db.Event{
 		ActorID:        userID,
-		ResourceTypeID: persist.ResourceTypeFeedEvent,
+		ResourceTypeID: persist.ResourceTypeAdmire,
 		SubjectID:      feedEventID,
 		FeedEventID:    feedEventID,
 		AdmireID:       admireID,
@@ -481,10 +481,11 @@ func (api InteractionAPI) CommentOnFeedEvent(ctx context.Context, feedEventID pe
 
 	err = dispatchEvent(ctx, db.Event{
 		ActorID:        actor,
-		ResourceTypeID: persist.ResourceTypeFeedEvent,
+		ResourceTypeID: persist.ResourceTypeComment,
 		SubjectID:      feedEventID,
 		FeedEventID:    feedEventID,
 		CommentID:      commentID,
+		Action:         persist.ActionCommentedOnFeedEvent,
 	}, api.validator)
 	if err != nil {
 		return "", err

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -131,7 +131,6 @@ type groupedNotificationHandler struct {
 }
 
 func (h groupedNotificationHandler) Handle(ctx context.Context, notif db.Notification) error {
-
 	curNotif, _ := h.queries.GetMostRecentNotificationByOwnerIDForAction(ctx, db.GetMostRecentNotificationByOwnerIDForActionParams{
 		OwnerID: notif.OwnerID,
 		Action:  notif.Action,
@@ -329,7 +328,7 @@ func updateAndPublishNotif(ctx context.Context, notif db.Notification, mostRecen
 	if err != nil {
 		return fmt.Errorf("error updating notification: %w", err)
 	}
-	updatedNotif, err := queries.GetNotificationByID(ctx, mostRecentNotif.ID)
+	updatedNotif, err := queries.GetNotificationByID(ctx, notif.ID)
 	if err != nil {
 		return err
 	}

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -14,7 +14,6 @@ const (
 	ResourceTypeGallery
 	ResourceTypeAdmire
 	ResourceTypeComment
-	ResourceTypeFeedEvent
 	ActionUserCreated                     Action = "UserCreated"
 	ActionUserFollowedUsers               Action = "UserFollowedUsers"
 	ActionCollectorsNoteAddedToToken      Action = "CollectorsNoteAddedToToken"

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -29,8 +29,6 @@ func (r *EventRepository) Add(ctx context.Context, event db.Event) (*db.Event, e
 		return r.AddAdmireEvent(ctx, event)
 	case persist.ResourceTypeComment:
 		return r.AddCommentEvent(ctx, event)
-	case persist.ResourceTypeFeedEvent:
-		return r.AddFeedEventEvent(ctx, event)
 	case persist.ResourceTypeGallery:
 		return r.AddGalleryEvent(ctx, event)
 	default:
@@ -95,18 +93,6 @@ func (r *EventRepository) AddCommentEvent(ctx context.Context, event db.Event) (
 		ResourceTypeID: event.ResourceTypeID,
 		CommentID:      event.CommentID,
 		FeedEventID:    event.FeedEventID,
-		Data:           event.Data,
-	})
-	return &event, err
-}
-
-func (r *EventRepository) AddFeedEventEvent(ctx context.Context, event db.Event) (*db.Event, error) {
-	event, err := r.Queries.CreateFeedEventEvent(ctx, db.CreateFeedEventEventParams{
-		ID:             persist.GenerateID(),
-		ActorID:        event.ActorID,
-		Action:         event.Action,
-		ResourceTypeID: event.ResourceTypeID,
-		FeedEventID:    event.SubjectID,
 		Data:           event.Data,
 	})
 	return &event, err

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -80,7 +80,7 @@ func (r *EventRepository) AddAdmireEvent(ctx context.Context, event db.Event) (*
 		ActorID:        event.ActorID,
 		Action:         event.Action,
 		ResourceTypeID: event.ResourceTypeID,
-		AdmireID:       event.SubjectID,
+		AdmireID:       event.AdmireID,
 		FeedEventID:    event.FeedEventID,
 		Data:           event.Data,
 	})
@@ -93,7 +93,7 @@ func (r *EventRepository) AddCommentEvent(ctx context.Context, event db.Event) (
 		ActorID:        event.ActorID,
 		Action:         event.Action,
 		ResourceTypeID: event.ResourceTypeID,
-		CommentID:      event.SubjectID,
+		CommentID:      event.CommentID,
 		FeedEventID:    event.FeedEventID,
 		Data:           event.Data,
 	})


### PR DESCRIPTION
Noticed while getting the Feed Caption branch up to date that foreign key errors popped up as I was commenting and admiring stuff. This also removes the `ResourceTypeFeedEvent` type since it doesn't seem to be needed anymore.