### PR TITLE
Feed grouping edge cases

### DIFF
--- a/feed/event.go
+++ b/feed/event.go
@@ -358,6 +358,16 @@ func (b *EventBuilder) createCollectionUpdatedFeedEvent(ctx context.Context, eve
 	if len(addedTokens) < 1 && (merged.event.Data.CollectionCollectorsNote == "" || !noteChanged) {
 		return nil, nil
 	}
+	// Treat the event as a collector's note event if no new tokens were added.
+	if len(addedTokens) < 1 && (merged.event.Data.CollectionCollectorsNote != "" && noteChanged) {
+		merged.event.Action = persist.ActionCollectorsNoteAddedToCollection
+		return b.createFeedEvent(ctx, merged.event)
+	}
+	// Treat the event as a tokens added event if the note didn't change or is empty.
+	if len(addedTokens) > 0 && (merged.event.Data.CollectionCollectorsNote == "" || !noteChanged) {
+		merged.event.Action = persist.ActionTokensAddedToCollection
+		return b.createFeedEvent(ctx, merged.event)
+	}
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:        persist.GenerateID(),


### PR DESCRIPTION
Adding a small check to the feed: if there is a collection updated event that has no new tokens added but a usable collector's note it gets treated as a collector's note event. And vice versa: if the event has new tokens but no collector's note it gets treated as a tokens added event.