### PR TITLE
GAL-517 Add Verification Email template

### DIFF
--- a/emails/templates/verificationEmail.html
+++ b/emails/templates/verificationEmail.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+  <html
+    dir="ltr"
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office">
+    <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="viewport" content="width=device-width"/>
+
+      <title> </title>
+
+      <style type="text/css">
+        td {
+          font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+        }
+
+        a {
+          text-decoration: none;
+          color: initial;
+        }
+
+      </style>
+
+      <!--[if gte mso 9]>
+        <xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml>
+      <![endif]-->
+    </head>
+    <body bgcolor="#F9F9F9" width="100%" style="-webkit-font-smoothing: antialiased; width:100% !important; background:#F9F9F9;-webkit-text-size-adjust:none; margin:0; padding:0; min-width:100%; direction: ltr;">
+      <table width="100%" style="margin-bottom: 100px;" border="0" cellspacing="0" cellpadding="0">
+        <tr>
+          <td align="center">
+            <img
+                height="22"
+                src="https://lh3.googleusercontent.com/0DwrXwGuKSGcsovfJgAeDlvCr6zBDO0yMuOEjaA_7viuMtbOr6_2EM1pQTmglDmvybFGj-a1qDLT8RbPBbCs6kDxHyMOL6cqwDpcPGmplRrg-pROo_vbVmIn0I9bOf-obL5fjgp6vWzkn4HQRoDv1fZrnxDNS6RsprGOFqgw4RMpafUuNlZfTEAeWRMckTv4bYcwOQHRdTRBYf7BvMPOX_SYRAWfYNoHMdrVEcamLhfzYT0Y1-aKI63vz61HGW6wsIXSgr4MimrfwjfwgFcdvFcckY7AK4RwuuaYwEjye-5vNDjV40A-BWSvG6_S4qaC6mxIzRnn6TXU_z100VRrqpKcDFkv38qsOcZkp382-Zp69BOAoYkBqZ370rDwAYLRc_jsxKi4e0QY66uBgmBgK9oXMBFv3BKaQQMswJ9R8HqNJ3V5KIMGD1Ts0G4IXOa8Jjn4ekfwW3cnWB4lURuUG8qlQ88MuarJOJiQPJZqMl2j1-DKA3ukiiOnWZvViiNlir4ePvirpkYCi7GeT6VPbFk5uVUPXiVlO84Z8LttutOCXKm6P8aPNl2XduseN2hJjzKNZ2gLyhKC9x0YBLvrjcoZK5CoIRHrF4uT6_1LJrPq0Ti1Ml7bwPKsMUB83FDPtwSLd-3_yRxZOExdc7cZw8QpUkfWkXmjjBwd8EAo2HeQGUX9kOrtr0pWYDzLX2875uVuP0uujBwGJ9VLQOHsYSjCtH3vTYyLgsKwX4CBXPWRINmDZ7yXcEoyALoJ-ZmZAwzZkGhmGygcIXwuH-kx6OxNmdVZCg6pEqBID8q7cy68hJwRlnbIwkZR16E6stOPSaSdhvY1L2D4IOmORb4vrLzlkAFHKKZ8W5-rajHCyYSrBUDt3fAFDwpMnNZGqgsWBosXvVSCgwJzeg5D0zG-5i8CTEE7CkOu_9Y8_ZRmzFfp=w292-h390-no?authuser=0"
+                style="margin-top: 40px;"
+              />
+          </td>
+        </tr>
+        <tr>
+            <td align="center">
+                <!-- Content -->
+                <table style="margin: 80px 0">
+                  <tr>
+                    <td style="padding-bottom: 16px;">Hi {username},</td>
+                  </tr>
+                  <tr>
+                    <td>Please verify your email address by pressing the button below.</td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 16px 0;">
+                      <a rel="noopener" target="_blank" href={verificationUrl} style="background-color: #141414; font-size: 12px; line-height: 16px; font-family: Helvetica, Arial, sans-serif; text-decoration: none; padding: 8px 24px; color: #ffffff; text-transform: uppercase; display: inline-block; mso-padding-alt: 0;">
+                        <!--[if mso]>
+                        <i style="letter-spacing: 25px; mso-font-width: -100%; mso-text-raise: 30pt;">&nbsp;</i>
+                        <![endif]-->
+                        <span style="mso-text-raise: 15pt;">Verify email address</span>
+                        <!--[if mso]>
+                        <i style="letter-spacing: 25px; mso-font-width: -100%;">&nbsp;</i>
+                        <![endif]-->
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Best,</td>
+                  </tr>
+                  <tr>
+                    <td>team@gallery.so</td>
+                  </tr>
+                </table>
+            </td>
+        </tr>
+        <tr align="center">
+          <td>
+            <table style="table-layout: fixed;">
+              <tr >
+                <td  colspan="2" style="font-size: 14px; line-height: 20px;">Share your collection with the world.</td>
+              </tr>
+              <tr >
+                <td style="text-align: center; vertical-align: middle; padding: 8px;"><a href="https://t.co/OHUN9oxuZV" style="font-size: 12px; line-height: 16px; color: #707070;">DISCORD</a></td>
+                <td style="text-align: center; vertical-align: middle; padding: 8px;"><a href="https://twitter.com/gallery" style="font-size: 12px; line-height: 16px; color: #707070;">TWITTER</a></td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <hr style="border-top: 1px solid #E2E2E2; margin:24px 0"/>
+          </td>
+        </tr>
+        <tr>
+          <td align="center" style="font-size: 14px; line-height: 20px;">
+            Turn off email notifications <a href={unsubscribeUrl} style="color: #707070;">here</a>.
+          </td>
+        </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds the template for the Verification Email.

It uses Handlebars, a templating language supported by Sendgrid.
[docs](https://www.google.com/search?client=safari&rls=en&q=sendgrid+handlebars&ie=UTF-8&oe=UTF-8&safari_group=7)

There are currently 3 variables in the template which the backend can populate:
- username
- verificationUrl
- unsubscribeUrl

I haven't tested email client compatibility yet, will do so using a tool like Litmus before we launch. The goal of this PR is so that we have an email template to test with that's close to the final thing.

What the html looks like rendered in a browser:
![Screen Shot 2022-11-03 at 15 37 55](https://user-images.githubusercontent.com/80802871/199660917-0692dc92-6f6f-4afa-b596-30ea07ee0848.png)
