### PR TITLE
Add GetTokensByContractAddressAndOwner to fallback provider

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -1235,6 +1235,15 @@ func (f FallbackProvider) GetTokensByTokenIdentifiersAndOwner(ctx context.Contex
 	return token, contract, nil
 }
 
+func (f FallbackProvider) GetTokensByContractAddressAndOwner(ctx context.Context, owner persist.Address, contractAddress persist.Address, limit int, offset int) ([]ChainAgnosticToken, ChainAgnosticContract, error) {
+	tokens, contract, err := f.Primary.GetTokensByContractAddressAndOwner(ctx, owner, contractAddress, limit, offset)
+	if err != nil {
+		return nil, ChainAgnosticContract{}, err
+	}
+	tokens = f.resolveTokens(ctx, tokens)
+	return tokens, contract, err
+}
+
 func (f FallbackProvider) resolveTokens(ctx context.Context, tokens []ChainAgnosticToken) []ChainAgnosticToken {
 	usableTokens := make([]ChainAgnosticToken, len(tokens))
 	var wg sync.WaitGroup


### PR DESCRIPTION
Tezos syncs were silently skipped because the provider for Tezos, `FallbackProvider` didn't implement the `tokensfetcher` interface which is required to run syncs. This PR adds `GetTokensByContractAddressAndOwner` so that it conforms to the interface.

Will follow up with a PR to validate our multichain configuration so that it fails if we don't have at least one valid `tokensfetcher` to use.