### PR TITLE
pointer panic caused by wrong variable

### DIFF
--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -325,7 +325,7 @@ func GetUserWithNonce(pCtx context.Context, pChainAddress persist.ChainAddress, 
 	if err != nil {
 		return nonceValue, user, err
 	}
-	if user.ID != "" {
+	if dbUser.ID != "" {
 		user = &dbUser
 	} else {
 		return nonceValue, user, persist.ErrUserNotFound{ChainAddress: pChainAddress}


### PR DESCRIPTION
Panic occurring on login due to the wrong variable being used and this variable was a pointer that was always nil at the time it was being called.