### PR TITLE
reduce cache and throttle time for communities

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const staleCommunityTime = time.Hour * 2
+const staleCommunityTime = time.Minute * 30
 
 const maxCommunitySize = 10_000
 

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -107,7 +107,7 @@ func setDefaults() {
 }
 
 func newThrottler() *throttle.Locker {
-	return throttle.NewThrottleLocker(redis.NewCache(redis.TokenProcessingThrottleDB), time.Hour*12)
+	return throttle.NewThrottleLocker(redis.NewCache(redis.TokenProcessingThrottleDB), time.Minute*30)
 }
 
 func initSentry() {


### PR DESCRIPTION
Changes:

- **Changed** cache and throttle times related to communities to 30 minutes