### PR TITLE
Allow missing tokens in resolver

### DIFF
--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -716,6 +716,9 @@ select t.media from tokens t, collections c, galleries g where g.id = $1 and c.i
 -- name: GetTokenByTokenIdentifiers :one
 select * from tokens where tokens.token_id = @token_hex and contract = (select contracts.id from contracts where contracts.address = @contract_address) and tokens.chain = @chain and tokens.deleted = false;
 
+-- name: GetTokensByIDs :many
+select * from tokens join unnest(@token_ids::varchar[]) with ordinality t(id, pos) using (id) where deleted = false order by t.pos asc;
+
 -- name: DeleteCollections :exec
 update collections set deleted = true, last_updated = now() where id = any(@ids::varchar[]);
 

--- a/emails/t__utils_test.go
+++ b/emails/t__utils_test.go
@@ -146,6 +146,7 @@ func seedNotifications(ctx context.Context, t *testing.T, q *coredb.Queries, rep
 		Action:         persist.ActionCollectionCreated,
 		ResourceTypeID: persist.ResourceTypeCollection,
 		CollectionID:   testGallery.Collections[0],
+		GalleryID:      gallery.ID,
 	})
 
 	if err != nil {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -81,6 +81,10 @@ func (r *collectionCreatedFeedEventDataResolver) NewTokens(ctx context.Context, 
 	return resolveCollectionTokensByTokenIDs(ctx, obj.CollectionID, obj.TokenIDs)
 }
 
+func (r *collectionTokenResolver) Collection(ctx context.Context, obj *model.CollectionToken) (*model.Collection, error) {
+	return resolveCollectionByCollectionID(ctx, obj.HelperCollectionTokenData.CollectionId)
+}
+
 func (r *collectionTokenResolver) TokenSettings(ctx context.Context, obj *model.CollectionToken) (*model.CollectionTokenSettings, error) {
 	return resolveTokenSettingsByIDs(ctx, obj.TokenId, obj.CollectionId)
 }
@@ -1484,12 +1488,9 @@ func (r *setSpamPreferencePayloadResolver) Tokens(ctx context.Context, obj *mode
 		tokenIDs[i] = token.Dbid
 	}
 
-	tokens, errors := publicapi.For(ctx).Token.GetTokensByTokenIDs(ctx, tokenIDs)
-
-	for _, err := range errors {
-		if err != nil {
-			return nil, err
-		}
+	tokens, err := publicapi.For(ctx).Token.GetTokensByIDs(ctx, tokenIDs)
+	if err != nil {
+		return nil, err
 	}
 
 	return tokensToModel(ctx, tokens), nil

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -338,7 +338,7 @@ type OwnerAtBlock {
 type CollectionToken implements Node @goEmbedHelper @goGqlId(fields: ["tokenId", "collectionId"]) {
   id: ID!
   token: Token
-  collection: Collection
+  collection: Collection @goField(forceResolver: true)
   tokenSettings: CollectionTokenSettings @goField(forceResolver: true)
 }
 

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -179,8 +179,12 @@ func (api TokenAPI) GetTokensByContractIdPaginate(ctx context.Context, contractI
 	return tokens, pageInfo, nil
 }
 
-func (api TokenAPI) GetTokensByTokenIDs(ctx context.Context, tokenIDs []persist.DBID) ([]db.Token, []error) {
-	return api.loaders.TokenByTokenID.LoadAll(tokenIDs)
+func (api TokenAPI) GetTokensByIDs(ctx context.Context, tokenIDs []persist.DBID) ([]db.Token, error) {
+	ids := make([]string, len(tokenIDs))
+	for i, t := range tokenIDs {
+		ids[i] = t.String()
+	}
+	return api.queries.GetTokensByIDs(ctx, ids)
 }
 
 // GetNewTokensByFeedEventID returns new tokens added to a collection from an event.


### PR DESCRIPTION
This PR updates resolvers that return `[CollectionToken]` to return even if some tokens have been `deleted`. For example, if a request is made for a collection updated event with tokens: `tokenA`, `tokenB`, and `tokenC`, but `tokenB` is deleted, the reply will be:
```
{
  "newTokens": [
     {
        "token": {
           "name": "tokenA"
        }
       ...other fields
     }
     null, -- tokenB is missing!
     {
        "token": {
           "name": "tokenC"
        }
       ...other fields
     }
  ]
}
```
A request for a feed event with one new token that is deleted:
```
{
  "newTokens": [
     null
  ]
}
```
A request for a feed event with no new tokens:
```
{
  "newTokens": []
}
```

This PR also changes the `collection` field of `CollectionToken` to a forced resolver so that we don't fetch a collection where it isn't needed.