### PR TITLE
Add sandbox env

### DIFF
--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -1,0 +1,43 @@
+name: install-build-deps
+
+inputs:
+  sentry-auth-token:
+    required: true
+  gcp-credentials-json:
+    required: true
+
+env:
+  CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Set Sentry Auth"
+      run: echo "SENTRY_AUTH_TOKEN=${{ inputs.sentry-auth-token }}" >> $GITHUB_ENV
+      shell: bash
+    - name: "Dump GitHub context"
+      run: echo "$GITHUB_CONTEXT"
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+    - name: "Update apt"
+      run: sudo apt-get update
+      shell: bash
+    - name: "Install Sentry CLI"
+      run: curl -sL https://sentry.io/get-cli/ | bash
+      shell: bash
+    - name: "Download sops"
+      run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
+      shell: bash
+    - name: "Install sops"
+      run: sudo apt-get install ./sops.deb
+      shell: bash
+    - id: "auth"
+      uses: "google-github-actions/auth@v0"
+      with:
+        credentials_json: ${{ inputs.gcp-credentials-json }}
+    - name: "Install gcloud cli"
+      uses: google-github-actions/setup-gcloud@v0
+    - name: "Docker auth"
+      run: gcloud auth configure-docker us-east1-docker.pkg.dev
+      shell: bash

--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -5,313 +5,125 @@ on:
       - main
 env:
   CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 jobs:
   deploy-dev-backend:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_DEV_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-dev-backend
   deploy-prod-backend:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_PROD_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-prod-backend
   deploy-dev-tokenprocessing:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_DEV_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-dev-tokenprocessing
   deploy-prod-tokenprocessing:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_PROD_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-prod-tokenprocessing
   deploy-prod-indexer-api:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_PROD_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-prod-indexer-server
   deploy-dev-emails:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_DEV_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-dev-emails
   deploy-prod-emails:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_PROD_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-prod-emails
   deploy-dev-feed:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_DEV_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-dev-feed
   deploy-prod-feed:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_PROD_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-prod-feed
   deploy-dev-feedbot:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_DEV_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-dev-feedbot
   deploy-prod-feedbot:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Install Sentry CLI"
-        run: curl -sL https://sentry.io/get-cli/ | bash
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
         with:
-          credentials_json: "${{ secrets.GCP_PROD_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
-      - name: "Docker auth"
-        run: gcloud auth configure-docker us-east1-docker.pkg.dev
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-prod-feedbot

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -1,0 +1,17 @@
+name: deployer-sandbox
+on:
+  workflow_dispatch:
+env:
+  CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+jobs:
+  deploy-sandbox-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
+        with:
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
+      - name: "Deploy"
+        run: make deploy-sandbox-backend

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,14 +3,13 @@ on: [push]
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_CREDENTIALS: ${{ secrets.GCP_DEV_CREDENTIALS }}
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
+        with:
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -19,20 +18,6 @@ jobs:
         run: |
           go mod download
           go install gotest.tools/gotestsum@v1.8.2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
-        with:
-          credentials_json: "${{ secrets.GCP_DEV_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
       - name: Test
         run: |
           mkdir -p /tmp/test-reports
@@ -46,11 +31,12 @@ jobs:
     env:
       GOOGLE_CREDENTIALS: ${{ secrets.GCP_DEV_CREDENTIALS }}
     steps:
-      - name: Dump GitHub context
-        run: echo "$GITHUB_CONTEXT"
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: actions/checkout@v2
+      - name: "Install build deps"
+        uses: ./.github/actions/build-deps
+        with:
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
@@ -59,25 +45,10 @@ jobs:
         run: |
           go mod download
           go install gotest.tools/gotestsum@v1.8.2
-      - name: "Update apt"
-        run: sudo apt-get update
-      - name: "Download sops"
-        run: curl -L https://github.com/mozilla/sops/releases/download/v3.7.3/sops_3.7.3_amd64.deb > sops.deb
-      - name: "Install sops"
-        run: sudo apt-get install ./sops.deb
-      - name: "ls"
-        run: ls
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
-        with:
-          credentials_json: "${{ secrets.GCP_DEV_CREDENTIALS }}"
-      - name: "Install gcloud cli"
-        uses: google-github-actions/setup-gcloud@v0
       - name: Test
         run: |
           mkdir -p /tmp/test-reports
           gotestsum --junitfile /tmp/test-reports/unit-tests.xml -- -short ./...
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ migrate-prod-coredb  : REQUIRED_SOPS_SECRETS := $(SOPS_PROD_SECRETS)
 
 # Environment-specific settings
 $(DEPLOY)-$(DEV)-%                : ENV                    := $(DEV)
