### PR TITLE
Remove configureRootContext

### DIFF
--- a/indexer/core.go
+++ b/indexer/core.go
@@ -29,7 +29,8 @@ import (
 func Init() {
 	router, i := coreInit()
 	logger.For(nil).Info("Starting indexer...")
-	go i.Start(configureRootContext())
+	ctx := sentry.SetHubOnContext(context.Background(), sentry.CurrentHub())
+	go i.Start(ctx)
 	http.Handle("/", router)
 }
 
@@ -45,6 +46,9 @@ func coreInit() (*gin.Engine, *indexer) {
 	setDefaults("indexer")
 	initSentry()
 	logger.InitWithGCPDefaults()
+	logger.SetLoggerOptions(func(logger *logrus.Logger) {
+		logger.AddHook(sentryutil.SentryLoggerHook)
+	})
 
 	var s *storage.Client
 	if viper.GetString("ENV") == "local" {
@@ -142,7 +146,7 @@ func coreInitServer() *gin.Engine {
 
 	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(viper.GetInt("CHAIN")), defaultTransferEvents, nil, nil, nil)
 
-	go processIncompleteTokens(configureRootContext(), queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), t)
+	go processIncompleteTokens(ctx, queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), t)
 	return handlersInitServer(router, queueChan, tokenRepo, contractRepo, ethClient, ipfsClient, arweaveClient, s, i)
 }
 
@@ -216,15 +220,4 @@ func initSentry() {
 	if err != nil {
 		logger.For(nil).Fatalf("failed to start sentry: %s", err)
 	}
-}
-
-// configureRootContext configures the main context from which other contexts are derived.
-func configureRootContext() context.Context {
-	ctx := logger.NewContextWithLogger(context.Background(), logrus.Fields{}, logrus.New())
-	if viper.GetString("ENV") != "production" {
-		logger.For(ctx).Logger.SetLevel(logrus.DebugLevel)
-	}
-	logger.For(ctx).Logger.SetReportCaller(true)
-	logger.For(ctx).Logger.AddHook(sentryutil.SentryLoggerHook)
-	return sentry.SetHubOnContext(ctx, sentry.CurrentHub())
 }

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -29,8 +29,7 @@ import (
 func Init() {
 	router, i := coreInit()
 	logger.For(nil).Info("Starting indexer...")
-	ctx := sentry.SetHubOnContext(context.Background(), sentry.CurrentHub())
-	go i.Start(ctx)
+	go i.Start(sentry.SetHubOnContext(context.Background(), sentry.CurrentHub()))
 	http.Handle("/", router)
 }
 

--- a/indexer/t__integration_test.go
+++ b/indexer/t__integration_test.go
@@ -17,7 +17,7 @@ func TestIndexLogs_Success(t *testing.T) {
 	i := newMockIndexer(db, pgx)
 
 	// Run the Indexer
-	i.catchUp(configureRootContext(), eventsToTopics(i.eventHashes))
+	i.catchUp(context.Background(), eventsToTopics(i.eventHashes))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()

--- a/indexer/t__integration_test.go
+++ b/indexer/t__integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
@@ -17,7 +18,7 @@ func TestIndexLogs_Success(t *testing.T) {
 	i := newMockIndexer(db, pgx)
 
 	// Run the Indexer
-	i.catchUp(context.Background(), eventsToTopics(i.eventHashes))
+	i.catchUp(sentry.SetHubOnContext(context.Background(), sentry.CurrentHub()), eventsToTopics(i.eventHashes))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancel()

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -3,9 +3,10 @@ package logger
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/viper"
 	"runtime"
 	"time"
+
+	"github.com/spf13/viper"
 
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
@@ -19,15 +20,6 @@ var defaultEntry = logrus.NewEntry(defaultLogger)
 // NewContextWithFields returns a new context with a log entry derived from the default logger.
 func NewContextWithFields(parent context.Context, fields logrus.Fields) context.Context {
 	return context.WithValue(parent, loggerContextKey, For(parent).WithFields(fields))
-}
-
-// NewContextWithLogger returns a new context with a log entry derived from the input logger. This is useful
-// when needing to configure the logger with options that differ from the default logger.
-func NewContextWithLogger(parent context.Context, fields logrus.Fields, logger *logrus.Logger) context.Context {
-	if logger == nil {
-		return NewContextWithFields(parent, fields)
-	}
-	return context.WithValue(parent, loggerContextKey, logger.WithFields(fields))
 }
 
 func SetLoggerOptions(optionsFunc func(logger *logrus.Logger)) {

--- a/service/sentry/sentry.go
+++ b/service/sentry/sentry.go
@@ -237,11 +237,6 @@ type sentryLoggerHook struct {
 	reportLevels    []logrus.Level
 }
 
-// SetSentryHookOptions configures the Sentry hook in the global namespace.
-func SetSentryHookOptions(optionsFunc func(hook *sentryLoggerHook)) {
-	optionsFunc(SentryLoggerHook)
-}
-
 // Levels returns the logging levels that the hook will fire on.
 func (h sentryLoggerHook) Levels() []logrus.Level {
 	return h.reportLevels

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -3,9 +3,10 @@ package tokenprocessing
 import (
 	"context"
 	"database/sql"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"net/http"
 	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
 
 	"cloud.google.com/go/storage"
 	"github.com/getsentry/sentry-go"

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -36,8 +36,6 @@ func InitServer() {
 }
 
 func coreInitServer() *gin.Engine {
-	ctx := configureRootContext()
-
 	setDefaults()
 	initSentry()
 	logger.InitWithGCPDefaults()
@@ -63,7 +61,7 @@ func coreInitServer() *gin.Engine {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	logger.For(ctx).Info("Registering handlers...")
+	logger.For(nil).Info("Registering handlers...")
 
 	t := newThrottler()
 	queries := coredb.New(postgres.NewPgxClient())
@@ -154,12 +152,4 @@ func newRepos(pq *sql.DB, pgx *pgxpool.Pool) *postgres.Repositories {
 		AdmireRepository:      postgres.NewAdmireRepository(queries),
 		CommentRepository:     postgres.NewCommentRepository(pq, queries),
 	}
-}
-
-// configureRootContext configures the main context from which other contexts are derived.
-func configureRootContext() context.Context {
-	ctx := logger.NewContextWithLogger(context.Background(), logrus.Fields{}, logrus.New())
-	logger.For(ctx).Logger.SetReportCaller(true)
-	logger.For(ctx).Logger.AddHook(sentryutil.SentryLoggerHook)
-	return sentry.SetHubOnContext(ctx, sentry.CurrentHub())
 }


### PR DESCRIPTION
Removes `configureRootContext` and adds the sentry logger for the Indexer after `InitWithGCPDefaults` is called.