### PR TITLE
conditional update, correct resolver, correct sql var names [GAL-1693]

### DIFF
--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -646,7 +646,7 @@ update galleries g set position = updates.position, last_updated = now() from up
 update galleries set name = @name, description = @description, last_updated = now() where id = @id and deleted = false;
 
 -- name: UpdateGallery :exec
-update galleries set name = @name, description = @description, collections = @collections, last_updated = now() where galleries.id = @id and galleries.deleted = false and (select count(*) from collections c where c.id = any(@collections) and c.gallery_id = @gallery_id and c.deleted = false) = coalesce(array_length(@collections, 1), 0);
+update galleries set name = case when @name_updated::bool then @name else name end, description = case when @description_updated::bool then @description else description end, collections = case when @collections_updated::bool then @collections else collections end, last_updated = now() where galleries.id = @gallery_id and galleries.deleted = false and (select count(*) from collections c where c.id = any(@collections) and c.gallery_id = @gallery_id and c.deleted = false) = cardinality(@collections);
 
 -- name: UpdateUserFeaturedGallery :exec
 update users set featured_gallery = @gallery_id, last_updated = now() from galleries where users.id = @user_id and galleries.id = @gallery_id and galleries.owner_user_id = @user_id and galleries.deleted = false;
@@ -670,4 +670,4 @@ update collections c set collectors_note = updates.collectors_note, layout = upd
 update collections set nfts = @nfts, last_updated = now() where id = @id and deleted = false;
 
 -- name: CreateCollection :one
-insert into collections (id, version, name, collectors_note, owner_user_id, gallery_id, layout, nfts, hidden, token_settings, created_at, last_updated) values (@id, 0, @name, @collectors_note, @owner_user_id, @gallery_id, @layout, @nfts, @hidden, @token_settings, now(), now()) on conflict (id) do update set version = excluded.version, name = excluded.name, collectors_note = excluded.collectors_note, owner_user_id = excluded.owner_user_id, gallery_id = excluded.gallery_id, layout = excluded.layout, nfts = excluded.nfts, hidden = excluded.hidden, token_settings = excluded.token_settings, last_updated = excluded.last_updated returning id;
+insert into collections (id, version, name, collectors_note, owner_user_id, gallery_id, layout, nfts, hidden, token_settings, created_at, last_updated) values (@id, 0, @name, @collectors_note, @owner_user_id, @gallery_id, @layout, @nfts, @hidden, @token_settings, now(), now()) returning id;

