### PR TITLE
Use CTE and skip "is null" check to speed up gallery_id migration

### DIFF
--- a/db/migrations/core/000044_multi_gallery.up.sql
+++ b/db/migrations/core/000044_multi_gallery.up.sql
@@ -9,7 +9,11 @@ alter table collections add column if not exists gallery_id varchar references g
 update galleries set position = 'a0' where position is null;
 alter table galleries alter column position set not null;
 
-update collections set gallery_id = (select id from galleries where collections.id = any(galleries.collections) and galleries.deleted = false) where gallery_id is null;
+with ids as (
+    select c.id as collection_id, g.id as gallery_id from galleries g, collections c where c.id = any(g.collections) and g.deleted = false
+)
+update collections set gallery_id = ids.gallery_id from ids where collections.id = ids.collection_id;
+
 update collections set gallery_id = (select id from galleries where collections.owner_user_id = galleries.owner_user_id order by galleries.deleted asc limit 1) where gallery_id is null;
 alter table collections alter column gallery_id set not null;
 


### PR DESCRIPTION
On my local database, reworking this SQL migration statement takes it from ~40 seconds to ~300ms, which is fast enough to run without scheduling downtime! The second `gallery_id` migration statement takes about 3s still, but I think that's fine for our purposes.