### PR TITLE
Add time factor to trending feed

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -2377,28 +2377,31 @@ func (q *Queries) GetTokensByWalletIds(ctx context.Context, ownedByWallets persi
 }
 
 const getTrendingFeedEventIDs = `-- name: GetTrendingFeedEventIDs :many
-select feed_event_id from events where action in ('CommentedOnFeedEvent', 'AdmiredFeedEvent') and created_at >= $1 and feed_event_id is not null
-group by feed_event_id order by count(*) desc, max(created_at) desc limit $2
+select feed_events.id, feed_events.created_at, count(*)
+from events as interactions, feed_events
+where interactions.action IN ('CommentedOnFeedEvent', 'AdmiredFeedEvent') and interactions.created_at >= $1 and interactions.feed_event_id is not null and interactions.feed_event_id = feed_events.id
+group by feed_events.id, feed_events.created_at
 `
 
-type GetTrendingFeedEventIDsParams struct {
-	WindowEnd time.Time
-	Limit     int32
+type GetTrendingFeedEventIDsRow struct {
+	ID        persist.DBID
+	CreatedAt time.Time
+	Count     int64
 }
 
-func (q *Queries) GetTrendingFeedEventIDs(ctx context.Context, arg GetTrendingFeedEventIDsParams) ([]persist.DBID, error) {
-	rows, err := q.db.Query(ctx, getTrendingFeedEventIDs, arg.WindowEnd, arg.Limit)
+func (q *Queries) GetTrendingFeedEventIDs(ctx context.Context, windowEnd time.Time) ([]GetTrendingFeedEventIDsRow, error) {
+	rows, err := q.db.Query(ctx, getTrendingFeedEventIDs, windowEnd)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []persist.DBID
+	var items []GetTrendingFeedEventIDsRow
 	for rows.Next() {
-		var feed_event_id persist.DBID
-		if err := rows.Scan(&feed_event_id); err != nil {
+		var i GetTrendingFeedEventIDsRow
+		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.Count); err != nil {
 			return nil, err
 		}
-		items = append(items, feed_event_id)
+		items = append(items, i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -787,8 +787,10 @@ update users set user_experiences = user_experiences || @experience where id = @
 select users.* from users join unnest(@user_ids::varchar[]) with ordinality t(id, pos) using (id) where deleted = false order by t.pos asc;
 
 -- name: GetTrendingFeedEventIDs :many
-select feed_event_id from events where action in ('CommentedOnFeedEvent', 'AdmiredFeedEvent') and created_at >= @window_end and feed_event_id is not null
-group by feed_event_id order by count(*) desc, max(created_at) desc limit sqlc.arg('limit');
+select feed_events.id, feed_events.created_at, count(*)
+from events as interactions, feed_events
+where interactions.action IN ('CommentedOnFeedEvent', 'AdmiredFeedEvent') and interactions.created_at >= @window_end and interactions.feed_event_id is not null and interactions.feed_event_id = feed_events.id
+group by feed_events.id, feed_events.created_at;
 
 -- name: UpdateCollectionGallery :exec
 update collections set gallery_id = @gallery_id, last_updated = now() where id = @id and deleted = false;

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"time"
 
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -240,6 +242,9 @@ func (api FeedAPI) PaginateTrendingFeed(ctx context.Context, before *string, aft
 		trendingIDs []persist.DBID
 		paginator   = positionPaginator{}
 		lookup      = make(map[persist.DBID]int)
+		// lambda determines how quickly the score decreases over time. A larger value (i.e. a smaller denominator) has a faster decay rate.
+		lambda     = float64(1) / 200000
+		reportSize = 100
 	)
 
 	// If a cursor is provided, we can skip querying the cache
@@ -253,10 +258,31 @@ func (api FeedAPI) PaginateTrendingFeed(ctx context.Context, before *string, aft
 		}
 	} else {
 		calcFunc := func(ctx context.Context) ([]persist.DBID, error) {
-			return api.queries.GetTrendingFeedEventIDs(ctx, db.GetTrendingFeedEventIDsParams{
-				WindowEnd: time.Now().Add(-time.Duration(72 * time.Hour)),
-				Limit:     100,
+			trendData, err := api.queries.GetTrendingFeedEventIDs(ctx, time.Now().Add(-time.Duration(72*time.Hour)))
+			if err != nil {
+				return nil, err
+			}
+
+			// Compute a new score for each event by weighting the current score by its relative age
+			scores := make(map[persist.DBID]float64)
+			now := time.Now()
+			for _, event := range trendData {
+				eventAge := now.Sub(event.CreatedAt).Seconds()
+				score := float64(event.Count) * math.Pow(math.E, (-lambda*eventAge))
+				// Invert the score so that events are in descending order (in terms of absolute value) below
+				scores[event.ID] = -score
+			}
+
+			sort.Slice(trendData, func(i, j int) bool {
+				return scores[trendData[i].ID] < scores[trendData[j].ID]
 			})
+
+			trendingIDs := make([]persist.DBID, 0)
+			for i := 0; i < len(trendData) && i < reportSize; i++ {
+				trendingIDs = append(trendingIDs, trendData[i].ID)
+			}
+
+			return trendingIDs, nil
 		}
 
 		t := trender{


### PR DESCRIPTION
This PR adds an [exponential decay](https://en.wikipedia.org/wiki/Exponential_decay) term to the trending feed calculation to penalize events that are older in age. This decay rate can be tuned using the `lambda` parameter which controls how quickly values decrease over time.