### PR TITLE
Stop using tokens.token_uri column

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -752,7 +752,6 @@ type ComplexityRoot struct {
 		TokenID               func(childComplexity int) int
 		TokenMetadata         func(childComplexity int) int
 		TokenType             func(childComplexity int) int
-		TokenURI              func(childComplexity int) int
 	}
 
 	TokenEdge struct {
@@ -4053,13 +4052,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Token.TokenType(childComplexity), true
 
-	case "Token.tokenUri":
-		if e.complexity.Token.TokenURI == nil {
-			break
-		}
-
-		return e.complexity.Token.TokenURI(childComplexity), true
-
 	case "TokenEdge.cursor":
 		if e.complexity.TokenEdge.Cursor == nil {
 			break
@@ -4907,7 +4899,6 @@ type Token implements Node {
     chain: Chain
     name: String
     description: String
-    tokenUri: String
     tokenId: String
     quantity: String # source is a hex string
     owner: GalleryUser @goField(forceResolver: true)
@@ -20157,38 +20148,6 @@ func (ec *executionContext) _Token_description(ctx context.Context, field graphq
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Token_tokenUri(ctx context.Context, field graphql.CollectedField, obj *model.Token) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:     "Token",
-		Field:      field,
-		Args:       nil,
-		IsMethod:   false,
-		IsResolver: false,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.TokenURI, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _Token_tokenId(ctx context.Context, field graphql.CollectedField, obj *model.Token) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -32368,13 +32327,6 @@ func (ec *executionContext) _Token(ctx context.Context, sel ast.SelectionSet, ob
 		case "description":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Token_description(ctx, field, obj)
-			}
-
-			out.Values[i] = innerFunc(ctx)
-
-		case "tokenUri":
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Token_tokenUri(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1114,7 +1114,6 @@ type Token struct {
 	Chain                 *persist.Chain        `json:"chain"`
 	Name                  *string               `json:"name"`
 	Description           *string               `json:"description"`
-	TokenURI              *string               `json:"tokenUri"`
 	TokenID               *string               `json:"tokenId"`
 	Quantity              *string               `json:"quantity"`
 	Owner                 *GalleryUser          `json:"owner"`

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1427,7 +1427,6 @@ func tokenToModel(ctx context.Context, token db.Token) *model.Token {
 		Name:             &token.Name.String,
 		Description:      &token.Description.String,
 		OwnedByWallets:   nil, // handled by dedicated resolver
-		TokenURI:         &token.TokenUri.String,
 		TokenID:          util.StringToPointer(token.TokenID.String()),
 		Quantity:         &token.Quantity.String,
 		Owner:            nil, // handled by dedicated resolver

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -285,7 +285,6 @@ type Token implements Node {
     chain: Chain
     name: String
     description: String
-    tokenUri: String
     tokenId: String
     quantity: String # source is a hex string
     owner: GalleryUser @goField(forceResolver: true)

--- a/service/persist/postgres/token_gallery.go
+++ b/service/persist/postgres/token_gallery.go
@@ -386,7 +386,7 @@ func (t *TokenGalleryRepository) UpdateByID(pCtx context.Context, pID persist.DB
 		res, err = t.updateInfoStmt.ExecContext(pCtx, update.CollectorsNote, update.LastUpdated, pID, pUserID)
 	case persist.TokenUpdateAllURIDerivedFieldsInput:
 		update := pUpdate.(persist.TokenUpdateAllURIDerivedFieldsInput)
-		res, err = t.updateMediaStmt.ExecContext(pCtx, update.Media, update.TokenURI, update.Metadata, update.LastUpdated, pID, pUserID)
+		res, err = t.updateMediaStmt.ExecContext(pCtx, update.Media, update.Metadata, update.LastUpdated, pID, pUserID)
 	default:
 		return fmt.Errorf("unsupported update type: %T", pUpdate)
 	}
@@ -419,7 +419,7 @@ func (t *TokenGalleryRepository) UpdateByTokenIdentifiersUnsafe(pCtx context.Con
 		res, err = t.updateInfoByTokenIdentifiersUnsafeStmt.ExecContext(pCtx, update.CollectorsNote, update.LastUpdated, pTokenID, contractID)
 	case persist.TokenUpdateAllURIDerivedFieldsInput:
 		update := pUpdate.(persist.TokenUpdateAllURIDerivedFieldsInput)
-		res, err = t.updateAllMetadataFieldsByTokenIdentifiersUnsafeStmt.ExecContext(pCtx, update.Media, update.TokenURI, update.Metadata, update.Name, update.Description, update.LastUpdated, pTokenID, contractID)
+		res, err = t.updateAllMetadataFieldsByTokenIdentifiersUnsafeStmt.ExecContext(pCtx, update.Media, update.Metadata, update.Name, update.Description, update.LastUpdated, pTokenID, contractID)
 	case persist.TokenUpdateMediaInput:
 		update := pUpdate.(persist.TokenUpdateMediaInput)
 		res, err = t.updateMediaByTokenIdentifiersUnsafeStmt.ExecContext(pCtx, update.Media, update.LastUpdated, pTokenID, contractID)

--- a/service/persist/postgres/token_gallery.go
+++ b/service/persist/postgres/token_gallery.go
@@ -73,13 +73,13 @@ func NewTokenGalleryRepository(db *sql.DB, queries *db.Queries) *TokenGalleryRep
 	updateInfoStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET COLLECTORS_NOTE = $1, LAST_UPDATED = $2 WHERE ID = $3 AND OWNER_USER_ID = $4;`)
 	checkNoErr(err)
 
-	updateMediaStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET MEDIA = $1, TOKEN_URI = $2, TOKEN_METADATA = $3, LAST_UPDATED = $4 WHERE ID = $5 AND OWNER_USER_ID = $6;`)
+	updateMediaStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET MEDIA = $1, TOKEN_URI = '', TOKEN_METADATA = $2, LAST_UPDATED = $3 WHERE ID = $4 AND OWNER_USER_ID = $5;`)
 	checkNoErr(err)
 
 	updateInfoByTokenIdentifiersUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET COLLECTORS_NOTE = $1, LAST_UPDATED = $2 WHERE TOKEN_ID = $3 AND CONTRACT = $4 AND DELETED = false;`)
 	checkNoErr(err)
 
-	updateURIDerivedFieldsByTokenIdentifiersUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET MEDIA = $1, TOKEN_URI = $2, TOKEN_METADATA = $3, NAME = $4, DESCRIPTION = $5, LAST_UPDATED = $6 WHERE TOKEN_ID = $7 AND CONTRACT = $8 AND DELETED = false;`)
+	updateURIDerivedFieldsByTokenIdentifiersUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET MEDIA = $1, TOKEN_URI = '', TOKEN_METADATA = $2, NAME = $3, DESCRIPTION = $4, LAST_UPDATED = $5 WHERE TOKEN_ID = $6 AND CONTRACT = $7 AND DELETED = false;`)
 	checkNoErr(err)
 
 	updateMediaByTokenIdentifiersUnsafeStmt, err := db.PrepareContext(ctx, `UPDATE tokens SET MEDIA = $1, LAST_UPDATED = $2 WHERE TOKEN_ID = $3 AND CONTRACT = $4 AND DELETED = false;`)
@@ -341,7 +341,7 @@ func (t *TokenGalleryRepository) bulkUpsert(pCtx context.Context, pTokens []pers
 	for i, token := range newTokens {
 		// 23 is the index of last_synced, the param that we want set to now()
 		sqlStr += generateValuesPlaceholders(paramsPerRow, i*paramsPerRow, []int{23}) + ","
-		vals = append(vals, persist.GenerateID(), token.CollectorsNote, token.Media, token.TokenType, token.Chain, token.Name, token.Description, token.TokenID, token.TokenURI, token.Quantity, token.OwnerUserID, pq.Array(token.OwnedByWallets), pq.Array(token.OwnershipHistory), token.TokenMetadata, token.Contract, token.ExternalURL, token.BlockNumber, token.Version, token.CreationTime, token.LastUpdated, token.Deleted, token.IsProviderMarkedSpam, token.LastSynced)
+		vals = append(vals, persist.GenerateID(), token.CollectorsNote, token.Media, token.TokenType, token.Chain, token.Name, token.Description, token.TokenID, "", token.Quantity, token.OwnerUserID, pq.Array(token.OwnedByWallets), pq.Array(token.OwnershipHistory), token.TokenMetadata, token.Contract, token.ExternalURL, token.BlockNumber, token.Version, token.CreationTime, token.LastUpdated, token.Deleted, token.IsProviderMarkedSpam, token.LastSynced)
 	}
 
 	sqlStr = sqlStr[:len(sqlStr)-1]


### PR DESCRIPTION
## What's new?
- Instead of outright dropping the `tokens.token_uri` column, this PR is a minimally invasive way to avoid the performance impact of large token URIs. It changes the 3 places where we write values to `token_uri` to write an empty string instead, and removes the `tokenURI` field from our GraphQL schema. Once this PR is merged, we should also run a SQL statement to set all existing `token_uri` values to the empty string.

- Why not drop the column entirely?
  - We'll drop the column soon enough, but dropping it right now would involve updating a bunch of places in the codebase that I'm about to refactor anyway. I'll start removing uses on a case-by-case basis, and eventually we won't use the column anymore.