### PR TITLE
Rotate auth JWTs

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,11 +3,8 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"strings"
-
-	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/sirupsen/logrus"
+	"net/http"
 
 	"github.com/getsentry/sentry-go"
 	sentrygin "github.com/getsentry/sentry-go/gin"
@@ -15,7 +12,6 @@ import (
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/tracing"
 
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -29,41 +25,6 @@ type errUserDoesNotHaveRequiredNFT struct {
 	addresses []persist.Wallet
 }
 
-// AuthRequired is a middleware that checks if the user is authenticated
-func AuthRequired(userRepository postgres.UserRepository, ethClient *ethclient.Client) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		header := c.GetHeader("Authorization")
-		authHeaders := strings.Split(header, " ")
-		if len(authHeaders) == 2 {
-			if authHeaders[0] == viper.GetString("ADMIN_PASS") {
-				auth.SetAuthStateForCtx(c, persist.DBID(authHeaders[1]), nil)
-				c.Next()
-				return
-			}
-		}
-		jwt, err := c.Cookie(auth.JWTCookieKey)
-		if err != nil {
-			if err == http.ErrNoCookie {
-				c.AbortWithStatusJSON(http.StatusUnauthorized, util.ErrorResponse{Error: auth.ErrNoCookie.Error()})
-				return
-			}
-			c.AbortWithStatusJSON(http.StatusUnauthorized, util.ErrorResponse{Error: auth.ErrInvalidJWT.Error()})
-			return
-		}
-
-		// use an env variable as jwt secret as upposed to using a stateful secret stored in
-		// database that is unique to every user and session
-		userID, err := auth.JWTParse(jwt, viper.GetString("JWT_SECRET"))
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, util.ErrorResponse{Error: err.Error()})
-			return
-		}
-
-		auth.SetAuthStateForCtx(c, userID, nil)
-		c.Next()
-	}
-}
-
 // AdminRequired is a middleware that checks if the user is authenticated as an admin
 func AdminRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -75,48 +36,9 @@ func AdminRequired() gin.HandlerFunc {
 	}
 }
 
-// AuthOptional is a middleware that checks if the user is authenticated and if so stores
-// auth data in the context
-func AuthOptional() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		header := c.GetHeader("Authorization")
-		authHeaders := strings.Split(header, " ")
-		if len(authHeaders) == 2 {
-			if authHeaders[0] == viper.GetString("ADMIN_PASS") {
-				auth.SetAuthStateForCtx(c, persist.DBID(authHeaders[1]), nil)
-				c.Next()
-				return
-			}
-		}
-		jwt, err := c.Cookie(auth.JWTCookieKey)
-		if err != nil {
-			if err == http.ErrNoCookie {
-				auth.SetAuthStateForCtx(c, "", err)
-				c.Next()
-				return
-			}
-			c.AbortWithError(http.StatusUnauthorized, err)
-			return
-		}
-		userID, err := auth.JWTParse(jwt, viper.GetString("JWT_SECRET"))
-		auth.SetAuthStateForCtx(c, userID, err)
-		c.Next()
-	}
-}
-
 // AddAuthToContext is a middleware that validates auth data and stores the results in the context
 func AddAuthToContext() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		header := c.GetHeader("Authorization")
