### PR TITLE
Unlock throttler after syncs

### DIFF
--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -46,6 +46,7 @@ func processMediaForUsersTokensOfChain(tokenRepo *postgres.TokenGalleryRepositor
 			util.ErrResponse(c, http.StatusOK, err)
 			return
 		}
+		defer throttler.Unlock(ctx, input.UserID.String())
 
 		allTokens, err := tokenRepo.GetByUserID(ctx, input.UserID, -1, -1)
 		if err != nil {

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -97,7 +97,7 @@ func setDefaults() {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"
-		if len(os.Args) > 0 {
+		if len(os.Args) > 1 {
 			fi = os.Args[1]
 		}
 		envFile := util.ResolveEnvFile("tokenprocessing", fi)


### PR DESCRIPTION
Realized after digging through the logs and the db tokens get stuck in `syncing` when a user tries to sync shortly after the first sync (they add a new wallet for example). There are two locks involved in syncs: one managed by the backend that has a 5 minute TTL, and the other managed by tokenprocessing that has a 30 minute TTL which only gets released after it expires.

what was happening:
```
* user syncs
* backend acquires lock (ttl 5 min)
* new tokens found and set to `syncing`
* backend sends message to tokenprocessing
* backend releases lock

* tokenprocessing gets lock for user (ttl 30 min)
* tokens get proccesed
```
then 10 minutes later the user tries to sync again:
```
* backend acquires lock (ttl 5 min)
* new tokens found and set to `syncing`
* backend sends message to tokenprocessing
* backend releases lock

* tokenprocessing fails to acquire lock because lock wasn't freed by first sync
* tokens stuck in `syncing` state
```