### PR TITLE
Add --enable-rpc flag to entrypoint

### DIFF
--- a/docker/indexer_api/Dockerfile
+++ b/docker/indexer_api/Dockerfile
@@ -23,4 +23,4 @@ ENV VERSION=$VERSION
 
 EXPOSE 6000
 USER nobody
-ENTRYPOINT ["./bin/indexer", "server"]
+ENTRYPOINT ["./bin/indexer", "server", "--enable-rpc"]


### PR DESCRIPTION
We always want RPC enabled for the indexer server, even on `dev`.