### PR TITLE
[GAL-480] Add Objkt Provider

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -247,12 +247,10 @@ func NewMultichainProvider(repos *postgres.Repositories, queries *coredb.Queries
 	overrides := multichain.ChainOverrideMap{persist.ChainPOAP: &ethChain}
 	ethProvider := eth.NewProvider(viper.GetString("INDEXER_HOST"), httpClient, ethClient, taskClient)
 	openseaProvider := opensea.NewProvider(ethClient, httpClient)
-	// XXX: tezosProvider := multichain.FallbackFetcher{
-	// XXX: 	Primary:   tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), httpClient, ipfsClient, arweaveClient, storageClient, tokenBucket),
-	// XXX: 	Fallback:  tezos.NewObjktProvider(viper.GetString("IPFS_URL")),
-	// XXX: 	EvalToken: multichain.HasMetadata,
-	// XXX: }
-	tezosProvider := tezos.NewObjktProvider(viper.GetString("IPFS_URL"))
+	tezosProvider := multichain.FallbackProvider{
+		Primary:  tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), httpClient, ipfsClient, arweaveClient, storageClient, tokenBucket),
+		Fallback: tezos.NewObjktProvider(viper.GetString("IPFS_URL")),
+	}
 	poapProvider := poap.NewProvider(httpClient, viper.GetString("POAP_API_KEY"), viper.GetString("POAP_AUTH_TOKEN"))
 	return multichain.NewProvider(context.Background(), repos, queries, cache, taskClient,
 		overrides,

--- a/server/server.go
+++ b/server/server.go
@@ -248,12 +248,14 @@ func NewMultichainProvider(repos *postgres.Repositories, queries *coredb.Queries
 	ethProvider := eth.NewProvider(viper.GetString("INDEXER_HOST"), httpClient, ethClient, taskClient)
 	openseaProvider := opensea.NewProvider(ethClient, httpClient)
 	tezosProvider := tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), httpClient, ipfsClient, arweaveClient, storageClient, tokenBucket)
+	tezosObjktProvider := tezos.NewObjktProvider()
 	poapProvider := poap.NewProvider(httpClient, viper.GetString("POAP_API_KEY"), viper.GetString("POAP_AUTH_TOKEN"))
 	return multichain.NewProvider(context.Background(), repos, queries, cache, taskClient,
 		overrides,
 		ethProvider,
 		openseaProvider,
 		tezosProvider,
+		tezosObjktProvider,
 		poapProvider,
 	)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -250,6 +250,7 @@ func NewMultichainProvider(repos *postgres.Repositories, queries *coredb.Queries
 	tezosProvider := multichain.FallbackProvider{
 		Primary:  tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), httpClient, ipfsClient, arweaveClient, storageClient, tokenBucket),
 		Fallback: tezos.NewObjktProvider(viper.GetString("IPFS_URL")),
+		Eval:     multichain.ContainsTezosKeywords,
 	}
 	poapProvider := poap.NewProvider(httpClient, viper.GetString("POAP_API_KEY"), viper.GetString("POAP_AUTH_TOKEN"))
 	return multichain.NewProvider(context.Background(), repos, queries, cache, taskClient,

--- a/server/server.go
+++ b/server/server.go
@@ -247,11 +247,12 @@ func NewMultichainProvider(repos *postgres.Repositories, queries *coredb.Queries
 	overrides := multichain.ChainOverrideMap{persist.ChainPOAP: &ethChain}
 	ethProvider := eth.NewProvider(viper.GetString("INDEXER_HOST"), httpClient, ethClient, taskClient)
 	openseaProvider := opensea.NewProvider(ethClient, httpClient)
-	tezosProvider := multichain.FallbackFetcher{
-		Primary:   tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), httpClient, ipfsClient, arweaveClient, storageClient, tokenBucket),
-		Fallback:  tezos.NewObjktProvider(),
-		EvalToken: multichain.HasMetadata,
-	}
+	// XXX: tezosProvider := multichain.FallbackFetcher{
+	// XXX: 	Primary:   tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), httpClient, ipfsClient, arweaveClient, storageClient, tokenBucket),
+	// XXX: 	Fallback:  tezos.NewObjktProvider(viper.GetString("IPFS_URL")),
+	// XXX: 	EvalToken: multichain.HasMetadata,
+	// XXX: }
+	tezosProvider := tezos.NewObjktProvider(viper.GetString("IPFS_URL"))
 	poapProvider := poap.NewProvider(httpClient, viper.GetString("POAP_API_KEY"), viper.GetString("POAP_AUTH_TOKEN"))
 	return multichain.NewProvider(context.Background(), repos, queries, cache, taskClient,
 		overrides,

--- a/server/server.go
+++ b/server/server.go
@@ -249,13 +249,18 @@ func NewMultichainProvider(repos *postgres.Repositories, queries *coredb.Queries
 	openseaProvider := opensea.NewProvider(ethClient, httpClient)
 	tezosProvider := tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), httpClient, ipfsClient, arweaveClient, storageClient, tokenBucket)
 	tezosObjktProvider := tezos.NewObjktProvider()
+	tezosFallbackProvider := multichain.FallbackFetcher{
+		Fetchers: []multichain.TokensFetcher{tezosProvider, tezosObjktProvider},
+		ChainInfoFn: func(context.Context) (multichain.BlockchainInfo, error) {
+			return multichain.BlockchainInfo{persist.ChainTezos, 0}, nil
+		},
+	}
 	poapProvider := poap.NewProvider(httpClient, viper.GetString("POAP_API_KEY"), viper.GetString("POAP_AUTH_TOKEN"))
 	return multichain.NewProvider(context.Background(), repos, queries, cache, taskClient,
 		overrides,
 		ethProvider,
 		openseaProvider,
-		tezosProvider,
-		tezosObjktProvider,
+		tezosFallbackProvider,
 		poapProvider,
 	)
 }

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -388,7 +388,7 @@ func FindImageAndAnimationURLs(ctx context.Context, tokenID persist.TokenID, con
 
 	for _, keyword := range animationKeywords.ForToken(tokenID, contractAddress) {
 		if it, ok := util.GetValueFromMapUnsafe(metadata, keyword, util.DefaultSearchDepth).(string); ok && it != "" {
-			logger.For(ctx).Infof("found initial animation url for with keyword %s: %s", keyword, it)
+			logger.For(ctx).Infof("found initial animation url with keyword %s: %s", keyword, it)
 			vURL = it
 			break
 		}
@@ -396,7 +396,7 @@ func FindImageAndAnimationURLs(ctx context.Context, tokenID persist.TokenID, con
 
 	for _, keyword := range imageKeywords.ForToken(tokenID, contractAddress) {
 		if it, ok := util.GetValueFromMapUnsafe(metadata, keyword, util.DefaultSearchDepth).(string); ok && it != "" && it != vURL {
-			logger.For(ctx).Infof("found initial image url for with keyword %s: %s", keyword, it)
+			logger.For(ctx).Infof("found initial image url with keyword %s: %s", keyword, it)
 			imgURL = it
 			break
 		}

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -229,29 +229,6 @@ func (p *Provider) GetContractByAddress(ctx context.Context, contract persist.Ad
 	}
 	return contractToContract(ctx, c, p.ethClient)
 }
-
-// UpdateMediaForWallet updates media for a wallet address
-// bool is whether or not to update all media content, including the tokens that already have media content
-func (p *Provider) UpdateMediaForWallet(context.Context, persist.Address, bool) error {
-	return nil
-}
-
-// ValidateTokensForWallet validates tokens for a wallet address
-// bool is whether or not to update all of the tokens regardless of whether we know they exist already
-func (p *Provider) ValidateTokensForWallet(context.Context, persist.Address, bool) error {
-	return nil
-}
-
-// RefreshToken refreshes the metadata for a given token.
-func (p *Provider) RefreshToken(context.Context, multichain.ChainAgnosticIdentifiers, persist.Address) error {
-	return nil
-}
-
-// RefreshContract refreshses the metadata for a contract
-func (p *Provider) RefreshContract(context.Context, persist.Address) error {
-	return nil
-}
-
 func (d *Provider) GetCommunityOwners(ctx context.Context, communityID persist.Address, limit, offset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
 	return []multichain.ChainAgnosticCommunityOwner{}, nil
 }

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -264,11 +264,6 @@ func (d *Provider) GetDisplayNameByAddress(ctx context.Context, addr persist.Add
 	return addr.String()
 }
 
-// DeepRefresh re-indexes a wallet address. Because this isn't possible through OS, this is a no-op.
-func (p *Provider) DeepRefresh(context.Context, persist.Address) error {
-	return nil
-}
-
 // VerifySignature will verify a signature using all available methods (eth_sign and personal_sign)
 func (p *Provider) VerifySignature(pCtx context.Context,
 	pAddressStr persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {

--- a/service/multichain/poap/poap.go
+++ b/service/multichain/poap/poap.go
@@ -326,32 +326,6 @@ func (d *Provider) GetDisplayNameByAddress(ctx context.Context, addr persist.Add
 	return addr.String()
 }
 
-// RefreshToken refreshes the metadata for a given token.
-func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
-	return nil
-}
-
-// UpdateMediaForWallet updates media for the tokens owned by a wallet on the Poap Blockchain
-func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
-	return nil
-}
-
-// RefreshContract refreshes the metadata for a contract
-func (d *Provider) RefreshContract(ctx context.Context, addr persist.Address) error {
-	return nil
-}
-
-// ValidateTokensForWallet validates tokens for a wallet address on the Poap Blockchain
-func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.Address, all bool) error {
-	return nil
-
-}
-
-// VerifySignature does nothing because POAPs are not really on a blockchain with a wallet
-func (d *Provider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
-	return true, nil
-}
-
 // we should assume when using this function that the array is all of the tokens un paginated and we will need to paginate it with the offset and limit
 func (d *Provider) poapsToTokens(pPoap []poapToken, limit, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract) {
 	tokens := make([]multichain.ChainAgnosticToken, 0, len(pPoap))

--- a/service/multichain/poap/poap.go
+++ b/service/multichain/poap/poap.go
@@ -331,11 +331,6 @@ func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnostic
 	return nil
 }
 
-// DeepRefresh re-indexes a wallet address. Because we don't index POAP ourselves, this is a no-op.
-func (p *Provider) DeepRefresh(context.Context, persist.Address) error {
-	return nil
-}
-
 // UpdateMediaForWallet updates media for the tokens owned by a wallet on the Poap Blockchain
 func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 	return nil

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -1,0 +1,31 @@
+package tezos
+
+import (
+	"context"
+
+	"github.com/machinebox/graphql"
+	"github.com/mikeydub/go-gallery/service/multichain"
+	"github.com/mikeydub/go-gallery/service/persist"
+)
+
+const maxResultSize = 500
+
+type objktToken struct {
+}
+
+type TezosObjktProvider struct {
+	gql *graphql.Client
+}
+
+func NewObjktProvider() *TezosObjktProvider {
+	return &TezosObjktProvider{}
+}
+
+func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, address persist.Address, limit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+	tezosAddress, err := toTzAddress(address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resultTokens := []objktToken{}
+}

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	maxResultSize = 500
+	maxPageSize   = 500
 	objktEndpoint = "https://data.objkt.com/v3/graphql"
 )
+
+type inputArgs map[string]interface{}
 
 type objktToken struct {
 }
@@ -23,7 +25,34 @@ type TezosObjktProvider struct {
 	gql *graphql.Client
 }
 
-type tokensByAddressQuery struct {
+type tokensByWalletQuery struct {
+}
+
+type tokensByContractQuery struct {
+	Fa struct {
+		Tokens []struct {
+			ArtifactURI  string
+			Decimals     int
+			Description  string
+			DisplayURI   string
+			Metadata     string
+			Name         string
+			Symbol       string
+			ThumbnailURI string
+			TokenID      tokenID
+			Level        int
+			Fa           struct {
+				Name      string
+				Contract  persist.Address
+				Type      tokenStandard
+				ShortName string
+				Creator   struct {
+					Address persist.Address
+					Alias   string
+				}
+			}
+		} `graphql:"tokens(limit: $limit, offset: $offset)"`
+	} `graphql:"fa(where: {contract: {_eq: $contractID}})"`
 }
 
 // Objkt's API has pretty strict usage limits (120 requests/minute, and 500 results per page)
@@ -41,13 +70,13 @@ func (d *TezosObjktProvider) GetBlockchainInfo(ctx context.Context) (multichain.
 	}, nil
 }
 
-func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, address persist.Address, limit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
-	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"address": address})
-	tezosAddress, err := toTzAddress(address)
+func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, ownerAddress persist.Address, limit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"ownerAddress": ownerAddress})
+	tezosAddress, err := toTzAddress(ownerAddress)
 	if err != nil {
 		return nil, nil, err
 	}
