### PR TITLE
Remove circle image and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,15 +36,6 @@ abi-gen:
 	abigen --abi=./contracts/abi/Cryptopunks.abi --pkg=contracts --type=Cryptopunks > ./contracts/Cryptopunks.go
 	abigen --abi=./contracts/abi/Zora.abi --pkg=contracts --type=Zora > ./contracts/Zora.go
 
-g-docker:
-	docker-compose down
-	docker-compose build
-	docker build -t bcgallery/gallery-postgres -f docker/postgres/DOCKERFILE .
-	docker build -t bcgallery/gallery-postgres:circle -f docker/postgres/circle/DOCKERFILE .
-	docker push bcgallery/gallery-postgres
-	docker push bcgallery/gallery-postgres:circle
-	docker-compose up -d
-
 docker-start-clean:	docker-build
 	docker-compose up -d
 

--- a/README.md
+++ b/README.md
@@ -212,14 +212,6 @@ Skip longer running tests with the `-short` flag:
 go test -short
 ```
 
-### Integration Testing
-
-Run integration tests against ethereum mainnet:
-
-```bash
-go test -run TestIntegrationTest ./server/... -args -chain ethereum -chainID 1
-```
-
 ### Running locally with live data
 
 If you have access to the `_encrypted_local` file, you can run the server locally with live data. This is useful for testing the server locally with real data.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ```bash
 $ git clone git@github.com:gallery-so/go-gallery.git
 $ cd go-gallery
-$ go get -u -d ./...
+$ go get -u=patch -d ./...
 ```
 
 ## Setup (Mac)
@@ -62,12 +62,6 @@ To remove running redis and postgres instance:
 ```bash
 $ make docker-stop
 ```
-
-**Deploying our Postgres image**
-
-`make g-docker` will push a new docker image that initializes a postgres instance with our custom schema. To get access to our dockerhub, contact a core team member.
-
-_Do not run this script if you've run the shell script for seeding NFT data._
 
 **Working with migrations**
 

--- a/docker/postgres/circle/DOCKERFILE
+++ b/docker/postgres/circle/DOCKERFILE
@@ -1,5 +1,0 @@
-FROM circleci/postgres
-ENV POSTGRES_HOST_AUTH_METHOD trust
-ENV POSTGRES_USER postgres
-ENV POSTGRES_DB postgres
-COPY db/migrations/*up.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Addresses https://github.com/gallery-so/go-gallery/issues/609 and https://github.com/gallery-so/go-gallery/issues/608

* Removes the old circleci postgres image since we create a new instance per test suite
* Removes some inaccurate README stuff