-		authHeaders := strings.Split(header, " ")
-		if len(authHeaders) == 2 {
-			if authHeaders[0] == viper.GetString("ADMIN_PASS") {
-				auth.SetAuthStateForCtx(c, persist.DBID(authHeaders[1]), nil)
-				c.Next()
-				return
-			}
-		}
-
 		jwt, err := c.Cookie(auth.JWTCookieKey)
 
 		// Treat empty cookies the same way we treat missing cookies, since setting a cookie to the empty

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -2,7 +2,8 @@ ENV: ENC[AES256_GCM,data:jivcdnV4Y3B3x+Y=,iv:SwhJ4YOYDw/hA5lcfemTU/vjj+dw85p7KPu
 JWT_TTL: ENC[AES256_GCM,data:jHUgBIBJxQ==,iv:GUpTpEpivTDIvfrRMW3m/vHePmZhVLRrCyUiuRQT7ic=,tag://jlzF/sAds08fjmWAzUsA==,type:str]
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:2XT4xhyFBcccjqFZtzWeZCq7TogjN/80GmWLO4f6ZxkWyosUPWdzo809uBexAqkw1uZLdg69l/Y4xsviCxN5Bj/HYl4J4Yg=,iv:ZO9CTIhPFGBhFpclrWDpjkkxfAva/q8rZjW0gsGtP70=,tag:qcfM8UWp5b3wwpf1kDgKLg==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:Y7TxzAMCJQ/6IA9x1V9Z/A==,iv:xjmc+J79hgutX20zZBpfC4bbZf4eSCJca5LLKHhhJcI=,tag:yiQjeRgQY41QqHXEIVNRrA==,type:str]
-JWT_SECRET: ENC[AES256_GCM,data:ZGnbO0kxCd3ZLTveFGMh9g==,iv:/pXoNHAIqRvYxLnThVuvcQVIOIpjA+Ot5mHfWG92E6k=,tag:4D0So/365VO60VZnCA1+xw==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:zDdW+PxHlAp9vMzG/zu+vMR1tBb/joiiOulIjMcqX9Q=,iv:rk1bo3G1to0NRKZV5qj67KQcF7y0xQVOmsrZUKmWSUQ=,tag:/youg7JoIGRqA6/Ztff5pw==,type:str]
+JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:L6ATLIViyIND9EFrVl8unQ==,iv:euMk5yJjGM698s9E/jMKYJxJG99KbiiID1ut6HPu8Uk=,tag:Pv7N/bj/KHqTc6jXP0N56w==,type:str]
 PREMIUM_CONTRACT_ADDRESS: ENC[AES256_GCM,data:IZTLviyFrvpJCSMCE1IxeTKMvdy1K3gI1APcjelBoO+OCjm7ItfcyL7Qup/31JaTufEpI08yyWArop6IsIg=,iv:mhCrfgQoa9P8wpNTmg+1eXveyWjCictTmvwJwaR+7Go=,tag:ClRLDUs4SRnR/JcJnztjQg==,type:str]
 CONTRACT_ADDRESSES: ENC[AES256_GCM,data:8pFih2gIn0H7zR1D3cbcspKrQ5Npbnw1wD0iIUebAD6/mZmWfxYr4HTAh359V47WuIBZKQi9Z1ns2FSjZ5s=,iv:NXlsYRl4s0AIpIl1GshnmTje509AsS1ehvK6utMHqNA=,tag:anOMBpAK/XtVCjdgK4Bm/g==,type:str]
 CONTRACT_INTERACTION_URL: ENC[AES256_GCM,data:4xMy1GOjoEeZcfpFdMPR4S84WgibL0eH9WMilhlcBnwf1LplWEqoJILsfH6kmL8BFz+bOaC7hNXy78bWV6rjOOaLfztT,iv:9j2PS8LLy8I5lqeMFXQIoDoYPZXxFfXaox+mi30F0kc=,tag:7EUo1UyOLjC4tsi7a+GgcA==,type:str]
@@ -54,8 +55,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-24T22:18:08Z"
-    mac: ENC[AES256_GCM,data:wkDTQ7Nr6j2kr9zViGIbYIVw3pFXLaJdpun53lblhaRtilXW8xLsidjRRiF1/AwgG9RnyfWDny024Y40lyK5wsKjfQP9sd69pTn7IAR6HX9MDVkHuhkJsIbIrgnaE4m7v7ORiOjnxP0T7LYEaRYQ5TTRLST0JAAl7+T5OhxW+QA=,iv:cIxmfFjA2jIElYnl37S9P7mM3b6ffV89h8LlFmLT7wE=,tag:pKuSdeyRvgl35neN+H5JQA==,type:str]
+    lastmodified: "2023-01-26T21:35:11Z"
+    mac: ENC[AES256_GCM,data:8Tovl7/1AVL7ib4yaDO8HaApsZj6yMWsuOEmo8lZDp4Ccd699cScaqr5U1LBa7Mx0bBYY/oHiuIun1VQ+7kJ5Sqnp77w2Vit/PsFoEvuACaWAf638NFof7ngdSr9uQJ7t2Miw6aTWBWM4pui6k/3BK4LENUX3voVSbk4G1YQyuA=,iv:sGbTeQEVTEv6jGrAHVipO4mfuniSwavLGUQfomu5lGU=,tag:mJvxR/MWxB1cIvVjbefuxA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-sandbox-env.yaml
+++ b/secrets/dev/backend-sandbox-env.yaml
@@ -2,7 +2,8 @@ ENV: ENC[AES256_GCM,data:FcBrEx0kSg==,iv:RQvWPLNjo5y/5vtrsf1kGV1ThWtWPDW3mTFYUHI
 JWT_TTL: ENC[AES256_GCM,data:XhqQ429/nQ==,iv:+8IPbQN2aOP2UHRUrISKtmt9Vbyvf8PRpRbSLu/qfqo=,tag:ExUrCVMfbGh+T+x0BL2PfQ==,type:str]
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:1/qVe+FYF9aqLXYrhPm+sj4Dchojp3rSyqk7oBvytfWV4cQ3fGuOoJN3xZsXo4xO39o773U2vzFetb1dBZ0VdW5bn4Q41BHucriT6B+wO2fArQBisChJ,iv:IrSSeDF7mpbVISSrO6kswxR9FalVaUKbBeyfYxJtKBY=,tag:yKGe4WnollH8GW/qsgvn4g==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:Es3UaGqFiARAVYVLGfu75w==,iv:rXFVheA4Z1ZWCfEHOcb0OtxkuY3wMuQR8wREA0LDdvc=,tag:gKCBe05g2W2NZCLPbmeudA==,type:str]
-JWT_SECRET: ENC[AES256_GCM,data:bdgB+2v3dbZQXhZH7X8acA==,iv:uIzPVY/uW4dvahjU4skNGiQs0tWDJQ0gy8CkxZyuSQI=,tag:a1t6wmNR+jAby8pAHeLt3w==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:opyxDjMYEP7wTMj8kNGXRpQodtmfn3Ag7eMso8nyWbQ=,iv:wnf99+TlUqRwF7EJesAGtJxjgmrP+yG2pzWgOHFcEBU=,tag:35Ww6lpMhgQzepS1js2bcA==,type:str]
+JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:VGP3JkOgnuXIxmlohs/Etg==,iv:Ntm1J4+NuzGSzf4/h2VatLOQI+xT6lYsUOYzP9BIB1s=,tag:GsitfTCP3hREDQ8oDFgBqw==,type:str]
 PREMIUM_CONTRACT_ADDRESS: ENC[AES256_GCM,data:3QpVPqM+dV/a0kJ3fIUMGLVrNDlboD5pCM5PRp9oQ+MmK0BlXHOd0FL4fQ6F9DmHUBfAkOUvz7H5I7Oxs7U=,iv:yrOEUQpU2Z5MAbTK789B4s6bbZ6/WxMtRf4+Czfe9OM=,tag:3x7qMyUjNm4D65T2d/LKlA==,type:str]
 CONTRACT_ADDRESSES: ENC[AES256_GCM,data:nXIEovYSZDPIQh4o+79Hpn0iZvBudDhCbn2Y7xDUXnVTvgPEc0lQTG7KAZ7d1oHcsxAiW1d2ozrbBem9JGc=,iv:pnMfZIYyZiLWywn1FJ1guI/ys0M9eWvhpkLLSy6H37A=,tag:k4vA7f4RZG3J2X0piXOq3g==,type:str]
 CONTRACT_INTERACTION_URL: ENC[AES256_GCM,data:Uj9cfl2pdw7TcOV833u3gDIX/h36vOH7lnhf2BDBFzQKkBmDJbsg9pTDexjS1g/DURCsun34zRo7orBTrDkKTybUgQfz,iv:4hU2DU4c80RMBNVobHP2ixIoP7Rx2klsq9KcBSXq6Zw=,tag:oYFYrrqbqZn40fUVbacwOA==,type:str]
