### PR TITLE
Change pagination order of hot feed

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -3093,10 +3093,10 @@ func (q *Queries) IsFeedUserActionBlocked(ctx context.Context, arg IsFeedUserAct
 
 const paginateTrendingFeed = `-- name: PaginateTrendingFeed :many
 select f.id, f.version, f.owner_id, f.action, f.data, f.event_time, f.event_ids, f.deleted, f.last_updated, f.created_at, f.caption from feed_events f join unnest($1::text[]) with ordinality t(id, pos) using(id) where f.deleted = false
-  and t.pos < $2::int
-  and t.pos > $3::int
-  order by case when $4::bool then t.pos end asc,
-          case when not $4::bool then t.pos end desc
+  and t.pos > $2::int
+  and t.pos < $3::int
+  order by case when $4::bool then t.pos end desc,
+          case when not $4::bool then t.pos end asc
   limit $5
 `
 

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -367,8 +367,8 @@ SELECT * FROM feed_events WHERE owner_id = sqlc.arg('owner_id') AND deleted = fa
 
 -- name: PaginateTrendingFeed :many
 select f.* from feed_events f join unnest(@feed_event_ids::text[]) with ordinality t(id, pos) using(id) where f.deleted = false
-  and t.pos < @cur_before_pos::int
-  and t.pos > @cur_after_pos::int
+  and t.pos > @cur_before_pos::int
+  and t.pos < @cur_after_pos::int
   order by case when @paging_forward::bool then t.pos end asc,
           case when not @paging_forward::bool then t.pos end desc
   limit sqlc.arg('limit');
@@ -724,7 +724,6 @@ select users.* from users join unnest(@user_ids::varchar[]) with ordinality t(id
 -- name: GetTrendingFeedEventIDs :many
 select feed_event_id from events where action in ('CommentedOnFeedEvent', 'AdmiredFeedEvent') and created_at >= @window_end and feed_event_id is not null
 group by feed_event_id order by count(*) desc, max(created_at) desc limit sqlc.arg('limit');
-
 
 -- name: UpdateCollectionGallery :exec
 update collections set gallery_id = @gallery_id, last_updated = now() where id = @id and deleted = false;

--- a/go.mod
+++ b/go.mod
@@ -88,8 +88,6 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220407094043-a94812496cf5 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
-	github.com/alexflint/go-arg v1.4.2 // indirect
-	github.com/alexflint/go-scalar v1.0.0 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.43.43 // indirect

--- a/go.sum
+++ b/go.sum
@@ -206,10 +206,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alexflint/go-arg v1.4.2 h1:lDWZAXxpAnZUq4qwb86p/3rIJJ2Li81EoMbTMujhVa0=
 github.com/alexflint/go-arg v1.4.2/go.mod h1:9iRbDxne7LcR/GSvEr7ma++GLpdIU1zrghf2y2768kM=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
-github.com/alexflint/go-scalar v1.0.0 h1:NGupf1XV/Xb04wXskDFzS0KWOLH632W/EO4fAFi+A70=
 github.com/alexflint/go-scalar v1.0.0/go.mod h1:GpHzbCOZXEKMEcygYQ5n/aa4Aq84zbxjy3MxYW0gjYw=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -7097,11 +7097,14 @@ input MoveCollectionToGalleryInput {
 }
 
 type MoveCollectionToGalleryPayload {
-  oldGallery: Gallery,
+  oldGallery: Gallery
   newGallery: Gallery
 }
 
-union MoveCollectionToGalleryPayloadOrError = MoveCollectionToGalleryPayload | ErrInvalidInput | ErrNotAuthorized
+union MoveCollectionToGalleryPayloadOrError =
+    MoveCollectionToGalleryPayload
+  | ErrInvalidInput
+  | ErrNotAuthorized
 
 type Mutation {
   # User Mutations
@@ -7204,7 +7207,9 @@ type Mutation {
   updateUserExperience(input: UpdateUserExperienceInput!): UpdateUserExperiencePayloadOrError
     @authRequired
 
-  moveCollectionToGallery(input: MoveCollectionToGalleryInput): MoveCollectionToGalleryPayloadOrError  @authRequired
+  moveCollectionToGallery(
+    input: MoveCollectionToGalleryInput
+  ): MoveCollectionToGalleryPayloadOrError @authRequired
 }
 
 type Subscription {

--- a/graphql/generated_test.go
+++ b/graphql/generated_test.go
@@ -375,11 +375,11 @@ func (v *__syncTokensMutationInput) GetChains() []Chain { return v.Chains }
 
 // __trendingFeedQueryInput is used internally by genqlient
 type __trendingFeedQueryInput struct {
-	First *int `json:"first"`
+	Last *int `json:"last"`
 }
 
-// GetFirst returns __trendingFeedQueryInput.First, and is useful for accessing the field via an interface.
-func (v *__trendingFeedQueryInput) GetFirst() *int { return v.First }
+// GetLast returns __trendingFeedQueryInput.Last, and is useful for accessing the field via an interface.
+func (v *__trendingFeedQueryInput) GetLast() *int { return v.Last }
 
 // __trendingUsersQueryInput is used internally by genqlient
 type __trendingUsersQueryInput struct {
@@ -5783,13 +5783,13 @@ mutation syncTokensMutation ($chains: [Chain!]) {
 func trendingFeedQuery(
 	ctx context.Context,
 	client graphql.Client,
-	first *int,
+	last *int,
 ) (*trendingFeedQueryResponse, error) {
 	req := &graphql.Request{
 		OpName: "trendingFeedQuery",
 		Query: `
-query trendingFeedQuery ($first: Int) {
-	trendingFeed(first: $first) {
+query trendingFeedQuery ($last: Int) {
+	trendingFeed(last: $last) {
 		edges {
 			node {
 				__typename
@@ -5806,7 +5806,7 @@ query trendingFeedQuery ($first: Int) {
 }
 `,
 		Variables: &__trendingFeedQueryInput{
-			First: first,
+			Last: last,
 		},
 	}
 	var err error

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -383,7 +383,11 @@ func testTrendingFeedEvents(t *testing.T) {
 	commentOnFeedEvent(t, ctx, c, userF.feedEventIDs[0], "a")
 	commentOnFeedEvent(t, ctx, c, userF.feedEventIDs[0], "b")
 	admireFeedEvent(t, ctx, c, userF.feedEventIDs[2])
-	expected := []persist.DBID{userF.feedEventIDs[1], userF.feedEventIDs[0], userF.feedEventIDs[2]}
+	expected := []persist.DBID{
+		userF.feedEventIDs[2],
+		userF.feedEventIDs[0],
+		userF.feedEventIDs[1],
+	}
 
 	actual := trendingFeedEvents(t, ctx, c, 10)
 

--- a/graphql/testdata/operations.graphql
+++ b/graphql/testdata/operations.graphql
@@ -82,8 +82,8 @@ query globalFeedQuery($first: Int) {
   }
 }
 
-query trendingFeedQuery($first: Int) {
-  trendingFeed(first: $first) {
+query trendingFeedQuery($last: Int) {
+  trendingFeed(last: $last) {
     edges {
       node {
         ... on Error {

--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -29,9 +29,9 @@ var (
 	defaultCursorAfterKey = ""
 
 	// Some position that comes after any other position
-	defaultCursorBeforeScore = math.MaxInt32
+	defaultCursorBeforePositon = -1
 	// Some position that comes before any other position
-	defaultCursorAfterScore = -1
+	defaultCursorAfterPosition = math.MaxInt32
 )
 
 type PageInfo struct {
@@ -525,8 +525,8 @@ func (p *positionPaginator) decodeCursor(cursor string) (int, []persist.DBID, er
 
 func (p *positionPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		curBeforePos := defaultCursorBeforeScore
-		curAfterPos := defaultCursorAfterScore
+		curBeforePos := defaultCursorBeforePositon
+		curAfterPos := defaultCursorAfterPosition
 
 		var err error
 		var ids []persist.DBID


### PR DESCRIPTION
Changes order of the hot feed connection so that the most popular feed item now appears last. For example, the query `trendingFeed(last: 5)`:
will return:
```
[
  eventA -- fifth most popular event
  eventB
  eventC
  eventD
  eventE -- most popular event
]
```
and the query `trendingFeed(last: 1, before: <cursor of eventE>)` will return:
```
[
  eventD -- second most popular event
]
```