### PR TITLE
Tokenprocessing fixups

### DIFF
--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -314,6 +314,9 @@ func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnostic
 	}
 
 	m, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
 
 	buf := bytes.NewBuffer(m)
 
@@ -328,7 +331,6 @@ func (d *Provider) RefreshToken(ctx context.Context, ti multichain.ChainAgnostic
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-
 		return util.GetErrFromResp(res)
 	}
 

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -640,12 +640,11 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 				}); err != nil {
 					return err
 				}
-				if !token.Media.IsServable() {
-					image, anim := ti.Chain.BaseKeywords()
-					err = p.processMedialessToken(ctx, ti.TokenID, ti.ContractAddress, ti.Chain, token.OwnerAddress, image, anim)
-					if err != nil {
-						return err
-					}
+
+				image, anim := ti.Chain.BaseKeywords()
+				err = p.processMedialessToken(ctx, ti.TokenID, ti.ContractAddress, ti.Chain, token.OwnerAddress, image, anim)
+				if err != nil {
+					return err
 				}
 
 				if err := p.Repos.ContractRepository.UpsertByAddress(ctx, ti.ContractAddress, ti.Chain, persist.ContractGallery{

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -610,7 +610,7 @@ func DecodeMetadataFromURI(ctx context.Context, turi persist.TokenURI, into *per
 		if err != nil {
 			return err
 		}
-		return json.Unmarshal(bs, into)
+		return json.Unmarshal(util.RemoveBOM(bs), into)
 	case persist.URITypeArweave:
 		path := strings.ReplaceAll(asString, "arweave://", "")
 		path = strings.ReplaceAll(path, "ar://", "")


### PR DESCRIPTION
**Changes**
* Always try to remove the BOM when reading JSON data of token URIs
* If an individual token is refreshed, we now will always try to have tokenprocessing cache the new media