@@ -54,8 +55,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-24T22:18:41Z"
-    mac: ENC[AES256_GCM,data:HvsbJztsbUZhr7dw/xfY6PibQpkX1fOEvF/g7KLaIN12sUNFHyDiQHaVnGBDsG6V7rUEPqYLBLp6MwybaEnucAAVz7l3oiSDkZ6JPBsiQ5R9JNbjwn2UJ5izGbMSVKyQrzSvpU/ayZ2U/sGgQxfDa3bl4b1T1DkK9Av9kysoP5k=,iv:OskcsKfn7bYEwKne0sgH0CZFg+891XWmUDYrj5DCSn0=,tag:fYi04CKNz8vsRvmAIGqWxg==,type:str]
+    lastmodified: "2023-01-26T21:35:54Z"
+    mac: ENC[AES256_GCM,data:tAAjeGWbc0NMa4hfou7eI2Z8xJogTVHq/MfdYGZ8ONwUG/LaqRXLUIgNQikOpA6dH41H04bVC/f5iH5NMFZBvnBlTwoJGH5PlEstVQat4T77XsCDNX96rMnWv94it8JvExNOOENBb4Lkcoiee715sqjKn0H/kvySESmWuBa1tNw=,iv:Vev/3Hwk/MiQH9FxvPaFp91FKpWmN3AsM6fHJgryGS4=,tag:fHOtcG179fJFMeZ6AjkhLQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/emails-server-env.yaml
+++ b/secrets/dev/emails-server-env.yaml
@@ -1,7 +1,8 @@
 ENV: ENC[AES256_GCM,data:gxgjU16VSNeoudg=,iv:alwcTOdeuiEzUaDpMsovzCOfZ6GNzQP430/1yQS4kJU=,tag:qM4NlK1j5Wv0jGPBwfWpYw==,type:str]
 JWT_TTL: ENC[AES256_GCM,data:ufmDQmET,iv:pxu99memKvn6rGNwfYEURsqxh99MO/2YboenVGvD7As=,tag:8rdqlpYe83FduDNCOxNU0g==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:vpHnVdDGYuRmQtMsyAq1wA==,iv:1jn7IsxnSTdRVPcsTF/XwDerHI7KwmyHXPnYIFDlXY4=,tag:jYxKg8cEp1FbUZZESPPEbQ==,type:str]
-JWT_SECRET: ENC[AES256_GCM,data:1utA+PEYTqzeOAOUi4gnOOaUrZg=,iv:ex9qBgJN0OW3p0A9D0aSheT4SZAFTawQZu93k1NzGfg=,tag:SzGHxPnW1aebNOTgIETmiw==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:MPNkASvw1klQut4vK06S1ZRD2/zdrWhOzworvbcx8h8=,iv:YVTRHHsNvGYIO+R+mrGlMQt4RgwagRLiDk9yTELJUE8=,tag:iU3xUaLkm6pWHRc3FMnO5g==,type:str]
+JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:xykDAF/fS5rSoNtj0wCmKbBPljQ=,iv:fa6SKe+GaKUQK2O5aa7SbGtiEcSuUgoaEi3hhhUgosE=,tag:NvdMuDmymj2wgizFLEsHSw==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:z+unMTcNBQKYIHHrl1htZQoxUpxu1wWw1ipD3NPpStkST4P8xPGr2tT+HeY0yYmRfFI9iA==,iv:Hsu72ZL3VtCbCkCMYJOOMLJCNs2Hdh4n70Mibkxq/q4=,tag:nbUkJFidYRniDXNKzVe4mQ==,type:str]
 POSTGRES_PORT: ENC[AES256_GCM,data:FLwIpg==,iv:C+7Bb9pYbBbuTFZn0FtxA8KANSP5qAXi5h2axwE+1x8=,tag:UD+YBNVXyiVqUK9o2p/Dhw==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:f8+1FBCmjEQ=,iv:EpY5o288w+zIoNqQSFOmRfJW3+MGFPtUTQCQP7xDFac=,tag:3wC3T+BK6TgPY/iuy47f1w==,type:str]
