### PR TITLE
Fix actor_id foreign key error

### DIFF
--- a/cmd/notifications_prepop/main.go
+++ b/cmd/notifications_prepop/main.go
@@ -109,7 +109,7 @@ func main() {
 		}
 		event := coredb.Event{
 			ID:             persist.GenerateID(),
-			ActorID:        id,
+			ActorID:        persist.DBIDToNullStr(id),
 			ResourceTypeID: resource,
 			SubjectID:      subject,
 			Action:         action,

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -113,7 +113,7 @@ type Event struct {
 	AdmireID       persist.DBID
 	FeedEventID    persist.DBID
 	ExternalID     persist.NullString
-	Caption        persist.NullString
+	Caption        sql.NullString
 }
 
 type Feature struct {
@@ -151,7 +151,7 @@ type FeedEvent struct {
 	Deleted     bool
 	LastUpdated time.Time
 	CreatedAt   time.Time
-	Caption     persist.NullString
+	Caption     sql.NullString
 }
 
 type Follow struct {

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -97,7 +97,7 @@ type EarlyAccess struct {
 type Event struct {
 	ID             persist.DBID
 	Version        int32
-	ActorID        persist.DBID
+	ActorID        sql.NullString
 	ResourceTypeID persist.ResourceType
 	SubjectID      persist.DBID
 	UserID         persist.DBID

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -201,7 +201,7 @@ type CreateCollectionEventParams struct {
 	ResourceTypeID persist.ResourceType
 	CollectionID   persist.DBID
 	Data           persist.EventData
-	Caption        persist.NullString
+	Caption        sql.NullString
 }
 
 func (q *Queries) CreateCollectionEvent(ctx context.Context, arg CreateCollectionEventParams) (Event, error) {
@@ -343,7 +343,7 @@ type CreateFeedEventParams struct {
 	Data      persist.FeedEventData
 	EventTime time.Time
 	EventIds  persist.DBIDList
-	Caption   persist.NullString
+	Caption   sql.NullString
 }
 
 func (q *Queries) CreateFeedEvent(ctx context.Context, arg CreateFeedEventParams) (FeedEvent, error) {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -105,7 +105,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_even
 
 type CreateAdmireEventParams struct {
 	ID             persist.DBID
-	ActorID        persist.DBID
+	ActorID        sql.NullString
 	Action         persist.Action
 	ResourceTypeID persist.ResourceType
 	AdmireID       persist.DBID
@@ -196,7 +196,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, collection_id, subje
 
 type CreateCollectionEventParams struct {
 	ID             persist.DBID
-	ActorID        persist.DBID
+	ActorID        sql.NullString
 	Action         persist.Action
 	ResourceTypeID persist.ResourceType
 	CollectionID   persist.DBID
@@ -245,7 +245,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_eve
 
 type CreateCommentEventParams struct {
 	ID             persist.DBID
-	ActorID        persist.DBID
+	ActorID        sql.NullString
 	Action         persist.Action
 	ResourceTypeID persist.ResourceType
 	CommentID      persist.DBID
@@ -419,7 +419,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, gallery_id, subject_
 
 type CreateGalleryEventParams struct {
 	ID             persist.DBID
-	ActorID        persist.DBID
+	ActorID        sql.NullString
 	Action         persist.Action
 	ResourceTypeID persist.ResourceType
 	GalleryID      persist.DBID
@@ -466,7 +466,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, token_id, subject_id
 
 type CreateTokenEventParams struct {
 	ID             persist.DBID
-	ActorID        persist.DBID
+	ActorID        sql.NullString
 	Action         persist.Action
 	ResourceTypeID persist.ResourceType
 	TokenID        persist.DBID
@@ -513,7 +513,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, user_id, subject_id,
 
 type CreateUserEventParams struct {
 	ID             persist.DBID
-	ActorID        persist.DBID
+	ActorID        sql.NullString
 	Action         persist.Action
 	ResourceTypeID persist.ResourceType
 	UserID         persist.DBID
@@ -2319,7 +2319,7 @@ select exists(
 `
 
 type IsActorActionActiveParams struct {
-	ActorID     persist.DBID
+	ActorID     sql.NullString
 	Actions     persist.ActionList
 	WindowStart time.Time
 	WindowEnd   time.Time
@@ -2348,7 +2348,7 @@ select exists(
 `
 
 type IsActorSubjectActionActiveParams struct {
-	ActorID     persist.DBID
+	ActorID     sql.NullString
 	SubjectID   persist.DBID
 	Actions     persist.ActionList
 	WindowStart time.Time
@@ -2378,7 +2378,7 @@ select exists(
 `
 
 type IsActorSubjectActiveParams struct {
-	ActorID     persist.DBID
+	ActorID     sql.NullString
 	SubjectID   persist.DBID
 	WindowStart time.Time
 	WindowEnd   time.Time

--- a/db/migrations/core/000040_drop_events_actor_id_non_null_constraint.down.sql
+++ b/db/migrations/core/000040_drop_events_actor_id_non_null_constraint.down.sql
@@ -1,0 +1,1 @@
+alter table events alter column actor_id set not null;

--- a/db/migrations/core/000040_drop_events_actor_id_non_null_constraint.down.sql
+++ b/db/migrations/core/000040_drop_events_actor_id_non_null_constraint.down.sql
@@ -1,1 +1,2 @@
+/* The migration will fail if there are null `actor_ids`. These rows should be set to some sensible default beforehand. */
 alter table events alter column actor_id set not null;

--- a/db/migrations/core/000040_drop_events_actor_id_non_null_constraint.up.sql
+++ b/db/migrations/core/000040_drop_events_actor_id_non_null_constraint.up.sql
@@ -1,0 +1,1 @@
+alter table events alter column actor_id drop not null;

--- a/event/event.go
+++ b/event/event.go
@@ -241,19 +241,19 @@ func (h notificationHandler) handleDelayed(ctx context.Context, persistedEvent d
 func (h notificationHandler) createNotificationDataForEvent(event db.Event) (data persist.NotificationData) {
 	switch event.Action {
 	case persist.ActionViewedGallery:
-		if event.ActorID != "" {
-			data.AuthedViewerIDs = []persist.DBID{event.ActorID}
+		if event.ActorID.String != "" {
+			data.AuthedViewerIDs = []persist.DBID{persist.NullStrToDBID(event.ActorID)}
 		}
 		if event.ExternalID != "" {
 			data.UnauthedViewerIDs = []persist.NullString{event.ExternalID}
 		}
 	case persist.ActionAdmiredFeedEvent:
-		if event.ActorID != "" {
-			data.AdmirerIDs = []persist.DBID{event.ActorID}
+		if event.ActorID.String != "" {
+			data.AdmirerIDs = []persist.DBID{persist.NullStrToDBID(event.ActorID)}
 		}
 	case persist.ActionUserFollowedUsers:
-		if event.ActorID != "" {
-			data.FollowerIDs = []persist.DBID{event.ActorID}
+		if event.ActorID.String != "" {
+			data.FollowerIDs = []persist.DBID{persist.NullStrToDBID(event.ActorID)}
 		}
 		data.FollowedBack = persist.NullBool(event.Data.UserFollowedBack)
 		data.Refollowed = persist.NullBool(event.Data.UserRefollowed)

--- a/feed/event.go
+++ b/feed/event.go
@@ -145,7 +145,7 @@ func (b *EventBuilder) createFeedEvent(ctx context.Context, event db.Event) (*db
 }
 
 func (b *EventBuilder) useEvent(ctx context.Context, event db.Event) (bool, error) {
-	blocked, err := b.feedBlocklistRepo.IsBlocked(ctx, event.ActorID, event.Action)
+	blocked, err := b.feedBlocklistRepo.IsBlocked(ctx, persist.NullStrToDBID(event.ActorID), event.Action)
 	if err != nil || blocked {
 		return false, err
 	}
@@ -178,7 +178,7 @@ func (b *EventBuilder) isStillEditing(ctx context.Context, event db.Event) (bool
 }
 
 func (b *EventBuilder) createUserCreatedFeedEvent(ctx context.Context, event db.Event) (*db.FeedEvent, error) {
-	priorEvent, err := b.feedRepo.LastPublishedUserFeedEvent(ctx, event.ActorID, event.CreatedAt, persist.ActionList{event.Action})
+	priorEvent, err := b.feedRepo.LastPublishedUserFeedEvent(ctx, persist.NullStrToDBID(event.ActorID), event.CreatedAt, persist.ActionList{event.Action})
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (b *EventBuilder) createUserCreatedFeedEvent(ctx context.Context, event db.
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:        persist.GenerateID(),
-		OwnerID:   event.ActorID,
+		OwnerID:   persist.NullStrToDBID(event.ActorID),
 		Action:    event.Action,
 		EventTime: event.CreatedAt,
 		Data:      persist.FeedEventData{UserBio: event.Data.UserBio},
@@ -211,7 +211,7 @@ func (b *EventBuilder) createUserFollowedUsersFeedEvent(ctx context.Context, eve
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:        persist.GenerateID(),
-		OwnerID:   merged.event.ActorID,
+		OwnerID:   persist.NullStrToDBID(merged.event.ActorID),
 		Action:    merged.event.Action,
 		EventTime: merged.event.CreatedAt,
 		EventIds:  merged.eventIDs,
@@ -233,7 +233,7 @@ func (b *EventBuilder) createCollectorsNoteAddedToTokenFeedEvent(ctx context.Con
 		return nil, nil
 	}
 
-	priorEvent, err := b.feedRepo.LastPublishedTokenFeedEvent(ctx, event.ActorID, event.TokenID, event.CreatedAt, collectionCollectorsNoteActions)
+	priorEvent, err := b.feedRepo.LastPublishedTokenFeedEvent(ctx, persist.NullStrToDBID(event.ActorID), event.TokenID, event.CreatedAt, collectionCollectorsNoteActions)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +245,7 @@ func (b *EventBuilder) createCollectorsNoteAddedToTokenFeedEvent(ctx context.Con
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.NullStrToDBID(event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			TokenID:                event.SubjectID,
@@ -266,7 +266,7 @@ func (b *EventBuilder) createCollectionCreatedFeedEvent(ctx context.Context, eve
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.NullStrToDBID(event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			CollectionID:                event.SubjectID,
@@ -292,7 +292,7 @@ func (b *EventBuilder) createCollectorsNoteAddedToCollectionFeedEvent(ctx contex
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.NullStrToDBID(event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			CollectionID:                event.SubjectID,
@@ -317,7 +317,7 @@ func (b *EventBuilder) createTokensAddedToCollectionFeedEvent(ctx context.Contex
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:      persist.GenerateID(),
-		OwnerID: event.ActorID,
+		OwnerID: persist.NullStrToDBID(event.ActorID),
 		Action:  event.Action,
 		Data: persist.FeedEventData{
 			CollectionID:          event.SubjectID,
@@ -371,7 +371,7 @@ func (b *EventBuilder) createCollectionUpdatedFeedEvent(ctx context.Context, eve
 
 	return b.feedRepo.Add(ctx, db.FeedEvent{
 		ID:        persist.GenerateID(),
-		OwnerID:   merged.event.ActorID,
+		OwnerID:   persist.NullStrToDBID(merged.event.ActorID),
 		Action:    merged.event.Action,
 		EventTime: merged.event.CreatedAt,
 		EventIds:  merged.eventIDs,
@@ -387,7 +387,7 @@ func (b *EventBuilder) createCollectionUpdatedFeedEvent(ctx context.Context, eve
 
 // getAddedTokens returns the new tokens that were added since the last published feed event.
 func getAddedTokens(ctx context.Context, feedRepo *postgres.FeedRepository, event db.Event) (added []persist.DBID, hasPrior bool, err error) {
-	priorEvent, err := feedRepo.LastPublishedCollectionFeedEvent(ctx, event.ActorID, event.CollectionID, event.CreatedAt, collectionTokensAddedActions)
+	priorEvent, err := feedRepo.LastPublishedCollectionFeedEvent(ctx, persist.NullStrToDBID(event.ActorID), event.CollectionID, event.CreatedAt, collectionTokensAddedActions)
 	if err != nil {
 		return added, true, err
 	}
@@ -404,7 +404,7 @@ func getAddedTokens(ctx context.Context, feedRepo *postgres.FeedRepository, even
 
 // isCollectionCollectorsNoteChanged returns true if the collector's note differs from the last published feed event.
 func isCollectionCollectorsNoteChanged(ctx context.Context, feedRepo *postgres.FeedRepository, event db.Event) (bool, error) {
-	priorEvent, err := feedRepo.LastPublishedCollectionFeedEvent(ctx, event.ActorID, event.CollectionID, event.CreatedAt, collectionCollectorsNoteActions)
+	priorEvent, err := feedRepo.LastPublishedCollectionFeedEvent(ctx, persist.NullStrToDBID(event.ActorID), event.CollectionID, event.CreatedAt, collectionCollectorsNoteActions)
 	if err != nil {
 		return false, err
 	}

--- a/feed/event.go
+++ b/feed/event.go
@@ -112,7 +112,7 @@ func (b *EventBuilder) NewFeedEventFromEvent(ctx context.Context, event db.Event
 	}
 	_, groupable := eventGroups[event.Action]
 	// Events with a caption are treated as a singular event.
-	if event.Caption != "" || !groupable {
+	if event.Caption.String != "" || !groupable {
 		return b.createFeedEvent(ctx, event)
 	}
 	return b.createGroupedFeedEvent(ctx, event)

--- a/publicapi/collection.go
+++ b/publicapi/collection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -174,7 +175,7 @@ func (api CollectionAPI) CreateCollection(ctx context.Context, galleryID persist
 
 	// Send event
 	feedEvent, err := dispatchEvent(ctx, db.Event{
-		ActorID:        userID,
+		ActorID:        persist.DBIDToNullStr(userID),
 		Action:         persist.ActionCollectionCreated,
 		ResourceTypeID: persist.ResourceTypeCollection,
 		CollectionID:   collectionID,
@@ -240,7 +241,7 @@ func (api CollectionAPI) UpdateCollectionInfo(ctx context.Context, collectionID 
 
 	// Send event
 	_, err = dispatchEvent(ctx, db.Event{
-		ActorID:        userID,
+		ActorID:        persist.DBIDToNullStr(userID),
 		Action:         persist.ActionCollectorsNoteAddedToCollection,
 		ResourceTypeID: persist.ResourceTypeCollection,
 		CollectionID:   collectionID,
@@ -308,7 +309,7 @@ func (api CollectionAPI) UpdateCollectionTokens(ctx context.Context, collectionI
 
 	// Send event
 	return dispatchEvent(ctx, db.Event{
-		ActorID:        userID,
+		ActorID:        persist.DBIDToNullStr(userID),
 		Action:         persist.ActionTokensAddedToCollection,
 		ResourceTypeID: persist.ResourceTypeCollection,
 		CollectionID:   collectionID,

--- a/publicapi/collection.go
+++ b/publicapi/collection.go
@@ -315,7 +315,7 @@ func (api CollectionAPI) UpdateCollectionTokens(ctx context.Context, collectionI
 		CollectionID:   collectionID,
 		SubjectID:      collectionID,
 		Data:           persist.EventData{CollectionTokenIDs: tokens},
-		Caption:        stringToNullable(caption),
+		Caption:        persist.StrToNullStr(caption),
 	}, api.validator, caption)
 }
 

--- a/publicapi/gallery.go
+++ b/publicapi/gallery.go
@@ -3,6 +3,8 @@ package publicapi
 import (
 	"context"
 	"fmt"
+
+	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/util"
 
@@ -10,7 +12,6 @@ import (
 	"github.com/go-playground/validator/v10"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
-	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
@@ -121,7 +122,7 @@ func (api GalleryAPI) ViewGallery(ctx context.Context, galleryID persist.DBID) (
 		// only view gallery if the user hasn't already viewed it in this most recent notification period
 
 		_, err = dispatchEvent(ctx, db.Event{
-			ActorID:        userID,
+			ActorID:        persist.DBIDToNullStr(userID),
 			ResourceTypeID: persist.ResourceTypeGallery,
 			SubjectID:      galleryID,
 			Action:         persist.ActionViewedGallery,

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/mikeydub/go-gallery/service/persist/postgres"
-	"github.com/mikeydub/go-gallery/validate"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mikeydub/go-gallery/service/persist/postgres"
+	"github.com/mikeydub/go-gallery/validate"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-playground/validator/v10"
@@ -379,7 +380,7 @@ func (api InteractionAPI) AdmireFeedEvent(ctx context.Context, feedEventID persi
 	admireID, err := api.repos.AdmireRepository.CreateAdmire(ctx, feedEventID, userID)
 
 	_, err = dispatchEvent(ctx, db.Event{
-		ActorID:        userID,
+		ActorID:        persist.DBIDToNullStr(userID),
 		ResourceTypeID: persist.ResourceTypeAdmire,
 		SubjectID:      feedEventID,
 		FeedEventID:    feedEventID,
@@ -480,7 +481,7 @@ func (api InteractionAPI) CommentOnFeedEvent(ctx context.Context, feedEventID pe
 	}
 
 	_, err = dispatchEvent(ctx, db.Event{
-		ActorID:        actor,
+		ActorID:        persist.DBIDToNullStr(actor),
 		ResourceTypeID: persist.ResourceTypeComment,
 		SubjectID:      feedEventID,
 		FeedEventID:    feedEventID,

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 
 	"github.com/gin-gonic/gin"
@@ -176,7 +177,7 @@ func dispatchEvent(ctx context.Context, evt db.Event, v *validator.Validate, cap
 
 func pushEvent(ctx context.Context, evt db.Event) {
 	if hub := sentryutil.SentryHubFromContext(ctx); hub != nil {
-		sentryutil.SetEventContext(hub.Scope(), evt.ActorID, evt.SubjectID, evt.Action)
+		sentryutil.SetEventContext(hub.Scope(), persist.NullStrToDBID(evt.ActorID), evt.SubjectID, evt.Action)
 	}
 	if err := event.DispatchDelayed(ctx, evt); err != nil {
 		logger.For(ctx).Error(err)

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -167,7 +167,7 @@ func dispatchEvent(ctx context.Context, evt db.Event, v *validator.Validate, cap
 	}
 
 	if caption != nil {
-		evt.Caption = stringToNullable(caption)
+		evt.Caption = persist.StrToNullStr(caption)
 		return event.DispatchImmediate(ctx, evt)
 	}
 
@@ -183,11 +183,4 @@ func pushEvent(ctx context.Context, evt db.Event) {
 		logger.For(ctx).Error(err)
 		sentryutil.ReportError(ctx, err)
 	}
-}
-
-func stringToNullable(caption *string) persist.NullString {
-	if caption == nil {
-		return ""
-	}
-	return persist.NullString(*caption)
 }

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -446,7 +446,7 @@ func (api TokenAPI) UpdateTokenInfo(ctx context.Context, tokenID persist.DBID, c
 
 	// Send event
 	_, err = dispatchEvent(ctx, db.Event{
-		ActorID:        userID,
+		ActorID:        persist.DBIDToNullStr(userID),
 		Action:         persist.ActionCollectorsNoteAddedToToken,
 		ResourceTypeID: persist.ResourceTypeToken,
 		TokenID:        tokenID,

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -240,7 +240,7 @@ func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authentica
 
 	// Send event
 	_, err = dispatchEvent(ctx, db.Event{
-		ActorID:        userID,
+		ActorID:        persist.DBIDToNullStr(userID),
 		Action:         persist.ActionUserCreated,
 		ResourceTypeID: persist.ResourceTypeUser,
 		UserID:         userID,
@@ -481,7 +481,7 @@ func dispatchFollowEventToFeed(ctx context.Context, api UserAPI, curUserID persi
 	}
 
 	pushEvent(ctx, db.Event{
-		ActorID:        curUserID,
+		ActorID:        persist.DBIDToNullStr(curUserID),
 		Action:         persist.ActionUserFollowedUsers,
 		ResourceTypeID: persist.ResourceTypeUser,
 		UserID:         curUserID,

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -165,7 +165,6 @@ func (h viewedNotificationHandler) Handle(ctx context.Context, notif db.Notifica
 		CreatedAfter: beginningOfDay(time.Now()),
 	})
 	if notifs == nil || len(notifs) == 0 {
-		panic(1)
 		return insertAndPublishNotif(ctx, notif, h.queries, h.pubSub)
 	}
 
@@ -220,11 +219,7 @@ func (h viewedNotificationHandler) Handle(ctx context.Context, notif db.Notifica
 	if time.Since(mostRecentNotif.CreatedAt) < window {
 		return updateAndPublishNotif(ctx, notif, mostRecentNotif, h.queries, h.pubSub)
 	}
-	err := insertAndPublishNotif(ctx, notif, h.queries, h.pubSub)
-	if err != nil {
-		panic(err)
-	}
-	panic("all god")
+	return insertAndPublishNotif(ctx, notif, h.queries, h.pubSub)
 }
 
 func (n *NotificationHandlers) receiveNewNotificationsFromPubSub() {

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -1,6 +1,7 @@
 package persist
 
 import (
+	"database/sql"
 	"fmt"
 )
 
@@ -74,4 +75,18 @@ type ErrUnknownResourceType struct {
 
 func (e ErrUnknownResourceType) Error() string {
 	return fmt.Sprintf("unknown resource type: %v", e.ResourceType)
+}
+
+func DBIDToNullStr(id DBID) sql.NullString {
+	if id == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{Valid: true, String: id.String()}
+}
+
+func NullStrToDBID(s sql.NullString) DBID {
+	if !s.Valid {
+		return ""
+	}
+	return DBID(s.String)
 }

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -77,16 +77,25 @@ func (e ErrUnknownResourceType) Error() string {
 	return fmt.Sprintf("unknown resource type: %v", e.ResourceType)
 }
 
-func DBIDToNullStr(id DBID) sql.NullString {
-	if id == "" {
+func StrToNullStr(s *string) sql.NullString {
+	if s == nil {
 		return sql.NullString{}
 	}
-	return sql.NullString{Valid: true, String: id.String()}
+	return sql.NullString{Valid: true, String: *s}
 }
 
-func NullStrToDBID(s sql.NullString) DBID {
+func NullStrToStr(s sql.NullString) string {
 	if !s.Valid {
 		return ""
 	}
-	return DBID(s.String)
+	return s.String
+}
+
+func DBIDToNullStr(id DBID) sql.NullString {
+	s := id.String()
+	return StrToNullStr(&s)
+}
+
+func NullStrToDBID(s sql.NullString) DBID {
+	return DBID(NullStrToStr(s))
 }

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -145,8 +145,6 @@ sql:
             go_type: "github.com/mikeydub/go-gallery/service/persist.NullString"
           - column: "*.media_url"
             go_type: "github.com/mikeydub/go-gallery/service/persist.NullString"
-          - column: "*.caption"
-            go_type: "github.com/mikeydub/go-gallery/service/persist.NullString"
           - column: "*.chain"
             go_type: "github.com/mikeydub/go-gallery/service/persist.Chain"
           - column: "*.email_type"

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -100,6 +100,8 @@ sql:
             go_type: "github.com/mikeydub/go-gallery/service/persist.NullInt"
           - column: "events.external_id"
             go_type: "github.com/mikeydub/go-gallery/service/persist.NullString"
+          - column: "events.actor_id"
+            go_type: "database/sql.NullString"
 
           # Comments
           - column: "comments.reply_to"


### PR DESCRIPTION
**Changes**

* Drops the non-nullable constrain from the `actor_id` column of `events` since its possible to have events not initiated by a gallery user (like viewing a gallery when unauthenticated)

* Fixed a bug that popped up after fixing that issue where the wrong notification event was being queried, resulting in no rows returned

* Changed the `caption` go backed typed from our `persist.NullString` to the builtin `database/sql.NullString` (sidenote: I was having issues having our `persist.NullString` type insert `NULL` values into the db, but didn't dig in too deeply) 