### PR TITLE
use one of the fonts we use for ens

### DIFF
--- a/indexer/metadatas.go
+++ b/indexer/metadatas.go
@@ -399,7 +399,7 @@ func ens(ctx context.Context, turi persist.TokenURI, addr persist.EthereumAddres
 	canvas.Square(0, 0, width, canvas.RGB(255, 255, 255))
 	result := domain.LabelName + ".eth"
 
-	canvas.Text(width/2, height/2, result, `font-size="16px"`, `text-anchor="middle"`, `alignment-baseline="middle"`)
+	canvas.Text(width/2, height/2, result, `font-size="16px"`, `text-anchor="middle"`, `alignment-baseline="middle"`, `font-family="Helvetica Neue"`)
 
 	canvas.End()
 


### PR DESCRIPTION
Changes:

- **Changed** ens handler to use `Helvetica Neue` which we seem to use on the frontend and does not require any fancy font hosting because it is default in most browsers.