@@ -25,8 +26,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:22:40Z"
-    mac: ENC[AES256_GCM,data:h9yq7odYmOsBsAdZOuwDJypOoTW3mrV7j9/hY7aKKb0zPDmznQUih3QFrhrLl1VVLi4va8ZxByB5DkGcop7SOM3z90xVOw1Va9tNNr2h/NuVmsNHJWnRNspAzVd4aubYOCIyjfoYVa3i3vLSvM0mfIQ9D39TM0STK6tlWpb1HHU=,iv:M5VjyRGSx+1fQoE9xeBfHQpVyXdbNNTXTDq7soGWxj4=,tag:WEQ71IpqqnljVOeSDFCnsg==,type:str]
+    lastmodified: "2023-01-26T21:38:55Z"
+    mac: ENC[AES256_GCM,data:Kp4etLB4+o9oIPm87p2tZtc5CzgrLRsxuLmuRhZsZ81kzLd2y8+O5zZapml7jVTbgSUGWnExFDluOSowmE/44qZs7N1yONmqfnKGay5rupDo2NWbgDm3RwYEH+ouIVsipWBwnRJlN3jVp6d37ztIAot6VqmcURA3ED453RuLjB4=,iv:kgYAyQ7Fe68QMbTQLOpPHnxWaXiyW3AcxSJlEj/WDK8=,tag:ZhhRlFHjCxg/JdAO1dbaOA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-emails.yaml
+++ b/secrets/dev/local/app-dev-emails.yaml
@@ -1,6 +1,7 @@
 ENV: ENC[AES256_GCM,data:Zp6DCeM=,iv:cRqvO72IUR3E3wSMFekuzpq2cxoxZA6mEZ5X2rchXW4=,tag:jTy2TojEWs3EU+WFE1vGIQ==,type:str]
 JWT_TTL: ENC[AES256_GCM,data:xJwLaf2V,iv:p/da/pvUx4t9zM5NoYfAIz89mepCLiWL31s32qitCy0=,tag:bYaDrQ9U5D1eJuGArQKpow==,type:str]
-JWT_SECRET: ENC[AES256_GCM,data:iDSEdAnptuXgv88vvabEz59wwidS,iv:bxyu6GkmOABZbynE8sIxKBRjksjJbVCO7+W4BRgpfJI=,tag:jcq3GIN/La+VdBKWRUFBhw==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:xlX1sc8L4y//ZHPm68MSNOKxQxs1NM+XJxZMzgmve0M=,iv:JXBVkGuRm7Ipk+HoEqWtc6k+fWXe3C63pUurzRbq+q8=,tag:djkLGj0YzI1XxcYhfjwp5g==,type:str]
+JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:9ziPkGLBHk/WPBrD0QcPbE0qMmsn,iv:Q2/F44Qqec7SlfIIJmaBZVhoYSumZrOumiJjejoKlIM=,tag:1KVcPMZx8GtaD2L5ypyXQA==,type:str]
 SENDGRID_API_KEY: ENC[AES256_GCM,data:/YrVqs7U+IOwZn0A7lqyqcDu6tQtq+8yscVkIFwnaLTxmGTrXILOIatRm2iNtIJyeH10vcqGNi4QvHzWtbPNOJjb+JiH,iv:LvhJT9sUBihUPVT/Bxk9/vVQOGNxsyjzhlSIhSCLnBk=,tag:ZPxECtJWHlpVs213J6uo0w==,type:str]
 SENDGRID_VALIDATION_KEY: ENC[AES256_GCM,data:2SodWvQrtmnNvMdcT+9Il4D7RmDU1dq9AF+SMzXqdxHggAe8zSZiD5P2O0noBpZg/T314AEumn99+7S0Ko+Cr7E3/4Op,iv:mtw7JcQ5Uz5xyrRbzxkUOv7iK+BzbC6lvk8lMeT2XUY=,tag:9A2IDKQdpL+/WxC/zBXN7g==,type:str]
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:Xc0dGaaONHCjo0ScozOBGWPXmCUPDIOJmxIODehzc9JwsQ==,iv:EQvur2c7bi5NFaMfnXep8E9zd0pPCZJu25y0hoW/WyM=,tag:wtg+r0Kp69MlZirH0cDgfA==,type:str]
@@ -18,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T15:42:36Z"
-    mac: ENC[AES256_GCM,data:TmkSxbPo40jC/G56NvRyfW8Wc0rXUxK/4GWWqVDCeYm8Hcz0mpHdDpI4VCi1n4w/4trcZ1HeG4tuzIa00V9YJ+0/GexOa+kTcDBc3PZv788XBmL05u3eyuux85yby9ziEWeRgYc2oftkzd2QKgc9v5lDKPYyqrX3kbZBfWa0YHk=,iv:hsAsbUxBmUVN8+o0woA917IjdKKGQiZmkSuk3lTk5RE=,tag:66NPvIjSNreppUUlh84UHg==,type:str]
+    lastmodified: "2023-01-26T21:40:05Z"
+    mac: ENC[AES256_GCM,data:ZIju74xxqNPhoSxrp1rB2hUtt77/T20cXyxvj8fxmigcQXSHyhMS8TyhWGjvvR1Xb7HRy/t42JO0oBgSOnsDomSrotnk4XYSjD94SbSo9fXnHYaD4Bi9TwMWdAe2gtDRikuX0xRH2ss99MhtMciMJ2JLktjNmCpV8MfGlhbhKmM=,iv:N0440GBSqRZcPT8wKzy2bWHatqJiHOJpLMkWsDJplkc=,tag:eEf/CmQyB7QMrFjfVWiVnw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-emails.yaml
+++ b/secrets/local/local/app-local-emails.yaml
@@ -1,6 +1,7 @@
 ENV: ENC[AES256_GCM,data:wdA+qao=,iv:ry/zqEMBwqeEnKoDs4Gqdop0KA2TkMa3mJavyB2HFRs=,tag:QPRq3CxF+Jkqkx0FzFmjWQ==,type:str]
 JWT_TTL: ENC[AES256_GCM,data:sSDrXWJb,iv:GYA4Nm61Kb5dZjAnKtmUS0KSYWVCADh4PZtIcsFp314=,tag:uARniN/VBvvIKRolJi5s/g==,type:str]
-JWT_SECRET: ENC[AES256_GCM,data:r6KgiuNxbgeSbUec4Mol2EcFDIPj,iv:+XtWA5KChLlazhT313oWNXCHrweid6/DhyLcVQy+o0I=,tag:mvmnZasiw84kX66pZteC2A==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:86Vqf2tP6G9cWcUAIGpDc8Gs9KCQZ8EvWA4+xQg7EL0=,iv:Sc+GA11CXJpomihsETH45QespOoSLrx7yB+rxwxrEXU=,tag:FYAiVzuNUa0ACIYLT6BAuw==,type:str]
+JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:B8uUvvOTn02W5NuA23h02uZTNNaR,iv:hvdg32BRt6gmR5WdzFYl+841nzn9ZuPyeBFV0BGaDPA=,tag:hD4nKsBrc6gqvchbvkxIVw==,type:str]
 SENDGRID_API_KEY: ENC[AES256_GCM,data:9jQnEXXJvCcRc/P4oyeqUEd0ItLoysG3/bUgJdJlyuqYtLzYod1MswVOMg4JI4v/+Wds+q6qKo6YrQjnYX4bwefUJjKN,iv:dzd62Pv6KB0zVX1TKlu9aaugNTHEUzzvq2WCkm4ZHdA=,tag:ytbBC9TeNYFmdW8r1kUhEw==,type:str]
 SENDGRID_VALIDATION_KEY: ENC[AES256_GCM,data:7cOENNXkgPopi5mPsWZm4Nl1rHZndq9AnKpx50Byp4wjA+iO5JSom00qgG/14E0rkjEY8Zs4AZ5KvR1PcfcYJRka3kcI,iv:2Tb2Wkiu/I9O30kR96wZkM1YvWxdHQciLcAkKeuJwEk=,tag:5KRFJ5KmJqvOMx+x+j34JA==,type:str]
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:+PmeNqQhZT77GCbjZIVqSw3vQBASrTXKjKzqzBIy1yfQbg==,iv:mJwv4X7rD6VW5FdAIvh4oPmsBCPMGHl352DPCTZrrQ4=,tag:5kMXWqN3y0AlupgUOfahhg==,type:str]
@@ -14,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:50:18Z"
-    mac: ENC[AES256_GCM,data:RctvvOJ1R5ga1QVUzQbfeuxe8bDn6chRVkE3bm/i+uAThjS2h8bex5iTgi06DVeJ8mhZaNfjQ8Y8zGBLr3Eh2ZgPOcBcn7c6uBP+tqq/BwVCs3Jf19+NZXFfC9+PZvnAgsV+OAg8bkqftKKtB8GlKvEw1L2v8lT0DykwyVJx2qQ=,iv:8Klci2i6w/6PgWb8svM5xllLsxBEM5/tkkjElwoj0cA=,tag:OF8RjuVQZrujZRYZ0Hor0w==,type:str]
+    lastmodified: "2023-01-26T21:41:01Z"
+    mac: ENC[AES256_GCM,data:65Ao7gTFtHjq5um6zMNZaybi+pjjEQVERY/IJhSP0X/g1u6xtjk0WFXI1F8Gs/2KRYwlrW5byWh7DwIiaGlw+NRfWKauVl5IdphdnCxVspiyMTMgoWxbO1L56+qI5rsh9AoX2Wuku7TRGiMQ7F3d69EuRz618DyO3zlQvg9PybA=,iv:0Ing8OxR/pxGcAUjjj0J6kZtqDbSeSWWepImK5bwB0g=,tag:CT9CtjU1P0dxCBRrJA4hIA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -2,7 +2,8 @@ ENV: ENC[AES256_GCM,data:uh2rtn8dtrq3Ug==,iv:nbhdIo874WQjb0d56JdYLVaUXkJ9UPC3L6x
 JWT_TTL: ENC[AES256_GCM,data:4+BA3Ldj,iv:fAvNETIgI7KsekeW1Bl5HioPuj8CbEiKrXyl5aDviT4=,tag:3cARfUpxYQ2SjvnO+vpWcg==,type:str]
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:AXSXYiGK4Qbdesp5MZWdOjP2XLtfAGqX+5dqC6OwBO0yOIj84egT6mtm8kqA5ipSgb/Y3J8zxuACT1eIFQBgOk+9gPARHB6f2azi5P0WhbqzuQ0dKgGu8P6bme+qWccqjvi1U877XTkXNKw=,iv:bVxlvHgIODlWsoig3QRoq90WEjPWsykQYSsJucVLkJE=,tag:NGyMnSdb9QKn9aHsv/DcDQ==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:6jzt2e62Q+n9+3uRL1s2gIynoA==,iv:DxMf4XlnULYkNTvqXD0IbjCLGqdRIy7FP0NvxWMxWSg=,tag:8WiJV2DQlYsBhGi3TgkAZw==,type:str]
-JWT_SECRET: ENC[AES256_GCM,data:EPYo9Z/CAri3G+Z6wsapeMjwZrU=,iv:EVxUyOWqXD7SwzcS4RHh1pprFENBUZW2vMDSZjQeJLU=,tag:aBdWKUAleaCg9WNFvNDr1w==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:4pO1PsQVLpChXNYbKcH55KS1CQFMvlOE5NSVJyElxPI=,iv:/CfUOa9QkOtRUSHRnHZO/6twxYSKl9+MjkRbBkGOk9c=,tag:SRQih+gbUA2wvpYY8oFssw==,type:str]
+JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:VQcB6H+5S7mT2RKEYgWOj5xM0QE=,iv:snzyqIGZuMNUh0TWUts5vqfrcI8kDHHdxtwxAEkTPuk=,tag:oWMrScJx0xYR4vLRoE71dg==,type:str]
 PREMIUM_CONTRACT_ADDRESS: ENC[AES256_GCM,data:cqMA/2lufayYk8X25f8NCJZ4NHKi9c4OJDfPJdgKyjrSxLCNO9uK1AgMox+Sqr0ymtQzpz1WgpVjLTsaKGA=,iv:IInvsMSWccf9s+gBLGfI2QlQcKbSpdFNOYH0UgyPeG8=,tag:0JL4dPmqfclj0790/hCaxQ==,type:str]
 CONTRACT_ADDRESSES: ENC[AES256_GCM,data:kznef1LHz2OnBjHB1b9qnVgB6GyJ6cE3ApNkuiuyobEx+5WlB5PESL3M67qTvTeai+KKe3RaLgaPDw21o9lPe8p0FZmXZ2bzGoLkfv8I1IPlM6VaiYhQUIqDfKcMjJS3hc1SRvkEEJ5iCNALxA==,iv:lbJ8W1eEf0XAb4Ozq2I+UB2wghHbVikAj3UnQQ0Ojng=,tag:frT49H/Gh+QQ2bsVa2UEeA==,type:str]
 CONTRACT_INTERACTION_URL: ENC[AES256_GCM,data:eReDBRSc5KqkOz4KGbgYfnAA8SnaUMvGW72/2cDyRqjDydZghmi5GJ+KKiy3Jg/Jc9CSvKFZE33wWNghQZLmlQ8669Iv,iv:WdfS/A7SVWngZS8Xzr7pQFC1Za4MIvLd0Y6hEXds8UM=,tag:Shgj4bGp6cfbQ8wx68L/Lw==,type:str]
