### PR TITLE
no upsert if user does not exist

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -507,6 +507,9 @@ func (p *Provider) GetTokensOfContractForWallet(ctx context.Context, contractAdd
 
 	user, err := p.Repos.UserRepository.GetByChainAddress(ctx, wallet)
 	if err != nil {
+		if _, ok := err.(persist.ErrWalletNotFound); ok {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Changes:

- **Changed** the `GetTokensOfContractForWallet` multichain function to not upsert tokens if there is no gallery user that owns the tokens (because the token requires an `owner_user_id` field)

The purpose of the upsert was just to take advantage of the fact that we are receiving up to date information from a provider and we might as well update our version of the token to optimistically keep it up to date, but it is not a necessary step in this function.