--- a/go.mod
+++ b/go.mod
@@ -65,10 +65,7 @@ require (
 
 require golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
 
-require (
-	github.com/mitchellh/mapstructure v1.4.3
-	gotest.tools v2.2.0+incompatible
-)
+require github.com/Khan/genqlient v0.5.0
 
 require (
 	cloud.google.com/go v0.105.0 // indirect
@@ -76,11 +73,8 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.1 // indirect
 	cloud.google.com/go/iam v0.7.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
-	github.com/Khan/genqlient v0.5.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
-	github.com/alexflint/go-arg v1.4.2 // indirect
-	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
@@ -154,6 +148,7 @@ require (
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,6 @@ cloud.google.com/go/storage v1.27.0/go.mod h1:x9DOL8TK/ygDUMieqwfhdpQryTeEkhGKMi
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
-github.com/99designs/gqlgen v0.17.1 h1:i2qQMPKHQjHgBWYIpO4TsaQpPqMHCPK1+h95ipvH8VU=
-github.com/99designs/gqlgen v0.17.1/go.mod h1:K5fzLKwtph+FFgh9j7nFbRUdBKvTcGnsta51fsMTn3o=
 github.com/99designs/gqlgen v0.17.2 h1:yczvlwMsfcVu/JtejqfrLwXuSP0yZFhmcss3caEvHw8=
 github.com/99designs/gqlgen v0.17.2/go.mod h1:K5fzLKwtph+FFgh9j7nFbRUdBKvTcGnsta51fsMTn3o=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
@@ -178,10 +176,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alexflint/go-arg v1.4.2 h1:lDWZAXxpAnZUq4qwb86p/3rIJJ2Li81EoMbTMujhVa0=
 github.com/alexflint/go-arg v1.4.2/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
-github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
@@ -1551,8 +1547,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vektah/gqlparser/v2 v2.4.0/go.mod h1:flJWIR04IMQPGz+BXLrORkrARBxv/rtyIAFvd/MceW0=
-github.com/vektah/gqlparser/v2 v2.4.1 h1:QOyEn8DAPMUMARGMeshKDkDgNmVoEaEGiDB0uWxcSlQ=
-github.com/vektah/gqlparser/v2 v2.4.1/go.mod h1:flJWIR04IMQPGz+BXLrORkrARBxv/rtyIAFvd/MceW0=
 github.com/vektah/gqlparser/v2 v2.4.5 h1:C02NsyEsL4TXJB7ndonqTfuQOL4XPIu0aAWugdmTgmc=
 github.com/vektah/gqlparser/v2 v2.4.5/go.mod h1:flJWIR04IMQPGz+BXLrORkrARBxv/rtyIAFvd/MceW0=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -6859,7 +6859,7 @@ input UpdateGalleryInput {
 
   deletedCollections: [DBID!]
 
-  updateCollections: [UpdateCollectionInput]
+  updatedCollections: [UpdateCollectionInput]
   createdCollections: [CreateCollectionInGalleryInput]
 
   order: [DBID!]
@@ -28712,11 +28712,11 @@ func (ec *executionContext) unmarshalInputUpdateGalleryInput(ctx context.Context
 			if err != nil {
 				return it, err
 			}
-		case "updateCollections":
+		case "updatedCollections":
 			var err error
 
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("updateCollections"))
-			it.UpdateCollections, err = ec.unmarshalOUpdateCollectionInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐUpdateCollectionInput(ctx, v)
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("updatedCollections"))
+			it.UpdatedCollections, err = ec.unmarshalOUpdateCollectionInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐUpdateCollectionInput(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1523,7 +1523,7 @@ type UpdateGalleryInput struct {
 	Description        *string                           `json:"description"`
 	Caption            *string                           `json:"caption"`
 	DeletedCollections []persist.DBID                    `json:"deletedCollections"`
-	UpdateCollections  []*UpdateCollectionInput          `json:"updateCollections"`
+	UpdatedCollections []*UpdateCollectionInput          `json:"updatedCollections"`
 	CreatedCollections []*CreateCollectionInGalleryInput `json:"createdCollections"`
 	Order              []persist.DBID                    `json:"order"`
 }

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -372,10 +372,19 @@ func resolveCollectionTokenByIDs(ctx context.Context, tokenID persist.DBID, coll
 }
 
 func resolveGalleryByGalleryID(ctx context.Context, galleryID persist.DBID) (*model.Gallery, error) {
+	dbGal, err := publicapi.For(ctx).Gallery.GetGalleryById(ctx, galleryID)
+	if err != nil {
+		return nil, err
+	}
 	gallery := &model.Gallery{
-		Dbid:        galleryID,
-		Owner:       nil, // handled by dedicated resolver
-		Collections: nil, // handled by dedicated resolver
+		Dbid:          galleryID,
+		Name:          &dbGal.Name,
+		Description:   &dbGal.Description,
+		Position:      &dbGal.Position,
+		Hidden:        &dbGal.Hidden,
+		TokenPreviews: nil, // handled by dedicated resolver
+		Owner:         nil, // handled by dedicated resolver
+		Collections:   nil, // handled by dedicated resolver
 	}
 
 	return gallery, nil

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1647,7 +1647,7 @@ input UpdateGalleryInput {
 
   deletedCollections: [DBID!]
 
-  updateCollections: [UpdateCollectionInput]
+  updatedCollections: [UpdateCollectionInput]
   createdCollections: [CreateCollectionInGalleryInput]
 
   order: [DBID!]

--- a/publicapi/gallery.go
+++ b/publicapi/gallery.go
@@ -109,8 +109,8 @@ func (api GalleryAPI) UpdateGallery(ctx context.Context, update model.UpdateGall
 
 	// update collections
 
-	if len(update.UpdateCollections) > 0 {
-		err = updateCollectionsInfoAndTokens(ctx, q, update.UpdateCollections)
+	if len(update.UpdatedCollections) > 0 {
+		err = updateCollectionsInfoAndTokens(ctx, q, update.UpdatedCollections)
 		if err != nil {
 			return db.Gallery{}, err
 		}
@@ -143,12 +143,17 @@ func (api GalleryAPI) UpdateGallery(ctx context.Context, update model.UpdateGall
 		}
 	}
 
-	err = q.UpdateGallery(ctx, db.UpdateGalleryParams{
-		ID:          update.GalleryID,
-		Name:        util.FromPointer(update.Name),
-		Description: util.FromPointer(update.Description),
-		Collections: update.Order,
-	})
+	params := db.UpdateGalleryParams{
+		GalleryID: update.GalleryID,
+	}
+
+	asList := persist.DBIDList(update.Order)
+
+	setConditionalValue(update.Name, &params.Name, &params.NameUpdated)
+	setConditionalValue(update.Description, &params.Description, &params.DescriptionUpdated)
+	setConditionalValue(&asList, &params.Collections, &params.CollectionsUpdated)
+
+	err = q.UpdateGallery(ctx, params)
 	if err != nil {
 		return db.Gallery{}, err
 	}

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -189,3 +189,12 @@ func pushEvent(ctx context.Context, evt db.Event) {
 		sentryutil.ReportError(ctx, err)
 	}
 }
+
+func setConditionalValue[T any](value *T, param *T, conditional *bool) {
+	if value != nil {
+		*param = *value
+		*conditional = true
+	} else {
+		*conditional = false
+	}
+}


### PR DESCRIPTION
Changes:

- **Changed** schema typo for `updatedCollections` field on update gallery input
- **Changed** sql var names in query for updating gallery to not use two versions of the gallery id (`id` and `gallery_id` were the same thing but only one was being set correctly)
- **Changed** sql query for updating gallery to use conditional logic for updating fields to only update the field if the field passed in was not null
- **Changed** `resolveGalleryByGalleryID` to actually resolve the new fields that are not resolved by other resolvers, fixing the bug where an update might occur correctly but the payload response for the update would not include the updated fields simply because they were not being included in the resolver