### PR TITLE
Fix indexer race conditions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Test
         run: |
           mkdir -p /tmp/test-reports
-          gotestsum --junitfile /tmp/test-reports/integration-tests.xml -- -run TestIntegrationTest ./server/... -args -chain ethereum -chainID 1
+          gotestsum --junitfile /tmp/test-reports/integration-tests.xml -- -race -run TestIntegrationTest ./server/... -args -chain ethereum -chainID 1
       - name: "Run indexer tests"
         run: |
           mkdir -p /tmp/test-reports
-          gotestsum --junitfile /tmp/test-reports/indexer-integration-tests.xml -- ./indexer/...
+          gotestsum --junitfile /tmp/test-reports/indexer-integration-tests.xml -- -race ./indexer/...
   unit:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR fixes race conditions that popped up when running `go test -race`. All these issues were because of updating indexer state, so the changes are pretty minor. Also updated the tests to include the `-race` flag so that they'll also check for race conditions.