### PR TITLE
no asm causing double unsub button

### DIFF
--- a/emails/send.go
+++ b/emails/send.go
@@ -210,7 +210,6 @@ func sendNotificationEmailsToAllUsers(c context.Context, queries *coredb.Queries
 
 		p.DynamicTemplateData = asMap
 
-		m.Asm = &mail.Asm{GroupID: viper.GetInt("SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID")}
 		m.AddPersonalizations(p)
 		p.AddTos(to)
 


### PR DESCRIPTION
Changes:

- **Changed** email send to not include ASM group ID so that sendgrid does not automatically send a second unsub button