### PR TITLE
tls insecure verify for certain projects [GAL-579]

### DIFF
--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -829,14 +829,8 @@ func getUpdateForToken(pCtx context.Context, uniqueHandlers uniqueMetadatas, tok
 		newMetadata = md
 	}
 
-	name, ok := util.GetValueFromMap(newMetadata, "name", util.DefaultSearchDepth).(string)
-	if !ok {
-		name = ""
-	}
-	description, ok := util.GetValueFromMap(newMetadata, "description", util.DefaultSearchDepth).(string)
-	if !ok {
-		description = ""
-	}
+	name, description := media.FindNameAndDescription(pCtx, newMetadata)
+
 	image, animation := media.KeywordsForChain(chain, imageKeywords, animationKeywords)
 
 	newMedia, err := media.MakePreviewsForMetadata(pCtx, newMetadata, persist.Address(contractAddress.String()), tokenID, newURI, chain, ipfsClient, arweaveClient, storageClient, tokenBucket, image, animation)

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -198,6 +199,7 @@ func newHTTPClientForRPC(continueTrace bool, spanOptions ...sentry.SpanOption) *
 			Dial:                (&net.Dialer{KeepAlive: defaultHTTPKeepAlive * time.Second}).Dial,
 			MaxIdleConns:        defaultHTTPMaxIdleConns,
 			MaxIdleConnsPerHost: defaultHTTPMaxIdleConnsPerHost,
+			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
 		}, continueTrace, spanOptions...),
 	}
 }


### PR DESCRIPTION
Changes:

- **Changed** the default http client in the RPC package to use the tls config param `InsecureSkipVerify` so that it can connect to http links with unvalidated certificates. This is for links like https://vibes.art/vibes/jpg/8095.jpg that are valid when opened in the browser but invalid when using a default `http.Get` request. The problem here, is this insecure parameter is supposedly just for testing, so I am inclined not even to merge this PR because I feel like they should just get valid certificates and it is not our fault that it is not loading. But this is the solution to the bug of these NFTs not appearing. 
 
I tried finding ways around this bug other ways as well such as detecting the cert error and trying to just use the raw URL in those cases but that results in an unknown media type since we need to get request the URL to even predict what type of media it will be.