@@ -55,8 +56,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-24T22:18:24Z"
-    mac: ENC[AES256_GCM,data:hLAakMhe5VOtJG/cR3yrTd2GEYHPGD8Soa7tdheCYaBF18pv/WhIU7KxGFJoxuUl+t+5F0KzKIJK2Dw1YI2iGv6Fre7Qgpm484qNbQ15QLJlgDyNrCH0aOQyWxQ2KHqYXxLWPr5SGhSS36fo9cPVOunoD0nKbV3mpshCJR8Uuq8=,iv:tNJ+jbut3ACETtSqtFfxVQIvZ8bCM8brr04VLMh94CA=,tag:mX5AoSBIDX0/d/G8yRt2qQ==,type:str]
+    lastmodified: "2023-01-26T21:29:00Z"
+    mac: ENC[AES256_GCM,data:UBrlQ8yDOxXnoohXRUkOmZ14JLpNgWuySdDEo/bPV6CtIKwllcgHf1qlUWP+ZI3GkI7+BHHD6aAy9R1Ntrm0dSrqBjumGylnA0ol4yph6AM/soLKonggpdYK67aBU5TPbuFPEHIMuP6MROUsNyiETE3WHtZJRkfIJelzo9s+rt4=,iv:X0MQmhzuLp7nCOIejkTWryFukKf/pPoHKhJ4geisK4Q=,tag:qC1Vh4rAjCUM0+9d8QNMHQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -1,5 +1,5 @@
 ENV: ENC[AES256_GCM,data:uh2rtn8dtrq3Ug==,iv:nbhdIo874WQjb0d56JdYLVaUXkJ9UPC3L6x5E8sATwE=,tag:cRlFJq4vUeg+yFy9eWYOvg==,type:str]
-JWT_TTL: ENC[AES256_GCM,data:4+BA3Ldj,iv:fAvNETIgI7KsekeW1Bl5HioPuj8CbEiKrXyl5aDviT4=,tag:3cARfUpxYQ2SjvnO+vpWcg==,type:str]
+JWT_TTL: ENC[AES256_GCM,data:cvrLpUFc5w==,iv:N7a0koeSfswf+hWvKZi8oiVV6CkON893jzs/Ze7aoVk=,tag:sCx8h90bPkMdSLY+rSJ7Kw==,type:str]
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:AXSXYiGK4Qbdesp5MZWdOjP2XLtfAGqX+5dqC6OwBO0yOIj84egT6mtm8kqA5ipSgb/Y3J8zxuACT1eIFQBgOk+9gPARHB6f2azi5P0WhbqzuQ0dKgGu8P6bme+qWccqjvi1U877XTkXNKw=,iv:bVxlvHgIODlWsoig3QRoq90WEjPWsykQYSsJucVLkJE=,tag:NGyMnSdb9QKn9aHsv/DcDQ==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:6jzt2e62Q+n9+3uRL1s2gIynoA==,iv:DxMf4XlnULYkNTvqXD0IbjCLGqdRIy7FP0NvxWMxWSg=,tag:8WiJV2DQlYsBhGi3TgkAZw==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:4pO1PsQVLpChXNYbKcH55KS1CQFMvlOE5NSVJyElxPI=,iv:/CfUOa9QkOtRUSHRnHZO/6twxYSKl9+MjkRbBkGOk9c=,tag:SRQih+gbUA2wvpYY8oFssw==,type:str]
@@ -56,8 +56,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-26T21:29:00Z"
-    mac: ENC[AES256_GCM,data:UBrlQ8yDOxXnoohXRUkOmZ14JLpNgWuySdDEo/bPV6CtIKwllcgHf1qlUWP+ZI3GkI7+BHHD6aAy9R1Ntrm0dSrqBjumGylnA0ol4yph6AM/soLKonggpdYK67aBU5TPbuFPEHIMuP6MROUsNyiETE3WHtZJRkfIJelzo9s+rt4=,iv:X0MQmhzuLp7nCOIejkTWryFukKf/pPoHKhJ4geisK4Q=,tag:qC1Vh4rAjCUM0+9d8QNMHQ==,type:str]
+    lastmodified: "2023-01-26T22:18:14Z"
+    mac: ENC[AES256_GCM,data:QY56xqbETZnLo3g/sx/OSkfcieFTp3vj+F9g+3+BMRxvnWCy5DH/hq7d0iKfhZteC3On2UQB269/epfS1FVcxMQQI+a2gQNQ+O5d1lxPKojfEcWuODHw4kX6izh3TbZopbQJE/2axap7NzapkcKX4JhXOegH5T3KIv0qbIdWONc=,iv:5gzuzGN2zEwXWNwlX1xo4MJQOjk/cLqEWbQobnzxUl8=,tag:4IL9bHomPXiSXLJwSjmjVA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/emails-server-env.yaml
+++ b/secrets/prod/emails-server-env.yaml
@@ -1,7 +1,8 @@
 ENV: ENC[AES256_GCM,data:XUjOhJJA+racCA==,iv:Af0kF9adn3ZVH6tRTSO9l2+RTFokV8FTvmAflvAKp2A=,tag:5DsuOpQyjYIZhpZxiGpNFw==,type:str]
 JWT_TTL: ENC[AES256_GCM,data:OZmABecM,iv:a8OywtiwZRKV4EAfHLU7wBz5uL/cR4GnnFiRhZrAnko=,tag:gRP2RlC3HmqNCJNFHPRSAg==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:3azHTlbCEq7B1LUFUD6IllF/+A==,iv:PbAcxC7zu8MIz16lOqx9b1KReBphHSS50BAMT9ncIHM=,tag:nhvPqV9Ji9nZc87Ll6ILhQ==,type:str]
-JWT_SECRET: ENC[AES256_GCM,data:J8r3YJBW8NS5hXCdZ6p4OybtqQw=,iv:zddvYBJTvwRDeXvuyADc4GWL7fn7h5TuOIJDVHrrwy8=,tag:PLnflcIUUIbxgo50kGgRew==,type:str]
+JWT_SECRET: ENC[AES256_GCM,data:WeE1Ro/fVMCbCZQDF3bNO5OXttZH/ln1KfevKAtAVDE=,iv:Px4ja+FZhNBroap8+7rtWbFsib3OANcOV1nCUlOFPDY=,tag:SA4Ek+9jeG+JL1Y4WX9fvQ==,type:str]
+JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:4OuTyQR4/z4dTfCvu22K+RpxemI=,iv:tXH6dJQOb3ZwHNbi8dRkODxROnk3lM2kHaceNS29rBA=,tag:DIjyEgbQRWrGkU6yRDL14g==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:GZs0jN2Sw1IflX6HgGKsOCDgtWlvZJdrEbcV5/HDzNPt0SJnYSBNlaEH6ePV0K9b11PTcphN,iv:AAcasC2b5B6aNasXVSM/O2HqowFM3jAaB+Psiu/9Rk4=,tag:iaf0uIgXf5MBPybvXsJyNw==,type:str]
 POSTGRES_PORT: ENC[AES256_GCM,data:yj3p3w==,iv:1YTQlAFOef9asMJRDtfcEbOopvE7ca9fE5pFUrRwxac=,tag:I9i32ukbYzwGb+EEfhUZQQ==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:ZE3AJ8/k7EU=,iv:q8JILYlpTLS/4855VPg2LzH6Bxo8UBvi3oDNqrxHgfE=,tag:SDJx0UC5WlB+5OVeBJbYwA==,type:str]