-$(DEPLOY)-$(SANDBOX)-%            : ENV                    := $(DEV)
+$(DEPLOY)-$(SANDBOX)-%            : ENV                    := $(SANDBOX)
 $(DEPLOY)-$(PROD)-%               : ENV                    := $(PROD)
 $(DEPLOY)-$(DEV)-%                : REQUIRED_SOPS_SECRETS  := $(SOPS_DEV_SECRETS)
 $(DEPLOY)-$(SANDBOX)-%            : REQUIRED_SOPS_SECRETS  := $(SOPS_DEV_SECRETS)
@@ -124,6 +124,7 @@ $(DEPLOY)-$(DEV)-emails                : SERVICE        := emails-dev
 $(DEPLOY)-$(PROD)-emails               : SERVICE        := emails-v2
 $(DEPLOY)-%-backend                    : REPO           := backend
 $(DEPLOY)-$(DEV)-backend               : DOCKER_FILE    := $(DOCKER_DIR)/backend/dev/Dockerfile
+$(DEPLOY)-$(SANDBOX)-backend           : DOCKER_FILE    := $(DOCKER_DIR)/backend/dev/Dockerfile
 $(DEPLOY)-$(PROD)-backend              : DOCKER_FILE    := $(DOCKER_DIR)/backend/prod/Dockerfile
 $(DEPLOY)-%-backend                    : PORT           := 4000
 $(DEPLOY)-%-backend                    : TIMEOUT        := $(BACKEND_TIMEOUT)
@@ -131,6 +132,7 @@ $(DEPLOY)-%-backend                    : CPU            := $(BACKEND_CPU)
 $(DEPLOY)-%-backend                    : MEMORY         := $(BACKEND_MEMORY)
 $(DEPLOY)-%-backend                    : CONCURRENCY    := $(BACKEND_CONCURRENCY)
 $(DEPLOY)-$(DEV)-backend               : SERVICE        := backend-dev
+$(DEPLOY)-$(SANDBOX)-backend           : SERVICE        := backend-sandbox
 $(DEPLOY)-$(PROD)-backend              : SERVICE        := backend
 $(DEPLOY)-%-feed                       : REPO           := feed
 $(DEPLOY)-%-feed                       : DOCKER_FILE    := $(DOCKER_DIR)/feed/Dockerfile
@@ -280,7 +282,7 @@ $(DEPLOY)-$(DEV)-feedbot          : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-fee
 $(DEPLOY)-$(DEV)-routing-rules    : _set-project-$(ENV) _$(DEPLOY)-routing-rules
 
 # SANDBOX deployments
-$(DEPLOY)-$(SANDBOX)-backend      : _set-project-$(ENV) _$(DEPLOY)-backend _$(RELEASE)-backend # go server that uses dev upstream services
+$(DEPLOY)-$(SANDBOX)-backend      : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-backend _$(RELEASE)-backend # go server that uses dev upstream services
 
 # PROD deployments
 $(DEPLOY)-$(PROD)-backend         : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-backend _$(RELEASE)-backend

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -44,6 +44,7 @@ FRONTEND_APQ_UPLOAD_AUTH_TOKEN: ENC[AES256_GCM,data:j+yWgCqznf9TH9a5cVaeCAz5tpDl
 GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:lPA1VpXRYL1n0S5uQ4LS1ing,iv:OHA0EztWD9bA02HFZo2e+4tUOEEwQ9zDtfQG9aIsI4E=,tag:tSFVSiPOn/uSouq2svGIRA==,type:str]
 FEED_URL: ENC[AES256_GCM,data:GKE9+N50XWa7apXhU0iOdrJNvjgiG/hAdKnbbisPXeQRQpo4BigvSg==,iv:Ytk4Z0nadPgVMNh44QF9MBr0TffS874rdXsK8uiVJus=,tag:HdOf53v3kTmibcZbbejqEg==,type:str]
 MAGIC_LINK_SECRET_KEY: ENC[AES256_GCM,data:W1NLioRt5mwYC9EjcRkvoHQwIUgDCpuz,iv:MsJ4x+r/Z0kUe7/9n8mrWT0EbgY96g40+yB0xOTiTOg=,tag:TrhCFFDiUZg/uAnaD3HKRg==,type:str]
