### PR TITLE
Benny/new feed event field

### DIFF
--- a/feed/event.go
+++ b/feed/event.go
@@ -262,13 +262,13 @@ func (b *EventBuilder) createGalleryUpdatedFeedEventFromEvents(ctx context.Conte
 		Caption:   persist.StrToNullStr(merged.caption),
 		GroupID:   persist.StrToNullStr(merged.groupID),
 		Data: persist.FeedEventData{
-			GalleryID:                           merged.galleryID,
-			GalleryName:                         merged.galleryName,
-			GalleryDescription:                  merged.galleryDescription,
-			GalleryNewCollections:               merged.newCollections,
-			GalleryNewCollectionTokenIDs:        merged.tokensAdded,
-			GalleryNewCollectionCollectorsNotes: merged.collectionCollectorsNotes,
-			GalleryNewTokenCollectorsNotes:      merged.tokenCollectorsNotes,
+			GalleryID:                                merged.galleryID,
+			GalleryName:                              merged.galleryName,
+			GalleryDescription:                       merged.galleryDescription,
+			GalleryNewCollections:                    merged.newCollections,
+			GalleryNewCollectionTokenIDs:             merged.tokensAdded,
+			GalleryNewCollectionCollectorsNotes:      merged.collectionCollectorsNotes,
+			GalleryNewCollectionTokenCollectorsNotes: merged.tokenCollectorsNotes,
 		},
 	})
 }

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1378,8 +1378,8 @@ func feedEventToSubEventDatas(ctx context.Context, event db.FeedEvent) ([]model.
 		}
 	}
 
