### PR TITLE
get merch tokens

### DIFF
--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -607,6 +607,7 @@ func (ErrInvalidInput) IsUserByIDOrError()                               {}
 func (ErrInvalidInput) IsUserByAddressOrError()                          {}
 func (ErrInvalidInput) IsCollectionByIDOrError()                         {}
 func (ErrInvalidInput) IsCommunityByAddressOrError()                     {}
+func (ErrInvalidInput) IsMerchTokensPayloadOrError()                     {}
 func (ErrInvalidInput) IsCreateCollectionPayloadOrError()                {}
 func (ErrInvalidInput) IsDeleteCollectionPayloadOrError()                {}
 func (ErrInvalidInput) IsUpdateCollectionInfoPayloadOrError()            {}
@@ -635,7 +636,6 @@ func (ErrInvalidInput) IsResendVerificationEmailPayloadOrError()         {}
 func (ErrInvalidInput) IsUpdateEmailNotificationSettingsPayloadOrError() {}
 func (ErrInvalidInput) IsUnsubscribeFromEmailTypePayloadOrError()        {}
 func (ErrInvalidInput) IsRedeemMerchPayloadOrError()                     {}
-func (ErrInvalidInput) IsMerchTokensPayloadOrError()                     {}
 
 type ErrInvalidToken struct {
 	Message string `json:"message"`

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -128,6 +128,11 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
+	"MerchTokensPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(MerchTokensPayloadOrError)
+		return obj, ok
+	},
+
 	"Node": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(Node)
 		return obj, ok

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -987,6 +987,18 @@ func (r *mutationResolver) RevokeRolesFromUser(ctx context.Context, username str
 	return userToModel(ctx, *user), nil
 }
 
