### PR TITLE
[GAL-637] Skip notifying self events

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -227,6 +227,10 @@ func (h notificationHandler) handleDelayed(ctx context.Context, persistedEvent d
 	if err != nil {
 		return err
 	}
+	// Don't notify the user on self events
+	if persist.DBID(persist.NullStrToStr(persistedEvent.ActorID)) == owner {
+		return nil
+	}
 	return h.notificationHandlers.Notifications.Dispatch(ctx, db.Notification{
 		OwnerID:     owner,
 		Action:      persistedEvent.Action,


### PR DESCRIPTION
Skips notifying the user if they're interacting with a resource they own themselves.