-	if event.Data.GalleryNewTokenCollectorsNotes != nil && len(event.Data.GalleryNewTokenCollectorsNotes) > 0 {
-		for collectionID, newNotes := range event.Data.GalleryNewTokenCollectorsNotes {
+	if event.Data.GalleryNewCollectionTokenCollectorsNotes != nil && len(event.Data.GalleryNewCollectionTokenCollectorsNotes) > 0 {
+		for collectionID, newNotes := range event.Data.GalleryNewCollectionTokenCollectorsNotes {
 			for tokenID, note := range newNotes {
 				result = append(result, model.CollectorsNoteAddedToTokenFeedEventData{
 					EventTime: &event.CreatedAt,

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -47,25 +47,26 @@ type EventData struct {
 }
 
 type FeedEventData struct {
-	UserBio                                  string                   `json:"user_bio"`
-	UserFollowedIDs                          DBIDList                 `json:"user_followed_ids"`
-	UserFollowedBack                         []bool                   `json:"user_followed_back"`
-	TokenID                                  DBID                     `json:"token_id"`
-	TokenCollectionID                        DBID                     `json:"token_collection_id"`
-	TokenGalleryID                           DBID                     `json:"token_gallery_id"`
-	TokenNewCollectorsNote                   string                   `json:"token_new_collectors_note"`
-	CollectionID                             DBID                     `json:"collection_id"`
-	CollectionGalleryID                      DBID                     `json:"collection_gallery_id"`
-	CollectionTokenIDs                       DBIDList                 `json:"collection_token_ids"`
-	CollectionNewCollectorsNote              string                   `json:"collection_new_collectors_note"`
-	CollectionIsPreFeed                      bool                     `json:"collection_is_pre_feed"`
-	CollectionIsNew                          bool                     `json:"collection_is_new"`
-	GalleryID                                DBID                     `json:"gallery_id"`
-	GalleryName                              string                   `json:"gallery_name"`
-	GalleryDescription                       string                   `json:"gallery_description"`
-	GalleryNewCollectionCollectorsNotes      map[DBID]string          `json:"gallery_new_collection_collectors_notes"`
-	GalleryNewCollectionTokenIDs             map[DBID]DBIDList        `json:"gallery_new_token_ids"`
-	GalleryNewCollections                    DBIDList                 `json:"gallery_new_collections"`
+	UserBio                             string            `json:"user_bio"`
+	UserFollowedIDs                     DBIDList          `json:"user_followed_ids"`
+	UserFollowedBack                    []bool            `json:"user_followed_back"`
+	TokenID                             DBID              `json:"token_id"`
+	TokenCollectionID                   DBID              `json:"token_collection_id"`
+	TokenGalleryID                      DBID              `json:"token_gallery_id"`
+	TokenNewCollectorsNote              string            `json:"token_new_collectors_note"`
+	CollectionID                        DBID              `json:"collection_id"`
+	CollectionGalleryID                 DBID              `json:"collection_gallery_id"`
+	CollectionTokenIDs                  DBIDList          `json:"collection_token_ids"`
+	CollectionNewCollectorsNote         string            `json:"collection_new_collectors_note"`
+	CollectionIsPreFeed                 bool              `json:"collection_is_pre_feed"`
+	CollectionIsNew                     bool              `json:"collection_is_new"`
+	GalleryID                           DBID              `json:"gallery_id"`
+	GalleryName                         string            `json:"gallery_name"`
+	GalleryDescription                  string            `json:"gallery_description"`
+	GalleryNewCollectionCollectorsNotes map[DBID]string   `json:"gallery_new_collection_collectors_notes"`
+	GalleryNewCollectionTokenIDs        map[DBID]DBIDList `json:"gallery_new_token_ids"`
+	GalleryNewCollections               DBIDList          `json:"gallery_new_collections"`
+	// this field should never be used again and should be replaced with its collection equivalent
 	GalleryNewTokenCollectorsNotes           map[DBID]string          `json:"gallery_new_token_collectors_notes"`
 	GalleryNewCollectionTokenCollectorsNotes map[DBID]map[DBID]string `json:"gallery_new_collection_token_collectors_notes"`
 }

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -47,26 +47,27 @@ type EventData struct {
 }
 
 type FeedEventData struct {
-	UserBio                             string                   `json:"user_bio"`
-	UserFollowedIDs                     DBIDList                 `json:"user_followed_ids"`
-	UserFollowedBack                    []bool                   `json:"user_followed_back"`
-	TokenID                             DBID                     `json:"token_id"`
-	TokenCollectionID                   DBID                     `json:"token_collection_id"`
-	TokenGalleryID                      DBID                     `json:"token_gallery_id"`
-	TokenNewCollectorsNote              string                   `json:"token_new_collectors_note"`
-	CollectionID                        DBID                     `json:"collection_id"`
-	CollectionGalleryID                 DBID                     `json:"collection_gallery_id"`
-	CollectionTokenIDs                  DBIDList                 `json:"collection_token_ids"`
-	CollectionNewCollectorsNote         string                   `json:"collection_new_collectors_note"`
-	CollectionIsPreFeed                 bool                     `json:"collection_is_pre_feed"`
-	CollectionIsNew                     bool                     `json:"collection_is_new"`
-	GalleryID                           DBID                     `json:"gallery_id"`
-	GalleryName                         string                   `json:"gallery_name"`
-	GalleryDescription                  string                   `json:"gallery_description"`
-	GalleryNewCollectionCollectorsNotes map[DBID]string          `json:"gallery_new_collection_collectors_notes"`
-	GalleryNewCollectionTokenIDs        map[DBID]DBIDList        `json:"gallery_new_token_ids"`
-	GalleryNewCollections               DBIDList                 `json:"gallery_new_collections"`
-	GalleryNewTokenCollectorsNotes      map[DBID]map[DBID]string `json:"gallery_new_token_collectors_notes"`
+	UserBio                                  string                   `json:"user_bio"`
+	UserFollowedIDs                          DBIDList                 `json:"user_followed_ids"`
+	UserFollowedBack                         []bool                   `json:"user_followed_back"`
+	TokenID                                  DBID                     `json:"token_id"`
+	TokenCollectionID                        DBID                     `json:"token_collection_id"`
+	TokenGalleryID                           DBID                     `json:"token_gallery_id"`
+	TokenNewCollectorsNote                   string                   `json:"token_new_collectors_note"`
+	CollectionID                             DBID                     `json:"collection_id"`
+	CollectionGalleryID                      DBID                     `json:"collection_gallery_id"`
+	CollectionTokenIDs                       DBIDList                 `json:"collection_token_ids"`
+	CollectionNewCollectorsNote              string                   `json:"collection_new_collectors_note"`
+	CollectionIsPreFeed                      bool                     `json:"collection_is_pre_feed"`
+	CollectionIsNew                          bool                     `json:"collection_is_new"`
+	GalleryID                                DBID                     `json:"gallery_id"`
+	GalleryName                              string                   `json:"gallery_name"`
+	GalleryDescription                       string                   `json:"gallery_description"`
+	GalleryNewCollectionCollectorsNotes      map[DBID]string          `json:"gallery_new_collection_collectors_notes"`
+	GalleryNewCollectionTokenIDs             map[DBID]DBIDList        `json:"gallery_new_token_ids"`
+	GalleryNewCollections                    DBIDList                 `json:"gallery_new_collections"`
+	GalleryNewTokenCollectorsNotes           map[DBID]string          `json:"gallery_new_token_collectors_notes"`
+	GalleryNewCollectionTokenCollectorsNotes map[DBID]map[DBID]string `json:"gallery_new_collection_token_collectors_notes"`
 }
 
 type ErrFeedEventNotFoundByID struct {


### PR DESCRIPTION
Changes:

- **Added** new feed event data field to be used instead of the current one but left the current one for some backwards compatibility. This is to support collection tokens for token collectors note updates

Considerations:

- This will make any of the past sub events with token collectors notes not load. It will not error, they simply will not show up. Given that the new feed changes for multi-gallery have not really been in full effect, I don't see an issue with this. If we really want those past sub events to load, we can add support for them but that would be increased lift for something that a user could never notice.