### PR TITLE
Scrub email and token values from email mutations

### DIFF
--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -959,6 +959,10 @@ type PageInfo struct {
 	EndCursor       string `json:"endCursor"`
 }
 
+type PreverifyEmailInput struct {
+	Email persist.Email `json:"email"`
+}
+
 type PreverifyEmailPayload struct {
 	Email  persist.Email        `json:"email"`
 	Result PreverifyEmailResult `json:"result"`
@@ -1350,6 +1354,10 @@ func (UserFollowedUsersFeedEventData) IsFeedEventData() {}
 type UsersConnection struct {
 	Edges    []*UserEdge `json:"edges"`
 	PageInfo *PageInfo   `json:"pageInfo"`
+}
+
+type VerifyEmailInput struct {
+	Token string `json:"token"`
 }
 
 type VerifyEmailPayload struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -937,9 +937,9 @@ func (r *mutationResolver) UpdateNotificationSettings(ctx context.Context, setti
 	return resolveViewerNotificationSettings(ctx)
 }
 
-func (r *mutationResolver) PreverifyEmail(ctx context.Context, email persist.Email) (model.PreverifyEmailPayloadOrError, error) {
+func (r *mutationResolver) PreverifyEmail(ctx context.Context, input model.PreverifyEmailInput) (model.PreverifyEmailPayloadOrError, error) {
 	// todo we could have the frontend send the source? right now I don't see any other sources of verification other than signing up
-	result, err := emails.PreverifyEmail(ctx, email, "signup")
+	result, err := emails.PreverifyEmail(ctx, input.Email, "signup")
 	if err != nil {
 		return nil, err
 	}
@@ -958,13 +958,13 @@ func (r *mutationResolver) PreverifyEmail(ctx context.Context, email persist.Ema
 	}
 
 	return model.PreverifyEmailPayload{
-		Email:  email,
+		Email:  input.Email,
 		Result: modelResult,
 	}, nil
 }
 
-func (r *mutationResolver) VerifyEmail(ctx context.Context, token string) (model.VerifyEmailPayloadOrError, error) {
-	return verifyEmail(ctx, token)
+func (r *mutationResolver) VerifyEmail(ctx context.Context, input model.VerifyEmailInput) (model.VerifyEmailPayloadOrError, error) {
+	return verifyEmail(ctx, input.Token)
 }
 
 func (r *mutationResolver) AddRolesToUser(ctx context.Context, username string, roles []*persist.Role) (model.AddRolesToUserPayloadOrError, error) {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -513,7 +513,7 @@ input UpdateEmailNotificationSettingsInput {
 
 input UnsubscribeFromEmailTypeInput {
     type: EmailUnsubscriptionType!
-    token: String!
+    token: String! @scrub
 }
 
 union UserByUsernameOrError = GalleryUser | ErrUserNotFound | ErrInvalidInput
@@ -1313,6 +1313,11 @@ union ViewGalleryPayloadOrError =
     ViewGalleryPayload
     | ErrAuthenticationFailed
 
+
+input VerifyEmailInput {
+    token: String! @scrub
+}
+
 type VerifyEmailPayload {
     email: Email!
 }
@@ -1320,6 +1325,10 @@ type VerifyEmailPayload {
 union VerifyEmailPayloadOrError =
     VerifyEmailPayload
     | ErrInvalidInput
+
+input PreverifyEmailInput {
+    email: Email! @scrub
+}
 
 enum PreverifyEmailResult {
     Invalid
@@ -1337,7 +1346,7 @@ union PreverifyEmailPayloadOrError =
     | ErrInvalidInput
 
 input UpdateEmailInput {
-    email: Email!
+    email: Email! @scrub
 }
 
 type UpdateEmailPayload {
@@ -1425,8 +1434,8 @@ type Mutation {
     updateNotificationSettings(settings: NotificationSettingsInput): NotificationSettings
 
 
-    preverifyEmail(email: Email!): PreverifyEmailPayloadOrError
-    verifyEmail(token: String!): VerifyEmailPayloadOrError
+    preverifyEmail(input: PreverifyEmailInput!): PreverifyEmailPayloadOrError
+    verifyEmail(input: VerifyEmailInput!): VerifyEmailPayloadOrError
 
     # Retool Specific Mutations
     addRolesToUser(username: String!, roles: [Role]): AddRolesToUserPayloadOrError @retoolAuth


### PR DESCRIPTION
Email-related mutations send tokens and email addresses that should be scrubbed. This PR adds the `@scrub` directive where necessary.

Our scrubber only handles GraphQL `Input` types, so I also updated `verifyEmail` and `preverifyEmail` to use input types. **This is a breaking change in the schema!**