### PR TITLE
trim space and un escape svg

### DIFF
--- a/service/media/media.go
+++ b/service/media/media.go
@@ -363,8 +363,8 @@ func remapPaths(mediaURL string) string {
 }
 
 func remapMedia(media persist.Media) persist.Media {
-	media.MediaURL = persist.NullString(remapPaths(media.MediaURL.String()))
-	media.ThumbnailURL = persist.NullString(remapPaths(media.ThumbnailURL.String()))
+	media.MediaURL = persist.NullString(remapPaths(strings.TrimSpace(media.MediaURL.String())))
+	media.ThumbnailURL = persist.NullString(remapPaths(strings.TrimSpace(media.ThumbnailURL.String())))
 	return media
 }
 

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -538,6 +538,11 @@ func GetDataFromURIAsReader(ctx context.Context, turi persist.TokenURI, ipfsClie
 
 		return util.NewFileHeaderReader(resp), nil
 	case persist.URITypeJSON, persist.URITypeSVG:
+		// query unescape asString first
+		asString, err := url.QueryUnescape(asString)
+		if err != nil {
+			return nil, err
+		}
 		idx := strings.IndexByte(asString, ',')
 		if idx == -1 {
 			buf := bytes.NewBuffer(util.RemoveBOM([]byte(asString)))


### PR DESCRIPTION
Changes:

- **Added** a space trim to the final media URLs because the browser freaks out when there is trailing space on an image url
- **Added** an unescape to SVGs because often times svgs will be query escaped in the token URI (have to test that this does not affect the already unescaped svgs before merging)