+func (r *mutationResolver) GetMerchTokens(ctx context.Context, wallet persist.Address) (*model.MerchTokensPayload, error) {
+	tokens, err := publicapi.For(ctx).Merch.GetMerchTokens(ctx, wallet)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &model.MerchTokensPayload{
+		Tokens: tokens,
+	}
+	return output, nil
+}
+
 func (r *mutationResolver) RedeemMerch(ctx context.Context, input model.RedeemMerchInput) (model.RedeemMerchPayloadOrError, error) {
 	tokenIDList := make([]persist.TokenID, len(input.TokenIds))
 	for i, id := range input.TokenIds {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -987,18 +987,6 @@ func (r *mutationResolver) RevokeRolesFromUser(ctx context.Context, username str
 	return userToModel(ctx, *user), nil
 }
 
-func (r *mutationResolver) GetMerchTokens(ctx context.Context, wallet persist.Address) (*model.MerchTokensPayload, error) {
-	tokens, err := publicapi.For(ctx).Merch.GetMerchTokens(ctx, wallet)
-	if err != nil {
-		return nil, err
-	}
-
-	output := &model.MerchTokensPayload{
-		Tokens: tokens,
-	}
-	return output, nil
-}
-
 func (r *mutationResolver) RedeemMerch(ctx context.Context, input model.RedeemMerchInput) (model.RedeemMerchPayloadOrError, error) {
 	tokenIDList := make([]persist.TokenID, len(input.TokenIds))
 	for i, id := range input.TokenIds {
@@ -1139,6 +1127,18 @@ func (r *queryResolver) GlobalFeed(ctx context.Context, before *string, after *s
 
 func (r *queryResolver) FeedEventByID(ctx context.Context, id persist.DBID) (model.FeedEventByIDOrError, error) {
 	return resolveFeedEventByEventID(ctx, id)
+}
+
+func (r *queryResolver) GetMerchTokens(ctx context.Context, wallet persist.Address) (*model.MerchTokensPayload, error) {
+	tokens, err := publicapi.For(ctx).Merch.GetMerchTokens(ctx, wallet)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &model.MerchTokensPayload{
+		Tokens: tokens,
+	}
+	return output, nil
 }
 
 func (r *queryResolver) UsersByRole(ctx context.Context, role persist.Role, before *string, after *string, first *int, last *int) (*model.UsersConnection, error) {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1413,6 +1413,27 @@ union RedeemMerchPayloadOrError =
     RedeemMerchPayload
     | ErrInvalidInput
 
+enum MerchType {
+    TShirt
+    Hat
+    Card
+}
+
+type MerchToken {
+    tokenId: String!
+    objectType: MerchType!
+    discountCode: String
+    redeemed: Boolean!
+}
+
+type MerchTokensPayload {
+    tokens: [MerchToken!]
+}
+
+union MerchTokensPayloadOrError =
+    MerchTokensPayload
+    | ErrInvalidInput
+
 type Mutation {
     # User Mutations
     addUserWallet(chainAddress: ChainAddressInput!, authMechanism: AuthMechanism!): AddUserWalletPayloadOrError @authRequired
@@ -1469,7 +1490,8 @@ type Mutation {
     # Retool Specific Mutations
     addRolesToUser(username: String!, roles: [Role]): AddRolesToUserPayloadOrError @retoolAuth
     revokeRolesFromUser(username: String!, roles: [Role]): RevokeRolesFromUserPayloadOrError @retoolAuth
-
+    
+    getMerchTokens(wallet: Address!): MerchTokensPayload
     redeemMerch(input: RedeemMerchInput!): RedeemMerchPayloadOrError @authRequired
 }
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -756,6 +756,25 @@ enum Role {
     BETA_TESTER
 }
 
+enum MerchType {
+  TShirt
+  Hat
+  Card
+}
+
+type MerchToken {
+  tokenId: String!
+  objectType: MerchType!
+  discountCode: String
+  redeemed: Boolean!
+}
+
+type MerchTokensPayload {
+  tokens: [MerchToken!]
+}
+
+union MerchTokensPayloadOrError = MerchTokensPayload | ErrInvalidInput
+
 type Query {
     node(id: ID!): Node
     viewer: ViewerOrError @authRequired
@@ -773,6 +792,7 @@ type Query {
     galleryOfTheWeekWinners: [GalleryUser!]
     globalFeed(before: String, after: String, first: Int, last: Int): FeedConnection
     feedEventById(id: DBID!): FeedEventByIdOrError
+    getMerchTokens(wallet: Address!): MerchTokensPayload
 
     # Retool Specific
     usersByRole(role: Role!, before: String, after: String, first: Int, last: Int): UsersConnection @retoolAuth
@@ -1413,27 +1433,6 @@ union RedeemMerchPayloadOrError =
     RedeemMerchPayload
     | ErrInvalidInput
 
-enum MerchType {
-    TShirt
-    Hat
-    Card
-}
-
-type MerchToken {
-    tokenId: String!
-    objectType: MerchType!
-    discountCode: String
-    redeemed: Boolean!
-}
-
-type MerchTokensPayload {
-    tokens: [MerchToken!]
-}
-
-union MerchTokensPayloadOrError =
-    MerchTokensPayload
-    | ErrInvalidInput
-
 type Mutation {
     # User Mutations
     addUserWallet(chainAddress: ChainAddressInput!, authMechanism: AuthMechanism!): AddUserWalletPayloadOrError @authRequired
@@ -1490,8 +1489,7 @@ type Mutation {
     # Retool Specific Mutations
     addRolesToUser(username: String!, roles: [Role]): AddRolesToUserPayloadOrError @retoolAuth
     revokeRolesFromUser(username: String!, roles: [Role]): RevokeRolesFromUserPayloadOrError @retoolAuth
-    
-    getMerchTokens(wallet: Address!): MerchTokensPayload
+
     redeemMerch(input: RedeemMerchInput!): RedeemMerchPayloadOrError @authRequired
 }
 

--- a/service/multichain/poap/poap.go
+++ b/service/multichain/poap/poap.go
@@ -183,6 +183,11 @@ func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddre
 	return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("poap has no way to retrieve tokens by contract address")
 }
 
+// GetTokensByContractAddressAndOwner retrieves tokens for a contract address with owner on the Poap Blockchain
+func (d *Provider) GetTokensByContractAddressAndOwner(ctx context.Context, owner, contractAddress persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("poap has no way to retrieve tokens by contract address")
+}
+
 func (d *Provider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, limit, offset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/events/%s", d.apiURL, contractAddress), nil)
 	if err != nil {


### PR DESCRIPTION
Changes:

- **Added** query for getting merch tokens and redeemed status
- **Added** multichain function for getting tokens of contract owned by a given wallet which required some changes, most notably to the `(*multichain.Provider).upsertTokens` function. In the dedupe step, there is now a final optional step that will include every one of a user's current tokens so that we can upsert small chunks of tokens without messing up a user's full list of tokens. This will basically make the upsert append/update only, no tokens will get removed. This optional step should only occur when we are searching for and updating a sub-section of a user's tokens, where as with a full sync, we do not want to include a user's current tokens in the upsert because some tokens may have been transferred out. In this case, we want the providers to be the source of truth.