+ETH_PRIVATE_KEY: ENC[AES256_GCM,data:fA==,iv:57YoZul3i/4wQAVHPiNS6WeMn7ELK9+5UFLuHA7e+Go=,tag:WKPIPmDbSFOwDAQk07DBsQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -53,8 +54,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:22:35Z"
-    mac: ENC[AES256_GCM,data:Cm6ABgnpT9iKmcMi3bapx0JKLMCrUA5fbPWU11c3LCl+cJPepEuveGGpnP+hyc1tKQCZPrAVpCht5Bsn5fdWQR5gEIV3yxyDPaeichOBfw0dXEB4QuyqzM2b05bX1Ixq31vyn13/YGvWYX/EtxJbEzzHvM2oO5e3sNywh1SMYqo=,iv:VY+y6bTjdBDl4L/4U2CSgeZdDCTFvTpIVBZX3FQ8hFo=,tag:8w6XjdiaapOO/RTQu3ErXA==,type:str]
+    lastmodified: "2023-01-24T22:18:08Z"
+    mac: ENC[AES256_GCM,data:wkDTQ7Nr6j2kr9zViGIbYIVw3pFXLaJdpun53lblhaRtilXW8xLsidjRRiF1/AwgG9RnyfWDny024Y40lyK5wsKjfQP9sd69pTn7IAR6HX9MDVkHuhkJsIbIrgnaE4m7v7ORiOjnxP0T7LYEaRYQ5TTRLST0JAAl7+T5OhxW+QA=,iv:cIxmfFjA2jIElYnl37S9P7mM3b6ffV89h8LlFmLT7wE=,tag:pKuSdeyRvgl35neN+H5JQA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-sandbox-env.yaml
+++ b/secrets/dev/backend-sandbox-env.yaml
@@ -17,7 +17,7 @@ POSTGRES_USER: ENC[AES256_GCM,data:8jTFLZ9ORPg=,iv:Lqb7sf/NhrEPA9rhyUptWTBMV2Z4x
 POSTGRES_DB: ENC[AES256_GCM,data:VRYMXfoMrW8=,iv:hP5OPkv8l7NxN8rORVd8eW/8sEePC20mV235o2Y1BbM=,tag:3r1pcewPEF1KKqa4KD1PAA==,type:str]
 POSTGRES_PASSWORD: ENC[AES256_GCM,data:YLf+5/yDFtaJhhlX,iv:SFQa9JkmRm+DC/RlSNvwBWE+Aq0bGHFNZ0QXYDgpLFk=,tag:YVD1wkINGnMJhZDkbURQMA==,type:str]
 POSTGRES_IP: ENC[AES256_GCM,data:lxh1jVdpE1cvTj+t,iv:Sk4XE27Kc0KxSi/1+o1AiRR54CdE4llwpigvWnLrkjA=,tag:TxdzKQVhZYR+9ELpHzC/uA==,type:str]
-INDEXER_HOST: ENC[AES256_GCM,data:z9g7h8YrutAbKJLAa+hhRtpm6+2v/S982FOHFXz1LEOJLh5dsdP4aXuBD3cG8xU=,iv:M9eN6N4RdI2d9pkWVBfidoVbQG0VX07U401V2GtdigU=,tag:EWayH5KtkOy+6tCzfKX3Cg==,type:str]
+INDEXER_HOST: ENC[AES256_GCM,data:DnuW8RW1i+37RbRUcElQuxSYHsP430Ez+NTob8Q0aXM8A+6Uo+G7oNRNKQ==,iv:glWQvZY06dyXK19UVTewwXkF4vURgsaPIZhDaf+TglQ=,tag:T+Qj5kYv9MQURPlEN0EaGQ==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:jdkwytuAw0wzrWtuOwUZkpikpUrsFsV6NgrdqkF8ars=,iv:IiTrtgwz0+3Pn3zkYsPXDcpIjBoE0greTjWOYxml2BQ=,tag:IC6lkXyCWQGBEyC9Xiye2g==,type:str]
 SENTRY_DSN: ENC[AES256_GCM,data:vxeO/GyItJzahNZUYirKJ/CAFNsJzAR2225MlbWGmG80rXUsfqoUjYydGbd5T4OPKmSMzLvnMfH7Y4FisND3Dzr1iNKZkQqWmMA=,iv:4DRZ6a76wTcOO9DiZLiZQel2aUfJrYu1AqNmTahm64E=,tag:sNaNtI5hIEtwypL/JEgruA==,type:str]
 SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:mHXj,iv:0aV3RyVHvV006JYTtyxnu8SbR7IMfJf4hDSRYIhL0ZA=,tag:upziwWB+PKxFs8KwdCR5Gg==,type:str]
@@ -41,6 +41,10 @@ EMAILS_HOST: ENC[AES256_GCM,data:/DEAc2Pd+vnjlWop7pmJxSiRBitBJ90rPK/IdGzG5NGKUvn
 RETOOL_AUTH_TOKEN: ENC[AES256_GCM,data:g5TNKXCBpq5I6hCR2ti7QSKwoK8YJhfd+VtysXrA,iv:NazFgyyF0yjYp6cjtuh6mQYUBA1nbJdlEXHu4pTJ/lo=,tag:TvhfRCUl9obdmHs32t3r5g==,type:str]
 BACKEND_SECRET: ENC[AES256_GCM,data:y2JxGLi0Ukf3jmbT8cIBpCBdUYuxOFiJoisQosnR9nM=,iv:gQFaTf+hwsfkP2rfjRLZlzAZzfjDH/1PTbULZd01wEY=,tag:eazw3KwjCdguB+aCdvKwJg==,type:str]
 FRONTEND_APQ_UPLOAD_AUTH_TOKEN: ENC[AES256_GCM,data:gvSo8N5ibadQjOg9NlparRKRHtLus3ERbZtcWQVQ,iv:2XKWfVEenTcR10kvgMCdYwsVorNFioUrgjbtYTnIr+U=,tag:Txa8efn9z9UcDb9erzbteQ==,type:str]
+GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:5xzcHY0BY/haETJVOnDfCzXA,iv:AlSCrRkyHrSgui2nKMPBrxCqaUgwnVsEY55HmMubm0I=,tag:gS7Y3JFIY6yQ85YsXin3Fw==,type:str]
+FEED_URL: ENC[AES256_GCM,data:gsk+SJozFIX+3TCT12jwgxtwmyv6/aysSS0dmK9ezAcuBfq3X4W6HA==,iv:5X1th42JsWqfbwn+WHNsqkMskcai+XcaAjmQlOOc0CQ=,tag:N9PDVE6xHTrMAd9x1y1NBg==,type:str]
+MAGIC_LINK_SECRET_KEY: ENC[AES256_GCM,data:r3SoRozlSqGujMVJuTzhnpUIwZlKbqGx,iv:2THy4rh9kRUNFNW8Bzv42Eo/qLnlfsU66CnR79aXejw=,tag:eoA18Xu2NxGw0z5dw+LOuA==,type:str]
+ETH_PRIVATE_KEY: ENC[AES256_GCM,data:GA==,iv:Ppciu8ty51nMpmJaqapJ6H6QdL8+Dd5CZum4dlnrP+M=,tag:CKlau9wlQMQuBo9cZ8Y+9Q==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -50,8 +54,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:21:58Z"
-    mac: ENC[AES256_GCM,data:8Iw3d4KzTX06n49J2wfASUOiMKT9KA+Oq3OuuiFWPy60dJfr66u5Q84HheUQ5j3NL7pRnXQztOH5YEpBuCYbVOqlpvaRvTPMXmZHuf72wbbHB+lNZwLMYoRUKQrPZx42P63iBDGNffc0sdcDaENNl9m2QjMxFNNhtI/KRD7FHlE=,iv:F9iy7N5DYooGpOWNQmMn1to4MofEiAmh/qo9zRq7NIk=,tag:F1aIdfeu4SgVl+NPtslcZw==,type:str]
+    lastmodified: "2023-01-24T22:18:41Z"
+    mac: ENC[AES256_GCM,data:HvsbJztsbUZhr7dw/xfY6PibQpkX1fOEvF/g7KLaIN12sUNFHyDiQHaVnGBDsG6V7rUEPqYLBLp6MwybaEnucAAVz7l3oiSDkZ6JPBsiQ5R9JNbjwn2UJ5izGbMSVKyQrzSvpU/ayZ2U/sGgQxfDa3bl4b1T1DkK9Av9kysoP5k=,iv:OskcsKfn7bYEwKne0sgH0CZFg+891XWmUDYrj5DCSn0=,tag:fYi04CKNz8vsRvmAIGqWxg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -45,6 +45,7 @@ FRONTEND_APQ_UPLOAD_AUTH_TOKEN: ENC[AES256_GCM,data:LioWZ+P0y833Q0oal8NbXmsfF9i7
 GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:dvKeQCB8xWpdqzoRS0H7HYhmXA==,iv:hr1f1q7C6KjYeaIxSA2COu0RnegMoAapGCfWeNU7pyM=,tag:5gpz9E+V5Ia/dBxB0N+9LQ==,type:str]
 FEED_URL: ENC[AES256_GCM,data:gm6uX6gBVryy2vAANm3kmmn0wl+tXzdvigzJgomBDi0wj2An,iv:I9NWNh8Vl4Yy3XiJtEBNd6ONTkgTfRsN97xDi5jtx+0=,tag:/4C+vOrN/qWITyd7I83Ymg==,type:str]
 MAGIC_LINK_SECRET_KEY: ENC[AES256_GCM,data:U6gNtGIqHRdy+zqrjMjybEem3PZpD2TD,iv:d4l+y6+TP1ds765rXVs505isqqDcmP71Kb2HgtGkeh8=,tag:Pi3Oy7mdvpHK7BksasWblw==,type:str]
+ETH_PRIVATE_KEY: ENC[AES256_GCM,data:cL+KBUyf7lzonX4j5glaMCrC3yny/ME/gCnJOK33QfWnEsrK7c5zmbdZa19cCHp/kB8s+Tsy8jEMvzh5jRXVmw==,iv:s7/rU9aqcoftwljzdOlwiQodEUlG0ruQND8QiKdPnxU=,tag:jX3/ycrRYBqyhwKIItYwKQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -54,8 +55,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:28:34Z"
-    mac: ENC[AES256_GCM,data:s6axGXwQNwIeEuFJylSHdfWBX9U1nIahD7Pj3rmhlaECS1QeYrpNqSkwb1eUoqfZQF1+N9UtkFduiD30QpVpnxKk9hCOWp2FzU1jy+h01SMzPgAO/j7bkayaGDU6SaQC1xZW9E+8Ps3hmqoxxC+AeaRc8XBjadNlu3g43M+hKbY=,iv:Uicw+JanmstgVujBr7LUj6D7hSXk8R/dyiHdINBDEME=,tag:GNnnNBvutl3gTHzWfuGbmw==,type:str]
+    lastmodified: "2023-01-24T22:18:24Z"
+    mac: ENC[AES256_GCM,data:hLAakMhe5VOtJG/cR3yrTd2GEYHPGD8Soa7tdheCYaBF18pv/WhIU7KxGFJoxuUl+t+5F0KzKIJK2Dw1YI2iGv6Fre7Qgpm484qNbQ15QLJlgDyNrCH0aOQyWxQ2KHqYXxLWPr5SGhSS36fo9cPVOunoD0nKbV3mpshCJR8Uuq8=,iv:tNJ+jbut3ACETtSqtFfxVQIvZ8bCM8brr04VLMh94CA=,tag:mX5AoSBIDX0/d/G8yRt2qQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
This PR brings back up [api.sandbox.gallery.so](https://api.sandbox.gallery.so) for the sandbox.

**Changes**
* Added a `sandbox.yml` workflow which currently only deploys the backend to the sandbox env. This workflow can be adhoc and a branch can be provided to deploy that specific branch.
* Moved the CI build dependencies (sentry, sops, gcloud) to a separate action `build-deps` which gets called in our workflows
* Added `ETH_PRIVATE_KEY` to our secret vars to replace the secrets managed by Secrets Manager
* Updates `backend-sandbox-env.yaml` which values from `backend-env.yaml`

**Post Merge Tasks** 
*  [ ] When deploying to `dev` and `prod` a new revision on Cloud Run will first need to be manually added thats removes the Secrets Manager connection. Cloud Run will complain that the env var is being set in two places otherwise. This revision will fail to startup because it's missing the env var, but Cloud Run won't move any traffic to it anyways.
* [ ] Delete the secret from Secrets Manager so it isn't in two places
