### PR TITLE
Don't send traces for OPTIONS requests

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -246,7 +246,9 @@ func Tracing() gin.HandlerFunc {
 		)
 
 		if c.Request.Method == "OPTIONS" {
-			// Don't sample OPTIONS requests; there's nothing to trace and they eat up our Sentry quota
+			// Don't sample OPTIONS requests; there's nothing to trace and they eat up our Sentry quota.
+			// Using a sampling decision here (instead of simply omitting the span) ensures that any
+			// child spans will also be filtered out.
 			span.Sampled = sentry.SampledFalse
 		}
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -245,6 +245,11 @@ func Tracing() gin.HandlerFunc {
 			sentry.ContinueFromRequest(c.Request),
 		)
 
+		if c.Request.Method == "OPTIONS" {
+			// Don't sample OPTIONS requests; there's nothing to trace and they eat up our Sentry quota
+			span.Sampled = sentry.SampledFalse
+		}
+
 		defer tracing.FinishSpan(span)
 
 		c.Request = c.Request.WithContext(ctx)


### PR DESCRIPTION
`OPTIONS` requests make up a lot of our Sentry traces, but they don't contain any useful data because there's nothing to trace. This PR filters them out so they won't count against our quota.