### PR TITLE
adjust schema for updates and featured gallery

### DIFF
--- a/db/migrations/core/000046_multi_gallery_adjustments.down.sql
+++ b/db/migrations/core/000046_multi_gallery_adjustments.down.sql
@@ -1,0 +1,2 @@
+alter table galleries drop constraint if exists exposition_cst;
+create unique index if not exists position_idx on galleries (owner_user_id, position) where deleted = false;

--- a/db/migrations/core/000046_multi_gallery_adjustments.up.sql
+++ b/db/migrations/core/000046_multi_gallery_adjustments.up.sql
@@ -1,0 +1,4 @@
+drop index if exists position_idx;
+alter table galleries add constraint position_cst unique (owner_user_id, position) deferrable;
+
+update users set featured_gallery = (select id from galleries where galleries.owner_user_id = users.id and galleries.deleted = false limit 1);

--- a/db/migrations/core/000046_multi_gallery_adjustments.up.sql
+++ b/db/migrations/core/000046_multi_gallery_adjustments.up.sql
@@ -1,4 +1,4 @@
 drop index if exists position_idx;
 alter table galleries add constraint position_cst unique (owner_user_id, position) deferrable;
 
-update users set featured_gallery = (select id from galleries where galleries.owner_user_id = users.id and galleries.deleted = false limit 1);
+update users set featured_gallery = (select id from galleries where galleries.owner_user_id = users.id and galleries.deleted = false limit 1) where deleted = false;

--- a/db/migrations/core/000046_multi_gallery_adjustments.up.sql
+++ b/db/migrations/core/000046_multi_gallery_adjustments.up.sql
@@ -1,4 +1,5 @@
 drop index if exists position_idx;
+create index if not exists position_idx on galleries (owner_user_id, position) where deleted = false;
 alter table galleries add constraint position_cst unique (owner_user_id, position) deferrable;
 
 update users set featured_gallery = (select id from galleries where galleries.owner_user_id = users.id and galleries.deleted = false limit 1) where deleted = false;


### PR DESCRIPTION
Changes:

- **Added** a constraint and dropped the position index on the galleries table so that we can update with deferred mode
- **Added** a migration step setting the featured gallery of every user

Considerations:

- I just removed the index altogether, do we still want the index even though we won't be using it to query or validate any constraints?