### PR TITLE
[GAL-692] Fix grouping of update events

### DIFF
--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -308,6 +308,7 @@ with recursive activity as (
         and e.created_at >= a.created_at - make_interval(secs => $2)
         and e.deleted = false
         and e.caption is null
+        and (not @include_subject::bool or e.subject_id = a.subject_id)
 )
 select * from events where id = any(select id from activity) order by (created_at, id) asc;
 

--- a/feed/event.go
+++ b/feed/event.go
@@ -175,7 +175,7 @@ func (b *EventBuilder) isStillEditing(ctx context.Context, event db.Event) (bool
 }
 
 func (b *EventBuilder) createUserFollowedUsersFeedEvent(ctx context.Context, event db.Event) (*db.FeedEvent, error) {
-	events, err := b.eventRepo.EventsInWindow(ctx, event.ID, viper.GetInt("FEED_WINDOW_SIZE"), persist.ActionList{event.Action})
+	events, err := b.eventRepo.EventsInWindow(ctx, event.ID, viper.GetInt("FEED_WINDOW_SIZE"), persist.ActionList{event.Action}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (b *EventBuilder) createTokensAddedToCollectionFeedEvent(ctx context.Contex
 }
 
 func (b *EventBuilder) createCollectionUpdatedFeedEvent(ctx context.Context, event db.Event) (*db.FeedEvent, error) {
-	events, err := b.eventRepo.EventsInWindow(ctx, event.ID, viper.GetInt("FEED_WINDOW_SIZE"), groupingConfig[persist.ActionCollectionUpdated])
+	events, err := b.eventRepo.EventsInWindow(ctx, event.ID, viper.GetInt("FEED_WINDOW_SIZE"), groupingConfig[persist.ActionCollectionUpdated], true)
 	if err != nil {
 		return nil, err
 	}

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -140,10 +140,11 @@ func (r *EventRepository) IsActorSubjectActionActive(ctx context.Context, event 
 }
 
 // EventsInWindow returns events belonging to the same window of activity as the given eventID.
-func (r *EventRepository) EventsInWindow(ctx context.Context, eventID persist.DBID, windowSeconds int, actions persist.ActionList) ([]db.Event, error) {
+func (r *EventRepository) EventsInWindow(ctx context.Context, eventID persist.DBID, windowSeconds int, actions persist.ActionList, includeSubject bool) ([]db.Event, error) {
 	return r.Queries.GetEventsInWindow(ctx, db.GetEventsInWindowParams{
-		ID:      eventID,
-		Secs:    float64(windowSeconds),
-		Actions: actions,
+		ID:             eventID,
+		Secs:           float64(windowSeconds),
+		Actions:        actions,
+		IncludeSubject: includeSubject,
 	})
 }


### PR DESCRIPTION
Events from different collections were grouped together. This PR adds a `include_subject` flag to the query to indicate if the query should only group events having the same subject.