### PR TITLE
Use server client for test

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -237,8 +237,9 @@ func testCreateCollection(t *testing.T) {
 }
 
 func testUpdateGalleryWithPublish(t *testing.T) {
+	serverF := newServerFixture(t)
 	userF := newUserWithTokensFixture(t)
-	c := authedHandlerClient(t, userF.id)
+	c := authedServerClient(t, serverF.server.URL, userF.id)
 
 	colResp, err := createCollectionMutation(context.Background(), c, CreateCollectionInput{
 		GalleryId:      userF.galleryID,


### PR DESCRIPTION
Using a server client instead of a handler client to make tests less flakey.