@@ -26,8 +27,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:28:25Z"
-    mac: ENC[AES256_GCM,data:mXSCjC77hs4z87Z67gvTNfl/PMtfNwr2bOgGcO0EKTlv09UQp8KsAFsnFG1oYdOBr71sAyaxN/zN5CBrNUyXXA1OZe9EChhcx+0JFInNow9qAooqEEjBv8rEdSL0F5GfROYBywvqVjUFbm7R5XF3xSP9Gq4qgp0JDIQ5++teJDQ=,iv:WLTGNUH7Bl4wWJE5lb/8O2tVdej+e7NrL9Z7SFElUM8=,tag:f4r+iQNdozZ/zm6sXeu46Q==,type:str]
+    lastmodified: "2023-01-26T21:42:18Z"
+    mac: ENC[AES256_GCM,data:9pve14qpafuurjVZuWJLnxnAi5anK/iIOj4KfSsofKfln5aEmlrDZj8z1T9Q9f3mblzm6QfsACp7HYgCbq/zCwu4RSvbQ7kUdiY+kdCKLaVZSRTeKLBG2id0q365O4h/9/OuYuwm5bDQJWBGhcDRScdiJuSS8lzFV/qb/x8YGWg=,iv:Wbpub+DG8ro2zOcjRq8BawtIYmzhcf1Dpgwgpg0TATQ=,tag:a0Qvf0UJXcKQlL/d3xRx1A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
It's time to rotate the JWTs we use for auth tokens! Since invalidating them immediately would log users out, this PR uses a transitional approach that checks for a JWT_SECRET_ROTATING_OUT variable, too.

How it works:
- new tokens are issued with JWT_SECRET
- existing tokens are validated with JWT_SECRET
  - if validation fails, existing tokens are validated with JWT_SECRET_ROTATING_OUT

We can remove all of the rotation stuff next week. Our JWT TTL on prod was set to 3 days (again, somehow!), so it won't take long for all the old tokens to expire.

Follow-ups: the rotation code I added for email JWTs is a little messy, but I'd like to see if we can clean everything up with generics and consolidate our JWT functions (as per the comment at the top of the emails JWT file!)