### PR TITLE
Use correct agg function in trending query

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -2156,7 +2156,7 @@ with rollup as (
   group by e.gallery_id
 )
 select p.id from (
-	select u.id, row_number() over(order by sum(r.view_count) + coalesce(sum(v.view_count),0) desc, max(u.created_at) desc) as position
+	select u.id, row_number() over(order by sum(r.view_count) + max(coalesce(v.view_count,0)) desc, max(u.created_at) desc) as position
 	from rollup r, galleries g, users u
 	left join legacy_views v on u.id = v.user_id and v.deleted = false and v.created_at >= $1
 	where r.gallery_id = g.id and g.owner_user_id = u.id and u.deleted = false and g.deleted = false

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -704,7 +704,7 @@ with rollup as (
   group by e.gallery_id
 )
 select p.id from (
-	select u.id, row_number() over(order by sum(r.view_count) + coalesce(sum(v.view_count),0) desc, max(u.created_at) desc) as position
+	select u.id, row_number() over(order by sum(r.view_count) + max(coalesce(v.view_count,0)) desc, max(u.created_at) desc) as position
 	from rollup r, galleries g, users u
 	left join legacy_views v on u.id = v.user_id and v.deleted = false and v.created_at >= @window_end
 	where r.gallery_id = g.id and g.owner_user_id = u.id and u.deleted = false and g.deleted = false


### PR DESCRIPTION
The old query was double counting legacy views because the granularity of the legacy views table is lower than the rollup CTE. In this case, we should use `min` or `max` or `avg` instead of `sum`.