### PR TITLE
name and description nets

### DIFF
--- a/cmd/update/main.go
+++ b/cmd/update/main.go
@@ -63,7 +63,7 @@ func processAddresses(addresses <-chan persist.Address, wg *sync.WaitGroup) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
 			defer cancel()
 
-			body := indexer.UpdateTokenMediaInput{
+			body := indexer.UpdateTokenInput{
 				OwnerAddress: persist.EthereumAddress(a),
 				UpdateAll:    true,
 			}

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -142,7 +142,7 @@ func coreInitServer() *gin.Engine {
 
 	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(viper.GetInt("CHAIN")), defaultTransferEvents, nil, nil, nil)
 
-	go processMedialessTokens(configureRootContext(), queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), t)
+	go processIncompleteTokens(configureRootContext(), queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), t)
 	return handlersInitServer(router, queueChan, tokenRepo, contractRepo, ethClient, ipfsClient, arweaveClient, s, i)
 }
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mikeydub/go-gallery/contracts"
 	"github.com/mikeydub/go-gallery/indexer/refresh"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
@@ -912,15 +913,10 @@ func (i *indexer) fieldMapsToTokens(ctx context.Context,
 		}
 		delete(previousOwners, k)
 		metadata := metadatas[k]
-		delete(metadatas, k)
-		var name, description string
 
-		if w, ok := findFirstFieldFromMetadata(metadata.md, "name").(string); ok {
-			name = w
-		}
-		if w, ok := findFirstFieldFromMetadata(metadata.md, "description").(string); ok {
-			description = w
-		}
+		name, description := media.FindNameAndDescription(ctx, metadata.md)
+
+		delete(metadatas, k)
 
 		uri := uris[k]
 		delete(uris, k)
@@ -955,15 +951,10 @@ func (i *indexer) fieldMapsToTokens(ctx context.Context,
 		}
 
 		metadata := metadatas[k]
-		delete(metadatas, k)
-		var name, description string
 
-		if v, ok := findFirstFieldFromMetadata(metadata.md, "name").(string); ok {
-			name = v
-		}
-		if v, ok := findFirstFieldFromMetadata(metadata.md, "description").(string); ok {
-			description = v
-		}
+		name, description := media.FindNameAndDescription(ctx, metadata.md)
+
+		delete(metadatas, k)
 
 		uri := uris[k]
 		delete(uris, k)
@@ -1103,16 +1094,6 @@ func fillContractFields(ctx context.Context, ethClient *ethclient.Client, contra
 }
 
 // HELPER FUNCS ---------------------------------------------------------------
-
-func findFirstFieldFromMetadata(metadata persist.TokenMetadata, fields ...string) interface{} {
-
-	for _, field := range fields {
-		if val := util.GetValueFromMapUnsafe(metadata, field, util.DefaultSearchDepth); val != nil {
-			return val
-		}
-	}
-	return nil
-}
 
 func transfersToTransfersAtBlock(transfers []rpc.Transfer) []transfersAtBlock {
 	transfersMap := map[persist.BlockNumber]transfersAtBlock{}

--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -221,7 +221,7 @@ func processIncompleteTokens(ctx context.Context, inputs <-chan processTokensInp
 						} else if token.Name == "" || token.Description == "" {
 							// token.Media.IsServable() because the tokens in tokensWithoutMedia will have all their metadata fields updated as well, including the ones that wold be updated for tokensWithoutMetadataFields
 							// we don't want to update them twice.
-							// also, the media being servable guaruntees that the metadata is valid, meaning that we actually have somewhere to look fro the metadata fields
+							// also, the media being servable guaruntees that the metadata is valid, meaning that we actually have somewhere to look from the metadata fields
 							tokensWithoutMetadataFields = append(tokensWithoutMetadataFields, token)
 						}
 					}

--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -62,20 +62,27 @@ var customManualIndex = map[persist.EthereumAddress]manualIndexHandler{
 	},
 }
 
-// UpdateTokenMediaInput is the input for the update media endpoint that will find all of the media content
+// UpdateTokenInput is the input for the update media endpoint that will find all of the media content
 // for an addresses NFTs and cache it in a storage bucket