-	var tokens tokensByAddressQuery
+	var tokens tokensByWalletQuery
 
 	// TODO: Test the rate-limit response, add backoff.
 	if err := p.gql.Query(ctx, &tokens, map[string]interface{}{
@@ -67,10 +96,77 @@ func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, addre
 	// XXX: return p.tokensToAgnosticTokensAndContracts(ctx, resultTokens)
 }
 
-func (d *TezosObjktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (p *TezosObjktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	panic("not implemented")
 }
 
-func (d *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	panic("not implemented")
+func (p *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"contractAddress": contractAddress})
+	tezosAddress, err := toTzAddress(contractAddress)
+	if err != nil {
+		return nil, multichain.ChainAgnosticContract{}, err
+	}
+
+	var tokens tokensByContractQuery
+
+	pageSize := maxLimit
+	if maxLimit > maxPageSize {
+		pageSize = maxPageSize
+	}
+
+	// TODO: Handle pagination and rate-limiting?
+	if err := p.gql.Query(ctx, &tokens, inputArgs{
+		"contractID": tezosAddress,
+		"limit":      pageSize,
+		"offset":     startOffset,
+	}); err != nil {
+		return nil, multichain.ChainAgnosticContract{}, err
+	}
+
+	returnTokens := make([]multichain.ChainAgnosticToken, 0, len(tokens.Fa.Tokens))
+	for _, t := range tokens.Fa.Tokens {
+		token := t
+		if token.Fa.Type == tokenStandardFa12 {
+			continue
+		}
+
+		agnosticToken := multichain.ChainAgnosticToken{
+			TokenType:       persist.TokenTypeERC1155,
+			Description:     token.Description,
+			Name:            token.Name,
+			TokenID:         persist.TokenID(token.TokenID.toBase16String()),
+			Media:           persist.Media{}, // TODO
+			ContractAddress: token.Fa.Contract,
+			Quantity:        "",  // TODO
+			TokenMetadata:   nil, // TODO
+			OwnerAddress:    "",  // TODO
+			BlockNumber:     persist.BlockNumber(token.Level),
+		}
+	}
+}
+
+type tokensByContractQuery struct {
+	Fa struct {
+		Tokens []struct {
+			ArtifactURI  string
+			Decimals     int
+			Description  string
+			DisplayURI   string
+			Metadata     string
+			Name         string
+			Symbol       string
+			ThumbnailURI string
+			TokenID      tokenID
+			Fa           struct {
+				Name      string
+				Contract  persist.Address
+				Type      tokenStandard
+				ShortName string
+				Creator   struct {
+					Address persist.Address
+					Alias   string
+				}
+			}
+		} `graphql:"tokens(limit: $limit, offset: $offset, distinct_on: token_id)"`
+	} `graphql:"fa(where: {contract: {_eq: $contractID}})"`
 }

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
@@ -23,61 +24,63 @@ type attribute struct {
 	Name  string
 	Value string
 	Type  string
-	ID    string
+	ID    int
 }
 
 type contract struct {
-	Name           string
-	Contract       persist.Address
-	Description    string
-	CreatorAddress persist.Address
-	Level          int
-	Type           tokenStandard
+	Name            string
+	Contract        persist.Address
+	Description     string
+	Creator_Address persist.Address
+	Level           int
+	Type            tokenStandard
 }
 
 type token struct {
-	ArtifactURI     string
-	Rights          string
-	Decimals        int
-	Description     string
-	DisplayURI      string
-	Metadata        string
-	Name            string
-	Symbol          string
-	ThumbnailURI    string
-	TokenID         tokenID
-	Level           int
-	IsBooleanAmount bool
-	Attributes      []struct {
+	Artifact_URI      string
+	Rights            string
+	Decimals          int
+	Description       string
+	Display_URI       string
+	Metadata          string
+	Name              string
+	Symbol            string
+	Thumbnail_URI     string
+	Token_ID          tokenID
+	Level             int
+	Is_Boolean_Amount bool
+	Attributes        []struct {
 		Attribute attribute
 	}
-}
-
-type holder struct {
-	Quantity      int
-	HolderAddress persist.Address
-}
-
-type heldToken struct {
-	token
-	Holders []holder `graphql:"holders(where: {quantity: {_gt: '0'}})"`
+	Holders []holder `graphql:"holders(where: {quantity: {_gt: 0}})"`
 	Fa      contract
 }
 
+type holder struct {
+	Quantity       int
+	Holder_Address persist.Address
+}
+
+type tokenNode struct {
+	Token token
+}
+
+type tokenHolder struct {
+	Held_Tokens []tokenNode `graphql:"held_tokens(limit: $limit, offset: $offset, where: {quantity: {_gt: 0}})"`
+}
+
 type tokensByWalletQuery struct {
-	Result []struct {
-		HeldTokens []heldToken `graphql:"held_tokens(limit: $limit, offset: $offset, where: {quantity: {_gt: '0'}})"`
-	} `graphql:"holder(where: {address: {_eq: $ownerAddress}}, limit: 1)"`
+	Holder []tokenHolder `graphql:"holder(where: {address: {_eq: $ownerAddress}}, limit: 1)"`
 }
 
 type tokensByContractQuery struct {
-	Result []struct {
-		Tokens []heldToken `graphql:"tokens(limit: $limit, offset: $offset, distinct_on: token_id)"`
-	} `graphql:"fa(where: {contract: {_eq: $contractAddress}, type: {_eq: 'fa2'}})"`
+	Fa []struct {
+		Tokens []token `graphql:"tokens(limit: $limit, offset: $offset, distinct_on: token_id)"`
+	} `graphql:"fa(where: {contract: {_eq: $contractAddress}, type: {_eq: fa2}})"`
 }
 
 type tokensByIdentifiersQuery struct {
-	Tokens []heldToken `graphql:"token(where: {fa_contract: {_eq: $contractAddress}, fa_type: {_eq: 'fa2'}, token_id: {_eq: $tokenID}, holders: {holder: {address: {_eq: $ownerAddress}}}, quantity: {_gt: '0'}}, distinct_on: token_id)"`
+	Token []token `graphql:"token(where: {fa: {type: {_eq: fa2}}, fa_contract: {_eq: $contractAddress}, token_id: {_eq: $tokenID}, holders: {quantity: {_gt: 0}, holder: {address: {_eq: $ownerAddress}}}})"`
 }
 
 // Objkt's API has pretty strict usage limits (120 requests/minute, and 500 results per page)
@@ -94,11 +97,15 @@ func NewObjktProvider(ipfsGatewayURL string) *TezosObjktProvider {
 	}
 }
 
-func (d *TezosObjktProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (p *TezosObjktProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
 	return multichain.BlockchainInfo{
 		Chain:   persist.ChainTezos,
 		ChainID: 0,
 	}, nil
+}
+
+func (p *TezosObjktProvider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
+	return nil
 }
 
 func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, ownerAddress persist.Address, maxLimit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
@@ -108,72 +115,79 @@ func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, owner
 		return nil, nil, err
 	}
 
-	pageSize := maxLimit
-	if maxLimit > maxPageSize {
-		pageSize = maxPageSize
+	pageSize := maxPageSize
+	if maxLimit > 0 && maxLimit < maxPageSize {
+		pageSize = maxLimit
 	}
 
-	var query tokensByWalletQuery
-	tokens := make([]heldToken, 0, maxLimit)
-
 	// Paginate results
-	for len(tokens) < maxLimit {
+	var query tokensByWalletQuery
+	tokens := make([]tokenNode, 0)
+	for {
 		if err := p.gql.Query(ctx, &query, inputArgs{
-			"limit":        pageSize,
-			"offset":       offset,
-			"ownerAddress": tzOwnerAddress,
+			"ownerAddress": graphql.String(tzOwnerAddress),
+			"limit":        graphql.Int(pageSize),
+			"offset":       graphql.Int(offset),
 		}); err != nil {
 			return nil, nil, err
 		}
 
-		if len(query.Result) < 1 || len(query.Result[0].HeldTokens) < 1 {
+		// No more results
+		if len(query.Holder) < 1 || len(query.Holder[0].Held_Tokens) < 1 {
 			break
 		}
 
-		tokens = append(tokens, query.Result[0].HeldTokens...)
-		offset += len(query.Result[0].HeldTokens)
+		// Exceeded fetch size
+		tokens = append(tokens, query.Holder[0].Held_Tokens...)
+		if maxLimit > 0 && len(tokens) >= maxLimit {
+			break
+		}
+
+		offset += len(query.Holder[0].Held_Tokens)
 	}
 
-	tokens = tokens[:maxLimit]
+	// Truncate tokens if there is a max limit
+	if maxLimit > 0 && len(tokens) > maxLimit {
+		tokens = tokens[:maxLimit]
+	}
+
 	returnTokens := make([]multichain.ChainAgnosticToken, 0, len(tokens))
 	returnContracts := make([]multichain.ChainAgnosticContract, 0)
 	dedupeContracts := make(map[persist.Address]multichain.ChainAgnosticContract)
 
-	for _, token := range tokens {
+	for _, node := range tokens {
 		// FA1.2 is the equivalent of ERC-20 on Tezos
-		if token.Fa.Type == tokenStandardFa12 {
+		if node.Token.Fa.Type == tokenStandardFa12 {
 			continue
 		}
 
-		// Create the metadata
-		metadata := createMetadata(token.token)
+		metadata := createMetadata(node.Token)
 
-		if _, ok := dedupeContracts[token.Fa.Contract]; !ok {
-			dedupeContracts[token.Fa.Contract] = multichain.ChainAgnosticContract{
-				Address:        token.Fa.Contract,
-				Symbol:         token.Symbol,
-				Name:           token.Fa.Name,
-				Description:    token.Fa.Description,
-				CreatorAddress: token.Fa.CreatorAddress,
-				LatestBlock:    persist.BlockNumber(token.Fa.Level),
+		if _, ok := dedupeContracts[node.Token.Fa.Contract]; !ok {
+			dedupeContracts[node.Token.Fa.Contract] = multichain.ChainAgnosticContract{
+				Address:        node.Token.Fa.Contract,
+				Symbol:         node.Token.Symbol,
+				Name:           node.Token.Fa.Name,
+				Description:    node.Token.Fa.Description,
+				CreatorAddress: node.Token.Fa.Creator_Address,
+				LatestBlock:    persist.BlockNumber(node.Token.Fa.Level),
 			}
-			returnContracts = append(returnContracts, dedupeContracts[token.Fa.Contract])
+			returnContracts = append(returnContracts, dedupeContracts[node.Token.Fa.Contract])
 		}
 
-		// Create the media
-		tokenID := persist.TokenID(token.TokenID.toBase16String())
-		media := makeTempMedia(ctx, tokenID, dedupeContracts[token.Fa.Contract].Address, metadata, p.ipfsGatewayURL)
+		tokenID := persist.TokenID(node.Token.Token_ID.toBase16String())
+		media := makeTempMedia(ctx, tokenID, dedupeContracts[node.Token.Fa.Contract].Address, metadata, p.ipfsGatewayURL)
 		agnosticToken := multichain.ChainAgnosticToken{
 			TokenType:       persist.TokenTypeERC1155,
-			Description:     token.Description,
-			Name:            token.Name,
+			Description:     node.Token.Description,
+			Name:            node.Token.Name,
 			TokenID:         tokenID,
 			Media:           media,
-			ContractAddress: dedupeContracts[token.Fa.Contract].Address,
-			Quantity:        persist.HexString(fmt.Sprintf("%x", token.Holders[0].Quantity)),
+			ContractAddress: dedupeContracts[node.Token.Fa.Contract].Address,
+			Quantity:        persist.HexString(fmt.Sprintf("%x", node.Token.Holders[0].Quantity)),
 			TokenMetadata:   metadata,
 			OwnerAddress:    tzOwnerAddress,
-			BlockNumber:     persist.BlockNumber(token.Level),
+			BlockNumber:     persist.BlockNumber(node.Token.Level),
 		}
 		returnTokens = append(returnTokens, agnosticToken)
 	}
@@ -188,32 +202,44 @@ func (p *TezosObjktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Con
 		"ownerAddress":    ownerAddress,
 	})
 
-	var query tokensByIdentifiersQuery
-
-	if err := p.gql.Query(ctx, &query, inputArgs{}); err != nil {
+	tzOwnerAddress, err := toTzAddress(ownerAddress)
+	if err != nil {
 		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, err
 	}
 
-	if len(query.Tokens) < 1 {
+	tokenInDecimal, err := strconv.ParseInt(tokenIdentifiers.TokenID.String(), 16, 32)
+	if err != nil {
+		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, err
+	}
+
+	var query tokensByIdentifiersQuery
+
+	if err := p.gql.Query(ctx, &query, inputArgs{
+		"contractAddress": graphql.String(tokenIdentifiers.ContractAddress),
+		"ownerAddress":    graphql.String(tzOwnerAddress),
+		"tokenID":         graphql.String(strconv.Itoa(int(tokenInDecimal))),
+	}); err != nil {
+		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, err
+	}
+
+	if len(query.Token) < 1 {
 		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, ErrNoTokensFoundByIdentifiers{tokenIdentifiers}
 	}
 
-	token := query.Tokens[0]
+	token := query.Token[0]
 
-	// Create the metadata
-	metadata := createMetadata(token.token)
+	metadata := createMetadata(token)
 
 	agnosticContract := multichain.ChainAgnosticContract{
 		Address:        token.Fa.Contract,
 		Symbol:         token.Symbol,
 		Name:           token.Fa.Name,
 		Description:    token.Fa.Description,
-		CreatorAddress: token.Fa.CreatorAddress,
+		CreatorAddress: token.Fa.Creator_Address,
 		LatestBlock:    persist.BlockNumber(token.Fa.Level),
 	}
 
-	// Create the media
-	tokenID := persist.TokenID(token.TokenID.toBase16String())
+	tokenID := persist.TokenID(token.Token_ID.toBase16String())
 	media := makeTempMedia(ctx, tokenID, agnosticContract.Address, metadata, p.ipfsGatewayURL)
 
 	agnosticToken := multichain.ChainAgnosticToken{
@@ -234,35 +260,36 @@ func (p *TezosObjktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Con
 
 func (p *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"contractAddress": contractAddress})
-	tzContractAddress, err := toTzAddress(contractAddress)
-	if err != nil {
-		return nil, multichain.ChainAgnosticContract{}, err
-	}
 
-	pageSize := maxLimit
-	if maxLimit > maxPageSize {
-		pageSize = maxPageSize
+	pageSize := maxPageSize
+	if maxLimit > 0 && maxLimit < maxPageSize {
+		pageSize = maxLimit
 	}
-
-	var query tokensByContractQuery
-	tokens := make([]heldToken, 0, maxLimit)
 
 	// Paginate results
-	for len(tokens) < maxLimit {
+	var query tokensByContractQuery
+	tokens := make([]token, 0, maxLimit)
+	for {
 		if err := p.gql.Query(ctx, &query, inputArgs{
-			"contractAddress": tzContractAddress,
-			"limit":           pageSize,
-			"offset":          offset,
+			"contractAddress": graphql.String(contractAddress),
+			"limit":           graphql.Int(pageSize),
+			"offset":          graphql.Int(offset),
 		}); err != nil {
 			return nil, multichain.ChainAgnosticContract{}, err
 		}
 
-		if len(query.Result) < 1 || len(query.Result[0].Tokens) < 1 {
+		// No more results
+		if len(query.Fa) < 1 || len(query.Fa[0].Tokens) < 1 {
 			break
 		}
 
-		tokens = append(tokens, query.Result[0].Tokens...)
-		offset += len(query.Result[0].Tokens)
+		// Exceeded fetch size
+		tokens = append(tokens, query.Fa[0].Tokens...)
+		if maxLimit > 0 && len(tokens) >= maxLimit {
+			break
+		}
+
+		offset += len(query.Fa[0].Tokens)
 	}
 
 	// No matching query results
@@ -270,23 +297,25 @@ func (p *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, con
 		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("no tokens found for contract")
 	}
 
-	tokens = tokens[:maxLimit]
+	// Truncate tokens if there is a max limit
+	if maxLimit > 0 && len(tokens) > maxLimit {
+		tokens = tokens[:maxLimit]
+	}
 
 	agnosticContract := multichain.ChainAgnosticContract{
 		Address:        tokens[0].Fa.Contract,
 		Symbol:         tokens[0].Symbol,
 		Name:           tokens[0].Fa.Name,
 		Description:    tokens[0].Fa.Description,
-		CreatorAddress: tokens[0].Fa.CreatorAddress,
+		CreatorAddress: tokens[0].Fa.Creator_Address,
 		LatestBlock:    persist.BlockNumber(tokens[0].Fa.Level),
 	}
 
 	returnTokens := make([]multichain.ChainAgnosticToken, 0, len(tokens))
 	for _, token := range tokens {
-		tokenID := persist.TokenID(token.TokenID.toBase16String())
-		metadata := createMetadata(token.token)
+		tokenID := persist.TokenID(token.Token_ID.toBase16String())
+		metadata := createMetadata(token)
 		media := makeTempMedia(ctx, tokenID, agnosticContract.Address, metadata, p.ipfsGatewayURL)
-
 		// Create token per holder
 		for _, holder := range token.Holders {
 			agnosticToken := multichain.ChainAgnosticToken{
@@ -298,7 +327,7 @@ func (p *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, con
 				ContractAddress: agnosticContract.Address,
 				Quantity:        persist.HexString(fmt.Sprintf("%x", holder.Quantity)),
 				TokenMetadata:   metadata,
-				OwnerAddress:    holder.HolderAddress,
+				OwnerAddress:    holder.Holder_Address,
 				BlockNumber:     persist.BlockNumber(token.Level),
 			}
 			returnTokens = append(returnTokens, agnosticToken)
@@ -315,10 +344,10 @@ func createMetadata(t token) persist.TokenMetadata {
 	metadata["symbol"] = t.Symbol
 	metadata["decimals"] = t.Decimals
 	metadata["attributes"] = t.Attributes
-	metadata["displayUri"] = t.DisplayURI
-	metadata["artifactUri"] = t.ArtifactURI
+	metadata["displayUri"] = t.Display_URI
+	metadata["artifactUri"] = t.Artifact_URI
 	metadata["description"] = t.Description
-	metadata["thumbnailUri"] = t.ThumbnailURI
-	metadata["isBooleanAmount"] = t.IsBooleanAmount
+	metadata["thumbnailUri"] = t.Thumbnail_URI
+	metadata["isBooleanAmount"] = t.Is_Boolean_Amount
 	return metadata
 }

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -2,13 +2,19 @@ package tezos
 
 import (
 	"context"
+	"net/http"
 
-	"github.com/machinebox/graphql"
+	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/shurcooL/graphql"
+	"github.com/sirupsen/logrus"
 )
 
-const maxResultSize = 500
+const (
+	maxResultSize = 500
+	objktEndpoint = "https://data.objkt.com/v3/graphql"
+)
 
 type objktToken struct {
 }
@@ -17,15 +23,44 @@ type TezosObjktProvider struct {
 	gql *graphql.Client
 }
 
+type tokensByAddressQuery struct {
+}
+
 func NewObjktProvider() *TezosObjktProvider {
-	return &TezosObjktProvider{}
+	return &TezosObjktProvider{
+		gql: graphql.NewClient(objktEndpoint, http.DefaultClient),
+	}
+}
+
+func (d *TezosObjktProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+	return multichain.BlockchainInfo{
+		Chain:   persist.ChainTezos,
+		ChainID: 0,
+	}, nil
 }
 
 func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, address persist.Address, limit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"address": address})
 	tezosAddress, err := toTzAddress(address)
 	if err != nil {
 		return nil, nil, err
 	}
+	var tokens tokensByAddressQuery
 
-	resultTokens := []objktToken{}
+	// TODO: Test the rate-limit response, add backoff.
+	if err := p.gql.Query(ctx, &tokens, map[string]interface{}{
+		"limit":       limit,
+		"distinct_on": "token_pk",
+		"where": map[string]interface{}{
+			"holder_address": map[string]interface{}{
+				"_eq": tezosAddress,
+			},
+		},
+	}); err != nil {
+		logger.For(ctx).WithError(err).Error("failed to fetch tokens")
+	}
+
+	// XXX: resultTokens := []objktToken{}
+	return nil, nil, nil
+	// XXX: return p.tokensToAgnosticTokensAndContracts(ctx, resultTokens)
 }

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -26,6 +26,8 @@ type TezosObjktProvider struct {
 type tokensByAddressQuery struct {
 }
 
+// Objkt's API has pretty strict usage limits (120 requests/minute, and 500 results per page)
+// so its best used as a fallback.
 func NewObjktProvider() *TezosObjktProvider {
 	return &TezosObjktProvider{
 		gql: graphql.NewClient(objktEndpoint, http.DefaultClient),
@@ -63,4 +65,12 @@ func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, addre
 	// XXX: resultTokens := []objktToken{}
 	return nil, nil, nil
 	// XXX: return p.tokensToAgnosticTokensAndContracts(ctx, resultTokens)
+}
+
+func (d *TezosObjktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	panic("not implemented")
+}
+
+func (d *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	panic("not implemented")
 }

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -2,6 +2,7 @@ package tezos
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -18,48 +19,78 @@ const (
 
 type inputArgs map[string]interface{}
 
-type objktToken struct {
+type attribute struct {
+	Name  string
+	Value string
+	Type  string
+	ID    string
 }
 
-type TezosObjktProvider struct {
-	gql *graphql.Client
+type contract struct {
+	Name           string
+	Contract       persist.Address
+	Description    string
+	CreatorAddress persist.Address
+	Level          int
+	Type           tokenStandard
+}
+
+type token struct {
+	ArtifactURI     string
+	Rights          string
+	Decimals        int
+	Description     string
+	DisplayURI      string
+	Metadata        string
+	Name            string
+	Symbol          string
+	ThumbnailURI    string
+	TokenID         tokenID
+	Level           int
+	IsBooleanAmount bool
+	Attributes      []struct {
+		Attribute attribute
+	}
+}
+
+type holder struct {
+	Quantity      int
+	HolderAddress persist.Address
+}
+
+type heldToken struct {
+	token
+	Holders []holder `graphql:"holders(where: {quantity: {_gt: '0'}})"`
+	Fa      contract
 }
 
 type tokensByWalletQuery struct {
+	Result []struct {
+		HeldTokens []heldToken `graphql:"held_tokens(limit: $limit, offset: $offset, where: {quantity: {_gt: '0'}})"`
+	} `graphql:"holder(where: {address: {_eq: $ownerAddress}}, limit: 1)"`
 }
 
 type tokensByContractQuery struct {
-	Fa struct {
-		Tokens []struct {
-			ArtifactURI  string
-			Decimals     int
-			Description  string
-			DisplayURI   string
-			Metadata     string
-			Name         string
-			Symbol       string
-			ThumbnailURI string
-			TokenID      tokenID
-			Level        int
-			Fa           struct {
-				Name      string
-				Contract  persist.Address
-				Type      tokenStandard
-				ShortName string
-				Creator   struct {
-					Address persist.Address
-					Alias   string
-				}
-			}
-		} `graphql:"tokens(limit: $limit, offset: $offset)"`
-	} `graphql:"fa(where: {contract: {_eq: $contractID}})"`
+	Result []struct {
+		Tokens []heldToken `graphql:"tokens(limit: $limit, offset: $offset, distinct_on: token_id)"`
+	} `graphql:"fa(where: {contract: {_eq: $contractAddress}, type: {_eq: 'fa2'}})"`
+}
+
+type tokensByIdentifiersQuery struct {
+	Tokens []heldToken `graphql:"token(where: {fa_contract: {_eq: $contractAddress}, fa_type: {_eq: 'fa2'}, token_id: {_eq: $tokenID}, holders: {holder: {address: {_eq: $ownerAddress}}}, quantity: {_gt: '0'}}, distinct_on: token_id)"`
 }
 
 // Objkt's API has pretty strict usage limits (120 requests/minute, and 500 results per page)
 // so its best used as a fallback.
-func NewObjktProvider() *TezosObjktProvider {
+type TezosObjktProvider struct {
+	gql            *graphql.Client
+	ipfsGatewayURL string
+}
+
+func NewObjktProvider(ipfsGatewayURL string) *TezosObjktProvider {
 	return &TezosObjktProvider{
-		gql: graphql.NewClient(objktEndpoint, http.DefaultClient),
+		gql:            graphql.NewClient(objktEndpoint, http.DefaultClient),
+		ipfsGatewayURL: ipfsGatewayURL,
 	}
 }
 
@@ -70,103 +101,224 @@ func (d *TezosObjktProvider) GetBlockchainInfo(ctx context.Context) (multichain.
 	}, nil
 }
 
-func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, ownerAddress persist.Address, limit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (p *TezosObjktProvider) GetTokensByWalletAddress(ctx context.Context, ownerAddress persist.Address, maxLimit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"ownerAddress": ownerAddress})
-	tezosAddress, err := toTzAddress(ownerAddress)
+	tzOwnerAddress, err := toTzAddress(ownerAddress)
 	if err != nil {
 		return nil, nil, err
 	}
-	var tokens tokensByWalletQuery
-
-	// TODO: Test the rate-limit response, add backoff.
-	if err := p.gql.Query(ctx, &tokens, map[string]interface{}{
-		"limit":       limit,
-		"distinct_on": "token_pk",
-		"where": map[string]interface{}{
-			"holder_address": map[string]interface{}{
-				"_eq": tezosAddress,
-			},
-		},
-	}); err != nil {
-		logger.For(ctx).WithError(err).Error("failed to fetch tokens")
-	}
-
-	// XXX: resultTokens := []objktToken{}
-	return nil, nil, nil
-	// XXX: return p.tokensToAgnosticTokensAndContracts(ctx, resultTokens)
-}
-
-func (p *TezosObjktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	panic("not implemented")
-}
-
-func (p *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"contractAddress": contractAddress})
-	tezosAddress, err := toTzAddress(contractAddress)
-	if err != nil {
-		return nil, multichain.ChainAgnosticContract{}, err
-	}
-
-	var tokens tokensByContractQuery
 
 	pageSize := maxLimit
 	if maxLimit > maxPageSize {
 		pageSize = maxPageSize
 	}
 
-	// TODO: Handle pagination and rate-limiting?
-	if err := p.gql.Query(ctx, &tokens, inputArgs{
-		"contractID": tezosAddress,
-		"limit":      pageSize,
-		"offset":     startOffset,
-	}); err != nil {
-		return nil, multichain.ChainAgnosticContract{}, err
+	var query tokensByWalletQuery
+	tokens := make([]heldToken, 0, maxLimit)
+
+	// Paginate results
+	for len(tokens) < maxLimit {
+		if err := p.gql.Query(ctx, &query, inputArgs{
+			"limit":        pageSize,
+			"offset":       offset,
+			"ownerAddress": tzOwnerAddress,
+		}); err != nil {
+			return nil, nil, err
+		}
+
+		if len(query.Result) < 1 || len(query.Result[0].HeldTokens) < 1 {
+			break
+		}
+
+		tokens = append(tokens, query.Result[0].HeldTokens...)
+		offset += len(query.Result[0].HeldTokens)
 	}
 
-	returnTokens := make([]multichain.ChainAgnosticToken, 0, len(tokens.Fa.Tokens))
-	for _, t := range tokens.Fa.Tokens {
-		token := t
+	tokens = tokens[:maxLimit]
+	returnTokens := make([]multichain.ChainAgnosticToken, 0, len(tokens))
+	returnContracts := make([]multichain.ChainAgnosticContract, 0)
+	dedupeContracts := make(map[persist.Address]multichain.ChainAgnosticContract)
+
+	for _, token := range tokens {
+		// FA1.2 is the equivalent of ERC-20 on Tezos
 		if token.Fa.Type == tokenStandardFa12 {
 			continue
 		}
 
+		// Create the metadata
+		metadata := createMetadata(token.token)
+
+		if _, ok := dedupeContracts[token.Fa.Contract]; !ok {
+			dedupeContracts[token.Fa.Contract] = multichain.ChainAgnosticContract{
+				Address:        token.Fa.Contract,
+				Symbol:         token.Symbol,
+				Name:           token.Fa.Name,
+				Description:    token.Fa.Description,
+				CreatorAddress: token.Fa.CreatorAddress,
+				LatestBlock:    persist.BlockNumber(token.Fa.Level),
+			}
+			returnContracts = append(returnContracts, dedupeContracts[token.Fa.Contract])
+		}
+
+		// Create the media
+		tokenID := persist.TokenID(token.TokenID.toBase16String())
+		media := makeTempMedia(ctx, tokenID, dedupeContracts[token.Fa.Contract].Address, metadata, p.ipfsGatewayURL)
 		agnosticToken := multichain.ChainAgnosticToken{
 			TokenType:       persist.TokenTypeERC1155,
 			Description:     token.Description,
 			Name:            token.Name,
-			TokenID:         persist.TokenID(token.TokenID.toBase16String()),
-			Media:           persist.Media{}, // TODO
-			ContractAddress: token.Fa.Contract,
-			Quantity:        "",  // TODO
-			TokenMetadata:   nil, // TODO
-			OwnerAddress:    "",  // TODO
+			TokenID:         tokenID,
+			Media:           media,
+			ContractAddress: dedupeContracts[token.Fa.Contract].Address,
+			Quantity:        persist.HexString(fmt.Sprintf("%x", token.Holders[0].Quantity)),
+			TokenMetadata:   metadata,
+			OwnerAddress:    tzOwnerAddress,
 			BlockNumber:     persist.BlockNumber(token.Level),
 		}
+		returnTokens = append(returnTokens, agnosticToken)
 	}
+
+	return returnTokens, returnContracts, nil
 }
 
-type tokensByContractQuery struct {
-	Fa struct {
-		Tokens []struct {
-			ArtifactURI  string
-			Decimals     int
-			Description  string
-			DisplayURI   string
-			Metadata     string
-			Name         string
-			Symbol       string
-			ThumbnailURI string
-			TokenID      tokenID
-			Fa           struct {
-				Name      string
-				Contract  persist.Address
-				Type      tokenStandard
-				ShortName string
-				Creator   struct {
-					Address persist.Address
-					Alias   string
-				}
+func (p *TezosObjktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	ctx = logger.NewContextWithFields(ctx, logrus.Fields{
+		"contractAddress": tokenIdentifiers.ContractAddress,
+		"tokenID":         tokenIdentifiers.TokenID,
+		"ownerAddress":    ownerAddress,
+	})
+
+	var query tokensByIdentifiersQuery
+
+	if err := p.gql.Query(ctx, &query, inputArgs{}); err != nil {
+		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, err
+	}
+
+	if len(query.Tokens) < 1 {
+		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, ErrNoTokensFoundByIdentifiers{tokenIdentifiers}
+	}
+
+	token := query.Tokens[0]
+
+	// Create the metadata
+	metadata := createMetadata(token.token)
+
+	agnosticContract := multichain.ChainAgnosticContract{
+		Address:        token.Fa.Contract,
+		Symbol:         token.Symbol,
+		Name:           token.Fa.Name,
+		Description:    token.Fa.Description,
+		CreatorAddress: token.Fa.CreatorAddress,
+		LatestBlock:    persist.BlockNumber(token.Fa.Level),
+	}
+
+	// Create the media
+	tokenID := persist.TokenID(token.TokenID.toBase16String())
+	media := makeTempMedia(ctx, tokenID, agnosticContract.Address, metadata, p.ipfsGatewayURL)
+
+	agnosticToken := multichain.ChainAgnosticToken{
+		TokenType:       persist.TokenTypeERC1155,
+		Description:     token.Description,
+		Name:            token.Name,
+		TokenID:         tokenID,
+		Media:           media,
+		ContractAddress: agnosticContract.Address,
+		Quantity:        persist.HexString(fmt.Sprintf("%x", token.Holders[0].Quantity)),
+		TokenMetadata:   metadata,
+		OwnerAddress:    ownerAddress,
+		BlockNumber:     persist.BlockNumber(token.Level),
+	}
+
+	return agnosticToken, agnosticContract, nil
+}
+
+func (p *TezosObjktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"contractAddress": contractAddress})
+	tzContractAddress, err := toTzAddress(contractAddress)
+	if err != nil {
+		return nil, multichain.ChainAgnosticContract{}, err
+	}
+
+	pageSize := maxLimit
+	if maxLimit > maxPageSize {
+		pageSize = maxPageSize
+	}
+
+	var query tokensByContractQuery
+	tokens := make([]heldToken, 0, maxLimit)
+
+	// Paginate results
+	for len(tokens) < maxLimit {
+		if err := p.gql.Query(ctx, &query, inputArgs{
+			"contractAddress": tzContractAddress,
+			"limit":           pageSize,
+			"offset":          offset,
+		}); err != nil {
+			return nil, multichain.ChainAgnosticContract{}, err
+		}
+
+		if len(query.Result) < 1 || len(query.Result[0].Tokens) < 1 {
+			break
+		}
+
+		tokens = append(tokens, query.Result[0].Tokens...)
+		offset += len(query.Result[0].Tokens)
+	}
+
+	// No matching query results
+	if len(tokens) < 1 {
+		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("no tokens found for contract")
+	}
+
+	tokens = tokens[:maxLimit]
+
+	agnosticContract := multichain.ChainAgnosticContract{
+		Address:        tokens[0].Fa.Contract,
+		Symbol:         tokens[0].Symbol,
+		Name:           tokens[0].Fa.Name,
+		Description:    tokens[0].Fa.Description,
+		CreatorAddress: tokens[0].Fa.CreatorAddress,
+		LatestBlock:    persist.BlockNumber(tokens[0].Fa.Level),
+	}
+
+	returnTokens := make([]multichain.ChainAgnosticToken, 0, len(tokens))
+	for _, token := range tokens {
+		tokenID := persist.TokenID(token.TokenID.toBase16String())
+		metadata := createMetadata(token.token)
+		media := makeTempMedia(ctx, tokenID, agnosticContract.Address, metadata, p.ipfsGatewayURL)
+
+		// Create token per holder
+		for _, holder := range token.Holders {
+			agnosticToken := multichain.ChainAgnosticToken{
+				TokenType:       persist.TokenTypeERC1155,
+				Description:     token.Description,
+				Name:            token.Name,
+				TokenID:         tokenID,
+				Media:           media,
+				ContractAddress: agnosticContract.Address,
+				Quantity:        persist.HexString(fmt.Sprintf("%x", holder.Quantity)),
+				TokenMetadata:   metadata,
+				OwnerAddress:    holder.HolderAddress,
+				BlockNumber:     persist.BlockNumber(token.Level),
 			}
-		} `graphql:"tokens(limit: $limit, offset: $offset, distinct_on: token_id)"`
-	} `graphql:"fa(where: {contract: {_eq: $contractID}})"`
+			returnTokens = append(returnTokens, agnosticToken)
+		}
+	}
+
+	return returnTokens, agnosticContract, nil
+}
+
+func createMetadata(t token) persist.TokenMetadata {
+	metadata := persist.TokenMetadata{}
+	metadata["name"] = t.Name
+	metadata["rights"] = t.Rights
+	metadata["symbol"] = t.Symbol
+	metadata["decimals"] = t.Decimals
+	metadata["attributes"] = t.Attributes
+	metadata["displayUri"] = t.DisplayURI
+	metadata["artifactUri"] = t.ArtifactURI
+	metadata["description"] = t.Description
+	metadata["thumbnailUri"] = t.ThumbnailURI
+	metadata["isBooleanAmount"] = t.IsBooleanAmount
+	return metadata
 }

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -114,8 +114,8 @@ type tzktContract struct {
 	} `json:"creator"`
 }
 
-// TezosTzktProvider is an the struct for retrieving data from the Tezos blockchain via Tzkt
-type TezosTzktProvider struct {
+// TezosProvider is an the struct for retrieving data from the Tezos blockchain
+type TezosProvider struct {
 	apiURL         string
 	mediaURL       string
 	ipfsGatewayURL string
@@ -127,9 +127,9 @@ type TezosTzktProvider struct {
 	tokenBucket    string
 }
 
-// NewTzktProvider creates a new TezosTzktProvider
-func NewTzktProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) *TezosTzktProvider {
-	return &TezosTzktProvider{
+// NewProvider creates a new Tezos Provider
+func NewProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) *TezosProvider {
+	return &TezosProvider{
 		apiURL:         tezosAPIUrl,
 		mediaURL:       mediaURL,
 		ipfsGatewayURL: ipfsGatewayURL,
@@ -142,8 +142,8 @@ func NewTzktProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *h
 	}
 }
 
-// GetBlockchainInfo retrieves blockchain info for ETH
-func (d *TezosTzktProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+// GetBlockchainInfo retrieves blockchain info for Tezos
+func (d *TezosProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
 	return multichain.BlockchainInfo{
 		Chain:   persist.ChainTezos,
 		ChainID: 0,
@@ -151,7 +151,7 @@ func (d *TezosTzktProvider) GetBlockchainInfo(ctx context.Context) (multichain.B
 }
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Tezos Blockchain
-func (d *TezosTzktProvider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address, maxLimit, startingOffset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (d *TezosProvider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address, maxLimit, startingOffset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	tzAddr, err := toTzAddress(addr)
 	if err != nil {
 		return nil, nil, err
@@ -200,7 +200,7 @@ func (d *TezosTzktProvider) GetTokensByWalletAddress(ctx context.Context, addr p
 }
 
 // GetTokensByContractAddress retrieves tokens for a contract address on the Tezos Blockchain
-func (d *TezosTzktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 
 	offset := startOffset
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
@@ -253,7 +253,7 @@ func (d *TezosTzktProvider) GetTokensByContractAddress(ctx context.Context, cont
 }
 
 // GetTokensByTokenIdentifiers retrieves tokens for a token identifiers on the Tezos Blockchain
-func (d *TezosTzktProvider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosProvider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	offset := startOffset
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
 	if limit < 1 {
@@ -307,7 +307,7 @@ func (d *TezosTzktProvider) GetTokensByTokenIdentifiers(ctx context.Context, tok
 
 }
 
-func (d *TezosTzktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/tokens/balances?token.standard=fa2&token.tokenId=%s&token.contract=%s&account=%s&limit=1", d.apiURL, tokenIdentifiers.TokenID.Base10String(), tokenIdentifiers.ContractAddress, ownerAddress), nil)
 	if err != nil {
@@ -345,7 +345,7 @@ func (d *TezosTzktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Cont
 }
 
 // GetContractByAddress retrieves an Tezos contract by address
-func (d *TezosTzktProvider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
+func (d *TezosProvider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/contracts/%s?type=contract", d.apiURL, addr.String()), nil)
 	if err != nil {
 		return multichain.ChainAgnosticContract{}, err
@@ -367,7 +367,7 @@ func (d *TezosTzktProvider) GetContractByAddress(ctx context.Context, addr persi
 
 }
 
-func (d *TezosTzktProvider) GetOwnedTokensByContract(ctx context.Context, contractAddress persist.Address, ownerAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosProvider) GetOwnedTokensByContract(ctx context.Context, contractAddress persist.Address, ownerAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	offset := 0
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
 	if limit < 1 {
@@ -418,7 +418,7 @@ func (d *TezosTzktProvider) GetOwnedTokensByContract(ctx context.Context, contra
 	return tokens, contract, nil
 }
 
-func (d *TezosTzktProvider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, maxLimit, maxOffset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
+func (d *TezosProvider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, maxLimit, maxOffset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
 	tokens, _, err := d.GetTokensByContractAddress(ctx, contractAddress, maxLimit, maxOffset)
 	if err != nil {
 		return nil, err
@@ -499,7 +499,7 @@ type tezDomainResponse struct {
 	} `json:"data"`
 }
 
-func (d *TezosTzktProvider) GetDisplayNameByAddress(ctx context.Context, addr persist.Address) string {
+func (d *TezosProvider) GetDisplayNameByAddress(ctx context.Context, addr persist.Address) string {
 	req := graphql.NewRequest(fmt.Sprintf(`{
 	  "query": "query ($addresses: [String!]) {
 		reverseRecords(
@@ -535,29 +535,29 @@ func (d *TezosTzktProvider) GetDisplayNameByAddress(ctx context.Context, addr pe
 }
 
 // RefreshToken refreshes the metadata for a given token.
-func (d *TezosTzktProvider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
+func (d *TezosProvider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
 	return nil
 }
 
 // UpdateMediaForWallet updates media for the tokens owned by a wallet on the Tezos Blockchain
-func (d *TezosTzktProvider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
+func (d *TezosProvider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 	return nil
 }
 
 // RefreshContract refreshes the metadata for a contract
-func (d *TezosTzktProvider) RefreshContract(ctx context.Context, addr persist.Address) error {
+func (d *TezosProvider) RefreshContract(ctx context.Context, addr persist.Address) error {
 	return nil
 }
 
 // ValidateTokensForWallet validates tokens for a wallet address on the Tezos Blockchain
-func (d *TezosTzktProvider) ValidateTokensForWallet(ctx context.Context, wallet persist.Address, all bool) error {
+func (d *TezosProvider) ValidateTokensForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 	return nil
 
 }
 
 // VerifySignature will verify a signature using the ed25519 algorithm
 // the address provided must be the tezos public key, not the hashed address
-func (d *TezosTzktProvider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
+func (d *TezosProvider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
 	key, err := tezos.ParseKey(pPubKey.String())
 	if err != nil {
 		return false, err
@@ -588,7 +588,7 @@ func (d *TezosTzktProvider) VerifySignature(pCtx context.Context, pPubKey persis
 	return key.Verify(hash.Sum(nil), sig) == nil, nil
 }
 
-func (d *TezosTzktProvider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzktBalanceToken, mediaKey string) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (d *TezosProvider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzktBalanceToken, mediaKey string) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	tzTokens = dedupeBalances(tzTokens)
 	seenContracts := map[string]bool{}
 	contractsLock := &sync.Mutex{}
@@ -675,7 +675,7 @@ func (d *TezosTzktProvider) tzBalanceTokensToTokens(pCtx context.Context, tzToke
 	}
 }
 
-func (d *TezosTzktProvider) makeTempMedia(ctx context.Context, tokenID persist.TokenID, contract persist.Address, agnosticMetadata persist.TokenMetadata, name string) persist.Media {
+func (d *TezosProvider) makeTempMedia(ctx context.Context, tokenID persist.TokenID, contract persist.Address, agnosticMetadata persist.TokenMetadata, name string) persist.Media {
 	med := persist.Media{
 		MediaType: persist.MediaTypeSyncing,
 	}
@@ -720,7 +720,7 @@ func dedupeBalances(tzTokens []tzktBalanceToken) []tzktBalanceToken {
 	return result
 }
 
-func (d *TezosTzktProvider) getPublicKeyFromAddress(ctx context.Context, address persist.Address) (persist.Address, error) {
+func (d *TezosProvider) getPublicKeyFromAddress(ctx context.Context, address persist.Address) (persist.Address, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/accounts/%s", d.apiURL, address), nil)
 	if err != nil {
 		return "", err
@@ -747,7 +747,7 @@ func (d *TezosTzktProvider) getPublicKeyFromAddress(ctx context.Context, address
 	return persist.Address(account.Public), nil
 }
 
-func (d *TezosTzktProvider) tzContractToContract(ctx context.Context, tzContract tzktContract) multichain.ChainAgnosticContract {
+func (d *TezosProvider) tzContractToContract(ctx context.Context, tzContract tzktContract) multichain.ChainAgnosticContract {
 	return multichain.ChainAgnosticContract{
 		Address:        persist.Address(tzContract.Address),
 		CreatorAddress: persist.Address(tzContract.Creator.Address),

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -69,19 +69,6 @@ type tzAccount struct {
 type tokenID string
 type balance string
 
-type tzktToken struct {
-	ID       uint64 `json:"id"`
-	Contract struct {
-		Alias   string          `json:"alias"`
-		Address persist.Address `json:"address"`
-	} `json:"contract"`
-	TokenID    tokenID       `json:"tokenId"`
-	Standard   tokenStandard `json:"standard"`
-	Metadata   tzMetadata    `json:"metadata"`
-	FirstLevel uint64        `json:"firstLevel"`
-	LastLevel  uint64        `json:"lastLevel"`
-}
-
 type tzktBalanceToken struct {
 	ID      uint64 `json:"id"`
 	Account struct {
@@ -114,8 +101,8 @@ type tzktContract struct {
 	} `json:"creator"`
 }
 
-// TezosProvider is an the struct for retrieving data from the Tezos blockchain
-type TezosProvider struct {
+// Provider is an the struct for retrieving data from the Tezos blockchain
+type Provider struct {
 	apiURL         string
 	mediaURL       string
 	ipfsGatewayURL string
@@ -128,8 +115,8 @@ type TezosProvider struct {
 }
 
 // NewProvider creates a new Tezos Provider
-func NewProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) *TezosProvider {
-	return &TezosProvider{
+func NewProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) *Provider {
+	return &Provider{
 		apiURL:         tezosAPIUrl,
 		mediaURL:       mediaURL,
 		ipfsGatewayURL: ipfsGatewayURL,
@@ -143,7 +130,7 @@ func NewProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.
 }
 
 // GetBlockchainInfo retrieves blockchain info for Tezos
-func (d *TezosProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
 	return multichain.BlockchainInfo{
 		Chain:   persist.ChainTezos,
 		ChainID: 0,
@@ -151,7 +138,7 @@ func (d *TezosProvider) GetBlockchainInfo(ctx context.Context) (multichain.Block
 }
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Tezos Blockchain
-func (d *TezosProvider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address, maxLimit, startingOffset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address, maxLimit, startingOffset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	tzAddr, err := toTzAddress(addr)
 	if err != nil {
 		return nil, nil, err
@@ -200,7 +187,7 @@ func (d *TezosProvider) GetTokensByWalletAddress(ctx context.Context, addr persi
 }
 
 // GetTokensByContractAddress retrieves tokens for a contract address on the Tezos Blockchain
-func (d *TezosProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 
 	offset := startOffset
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
@@ -253,7 +240,7 @@ func (d *TezosProvider) GetTokensByContractAddress(ctx context.Context, contract
 }
 
 // GetTokensByTokenIdentifiers retrieves tokens for a token identifiers on the Tezos Blockchain
-func (d *TezosProvider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	offset := startOffset
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
 	if limit < 1 {
@@ -307,7 +294,7 @@ func (d *TezosProvider) GetTokensByTokenIdentifiers(ctx context.Context, tokenId
 
 }
 
-func (d *TezosProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *Provider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/tokens/balances?token.standard=fa2&token.tokenId=%s&token.contract=%s&account=%s&limit=1", d.apiURL, tokenIdentifiers.TokenID.Base10String(), tokenIdentifiers.ContractAddress, ownerAddress), nil)
 	if err != nil {
@@ -345,7 +332,7 @@ func (d *TezosProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context,
 }
 
 // GetContractByAddress retrieves an Tezos contract by address
-func (d *TezosProvider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
+func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/contracts/%s?type=contract", d.apiURL, addr.String()), nil)
 	if err != nil {
 		return multichain.ChainAgnosticContract{}, err
@@ -367,7 +354,7 @@ func (d *TezosProvider) GetContractByAddress(ctx context.Context, addr persist.A
 
 }
 
-func (d *TezosProvider) GetOwnedTokensByContract(ctx context.Context, contractAddress persist.Address, ownerAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *Provider) GetOwnedTokensByContract(ctx context.Context, contractAddress persist.Address, ownerAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	offset := 0
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
 	if limit < 1 {
@@ -418,7 +405,7 @@ func (d *TezosProvider) GetOwnedTokensByContract(ctx context.Context, contractAd
 	return tokens, contract, nil
 }
 
-func (d *TezosProvider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, maxLimit, maxOffset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
+func (d *Provider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, maxLimit, maxOffset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
 	tokens, _, err := d.GetTokensByContractAddress(ctx, contractAddress, maxLimit, maxOffset)
 	if err != nil {
 		return nil, err
@@ -499,7 +486,7 @@ type tezDomainResponse struct {
 	} `json:"data"`
 }
 
-func (d *TezosProvider) GetDisplayNameByAddress(ctx context.Context, addr persist.Address) string {
+func (d *Provider) GetDisplayNameByAddress(ctx context.Context, addr persist.Address) string {
 	req := graphql.NewRequest(fmt.Sprintf(`{
 	  "query": "query ($addresses: [String!]) {
 		reverseRecords(
@@ -535,29 +522,29 @@ func (d *TezosProvider) GetDisplayNameByAddress(ctx context.Context, addr persis
 }
 
 // RefreshToken refreshes the metadata for a given token.
-func (d *TezosProvider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
+func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
 	return nil
 }
 
 // UpdateMediaForWallet updates media for the tokens owned by a wallet on the Tezos Blockchain
-func (d *TezosProvider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
+func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 	return nil
 }
 
 // RefreshContract refreshes the metadata for a contract
-func (d *TezosProvider) RefreshContract(ctx context.Context, addr persist.Address) error {
+func (d *Provider) RefreshContract(ctx context.Context, addr persist.Address) error {
 	return nil
 }
 
 // ValidateTokensForWallet validates tokens for a wallet address on the Tezos Blockchain
-func (d *TezosProvider) ValidateTokensForWallet(ctx context.Context, wallet persist.Address, all bool) error {
+func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 	return nil
 
 }
 
 // VerifySignature will verify a signature using the ed25519 algorithm
 // the address provided must be the tezos public key, not the hashed address
-func (d *TezosProvider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
+func (d *Provider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
 	key, err := tezos.ParseKey(pPubKey.String())
 	if err != nil {
 		return false, err
@@ -588,7 +575,7 @@ func (d *TezosProvider) VerifySignature(pCtx context.Context, pPubKey persist.Pu
 	return key.Verify(hash.Sum(nil), sig) == nil, nil
 }
 
-func (d *TezosProvider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzktBalanceToken, mediaKey string) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (d *Provider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzktBalanceToken, mediaKey string) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	tzTokens = dedupeBalances(tzTokens)
 	seenContracts := map[string]bool{}
 	contractsLock := &sync.Mutex{}
@@ -675,7 +662,7 @@ func (d *TezosProvider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens [
 	}
 }
 
-func (d *TezosProvider) makeTempMedia(ctx context.Context, tokenID persist.TokenID, contract persist.Address, agnosticMetadata persist.TokenMetadata, name string) persist.Media {
+func (d *Provider) makeTempMedia(ctx context.Context, tokenID persist.TokenID, contract persist.Address, agnosticMetadata persist.TokenMetadata, name string) persist.Media {
 	med := persist.Media{
 		MediaType: persist.MediaTypeSyncing,
 	}
@@ -720,7 +707,7 @@ func dedupeBalances(tzTokens []tzktBalanceToken) []tzktBalanceToken {
 	return result
 }
 
-func (d *TezosProvider) getPublicKeyFromAddress(ctx context.Context, address persist.Address) (persist.Address, error) {
+func (d *Provider) getPublicKeyFromAddress(ctx context.Context, address persist.Address) (persist.Address, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/accounts/%s", d.apiURL, address), nil)
 	if err != nil {
 		return "", err
@@ -747,7 +734,7 @@ func (d *TezosProvider) getPublicKeyFromAddress(ctx context.Context, address per
 	return persist.Address(account.Public), nil
 }
 
-func (d *TezosProvider) tzContractToContract(ctx context.Context, tzContract tzktContract) multichain.ChainAgnosticContract {
+func (d *Provider) tzContractToContract(ctx context.Context, tzContract tzktContract) multichain.ChainAgnosticContract {
 	return multichain.ChainAgnosticContract{
 		Address:        persist.Address(tzContract.Address),
 		CreatorAddress: persist.Address(tzContract.Creator.Address),

--- a/service/multichain/tezos/tzkt.go
+++ b/service/multichain/tezos/tzkt.go
@@ -114,8 +114,8 @@ type tzktContract struct {
 	} `json:"creator"`
 }
 
-// Provider is an the struct for retrieving data from the Tezos blockchain
-type Provider struct {
+// TezosTzktProvider is an the struct for retrieving data from the Tezos blockchain via Tzkt
+type TezosTzktProvider struct {
 	apiURL         string
 	mediaURL       string
 	ipfsGatewayURL string
@@ -127,9 +127,9 @@ type Provider struct {
 	tokenBucket    string
 }
 
-// NewProvider creates a new Tezos Provider
-func NewProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) *Provider {
-	return &Provider{
+// NewTzktProvider creates a new TezosTzktProvider
+func NewTzktProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenBucket string) *TezosTzktProvider {
+	return &TezosTzktProvider{
 		apiURL:         tezosAPIUrl,
 		mediaURL:       mediaURL,
 		ipfsGatewayURL: ipfsGatewayURL,
@@ -143,7 +143,7 @@ func NewProvider(tezosAPIUrl, mediaURL, ipfsGatewayURL string, httpClient *http.
 }
 
 // GetBlockchainInfo retrieves blockchain info for ETH
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *TezosTzktProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
 	return multichain.BlockchainInfo{
 		Chain:   persist.ChainTezos,
 		ChainID: 0,
@@ -151,7 +151,7 @@ func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.Blockchain
 }
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Tezos Blockchain
-func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address, maxLimit, startingOffset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (d *TezosTzktProvider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address, maxLimit, startingOffset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	tzAddr, err := toTzAddress(addr)
 	if err != nil {
 		return nil, nil, err
@@ -200,7 +200,7 @@ func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Ad
 }
 
 // GetTokensByContractAddress retrieves tokens for a contract address on the Tezos Blockchain
-func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosTzktProvider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 
 	offset := startOffset
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
@@ -253,7 +253,7 @@ func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddre
 }
 
 // GetTokensByTokenIdentifiers retrieves tokens for a token identifiers on the Tezos Blockchain
-func (d *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosTzktProvider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	offset := startOffset
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
 	if limit < 1 {
@@ -307,7 +307,7 @@ func (d *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tokenIdentif
 
 }
 
-func (d *Provider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosTzktProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, tokenIdentifiers multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/tokens/balances?token.standard=fa2&token.tokenId=%s&token.contract=%s&account=%s&limit=1", d.apiURL, tokenIdentifiers.TokenID.Base10String(), tokenIdentifiers.ContractAddress, ownerAddress), nil)
 	if err != nil {
@@ -345,7 +345,7 @@ func (d *Provider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, toke
 }
 
 // GetContractByAddress retrieves an Tezos contract by address
-func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
+func (d *TezosTzktProvider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/contracts/%s?type=contract", d.apiURL, addr.String()), nil)
 	if err != nil {
 		return multichain.ChainAgnosticContract{}, err
@@ -367,7 +367,7 @@ func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Addres
 
 }
 
-func (d *Provider) GetOwnedTokensByContract(ctx context.Context, contractAddress persist.Address, ownerAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+func (d *TezosTzktProvider) GetOwnedTokensByContract(ctx context.Context, contractAddress persist.Address, ownerAddress persist.Address, maxLimit, startOffset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	offset := 0
 	limit := int(math.Min(float64(maxLimit), float64(pageSize)))
 	if limit < 1 {
@@ -418,7 +418,7 @@ func (d *Provider) GetOwnedTokensByContract(ctx context.Context, contractAddress
 	return tokens, contract, nil
 }
 
-func (d *Provider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, maxLimit, maxOffset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
+func (d *TezosTzktProvider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, maxLimit, maxOffset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
 	tokens, _, err := d.GetTokensByContractAddress(ctx, contractAddress, maxLimit, maxOffset)
 	if err != nil {
 		return nil, err
@@ -499,7 +499,7 @@ type tezDomainResponse struct {
 	} `json:"data"`
 }
 
-func (d *Provider) GetDisplayNameByAddress(ctx context.Context, addr persist.Address) string {
+func (d *TezosTzktProvider) GetDisplayNameByAddress(ctx context.Context, addr persist.Address) string {
 	req := graphql.NewRequest(fmt.Sprintf(`{
 	  "query": "query ($addresses: [String!]) {
 		reverseRecords(
@@ -535,34 +535,29 @@ func (d *Provider) GetDisplayNameByAddress(ctx context.Context, addr persist.Add
 }
 
 // RefreshToken refreshes the metadata for a given token.
-func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
-	return nil
-}
-
-// DeepRefresh re-indexes a wallet address. Because we don't index Tezos ourselves, this is a no-op.
-func (p *Provider) DeepRefresh(context.Context, persist.Address) error {
+func (d *TezosTzktProvider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {
 	return nil
 }
 
 // UpdateMediaForWallet updates media for the tokens owned by a wallet on the Tezos Blockchain
-func (d *Provider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
+func (d *TezosTzktProvider) UpdateMediaForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 	return nil
 }
 
 // RefreshContract refreshes the metadata for a contract
-func (d *Provider) RefreshContract(ctx context.Context, addr persist.Address) error {
+func (d *TezosTzktProvider) RefreshContract(ctx context.Context, addr persist.Address) error {
 	return nil
 }
 
 // ValidateTokensForWallet validates tokens for a wallet address on the Tezos Blockchain
-func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.Address, all bool) error {
+func (d *TezosTzktProvider) ValidateTokensForWallet(ctx context.Context, wallet persist.Address, all bool) error {
 	return nil
 
 }
 
 // VerifySignature will verify a signature using the ed25519 algorithm
 // the address provided must be the tezos public key, not the hashed address
-func (d *Provider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
+func (d *TezosTzktProvider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
 	key, err := tezos.ParseKey(pPubKey.String())
 	if err != nil {
 		return false, err
@@ -593,7 +588,7 @@ func (d *Provider) VerifySignature(pCtx context.Context, pPubKey persist.PubKey,
 	return key.Verify(hash.Sum(nil), sig) == nil, nil
 }
 
-func (d *Provider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzktBalanceToken, mediaKey string) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+func (d *TezosTzktProvider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzktBalanceToken, mediaKey string) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
 	tzTokens = dedupeBalances(tzTokens)
 	seenContracts := map[string]bool{}
 	contractsLock := &sync.Mutex{}
@@ -680,7 +675,7 @@ func (d *Provider) tzBalanceTokensToTokens(pCtx context.Context, tzTokens []tzkt
 	}
 }
 
-func (d *Provider) makeTempMedia(ctx context.Context, tokenID persist.TokenID, contract persist.Address, agnosticMetadata persist.TokenMetadata, name string) persist.Media {
+func (d *TezosTzktProvider) makeTempMedia(ctx context.Context, tokenID persist.TokenID, contract persist.Address, agnosticMetadata persist.TokenMetadata, name string) persist.Media {
 	med := persist.Media{
 		MediaType: persist.MediaTypeSyncing,
 	}
@@ -725,7 +720,7 @@ func dedupeBalances(tzTokens []tzktBalanceToken) []tzktBalanceToken {
 	return result
 }
 
-func (d *Provider) getPublicKeyFromAddress(ctx context.Context, address persist.Address) (persist.Address, error) {
+func (d *TezosTzktProvider) getPublicKeyFromAddress(ctx context.Context, address persist.Address) (persist.Address, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/v1/accounts/%s", d.apiURL, address), nil)
 	if err != nil {
 		return "", err
@@ -752,7 +747,7 @@ func (d *Provider) getPublicKeyFromAddress(ctx context.Context, address persist.
 	return persist.Address(account.Public), nil
 }
 
-func (d *Provider) tzContractToContract(ctx context.Context, tzContract tzktContract) multichain.ChainAgnosticContract {
+func (d *TezosTzktProvider) tzContractToContract(ctx context.Context, tzContract tzktContract) multichain.ChainAgnosticContract {
 	return multichain.ChainAgnosticContract{
 		Address:        persist.Address(tzContract.Address),
 		CreatorAddress: persist.Address(tzContract.Creator.Address),


### PR DESCRIPTION
**Changes**
This PR adds the `ObjktProvider` to Tezos and also some refactoring along the way:

I broke up the multichain `ChainProvider` interface into several, smaller interfaces. This should make it easier to add new providers and also makes it easier to test specific functionality of our providers. 

I also added a generic `FallbackProvider` which calls a "backup" provider for token responses that contain no metadata, which happens semi-frequently for the tzkt API. Tezos is configured with tzkt as the main provider, and objkt as the backup. I went this route because objkt has pretty strict usage requirements and was a little worried that we'd hit their usage limits if we were to call it for each tezos sync as we do for OpenSea. Note this means that this provider only replaces tokens, it doesn't add tokens missing from the first provider as what happens with eth (but we haven't had an issue with missing tokens on tezos yet, so this should be ok)

This could be a little premature given our current scale, but luckily we can easily configure the objkt provider to be another "primary" tezos provider if we want to since it also implements the new `tokenRefresherFetcher` interface.