### PR TITLE
Trim collection names

### DIFF
--- a/publicapi/collection.go
+++ b/publicapi/collection.go
@@ -135,7 +135,7 @@ func (api CollectionAPI) CreateCollection(ctx context.Context, galleryID persist
 	}
 
 	// Sanitize
-	name = validate.SanitizationPolicy.Sanitize(name)
+	name = validate.SanitizationPolicy.Sanitize(strings.TrimSpace(name))
 	collectorsNote = validate.SanitizationPolicy.Sanitize(collectorsNote)
 
 	userID, err := getAuthenticatedUser(ctx)


### PR DESCRIPTION
This PR trims leading and trailing whitespace chars from the collection name input.