### PR TITLE
Change subscription expiration from 31 days to 3 days

### DIFF
--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -260,7 +260,8 @@ func (h viewedNotificationHandler) Handle(ctx context.Context, notif db.Notifica
 
 func (n *NotificationHandlers) receiveNewNotificationsFromPubSub() {
 	sub, err := n.pubSub.CreateSubscription(context.Background(), fmt.Sprintf("new-notifications-%s", persist.GenerateID()), pubsub.SubscriptionConfig{
-		Topic: n.pubSub.Topic(viper.GetString("PUBSUB_TOPIC_NEW_NOTIFICATIONS")),
+		Topic:            n.pubSub.Topic(viper.GetString("PUBSUB_TOPIC_NEW_NOTIFICATIONS")),
+		ExpirationPolicy: time.Hour * 24 * 3,
 	})
 	if err != nil {
 		logger.For(nil).Errorf("error creating updated notifications subscription: %s", err)
@@ -303,7 +304,8 @@ func (n *NotificationHandlers) receiveNewNotificationsFromPubSub() {
 
 func (n *NotificationHandlers) receiveUpdatedNotificationsFromPubSub() {
 	sub, err := n.pubSub.CreateSubscription(context.Background(), fmt.Sprintf("updated-notifications-%s", persist.GenerateID()), pubsub.SubscriptionConfig{
-		Topic: n.pubSub.Topic(viper.GetString("PUBSUB_TOPIC_UPDATED_NOTIFICATIONS")),
+		Topic:            n.pubSub.Topic(viper.GetString("PUBSUB_TOPIC_UPDATED_NOTIFICATIONS")),
+		ExpirationPolicy: time.Hour * 24 * 3,
 	})
 	if err != nil {
 		logger.For(nil).Errorf("error creating updated notifications subscription: %s", err)

--- a/service/pubsub/gcp/pubsub.go
+++ b/service/pubsub/gcp/pubsub.go
@@ -61,8 +61,9 @@ func (g *PubSub) Publish(pCtx context.Context, topicName string, message []byte,
 func (g *PubSub) Subscribe(pCtx context.Context, topicName string, handler func(context.Context, []byte) error) error {
 
 	sub, err := g.pubsub.CreateSubscription(pCtx, topicName, pubsub.SubscriptionConfig{
-		Topic:       g.pubsub.Topic(topicName),
-		AckDeadline: time.Second * 10,
+		Topic:            g.pubsub.Topic(topicName),
+		AckDeadline:      time.Second * 10,
+		ExpirationPolicy: time.Hour * 24 * 3,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Background:
Whenever a backend instance starts, it creates a new subscription to the notification pubsub topics so that it can receive notifications published by other instances. However, there is a quota limit of 10,000 subscriptions per project: https://cloud.google.com/pubsub/quotas. I noticed that the dev backend was failing to start because we had already exceeded the quota for that project. 

This PR reduces the expiration of a subscription from 31 days to 3 days. This means that if a subscriber hasn't consumed from that subscription in 3 days, that subscription will be deleted. In the future, I think we can look into re-using subscriptions or cleaning up the subscription when the server spins down.