### PR TITLE
artifact is better for hic et nunc [GAL-743]

### DIFF
--- a/service/media/media.go
+++ b/service/media/media.go
@@ -790,7 +790,7 @@ func (i TezImageKeywords) ForToken(tokenID persist.TokenID, contract persist.Add
 	switch contract {
 
 	case hicEtNunc:
-		return []string{"displayUri", "image", "artifactUri"}
+		return []string{"artifactUri", "displayUri", "image"}
 		// fxhash
 	case fxHash, fxHash2:
 		return []string{"displayUri", "artifactUri", "image", "uri"}


### PR DESCRIPTION
Changes:

- **Changed** hic et nunc keywords to prioritize artifact which is normally the only URI that exists for a token but is sometimes overridden by a lower quality display URI