### PR TITLE
Add legacy views

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,9 @@ Run all tests in subdirectory (e.g. /server):
 $ go test ./server/...
 ```
 
-Run a specific test by passing the name as an option:
-
+Run a specific test by passing including the `-run` flag. The example will run GraphQL tests under the `TestMain` suite that start with "should get trending".
 ```bash
-go test -run {testName}
+go test -run=TestMain/"test GraphQL"/"should get trending" ./graphql
 ```
 
 Add `-v` for detailed logs.

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -184,6 +184,14 @@ type Gallery struct {
 	Position    string
 }
 
+type LegacyView struct {
+	UserID      persist.DBID
+	ViewCount   sql.NullInt32
+	LastUpdated time.Time
+	CreatedAt   time.Time
+	Deleted     sql.NullBool
+}
+
 type LoginAttempt struct {
 	ID                 persist.DBID
 	Deleted            bool

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -2135,24 +2135,28 @@ func (q *Queries) GetTrendingFeedEventIDs(ctx context.Context, arg GetTrendingFe
 
 const getTrendingUserIDs = `-- name: GetTrendingUserIDs :many
 with rollup as (
-	select e.gallery_id, count(*) view_count from events e where action = 'ViewedGallery' and e.created_At >= $2 group by e.gallery_id
+  select e.gallery_id, count(*) view_count
+  from events e
+  where action = 'ViewedGallery' and e.created_at >= $1
+  group by e.gallery_id
 )
 select p.id from (
-	select u.id, row_number() over(order by sum(view_count) desc, max(u.created_at) desc) as position
+	select u.id, row_number() over(order by sum(r.view_count) + coalesce(sum(v.view_count),0) desc, max(u.created_at) desc) as position
 	from rollup r, galleries g, users u
+	left join legacy_views v on u.id = v.user_id and v.deleted = false and v.created_at >= $1
 	where r.gallery_id = g.id and g.owner_user_id = u.id and u.deleted = false and g.deleted = false
 	group by u.id
 ) p
-where position <= $1::int
+where position <= $2::int
 `
 
 type GetTrendingUserIDsParams struct {
-	Size      int32
 	WindowEnd time.Time
+	Size      int32
 }
 
 func (q *Queries) GetTrendingUserIDs(ctx context.Context, arg GetTrendingUserIDsParams) ([]persist.DBID, error) {
-	rows, err := q.db.Query(ctx, getTrendingUserIDs, arg.Size, arg.WindowEnd)
+	rows, err := q.db.Query(ctx, getTrendingUserIDs, arg.WindowEnd, arg.Size)
 	if err != nil {
 		return nil, err
 	}

--- a/db/migrations/core/000051_add_legacy_views.down.sql
+++ b/db/migrations/core/000051_add_legacy_views.down.sql
@@ -1,0 +1,1 @@
+drop table if exists legacy_views;

--- a/db/migrations/core/000051_add_legacy_views.up.sql
+++ b/db/migrations/core/000051_add_legacy_views.up.sql
@@ -1,0 +1,7 @@
+create table if not exists legacy_views (
+  user_id varchar(255) references users(id),
+  view_count int,
+  last_updated timestamptz not null default current_timestamp,
+  created_at timestamptz not null default current_timestamp,
+  deleted boolean default false
+);

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -698,11 +698,15 @@ insert into collections (id, version, name, collectors_note, owner_user_id, gall
 
 -- name: GetTrendingUserIDs :many
 with rollup as (
-	select e.gallery_id, count(*) view_count from events e where action = 'ViewedGallery' and e.created_At >= @window_end group by e.gallery_id
+  select e.gallery_id, count(*) view_count
+  from events e
+  where action = 'ViewedGallery' and e.created_at >= @window_end
+  group by e.gallery_id
 )
 select p.id from (
-	select u.id, row_number() over(order by sum(view_count) desc, max(u.created_at) desc) as position
+	select u.id, row_number() over(order by sum(r.view_count) + coalesce(sum(v.view_count),0) desc, max(u.created_at) desc) as position
 	from rollup r, galleries g, users u
+	left join legacy_views v on u.id = v.user_id and v.deleted = false and v.created_at >= @window_end
 	where r.gallery_id = g.id and g.owner_user_id = u.id and u.deleted = false and g.deleted = false
 	group by u.id
 ) p


### PR DESCRIPTION
Adds a table of views from Mixpanel and Google Analytics with data prior to when we started tracking external IDs to include in the all time trending users report.

**Post Merge Tasks**
* [ ] Run migration to add new `legacy_views` table
* [ ] Insert data into table