### PR TITLE
Update User Trending Report

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -828,6 +828,48 @@ func (q *Queries) GetAdmiresByAdmireIDs(ctx context.Context, admireIds persist.D
 	return items, nil
 }
 
+const getAllTimeTrendingUserIDs = `-- name: GetAllTimeTrendingUserIDs :many
+with gallery_views as (
+  select gallery_id, count(*)
+  from events
+  where action = 'ViewedGallery'
+  group by gallery_id
+)
+
+select users.id
+from events, galleries, users
+left join legacy_views on users.id = legacy_views.user_id
+where action = 'ViewedGallery'
+  and events.gallery_id = galleries.id
+  and users.id = galleries.owner_user_id
+  and galleries.deleted = false
+  and users.deleted = false
+  and legacy_views.deleted = false
+group by users.id
+order by row_number() over(order by count(events.id) + max(legacy_views.view_count) desc, max(users.created_at) desc)
+limit $1
+`
+
+func (q *Queries) GetAllTimeTrendingUserIDs(ctx context.Context, limit int32) ([]persist.DBID, error) {
+	rows, err := q.db.Query(ctx, getAllTimeTrendingUserIDs, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []persist.DBID
+	for rows.Next() {
+		var id persist.DBID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getCollectionById = `-- name: GetCollectionById :one
 SELECT id, deleted, owner_user_id, nfts, version, last_updated, created_at, hidden, collectors_note, name, layout, token_settings, gallery_id FROM collections WHERE id = $1 AND deleted = false
 `
@@ -2372,48 +2414,6 @@ func (q *Queries) GetTrendingFeedEventIDs(ctx context.Context, arg GetTrendingFe
 	return items, nil
 }
 
-const getTrendingUserIDs = `-- name: GetTrendingUserIDs :many
-with rollup as (
-  select e.gallery_id, count(*) view_count
-  from events e
-  where action = 'ViewedGallery' and e.created_at >= $1
-  group by e.gallery_id
-)
-select p.id from (
-	select u.id, row_number() over(order by sum(r.view_count) + max(coalesce(v.view_count,0)) desc, max(u.created_at) desc) as position
-	from rollup r, galleries g, users u
-	left join legacy_views v on u.id = v.user_id and v.deleted = false and v.created_at >= $1
-	where r.gallery_id = g.id and g.owner_user_id = u.id and u.deleted = false and g.deleted = false
-	group by u.id
-) p
-where position <= $2::int
-`
-
-type GetTrendingUserIDsParams struct {
-	WindowEnd time.Time
-	Size      int32
-}
-
-func (q *Queries) GetTrendingUserIDs(ctx context.Context, arg GetTrendingUserIDsParams) ([]persist.DBID, error) {
-	rows, err := q.db.Query(ctx, getTrendingUserIDs, arg.WindowEnd, arg.Size)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []persist.DBID
-	for rows.Next() {
-		var id persist.DBID
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		items = append(items, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getTrendingUsersByIDs = `-- name: GetTrendingUsersByIDs :many
 select users.id, users.deleted, users.version, users.last_updated, users.created_at, users.username, users.username_idempotent, users.wallets, users.bio, users.traits, users.universal, users.notification_settings, users.email_verified, users.email_unsubscriptions, users.featured_gallery, users.primary_wallet_id, users.user_experiences from users join unnest($1::varchar[]) with ordinality t(id, pos) using (id) where deleted = false order by t.pos asc
 `
@@ -3205,6 +3205,56 @@ func (q *Queries) GetWalletsByUserID(ctx context.Context, id persist.DBID) ([]Wa
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getWindowedTrendingUserIDs = `-- name: GetWindowedTrendingUserIDs :many
+with viewers as (
+  select gallery_id, count(distinct coalesce(actor_id, external_id)) viewer_count
+  from events
+  where action = 'ViewedGallery' and events.created_at >= $2
+  group by gallery_id
+),
+edit_events as (
+  select actor_id
+  from events
+  where action in ('CollectionCreated', 'CollectorsNoteAddedToCollection', 'CollectorsNoteAddedToToken', 'TokensAddedToCollection') and created_at >= $2
+  group by actor_id
+)
+select users.id
+from viewers, galleries, users, edit_events
+where viewers.gallery_id = galleries.id
+	and galleries.owner_user_id = users.id
+	and users.deleted = false
+	and galleries.deleted = false
+  and users.id = edit_events.actor_id
+group by users.id
+order by row_number() over(order by sum(viewers.viewer_count) desc, max(users.created_at) desc)
+limit $1
+`
+
+type GetWindowedTrendingUserIDsParams struct {
+	Limit     int32
+	WindowEnd time.Time
+}
+
+func (q *Queries) GetWindowedTrendingUserIDs(ctx context.Context, arg GetWindowedTrendingUserIDsParams) ([]persist.DBID, error) {
+	rows, err := q.db.Query(ctx, getWindowedTrendingUserIDs, arg.Limit, arg.WindowEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []persist.DBID
+	for rows.Next() {
+		var id persist.DBID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/db/migrations/core/000054_add_events_gallery_edit_index.down.sql
+++ b/db/migrations/core/000054_add_events_gallery_edit_index.down.sql
@@ -1,0 +1,1 @@
+drop index if exists events_gallery_edit_idx;

--- a/db/migrations/core/000054_add_events_gallery_edit_index.up.sql
+++ b/db/migrations/core/000054_add_events_gallery_edit_index.up.sql
@@ -1,1 +1,1 @@
-create index if not exists events_gallery_edit_idx on events (created_at, actor_id) where action in ('CollectionCreated', 'CollectorsNoteAddedToCollection', 'CollectorsNoteAddedToToken', 'TokensAddedToCollection') and deleted = false;
+create index if not exists events_gallery_edit_idx on events (created_at, actor_id) where action in ('CollectionCreated', 'CollectorsNoteAddedToCollection', 'CollectorsNoteAddedToToken', 'TokensAddedToCollection');

--- a/db/migrations/core/000054_add_events_gallery_edit_index.up.sql
+++ b/db/migrations/core/000054_add_events_gallery_edit_index.up.sql
@@ -1,0 +1,1 @@
+create index if not exists events_gallery_edit_idx on events (created_at, actor_id) where action in ('CollectionCreated', 'CollectorsNoteAddedToCollection', 'CollectorsNoteAddedToToken', 'TokensAddedToCollection') and deleted = false;

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -6382,6 +6382,7 @@ union GalleryByIdPayloadOrError = Gallery | ErrGalleryNotFound
 union ViewerGalleryByIdPayloadOrError = ViewerGallery | ErrGalleryNotFound
 
 enum ReportWindow {
+  LAST_5_DAYS
   LAST_7_DAYS
   ALL_TIME
 }

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -566,21 +566,27 @@ func testViewsAreRolledUp(t *testing.T) {
 
 func testTrendingUsers(t *testing.T) {
 	serverF := newServerFixture(t)
-	bob := newUserFixture(t)
-	alice := newUserFixture(t)
-	dave := newUserFixture(t)
+	bob := newUserWithFeedEventsFixture(t)
+	alice := newUserWithFeedEventsFixture(t)
+	dave := newUserWithFeedEventsFixture(t)
 	ctx := context.Background()
-	c := defaultServerClient(t, serverF.server.URL)
+	var c *serverClient
 	// view bob a few times
 	for i := 0; i < 5; i++ {
+		viewer := newUserFixture(t)
+		c = authedServerClient(t, serverF.server.URL, viewer.id)
 		viewGallery(t, ctx, c, bob.galleryID)
 	}
 	// view alice a few times
 	for i := 0; i < 3; i++ {
+		viewer := newUserFixture(t)
+		c = authedServerClient(t, serverF.server.URL, viewer.id)
 		viewGallery(t, ctx, c, alice.galleryID)
 	}
 	// view dave a few times
 	for i := 0; i < 1; i++ {
+		viewer := newUserFixture(t)
+		c = authedServerClient(t, serverF.server.URL, viewer.id)
 		viewGallery(t, ctx, c, dave.galleryID)
 	}
 	expected := []persist.DBID{bob.id, alice.id, dave.id}
@@ -594,6 +600,11 @@ func testTrendingUsers(t *testing.T) {
 		}
 		return actual
 	}
+
+	t.Run("should pull the last 5 days", func(t *testing.T) {
+		actual := getTrending(t, "LAST_5_DAYS")
+		assert.EqualValues(t, expected, actual)
+	})
 
 	t.Run("should pull the last 7 days", func(t *testing.T) {
 		actual := getTrending(t, "LAST_7_DAYS")

--- a/graphql/model/models.go
+++ b/graphql/model/models.go
@@ -142,6 +142,7 @@ type Window struct {
 }
 
 var (
+	lastFiveDaysWindow  = Window{5 * 24 * time.Hour, "LAST_5_DAYS"}
 	lastSevenDaysWindow = Window{7 * 24 * time.Hour, "LAST_7_DAYS"}
 	allTimeWindow       = Window{1<<63 - 1, "ALL_TIME"}
 )
@@ -152,6 +153,8 @@ func (w *Window) UnmarshalGQL(v interface{}) error {
 		return fmt.Errorf("Window must be a string")
 	}
 	switch window {
+	case lastFiveDaysWindow.Name:
+		*w = lastFiveDaysWindow
 	case lastSevenDaysWindow.Name:
 		*w = lastSevenDaysWindow
 	case allTimeWindow.Name:
@@ -164,6 +167,8 @@ func (w *Window) UnmarshalGQL(v interface{}) error {
 
 func (w Window) MarshalGQL(wt io.Writer) {
 	switch {
+	case w == lastFiveDaysWindow:
+		wt.Write([]byte(fmt.Sprintf(`"%s"`, lastFiveDaysWindow.Name)))
 	case w == lastSevenDaysWindow:
 		wt.Write([]byte(fmt.Sprintf(`"%s"`, lastSevenDaysWindow.Name)))
 	case w == allTimeWindow:

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -833,6 +833,7 @@ union GalleryByIdPayloadOrError = Gallery | ErrGalleryNotFound
 union ViewerGalleryByIdPayloadOrError = ViewerGallery | ErrGalleryNotFound
 
 enum ReportWindow {
+  LAST_5_DAYS
   LAST_7_DAYS
   ALL_TIME
 }

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -316,9 +316,12 @@ func (api FeedAPI) PaginateTrendingFeed(ctx context.Context, before *string, aft
 
 func (api FeedAPI) TrendingUsers(ctx context.Context, report model.Window) ([]db.User, error) {
 	calcFunc := func(ctx context.Context) ([]persist.DBID, error) {
-		return api.queries.GetTrendingUserIDs(ctx, db.GetTrendingUserIDsParams{
+		if report.Name == "ALL_TIME" {
+			return api.queries.GetAllTimeTrendingUserIDs(ctx, 24)
+		}
+		return api.queries.GetWindowedTrendingUserIDs(ctx, db.GetWindowedTrendingUserIDsParams{
 			WindowEnd: time.Now().Add(-time.Duration(report.Duration)),
-			Size:      24,
+			Limit:     24,
 		})
 	}
 


### PR DESCRIPTION
This PR updates the trending user report to only consider users that made edits to their galleries during the reporting window and also to use unique viewers as the criteria instead of views. This should help decorrelate weekly trending users from all time users and have more variety of users because each report uses a different set of criteria.

**Post Merge TODOs**
* [ ] Run migrations to add new index