### PR TITLE
Fix owned_by_wallets null constraint error

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -842,7 +842,7 @@ func (d *Provider) upsertContracts(ctx context.Context, allContracts []chainCont
 	for chain, addresses := range contractsForChain {
 		newContracts, err := d.Repos.ContractRepository.GetByAddresses(ctx, addresses, chain)
 		if err != nil {
-			return nil, fmt.Errorf("error upserting tokens: %s", err)
+			return nil, fmt.Errorf("error fetching contracts: %s", err)
 		}
 		for _, c := range newContracts {
 			addressesToContracts[c.Chain.NormalizeAddress(c.Address)] = c.ID

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -162,7 +162,7 @@ func (p *Provider) GetTokensByWalletAddress(ctx context.Context, address persist
 		FetchAssets(ctx, assetsChan, persist.EthereumAddress(address.String()), "", "", "", 0, nil)
 	}()
 
-	return assetsToTokens(ctx, address, assetsChan, p.ethClient)
+	return assetsToTokens(ctx, assetsChan, p.ethClient)
 }
 
 // GetTokensByContractAddress returns a list of tokens for a contract address
@@ -172,8 +172,7 @@ func (p *Provider) GetTokensByContractAddress(ctx context.Context, address persi
 		defer close(assetsChan)
 		FetchAssets(ctx, assetsChan, "", persist.EthereumAddress(address), "", "", 0, nil)
 	}()
-	// TODO: Fill in this address or change something else
-	tokens, contracts, err := assetsToTokens(ctx, "", assetsChan, p.ethClient)
+	tokens, contracts, err := assetsToTokens(ctx, assetsChan, p.ethClient)
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
@@ -191,8 +190,7 @@ func (p *Provider) GetTokensByTokenIdentifiers(ctx context.Context, ti multichai
 		defer close(assetsChan)
 		FetchAssets(ctx, assetsChan, "", persist.EthereumAddress(ti.ContractAddress), TokenID(ti.TokenID.Base10String()), "", 0, nil)
 	}()
-	// TODO: Fill in this address or change something else
-	tokens, contracts, err := assetsToTokens(ctx, "", assetsChan, p.ethClient)
+	tokens, contracts, err := assetsToTokens(ctx, assetsChan, p.ethClient)
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
@@ -209,8 +207,7 @@ func (p *Provider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, ti m
 		defer close(assetsChan)
 		FetchAssets(ctx, assetsChan, persist.EthereumAddress(ownerAddress), persist.EthereumAddress(ti.ContractAddress), TokenID(ti.TokenID.Base10String()), "", 0, nil)
 	}()
-	// TODO: Fill in this address or change something else
-	tokens, contracts, err := assetsToTokens(ctx, "", assetsChan, p.ethClient)
+	tokens, contracts, err := assetsToTokens(ctx, assetsChan, p.ethClient)
 	if err != nil {
 		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, err
 	}
@@ -603,7 +600,7 @@ func FetchContractByAddress(pCtx context.Context, pContract persist.EthereumAddr
 	return response, nil
 }
 
-func assetsToTokens(ctx context.Context, address persist.Address, assetsChan <-chan assetsReceieved, ethClient *ethclient.Client) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func assetsToTokens(ctx context.Context, assetsChan <-chan assetsReceieved, ethClient *ethclient.Client) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 
 	block, err := ethClient.BlockNumber(ctx)
 	if err != nil {
@@ -694,7 +691,7 @@ func assetsToTokens(ctx context.Context, address persist.Address, assetsChan <-c
 						Description:     nft.Description,
 						TokenURI:        persist.TokenURI(nft.TokenMetadataURL),
 						TokenID:         persist.TokenID(nft.TokenID.ToBase16()),
-						OwnerAddress:    address,
+						OwnerAddress:    persist.Address(nft.Owner.Address),
 						ContractAddress: persist.Address(nft.Contract.ContractAddress.String()),
 						ExternalURL:     nft.ExternalURL,
 						BlockNumber:     persist.BlockNumber(block),


### PR DESCRIPTION
**Changes**
Tokens returned by the OpenSea provider would occasionally return tokens with no owner. The fix is to use the address returned by the OpenSea API versus using the input `address` as the owner.

Tested by refreshing a few communities and verifying that the `owned_by_wallets` field is not null and also owned by the expected wallet.