### PR TITLE
get name and desc in sync if not set

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -932,6 +932,17 @@ func tokensToNewDedupedTokens(ctx context.Context, tokens []chainTokens, contrac
 	res := make([]persist.TokenGallery, len(seenTokens))
 	i := 0
 	for _, t := range seenTokens {
+		if t.Name == "" || t.Description == "" {
+			name, ok := util.GetValueFromMapUnsafe(t.TokenMetadata, "name", util.DefaultSearchDepth).(string)
+			if ok {
+				t.Name = persist.NullString(name)
+			}
+			description, ok := util.GetValueFromMapUnsafe(t.TokenMetadata, "description", util.DefaultSearchDepth).(string)
+			if ok {
+				t.Description = persist.NullString(description)
+			}
+		}
+
 		res[i] = t
 		i++
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -932,11 +932,13 @@ func tokensToNewDedupedTokens(ctx context.Context, tokens []chainTokens, contrac
 	res := make([]persist.TokenGallery, len(seenTokens))
 	i := 0
 	for _, t := range seenTokens {
-		if t.Name == "" || t.Description == "" {
+		if t.Name == "" {
 			name, ok := util.GetValueFromMapUnsafe(t.TokenMetadata, "name", util.DefaultSearchDepth).(string)
 			if ok {
 				t.Name = persist.NullString(name)
 			}
+		}
+		if t.Description == "" {
 			description, ok := util.GetValueFromMapUnsafe(t.TokenMetadata, "description", util.DefaultSearchDepth).(string)
 			if ok {
 				t.Description = persist.NullString(description)


### PR DESCRIPTION
Changes:

- **Added** one extremely short little check at the end of the sync step to try to get name and description fields from the metadata if they are not set for a token. 

Considerations:

- When a token has valid media in the indexer server or token processing server, it will not get processed regardless of whether it has a name or description. We used to have a check for this but got rid of it. I think it would be best to add a separate check on these services for other metadata fields that are required like `name` and `description`, and it will be a separate check so we don't need to do a full media refresh just for a missing name. I can work on this tomorrow or this can be a part of the `token_metadata` table addition we are planning to add. 