### PR TITLE
Fix syncTokensForUsername for Retool and deprecate old admin behavior

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -569,7 +569,7 @@ type ComplexityRoot struct {
 		ResendVerificationEmail         func(childComplexity int) int
 		RevokeRolesFromUser             func(childComplexity int, username string, roles []*persist.Role) int
 		SetSpamPreference               func(childComplexity int, input model.SetSpamPreferenceInput) int
-		SyncTokens                      func(childComplexity int, chains []persist.Chain, userID *persist.DBID) int
+		SyncTokens                      func(childComplexity int, chains []persist.Chain) int
 		SyncTokensForUsername           func(childComplexity int, username string, chains []persist.Chain) int
 		UnfollowUser                    func(childComplexity int, userID persist.DBID) int
 		UnsubscribeFromEmailType        func(childComplexity int, input model.UnsubscribeFromEmailTypeInput) int
@@ -1067,7 +1067,7 @@ type MutationResolver interface {
 	UpdateCollectionHidden(ctx context.Context, input model.UpdateCollectionHiddenInput) (model.UpdateCollectionHiddenPayloadOrError, error)
 	UpdateTokenInfo(ctx context.Context, input model.UpdateTokenInfoInput) (model.UpdateTokenInfoPayloadOrError, error)
 	SetSpamPreference(ctx context.Context, input model.SetSpamPreferenceInput) (model.SetSpamPreferencePayloadOrError, error)
-	SyncTokens(ctx context.Context, chains []persist.Chain, userID *persist.DBID) (model.SyncTokensPayloadOrError, error)
+	SyncTokens(ctx context.Context, chains []persist.Chain) (model.SyncTokensPayloadOrError, error)
 	RefreshToken(ctx context.Context, tokenID persist.DBID) (model.RefreshTokenPayloadOrError, error)
 	RefreshCollection(ctx context.Context, collectionID persist.DBID) (model.RefreshCollectionPayloadOrError, error)
 	RefreshContract(ctx context.Context, contractID persist.DBID) (model.RefreshContractPayloadOrError, error)
@@ -3155,7 +3155,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.SyncTokens(childComplexity, args["chains"].([]persist.Chain), args["userID"].(*persist.DBID)), true
+		return e.complexity.Mutation.SyncTokens(childComplexity, args["chains"].([]persist.Chain)), true
 
 	case "Mutation.syncTokensForUsername":
 		if e.complexity.Mutation.SyncTokensForUsername == nil {
@@ -5726,7 +5726,7 @@ enum MerchType {
 }
 
 type MerchToken @goGqlId(fields: ["tokenId"]) {
-  id: ID! 
+  id: ID!
   tokenId: String!
   objectType: MerchType!
   discountCode: String
@@ -6439,7 +6439,7 @@ type Mutation {
     updateTokenInfo(input: UpdateTokenInfoInput!): UpdateTokenInfoPayloadOrError @authRequired
     setSpamPreference(input: SetSpamPreferenceInput!): SetSpamPreferencePayloadOrError @authRequired
 
-    syncTokens(chains: [Chain!], userID: DBID): SyncTokensPayloadOrError @authRequired
+    syncTokens(chains: [Chain!]): SyncTokensPayloadOrError @authRequired
     refreshToken(tokenId: DBID!): RefreshTokenPayloadOrError
     refreshCollection(collectionId: DBID!): RefreshCollectionPayloadOrError
     refreshContract(contractId: DBID!): RefreshContractPayloadOrError
@@ -7267,15 +7267,6 @@ func (ec *executionContext) field_Mutation_syncTokens_args(ctx context.Context, 
 		}
 	}
 	args["chains"] = arg0
-	var arg1 *persist.DBID
-	if tmp, ok := rawArgs["userID"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("userID"))
-		arg1, err = ec.unmarshalODBID2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["userID"] = arg1
 	return args, nil
 }
 
@@ -16318,7 +16309,7 @@ func (ec *executionContext) _Mutation_syncTokens(ctx context.Context, field grap
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		directive0 := func(rctx context.Context) (interface{}, error) {
 			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.Mutation().SyncTokens(rctx, args["chains"].([]persist.Chain), args["userID"].(*persist.DBID))
+			return ec.resolvers.Mutation().SyncTokens(rctx, args["chains"].([]persist.Chain))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.AuthRequired == nil {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -995,6 +995,7 @@ func (r *mutationResolver) SyncTokens(ctx context.Context, chains []persist.Chai
 	if chains == nil || len(chains) == 0 {
 		chains = []persist.Chain{persist.ChainETH}
 	}
+
 	err := api.Token.SyncTokens(ctx, chains)
 	if err != nil {
 		return nil, err

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -615,6 +615,24 @@ func (r *mutationResolver) SetSpamPreference(ctx context.Context, input model.Se
 	return model.SetSpamPreferencePayload{Tokens: tokens}, nil
 }
 
+func (r *mutationResolver) SyncTokens(ctx context.Context, chains []persist.Chain) (model.SyncTokensPayloadOrError, error) {
+	api := publicapi.For(ctx)
+
+	if chains == nil || len(chains) == 0 {
+		chains = []persist.Chain{persist.ChainETH}
+	}
+
+	err := api.Token.SyncTokens(ctx, chains)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &model.SyncTokensPayload{
+		Viewer: resolveViewer(ctx),
+	}
+
+	return output, nil
+}
 
 func (r *mutationResolver) RefreshToken(ctx context.Context, tokenID persist.DBID) (model.RefreshTokenPayloadOrError, error) {
 	api := publicapi.For(ctx)
@@ -987,25 +1005,6 @@ func (r *mutationResolver) RevokeRolesFromUser(ctx context.Context, username str
 	}
 
 	return userToModel(ctx, *user), nil
-}
-
-func (r *mutationResolver) SyncTokens(ctx context.Context, chains []persist.Chain, userID *persist.DBID) (model.SyncTokensPayloadOrError, error) {
-	api := publicapi.For(ctx)
-
-	if chains == nil || len(chains) == 0 {
-		chains = []persist.Chain{persist.ChainETH}
-	}
-
-	err := api.Token.SyncTokens(ctx, chains)
-	if err != nil {
-		return nil, err
-	}
-
-	output := &model.SyncTokensPayload{
-		Viewer: resolveViewer(ctx),
-	}
-
-	return output, nil
 }
 
 func (r *mutationResolver) SyncTokensForUsername(ctx context.Context, username string, chains []persist.Chain) (model.SyncTokensForUsernamePayloadOrError, error) {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -615,23 +615,6 @@ func (r *mutationResolver) SetSpamPreference(ctx context.Context, input model.Se
 	return model.SetSpamPreferencePayload{Tokens: tokens}, nil
 }
 
-func (r *mutationResolver) SyncTokens(ctx context.Context, chains []persist.Chain, userID *persist.DBID) (model.SyncTokensPayloadOrError, error) {
-	api := publicapi.For(ctx)
-
-	if chains == nil || len(chains) == 0 {
-		chains = []persist.Chain{persist.ChainETH}
-	}
-	err := api.Token.SyncTokens(ctx, chains, userID)
-	if err != nil {
-		return nil, err
-	}
-
-	output := &model.SyncTokensPayload{
-		Viewer: resolveViewer(ctx),
-	}
-
-	return output, nil
-}
 
 func (r *mutationResolver) RefreshToken(ctx context.Context, tokenID persist.DBID) (model.RefreshTokenPayloadOrError, error) {
 	api := publicapi.For(ctx)
@@ -1006,6 +989,24 @@ func (r *mutationResolver) RevokeRolesFromUser(ctx context.Context, username str
 	return userToModel(ctx, *user), nil
 }
 
+func (r *mutationResolver) SyncTokens(ctx context.Context, chains []persist.Chain, userID *persist.DBID) (model.SyncTokensPayloadOrError, error) {
+	api := publicapi.For(ctx)
+
+	if chains == nil || len(chains) == 0 {
+		chains = []persist.Chain{persist.ChainETH}
+	}
+	err := api.Token.SyncTokens(ctx, chains)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &model.SyncTokensPayload{
+		Viewer: resolveViewer(ctx),
+	}
+
+	return output, nil
+}
+
 func (r *mutationResolver) SyncTokensForUsername(ctx context.Context, username string, chains []persist.Chain) (model.SyncTokensForUsernamePayloadOrError, error) {
 	api := publicapi.For(ctx)
 
@@ -1019,7 +1020,7 @@ func (r *mutationResolver) SyncTokensForUsername(ctx context.Context, username s
 		chains = []persist.Chain{persist.ChainETH}
 	}
 
-	err = api.Token.SyncTokens(ctx, chains, &user.ID)
+	err = api.Token.SyncTokensAdmin(ctx, chains, user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -766,7 +766,7 @@ enum MerchType {
 }
 
 type MerchToken @goGqlId(fields: ["tokenId"]) {
-  id: ID! 
+  id: ID!
   tokenId: String!
   objectType: MerchType!
   discountCode: String
@@ -1479,7 +1479,7 @@ type Mutation {
     updateTokenInfo(input: UpdateTokenInfoInput!): UpdateTokenInfoPayloadOrError @authRequired
     setSpamPreference(input: SetSpamPreferenceInput!): SetSpamPreferencePayloadOrError @authRequired
 
-    syncTokens(chains: [Chain!], userID: DBID): SyncTokensPayloadOrError @authRequired
+    syncTokens(chains: [Chain!]): SyncTokensPayloadOrError @authRequired
     refreshToken(tokenId: DBID!): RefreshTokenPayloadOrError
     refreshCollection(collectionId: DBID!): RefreshCollectionPayloadOrError
     refreshContract(contractId: DBID!): RefreshContractPayloadOrError


### PR DESCRIPTION
Since we're moving to Retool for admin-esque things. I've separated out the logic for syncing tokens based on the use case.

1. Syncing tokens as an admin (from Retool). Takes a username and is assumed to be authenticated by the time you're in that context.
2. Syncing tokens as a user. This mutation should not take a `userId`. Totally made sense before when we didn't have Retool.

This is technically a breaking change (removing a parameter from a mutation) but we're not actually using it on the frontend so I'm not super concerned.