-type UpdateTokenMediaInput struct {
+type UpdateTokenInput struct {
 	OwnerAddress    persist.EthereumAddress `json:"owner_address,omitempty"`
 	TokenID         persist.TokenID         `json:"token_id,omitempty"`
 	ContractAddress persist.EthereumAddress `json:"contract_address,omitempty"`
 	UpdateAll       bool                    `json:"update_all"`
 }
 
-type tokenUpdate struct {
+type tokenFullUpdate struct {
 	TokenDBID       persist.DBID
 	TokenID         persist.TokenID
 	ContractAddress persist.EthereumAddress
-	Update          persist.TokenUpdateMediaInput
+	Update          persist.TokenUpdateAllURIDerivedFieldsInput
+}
+
+type tokenMetadataFieldsUpdate struct {
+	TokenDBID       persist.DBID
+	TokenID         persist.TokenID
+	ContractAddress persist.EthereumAddress
+	Update          persist.TokenUpdateMetadataFieldsInput
 }
 
 type getTokensInput struct {
@@ -189,7 +196,7 @@ type processTokensInput struct {
 	contracts []persist.Contract
 }
 
-func processMedialessTokens(ctx context.Context, inputs <-chan processTokensInput, nftRepository persist.TokenRepository, contractRepository persist.ContractRepository, ipfsClient *shell.Shell, ethClient *ethclient.Client, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string, throttler *throttle.Locker) {
+func processIncompleteTokens(ctx context.Context, inputs <-chan processTokensInput, nftRepository persist.TokenRepository, contractRepository persist.ContractRepository, ipfsClient *shell.Shell, ethClient *ethclient.Client, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string, throttler *throttle.Locker) {
 	wp := workerpool.New(10)
 	for input := range inputs {
 		i := input
@@ -205,12 +212,22 @@ func processMedialessTokens(ctx context.Context, inputs <-chan processTokensInpu
 					defer throttler.Unlock(ctx, i.key)
 					tokensWithoutMedia := make([]persist.Token, 0, len(i.tokens))
 					contractsWithoutMedia := make([]persist.Contract, 0, len(i.contracts))
+					tokensWithoutMetadataFields := make([]persist.Token, 0, len(i.tokens))
 					for _, token := range i.tokens {
+						// if the media is not servable, we need to update it as well as the fields it is derived from that could be causing it not to be valid
+						// (token URI, metadata, etc.)
 						if !token.Media.IsServable() {
 							tokensWithoutMedia = append(tokensWithoutMedia, token)
 						}
+						// token.Media.IsServable() because the tokens in tokensWithoutMedia will have all their metadata fields updated as well, including the ones that wold be updated for tokensWithoutMetadataFields
+						// we don't want to update them twice.
+						// also, the media being servable guaruntees that the metadata is valid, meaning that we actually have somewhere to look fro the metadata fields
+						if token.Name == "" || token.Description == "" && token.Media.IsServable() {
+							tokensWithoutMetadataFields = append(tokensWithoutMetadataFields, token)
+						}
 					}
 					for _, contract := range i.contracts {
+						// the contract name is the most important field and the only field we use at the indexer level as far as contract metadata goes, but we may want to consider updating if other fields are empty in the future as well (such as a description if we start retrieving that field from somewhere)
 						if contract.Name == "" {
 							contractsWithoutMedia = append(contractsWithoutMedia, contract)
 						}
@@ -221,7 +238,7 @@ func processMedialessTokens(ctx context.Context, inputs <-chan processTokensInpu
 						t := token
 						nwp.Submit(func() {
 							ctx := sentryutil.NewSentryHubContext(ctx)
-							err := refreshToken(ctx, UpdateTokenMediaInput{TokenID: t.TokenID, ContractAddress: t.ContractAddress}, nftRepository, ethClient, ipfsClient, arweaveClient, storageClient, tokenBucket)
+							err := refreshTokenMedias(ctx, UpdateTokenInput{TokenID: t.TokenID, ContractAddress: t.ContractAddress}, nftRepository, ethClient, ipfsClient, arweaveClient, storageClient, tokenBucket)
 							if err != nil {
 								logEntry := logger.For(ctx).WithError(err).WithFields(logrus.Fields{
 									"tokenID":         t.TokenID,
@@ -247,6 +264,21 @@ func processMedialessTokens(ctx context.Context, inputs <-chan processTokensInpu
 							if err != nil {
 								logEntry := logger.For(ctx).WithError(err).WithFields(logrus.Fields{"contractAddress": c.Address})
 								logEthCallRPCError(logEntry, err, "failed to update contract media")
+							}
+						})
+					}
+					// these tokens have valid metadata and media but are missing metadata fields (name, description)
+					for _, token := range tokensWithoutMetadataFields {
+						t := token
+						nwp.Submit(func() {
+							ctx := sentryutil.NewSentryHubContext(ctx)
+							err := updateMetadataFieldsForToken(ctx, t.TokenID, t.ContractAddress, t.TokenMetadata, nftRepository)
+							if err != nil {
+								logEntry := logger.For(ctx).WithError(err).WithFields(logrus.Fields{
+									"tokenID":         t.TokenID,
+									"contractAddress": t.ContractAddress,
+								})
+								logEntry.Error("failed to update token metadata fields")
 							}
 						})
 					}
@@ -435,10 +467,12 @@ func processAccountedForNFTs(ctx context.Context, tokens []persist.Token, tokenR
 		}
 
 		if needsUpdate {
-			update := persist.TokenUpdateMediaInput{
-				TokenURI: token.TokenURI,
-				Metadata: token.TokenMetadata,
-				Media:    token.Media,
+			update := persist.TokenUpdateAllURIDerivedFieldsInput{
+				TokenURI:    token.TokenURI,
+				Metadata:    token.TokenMetadata,
+				Media:       token.Media,
+				Name:        token.Name,
+				Description: token.Description,
 			}
 
 			if err := tokenRepository.UpdateByID(ctx, token.ID, update); err != nil {
@@ -551,13 +585,13 @@ func processUnaccountedForNFTs(ctx context.Context, assets []opensea.Asset, addr
 
 func updateTokens(tokenRepository persist.TokenRepository, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		input := UpdateTokenMediaInput{}
+		input := UpdateTokenInput{}
 		if err := c.ShouldBindJSON(&input); err != nil {
 			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
 
-		err := refreshToken(c, input, tokenRepository, ethClient, ipfsClient, arweaveClient, storageClient, tokenBucket)
+		err := refreshTokenMedias(c, input, tokenRepository, ethClient, ipfsClient, arweaveClient, storageClient, tokenBucket)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return
@@ -667,8 +701,8 @@ func filterTransfers(ctx context.Context, m task.DeepRefreshMessage, transfers [
 	return result
 }
 
-// refreshToken will find all of the media content for an addresses NFTs and possibly cache it in a storage bucket
-func refreshToken(c context.Context, input UpdateTokenMediaInput, tokenRepository persist.TokenRepository, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) error {
+// refreshTokenMedias will find all of the media content for an addresses NFTs and possibly cache it in a storage bucket
+func refreshTokenMedias(c context.Context, input UpdateTokenInput, tokenRepository persist.TokenRepository, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) error {
 	c = sentryutil.NewSentryHubContext(c)
 	c = logger.NewContextWithFields(c, logrus.Fields{"tokenID": input.TokenID, "contractAddress": input.ContractAddress})
 	if input.TokenID != "" && input.ContractAddress != "" {
@@ -738,7 +772,7 @@ func refreshToken(c context.Context, input UpdateTokenMediaInput, tokenRepositor
 		tokens = res
 	}
 
-	tokenUpdateChan := make(chan tokenUpdate)
+	tokenUpdateChan := make(chan tokenFullUpdate)
 	errChan := make(chan error)
 	// iterate over len tokens
 	updateMediaForTokens(c, tokenUpdateChan, errChan, tokens, ethClient, ipfsClient, arweaveClient, storageClient, tokenBucket)
@@ -761,7 +795,7 @@ func refreshToken(c context.Context, input UpdateTokenMediaInput, tokenRepositor
 }
 
 // updateMediaForTokens will return two channels that will collectively receive the length of the tokens passed in
-func updateMediaForTokens(pCtx context.Context, updateChan chan<- tokenUpdate, errChan chan<- error, tokens []persist.Token, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) {
+func updateMediaForTokens(pCtx context.Context, updateChan chan<- tokenFullUpdate, errChan chan<- error, tokens []persist.Token, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) {
 
 	wp := workerpool.New(10)
 
@@ -788,7 +822,7 @@ func updateMediaForTokens(pCtx context.Context, updateChan chan<- tokenUpdate, e
 	}
 }
 
-func getUpdateForToken(pCtx context.Context, uniqueHandlers uniqueMetadatas, tokenType persist.TokenType, chain persist.Chain, tokenID persist.TokenID, contractAddress persist.EthereumAddress, metadata persist.TokenMetadata, uri persist.TokenURI, mediaType persist.MediaType, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) (tokenUpdate, error) {
+func getUpdateForToken(pCtx context.Context, uniqueHandlers uniqueMetadatas, tokenType persist.TokenType, chain persist.Chain, tokenID persist.TokenID, contractAddress persist.EthereumAddress, metadata persist.TokenMetadata, uri persist.TokenURI, mediaType persist.MediaType, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) (tokenFullUpdate, error) {
 	newMetadata := metadata
 	newURI := uri
 
@@ -809,7 +843,7 @@ func getUpdateForToken(pCtx context.Context, uniqueHandlers uniqueMetadatas, tok
 		logger.For(pCtx).Infof("Using %v metadata handler for %s", handler, contractAddress)
 		u, md, err := handler(pCtx, newURI, persist.EthereumAddress(contractAddress.String()), tokenID, ethClient, ipfsClient, arweaveClient)
 		if err != nil {
-			return tokenUpdate{}, UniqueMetadataUpdateErr{
+			return tokenFullUpdate{}, UniqueMetadataUpdateErr{
 				contractAddress: persist.Address(contractAddress),
 				tokenID:         tokenID,
 				err:             err,
@@ -820,7 +854,7 @@ func getUpdateForToken(pCtx context.Context, uniqueHandlers uniqueMetadatas, tok
 	} else {
 		md, err := rpc.GetMetadataFromURI(pCtx, newURI, ipfsClient, arweaveClient)
 		if err != nil {
-			return tokenUpdate{}, MetadataUpdateErr{
+			return tokenFullUpdate{}, MetadataUpdateErr{
 				contractAddress: persist.Address(contractAddress),
 				tokenID:         tokenID,
 				err:             err,
@@ -829,28 +863,22 @@ func getUpdateForToken(pCtx context.Context, uniqueHandlers uniqueMetadatas, tok
 		newMetadata = md
 	}
 
-	name, ok := util.GetValueFromMap(newMetadata, "name", util.DefaultSearchDepth).(string)
-	if !ok {
-		name = ""
-	}
-	description, ok := util.GetValueFromMap(newMetadata, "description", util.DefaultSearchDepth).(string)
-	if !ok {
-		description = ""
-	}
+	name, description := media.FindNameAndDescription(pCtx, newMetadata)
+
 	image, animation := media.KeywordsForChain(chain, imageKeywords, animationKeywords)
 
 	newMedia, err := media.MakePreviewsForMetadata(pCtx, newMetadata, persist.Address(contractAddress.String()), tokenID, newURI, chain, ipfsClient, arweaveClient, storageClient, tokenBucket, image, animation)
 	if err != nil {
-		return tokenUpdate{}, MetadataPreviewUpdateErr{
+		return tokenFullUpdate{}, MetadataPreviewUpdateErr{
 			contractAddress: persist.Address(contractAddress),
 			tokenID:         tokenID,
 			err:             err,
 		}
 	}
-	up := tokenUpdate{
+	up := tokenFullUpdate{
 		TokenID:         tokenID,
 		ContractAddress: persist.EthereumAddress(contractAddress),
-		Update: persist.TokenUpdateMediaInput{
+		Update: persist.TokenUpdateAllURIDerivedFieldsInput{
 			TokenURI:    newURI,
 			Metadata:    newMetadata,
 			Media:       newMedia,
@@ -859,6 +887,14 @@ func getUpdateForToken(pCtx context.Context, uniqueHandlers uniqueMetadatas, tok
 		},
 	}
 	return up, nil
+}
+
+func updateMetadataFieldsForToken(pCtx context.Context, tokenID persist.TokenID, contractAddress persist.EthereumAddress, tokenMetadata persist.TokenMetadata, tokenRepo persist.TokenRepository) error {
+	name, desc := media.FindNameAndDescription(pCtx, tokenMetadata)
+	return tokenRepo.UpdateByTokenIdentifiers(pCtx, tokenID, contractAddress, persist.TokenUpdateMetadataFieldsInput{
+		Name:        persist.NullString(name),
+		Description: persist.NullString(desc),
+	})
 }
 
 func manuallyIndexToken(pCtx context.Context, tokenID persist.TokenID, contractAddress, ownerAddress persist.EthereumAddress, ec *ethclient.Client, tokenRepo persist.TokenRepository) (t persist.Token, err error) {

--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -218,11 +218,10 @@ func processIncompleteTokens(ctx context.Context, inputs <-chan processTokensInp
 						// (token URI, metadata, etc.)
 						if !token.Media.IsServable() {
 							tokensWithoutMedia = append(tokensWithoutMedia, token)
-						}
-						// token.Media.IsServable() because the tokens in tokensWithoutMedia will have all their metadata fields updated as well, including the ones that wold be updated for tokensWithoutMetadataFields
-						// we don't want to update them twice.
-						// also, the media being servable guaruntees that the metadata is valid, meaning that we actually have somewhere to look fro the metadata fields
-						if token.Name == "" || token.Description == "" && token.Media.IsServable() {
+						} else if token.Name == "" || token.Description == "" {
+							// token.Media.IsServable() because the tokens in tokensWithoutMedia will have all their metadata fields updated as well, including the ones that wold be updated for tokensWithoutMetadataFields
+							// we don't want to update them twice.
+							// also, the media being servable guaruntees that the metadata is valid, meaning that we actually have somewhere to look fro the metadata fields
 							tokensWithoutMetadataFields = append(tokensWithoutMetadataFields, token)
 						}
 					}

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -276,7 +276,7 @@ func (d *Provider) GetDisplayNameByAddress(ctx context.Context, addr persist.Add
 // RefreshToken refreshes the metadata for a given token.
 func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) error {
 
-	input := indexer.UpdateTokenMediaInput{
+	input := indexer.UpdateTokenInput{
 		OwnerAddress:    persist.EthereumAddress(ownerAddress.String()),
 		TokenID:         ti.TokenID,
 		ContractAddress: persist.EthereumAddress(persist.ChainETH.NormalizeAddress(ti.ContractAddress)),
@@ -340,7 +340,7 @@ func (d *Provider) DeepRefresh(ctx context.Context, ownerAddress persist.Address
 // UpdateMediaForWallet updates media for the tokens owned by a wallet on the Ethereum Blockchain
 func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 
-	input := indexer.UpdateTokenMediaInput{
+	input := indexer.UpdateTokenInput{
 		OwnerAddress: persist.EthereumAddress(persist.ChainETH.NormalizeAddress(wallet)),
 		UpdateAll:    all,
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -460,7 +460,7 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 					return err
 				}
 
-				if err := p.Repos.TokenRepository.UpdateByTokenIdentifiersUnsafe(ctx, ti.TokenID, ti.ContractAddress, ti.Chain, persist.TokenUpdateMediaInput{
+				if err := p.Repos.TokenRepository.UpdateByTokenIdentifiersUnsafe(ctx, ti.TokenID, ti.ContractAddress, ti.Chain, persist.TokenUpdateAllURIDerivedFieldsInput{
 					Media:       token.Media,
 					Metadata:    token.TokenMetadata,
 					Name:        persist.NullString(token.Name),

--- a/service/persist/token_gallery.go
+++ b/service/persist/token_gallery.go
@@ -109,8 +109,8 @@ type TokenUpdateInfoInput struct {
 	CollectorsNote NullString `json:"collectors_note"`
 }
 
-// TokenUpdateMediaInput represents an update to a tokens image properties
-type TokenUpdateMediaInput struct {
+// TokenUpdateAllURIDerivedFieldsInput represents an update to any field that can be derived from the token URI, including the metadata itself and tokenURI where the metadata is hosted
+type TokenUpdateAllURIDerivedFieldsInput struct {
 	LastUpdated LastUpdatedTime `json:"last_updated"`
 
 	Media       Media         `json:"media"`
@@ -118,6 +118,21 @@ type TokenUpdateMediaInput struct {
 	TokenURI    TokenURI      `json:"token_uri"`
 	Name        NullString    `json:"name"`
 	Description NullString    `json:"description"`
+}
+
+// TokenUpdateMediaInput represents an update to just a token's media fields
+type TokenUpdateMediaInput struct {
+	LastUpdated LastUpdatedTime `json:"last_updated"`
+
+	Media Media `json:"media"`
+}
+
+// TokenUpdateMetadataFieldsInput represents an update to any field that can be derived from the token metadata
+type TokenUpdateMetadataFieldsInput struct {
+	LastUpdated LastUpdatedTime `json:"last_updated"`
+
+	Name        NullString `json:"name"`
+	Description NullString `json:"description"`
 }
 
 // TokenGalleryRepository represents a repository for interacting with persisted tokens


### PR DESCRIPTION
Changes:

- **Added** another check at the indexer level for tokens with valid media and metadata but without a name or description so that those fields can get updated even when the media is all good
- **Changed** some naming as well as started using a consistent shorthand function for getting metadata fields from the metadata `media.FindNameAndDescription`