### PR TITLE
no index on position

### DIFF
--- a/db/migrations/core/000048_multi_gallery_adjustments.up.sql
+++ b/db/migrations/core/000048_multi_gallery_adjustments.up.sql
@@ -1,5 +1,4 @@
 drop index if exists position_idx;
-create index if not exists position_idx on galleries (owner_user_id, position) where deleted = false;
 alter table galleries add constraint position_cst unique (owner_user_id, position) deferrable;
 
 update users set featured_gallery = (select id from galleries where galleries.owner_user_id = users.id and galleries.deleted = false limit 1) where deleted = false;


### PR DESCRIPTION
Changes:

- **Removed** position, owner_user_id index on galleries because the constraint on those fields already creates an index