### PR TITLE
have gcp manage secret access by pushing into env

### DIFF
--- a/publicapi/merch.go
+++ b/publicapi/merch.go
@@ -17,7 +17,6 @@ import (
 	"github.com/spf13/viper"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
-	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"cloud.google.com/go/storage"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -283,14 +282,12 @@ func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.Tok
 	}
 
 	if chainID.Cmp(big.NewInt(1)) == 0 && viper.GetString("ENV") == "production" {
-		privateKey, err := api.secrets.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{
-			Name: "backend-eth-private-key",
-		})
+		privateKey := viper.GetString("ETH_PRIVATE_KEY")
 		if err != nil {
 			return nil, err
 		}
 
-		key, err := x509.ParseECPrivateKey(privateKey.Payload.Data)
+		key, err := x509.ParseECPrivateKey([]byte(privateKey))
 		if err != nil {
 			return nil, err
 		}

--- a/publicapi/merch.go
+++ b/publicapi/merch.go
@@ -2,7 +2,6 @@ package publicapi
 
 import (
 	"context"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -20,6 +19,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-playground/validator/v10"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
@@ -287,7 +287,7 @@ func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.Tok
 			return nil, err
 		}
 
-		key, err := x509.ParseECPrivateKey([]byte(privateKey))
+		key, err := crypto.HexToECDSA(privateKey)
 		if err != nil {
 			return nil, err
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -104,6 +104,7 @@ func CoreInit(pqClient *sql.DB, pgx *pgxpool.Pool) *gin.Engine {
 	}
 	taskClient := task.NewClient(context.Background())
 	secretClient := newSecretsClient()
+
 	lock := redis.NewLockClient(redis.NotificationLockDB)
 
 	graphqlAPQCache := redis.NewCache(redis.GraphQLAPQ)
@@ -124,6 +125,7 @@ func newSecretsClient() *secretmanager.Client {
 	if err != nil {
 		panic(fmt.Sprintf("error creating secrets client: %v", err))
 	}
+
 	return c
 }
 
@@ -176,6 +178,7 @@ func setDefaults() {
 	viper.SetDefault("RETOOL_AUTH_TOKEN", "TEST_TOKEN")
 	viper.SetDefault("BACKEND_SECRET", "BACKEND_SECRET")
 	viper.SetDefault("MERCH_CONTRACT_ADDRESS", "0x01f55be815fbd10b1770b008b8960931a30e7f65")
+	viper.SetDefault("ETH_PRIVATE_KEY", "")
 
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
Changes:

- **Changed** redeem token to not use secret manager but use env instead because cloud run will now be using secret manager to put the key into the env