### PR TITLE
Bump JWT expiration + remove migration path

### DIFF
--- a/emails/jwt.go
+++ b/emails/jwt.go
@@ -2,7 +2,6 @@ package emails
 
 import (
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
@@ -28,19 +27,6 @@ func jwtParse(pJWTtokenStr string) (persist.DBID, string, error) {
 		func(pJWTtoken *jwt.Token) (interface{}, error) {
 			return []byte(viper.GetString("JWT_SECRET")), nil
 		})
-
-	if err != nil || !JWTtoken.Valid {
-		// If the token wasn't valid, see if we're rotating an existing key out.
-		// If so, try validating the token with that key.
-		oldKey := viper.GetString("JWT_SECRET_ROTATING_OUT")
-		if strings.TrimSpace(oldKey) != "" {
-			JWTtoken, err = jwt.ParseWithClaims(pJWTtokenStr,
-				&claims,
-				func(pJWTtoken *jwt.Token) (interface{}, error) {
-					return []byte(oldKey), nil
-				})
-		}
-	}
 
 	if err != nil || !JWTtoken.Valid {
 		return "", "", errInvalidJWT

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,15 +3,13 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"net/http"
-	"strings"
-
 	"github.com/getsentry/sentry-go"
 	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/mikeydub/go-gallery/service/logger"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/tracing"
+	"github.com/sirupsen/logrus"
+	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/service/auth"
@@ -58,18 +56,7 @@ func AddAuthToContext() gin.HandlerFunc {
 			return
 		}
 
-		// See if the user's token is valid based on our current JWT secret
 		userID, err := auth.JWTParse(jwt, viper.GetString("JWT_SECRET"))
-
-		if err != nil {
-			// If the token wasn't valid, see if we're rotating an existing key out.
-			// If so, try validating the token with that key.
-			oldKey := viper.GetString("JWT_SECRET_ROTATING_OUT")
-			if strings.TrimSpace(oldKey) != "" {
-				userID, err = auth.JWTParse(jwt, oldKey)
-			}
-		}
-
 		auth.SetAuthStateForCtx(c, userID, err)
 
 		// If we have a successfully authenticated user, add their ID to all subsequent logging

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -3,7 +3,6 @@ JWT_TTL: ENC[AES256_GCM,data:Qg2ZYbPahA==,iv:9PRjN1LMxGq7bgnog8+Wg7VxlqbUh4Z+Af4
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:2XT4xhyFBcccjqFZtzWeZCq7TogjN/80GmWLO4f6ZxkWyosUPWdzo809uBexAqkw1uZLdg69l/Y4xsviCxN5Bj/HYl4J4Yg=,iv:ZO9CTIhPFGBhFpclrWDpjkkxfAva/q8rZjW0gsGtP70=,tag:qcfM8UWp5b3wwpf1kDgKLg==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:Y7TxzAMCJQ/6IA9x1V9Z/A==,iv:xjmc+J79hgutX20zZBpfC4bbZf4eSCJca5LLKHhhJcI=,tag:yiQjeRgQY41QqHXEIVNRrA==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:zDdW+PxHlAp9vMzG/zu+vMR1tBb/joiiOulIjMcqX9Q=,iv:rk1bo3G1to0NRKZV5qj67KQcF7y0xQVOmsrZUKmWSUQ=,tag:/youg7JoIGRqA6/Ztff5pw==,type:str]
-JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:L6ATLIViyIND9EFrVl8unQ==,iv:euMk5yJjGM698s9E/jMKYJxJG99KbiiID1ut6HPu8Uk=,tag:Pv7N/bj/KHqTc6jXP0N56w==,type:str]
 PREMIUM_CONTRACT_ADDRESS: ENC[AES256_GCM,data:IZTLviyFrvpJCSMCE1IxeTKMvdy1K3gI1APcjelBoO+OCjm7ItfcyL7Qup/31JaTufEpI08yyWArop6IsIg=,iv:mhCrfgQoa9P8wpNTmg+1eXveyWjCictTmvwJwaR+7Go=,tag:ClRLDUs4SRnR/JcJnztjQg==,type:str]
 CONTRACT_ADDRESSES: ENC[AES256_GCM,data:8pFih2gIn0H7zR1D3cbcspKrQ5Npbnw1wD0iIUebAD6/mZmWfxYr4HTAh359V47WuIBZKQi9Z1ns2FSjZ5s=,iv:NXlsYRl4s0AIpIl1GshnmTje509AsS1ehvK6utMHqNA=,tag:anOMBpAK/XtVCjdgK4Bm/g==,type:str]
 RPC_URL: ENC[AES256_GCM,data:7noHpqwuruF7QdQtBXd+dd8Lj+Bk/kDr7o65bxJqn68RfwgzRknWDlO9kAM2LI7JWHLVg65Doxi8MZA/vGWjCf39MwA6,iv:Zy0//W8S/gkMwG8NYb6NFv+WGOw8GhIYubiX2Ilsnjk=,tag:WI2QPGNK2INY8pBjBYOgMA==,type:str]
@@ -61,8 +60,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-17T19:32:07Z"
-    mac: ENC[AES256_GCM,data:jrks/9cKpt4/0wt4qUgNvJ0+FhmDSDwBTaCE6pGohvpUIsjJWQ6XSoJS5VL2OfsDTAD85jJ+fxV71GFPhssW1hEYKe00vV9uauzyh/T4i/IGsh2T1HdTxYnOzYRzI7T2AwsHnZoGW29+Znrfk+QeP47nNeMKPTWBStYwWybjkrs=,iv:/GYiT6+8UdOJuQL8NhP1Iwvj/gFFYAR6U0iblXZo820=,tag:MguYF3jOA+Xw38QJhEFHng==,type:str]
+    lastmodified: "2023-02-17T19:36:47Z"
+    mac: ENC[AES256_GCM,data:79gPrqL/2nnRdWqszl3BU0bhS51rop5Iv3/kHry5kj8Mqtl6weMLAFS+/QDOaQRPwoIl0jXLCqp0vusW7/8xMk3TkVMz4U2Uw85vNFpvZOIn3eEeu/ux1IjrkTmDZp7vNfQ7dxT3PWgWvkQDWDodu0AMUw7ZShxsBKb8DThA+Uc=,iv:42Oj7rWB75Eq8l03ekyJ2rpy7WgZj18PAj1KpxvWCnU=,tag:0pmqwcEfaqkQjACQoGAKyQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -1,5 +1,5 @@
 ENV: ENC[AES256_GCM,data:BlCMzXTTXaTUBhs=,iv:KJBDHX7b4CqLr+ZM+o9eONcJL7SJREy1ATJZHPLNoVo=,tag:MpH47AY4pNd41LDFcx4pwA==,type:str]
-JWT_TTL: ENC[AES256_GCM,data:jHUgBIBJxQ==,iv:GUpTpEpivTDIvfrRMW3m/vHePmZhVLRrCyUiuRQT7ic=,tag://jlzF/sAds08fjmWAzUsA==,type:str]
+JWT_TTL: ENC[AES256_GCM,data:Qg2ZYbPahA==,iv:9PRjN1LMxGq7bgnog8+Wg7VxlqbUh4Z+Af4Z57MZjd4=,tag:odkSZrTL4AZBF4TLTkvyUA==,type:str]
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:2XT4xhyFBcccjqFZtzWeZCq7TogjN/80GmWLO4f6ZxkWyosUPWdzo809uBexAqkw1uZLdg69l/Y4xsviCxN5Bj/HYl4J4Yg=,iv:ZO9CTIhPFGBhFpclrWDpjkkxfAva/q8rZjW0gsGtP70=,tag:qcfM8UWp5b3wwpf1kDgKLg==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:Y7TxzAMCJQ/6IA9x1V9Z/A==,iv:xjmc+J79hgutX20zZBpfC4bbZf4eSCJca5LLKHhhJcI=,tag:yiQjeRgQY41QqHXEIVNRrA==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:zDdW+PxHlAp9vMzG/zu+vMR1tBb/joiiOulIjMcqX9Q=,iv:rk1bo3G1to0NRKZV5qj67KQcF7y0xQVOmsrZUKmWSUQ=,tag:/youg7JoIGRqA6/Ztff5pw==,type:str]
@@ -61,8 +61,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-15T18:13:28Z"
-    mac: ENC[AES256_GCM,data:jJTUMkr7y8HqkUz2jx8tHAXz9FcHIkqA9KplgJYgL1onPvuJnJaYRg7qJNsLOYfkMerb1TPiAPUbGltRJcOALUXC3W/dzPdqlkrB1Pr/I14LtlKzFiQc6kwP6bn4+Rc1s7pts98qa9nGeUZMBA3PoIB/nufB6Rs6oX0eTNqDmuY=,iv:cIStZx+CT4pnh4bdUjmnJ49BUzyt+LKm4LWwtcuuFDo=,tag:O880bG3PCBwoqIW6pmEcBw==,type:str]
+    lastmodified: "2023-02-17T19:32:07Z"
+    mac: ENC[AES256_GCM,data:jrks/9cKpt4/0wt4qUgNvJ0+FhmDSDwBTaCE6pGohvpUIsjJWQ6XSoJS5VL2OfsDTAD85jJ+fxV71GFPhssW1hEYKe00vV9uauzyh/T4i/IGsh2T1HdTxYnOzYRzI7T2AwsHnZoGW29+Znrfk+QeP47nNeMKPTWBStYwWybjkrs=,iv:/GYiT6+8UdOJuQL8NhP1Iwvj/gFFYAR6U0iblXZo820=,tag:MguYF3jOA+Xw38QJhEFHng==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-sandbox-env.yaml
+++ b/secrets/dev/backend-sandbox-env.yaml
@@ -3,7 +3,6 @@ JWT_TTL: ENC[AES256_GCM,data:XhqQ429/nQ==,iv:+8IPbQN2aOP2UHRUrISKtmt9Vbyvf8PRpRb
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:1/qVe+FYF9aqLXYrhPm+sj4Dchojp3rSyqk7oBvytfWV4cQ3fGuOoJN3xZsXo4xO39o773U2vzFetb1dBZ0VdW5bn4Q41BHucriT6B+wO2fArQBisChJ,iv:IrSSeDF7mpbVISSrO6kswxR9FalVaUKbBeyfYxJtKBY=,tag:yKGe4WnollH8GW/qsgvn4g==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:Es3UaGqFiARAVYVLGfu75w==,iv:rXFVheA4Z1ZWCfEHOcb0OtxkuY3wMuQR8wREA0LDdvc=,tag:gKCBe05g2W2NZCLPbmeudA==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:opyxDjMYEP7wTMj8kNGXRpQodtmfn3Ag7eMso8nyWbQ=,iv:wnf99+TlUqRwF7EJesAGtJxjgmrP+yG2pzWgOHFcEBU=,tag:35Ww6lpMhgQzepS1js2bcA==,type:str]
-JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:VGP3JkOgnuXIxmlohs/Etg==,iv:Ntm1J4+NuzGSzf4/h2VatLOQI+xT6lYsUOYzP9BIB1s=,tag:GsitfTCP3hREDQ8oDFgBqw==,type:str]
 PREMIUM_CONTRACT_ADDRESS: ENC[AES256_GCM,data:3QpVPqM+dV/a0kJ3fIUMGLVrNDlboD5pCM5PRp9oQ+MmK0BlXHOd0FL4fQ6F9DmHUBfAkOUvz7H5I7Oxs7U=,iv:yrOEUQpU2Z5MAbTK789B4s6bbZ6/WxMtRf4+Czfe9OM=,tag:3x7qMyUjNm4D65T2d/LKlA==,type:str]
 CONTRACT_ADDRESSES: ENC[AES256_GCM,data:nXIEovYSZDPIQh4o+79Hpn0iZvBudDhCbn2Y7xDUXnVTvgPEc0lQTG7KAZ7d1oHcsxAiW1d2ozrbBem9JGc=,iv:pnMfZIYyZiLWywn1FJ1guI/ys0M9eWvhpkLLSy6H37A=,tag:k4vA7f4RZG3J2X0piXOq3g==,type:str]
 RPC_URL: ENC[AES256_GCM,data:x++xQSV3X64SKRh1P5jpArshr33mMCUy0mS6ZsAjjtCqwu94oTOgpetQk3s3WvKn5YfTuQXbK6/qol3N1RXEvmHUGJgj,iv:URucRBNeSTnwQbn5ivAelLqrGLF4GgiL0CBrdDMM5X4=,tag:iEqAu9omfr/3PTVaMmDuxQ==,type:str]
@@ -55,8 +54,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-07T06:33:35Z"
-    mac: ENC[AES256_GCM,data:ChSgqTYLszh0aQCPQafoDjAQxGorwLZCh87LhAyhE40R9a4IwHdedGPxNnerCzCTTGDGoDEBzE6aJALlTxrPapyKV+FjNIaYImTwiOhBUApGXmdOsiuCfDTbZZDjiSP3W6yBt9cn2wI78kNV+OlGRmYlG+uLv+z2NUyxYnMauLU=,iv:excefG9lmFE1JxvlxEBzwgswHMtT9NB6TlxjYuCYIrQ=,tag:wyPyOWv5WmrdRm663J42PA==,type:str]
+    lastmodified: "2023-02-17T19:37:17Z"
+    mac: ENC[AES256_GCM,data:ZYY9Jh0ZMK8Z2B8Zg/qSH9WtkdwE5u/cy0X23uSeLfaPSMCTfufFvX6oCDR5Uow8BjmUI2/if/ioHbJijqUONoffkFFqW7VxES/4+wNbQ3QjiFOiA6XpR707lWIsS8wOG5vkEPj29BkE8scUnw9NTnc+TaP36XLwtXEdyDPUGE4=,iv:xQ4a+QmpZXhTbz6+XRe/8D+L3Lg6945GuIOvjlzEVD8=,tag:+K/fkSFSkd6ul0pFM4c3zQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/emails-server-env.yaml
+++ b/secrets/dev/emails-server-env.yaml
@@ -2,7 +2,6 @@ ENV: ENC[AES256_GCM,data:gxgjU16VSNeoudg=,iv:alwcTOdeuiEzUaDpMsovzCOfZ6GNzQP430/
 JWT_TTL: ENC[AES256_GCM,data:ufmDQmET,iv:pxu99memKvn6rGNwfYEURsqxh99MO/2YboenVGvD7As=,tag:8rdqlpYe83FduDNCOxNU0g==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:vpHnVdDGYuRmQtMsyAq1wA==,iv:1jn7IsxnSTdRVPcsTF/XwDerHI7KwmyHXPnYIFDlXY4=,tag:jYxKg8cEp1FbUZZESPPEbQ==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:MPNkASvw1klQut4vK06S1ZRD2/zdrWhOzworvbcx8h8=,iv:YVTRHHsNvGYIO+R+mrGlMQt4RgwagRLiDk9yTELJUE8=,tag:iU3xUaLkm6pWHRc3FMnO5g==,type:str]
-JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:xykDAF/fS5rSoNtj0wCmKbBPljQ=,iv:fa6SKe+GaKUQK2O5aa7SbGtiEcSuUgoaEi3hhhUgosE=,tag:NvdMuDmymj2wgizFLEsHSw==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:z+unMTcNBQKYIHHrl1htZQoxUpxu1wWw1ipD3NPpStkST4P8xPGr2tT+HeY0yYmRfFI9iA==,iv:Hsu72ZL3VtCbCkCMYJOOMLJCNs2Hdh4n70Mibkxq/q4=,tag:nbUkJFidYRniDXNKzVe4mQ==,type:str]
 POSTGRES_IP: ENC[AES256_GCM,data:oEwHTfMx7PWD+jPm1g==,iv:+wrBllQ+DMGBW35tIsHSk6UP2GtzL/l2sEXiH5qp+4M=,tag:lvjhkwtveHHXoqiSw416Gw==,type:str]
 POSTGRES_PORT: ENC[AES256_GCM,data:FLwIpg==,iv:C+7Bb9pYbBbuTFZn0FtxA8KANSP5qAXi5h2axwE+1x8=,tag:UD+YBNVXyiVqUK9o2p/Dhw==,type:str]
@@ -26,8 +25,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-01T03:49:08Z"
-    mac: ENC[AES256_GCM,data:HKHUgbPURbJQMSBThofe80AuGVsIR/ecPO4LHWIJtorA8mUpfHMoxW5M/S7xuLqo+OnvJw2VxkLji9V0roNJc6fXmJ0Cg4oVHhb//fhgHfvxB705yF+1fPFsgnev77Qgflc9OoU/D7AqqIPcglsTx4z0+Y15yYHv6CEyUdi8Qfs=,iv:bG57vaxleAbqf31DBqXFL3AlyW7gj8PAa0togX1kIYE=,tag:ZBGVVvCt0tVW43QXM39BXQ==,type:str]
+    lastmodified: "2023-02-17T19:36:55Z"
+    mac: ENC[AES256_GCM,data:Nn9mDKTKaq2EGCOxtk+vVElvDHFxNj7ZzLHjFVVrYtUc/S8AMLY+hx4napqFpdMJlpdGGmhZFvAqoWNBGWRElwEJw8DpFjnZLMLgUsgudfpkOBgk2AHBuVV89M4N9I30OCHkAYoHs0x4zRWR5ORlZCSWcwtw+EWnM6ILx3ZWJ2Q=,iv:DPs6atV7r42HG6PeGh7KyWFzAXOoK7W3/Fj4MUPupRM=,tag:oDG70r63iG4VaBvUEH4c0A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-emails.yaml
+++ b/secrets/dev/local/app-dev-emails.yaml
@@ -1,7 +1,6 @@
 ENV: ENC[AES256_GCM,data:Zp6DCeM=,iv:cRqvO72IUR3E3wSMFekuzpq2cxoxZA6mEZ5X2rchXW4=,tag:jTy2TojEWs3EU+WFE1vGIQ==,type:str]
 JWT_TTL: ENC[AES256_GCM,data:xJwLaf2V,iv:p/da/pvUx4t9zM5NoYfAIz89mepCLiWL31s32qitCy0=,tag:bYaDrQ9U5D1eJuGArQKpow==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:xlX1sc8L4y//ZHPm68MSNOKxQxs1NM+XJxZMzgmve0M=,iv:JXBVkGuRm7Ipk+HoEqWtc6k+fWXe3C63pUurzRbq+q8=,tag:djkLGj0YzI1XxcYhfjwp5g==,type:str]
-JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:9ziPkGLBHk/WPBrD0QcPbE0qMmsn,iv:Q2/F44Qqec7SlfIIJmaBZVhoYSumZrOumiJjejoKlIM=,tag:1KVcPMZx8GtaD2L5ypyXQA==,type:str]
 SENDGRID_API_KEY: ENC[AES256_GCM,data:/YrVqs7U+IOwZn0A7lqyqcDu6tQtq+8yscVkIFwnaLTxmGTrXILOIatRm2iNtIJyeH10vcqGNi4QvHzWtbPNOJjb+JiH,iv:LvhJT9sUBihUPVT/Bxk9/vVQOGNxsyjzhlSIhSCLnBk=,tag:ZPxECtJWHlpVs213J6uo0w==,type:str]
 SENDGRID_VALIDATION_KEY: ENC[AES256_GCM,data:2SodWvQrtmnNvMdcT+9Il4D7RmDU1dq9AF+SMzXqdxHggAe8zSZiD5P2O0noBpZg/T314AEumn99+7S0Ko+Cr7E3/4Op,iv:mtw7JcQ5Uz5xyrRbzxkUOv7iK+BzbC6lvk8lMeT2XUY=,tag:9A2IDKQdpL+/WxC/zBXN7g==,type:str]
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:Xc0dGaaONHCjo0ScozOBGWPXmCUPDIOJmxIODehzc9JwsQ==,iv:EQvur2c7bi5NFaMfnXep8E9zd0pPCZJu25y0hoW/WyM=,tag:wtg+r0Kp69MlZirH0cDgfA==,type:str]
@@ -20,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-01T03:58:06Z"
-    mac: ENC[AES256_GCM,data:dkBfQY7V9XMPOhBEDDU84lpRbdyhJQ2cYGEOGOIG8+IaK9ijvlOxRaoYKRKDxDlte4t8uxX/B+mxWdxBZ9irHwol5bAy1z9rG6WNl+XuMIqanMT9bb7O49LL4no7A1ft4Wi+Mz74+FzToI/xLlUS3Am2BTlizf8ofNXas0bSa4c=,iv:tguvUBcQ4Fke8z9JAwSfDe8W/4Cq8YcjC111llx/xBk=,tag:DBjNcn0RHc8EqRmx0l8Qwg==,type:str]
+    lastmodified: "2023-02-17T19:37:06Z"
+    mac: ENC[AES256_GCM,data:KSRqU9EIpBCK5cSLxnbZyRHD0ZbqPGKNjbnIaH5rmwFqsahWmT99dSV7yFs0GCd2dYOJQl9zo1unppsNq0CQYd71fkpOEp41vqZEnynO192VE6VUEZ1wJFNVO5nDjr0q8UpDzVMBhynZt7/CQhO2hgfWR0Ch4fgtZGkLEc79ruE=,iv:0VReg5XV8nZHw5UIWqqDdGgmYCshFGjKAJ9NmnSmbRY=,tag:v3Hm/FngLozy3AVxE4noeA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-emails.yaml
+++ b/secrets/local/local/app-local-emails.yaml
@@ -1,7 +1,6 @@
 ENV: ENC[AES256_GCM,data:wdA+qao=,iv:ry/zqEMBwqeEnKoDs4Gqdop0KA2TkMa3mJavyB2HFRs=,tag:QPRq3CxF+Jkqkx0FzFmjWQ==,type:str]
 JWT_TTL: ENC[AES256_GCM,data:sSDrXWJb,iv:GYA4Nm61Kb5dZjAnKtmUS0KSYWVCADh4PZtIcsFp314=,tag:uARniN/VBvvIKRolJi5s/g==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:86Vqf2tP6G9cWcUAIGpDc8Gs9KCQZ8EvWA4+xQg7EL0=,iv:Sc+GA11CXJpomihsETH45QespOoSLrx7yB+rxwxrEXU=,tag:FYAiVzuNUa0ACIYLT6BAuw==,type:str]
-JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:B8uUvvOTn02W5NuA23h02uZTNNaR,iv:hvdg32BRt6gmR5WdzFYl+841nzn9ZuPyeBFV0BGaDPA=,tag:hD4nKsBrc6gqvchbvkxIVw==,type:str]
 SENDGRID_API_KEY: ENC[AES256_GCM,data:9jQnEXXJvCcRc/P4oyeqUEd0ItLoysG3/bUgJdJlyuqYtLzYod1MswVOMg4JI4v/+Wds+q6qKo6YrQjnYX4bwefUJjKN,iv:dzd62Pv6KB0zVX1TKlu9aaugNTHEUzzvq2WCkm4ZHdA=,tag:ytbBC9TeNYFmdW8r1kUhEw==,type:str]
 SENDGRID_VALIDATION_KEY: ENC[AES256_GCM,data:7cOENNXkgPopi5mPsWZm4Nl1rHZndq9AnKpx50Byp4wjA+iO5JSom00qgG/14E0rkjEY8Zs4AZ5KvR1PcfcYJRka3kcI,iv:2Tb2Wkiu/I9O30kR96wZkM1YvWxdHQciLcAkKeuJwEk=,tag:5KRFJ5KmJqvOMx+x+j34JA==,type:str]
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:+PmeNqQhZT77GCbjZIVqSw3vQBASrTXKjKzqzBIy1yfQbg==,iv:mJwv4X7rD6VW5FdAIvh4oPmsBCPMGHl352DPCTZrrQ4=,tag:5kMXWqN3y0AlupgUOfahhg==,type:str]
@@ -15,8 +14,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-26T21:41:01Z"
-    mac: ENC[AES256_GCM,data:65Ao7gTFtHjq5um6zMNZaybi+pjjEQVERY/IJhSP0X/g1u6xtjk0WFXI1F8Gs/2KRYwlrW5byWh7DwIiaGlw+NRfWKauVl5IdphdnCxVspiyMTMgoWxbO1L56+qI5rsh9AoX2Wuku7TRGiMQ7F3d69EuRz618DyO3zlQvg9PybA=,iv:0Ing8OxR/pxGcAUjjj0J6kZtqDbSeSWWepImK5bwB0g=,tag:CT9CtjU1P0dxCBRrJA4hIA==,type:str]
+    lastmodified: "2023-02-17T19:37:28Z"
+    mac: ENC[AES256_GCM,data:7lNJGTLsKQ1EsmQBS+4P+qg6Tjza38VAb0GhYRvxyBmCT12KXn5UJq5NgLa2MleUzImUZtjEaN/+EOnG4q6/9xzoiXT2JtjyLZwFSWnrZQSyRtxDFIDsFld6XGczZEGAheFwXbfyh4jMlUbQ1B+odZ+cwZkcM/O7o176QROuvl4=,iv:MLlJ+PrsP4Na8fJijiUiiLAZFiPOVER6rzIhnZeELlc=,tag:wEOKPNGxVQFNrhLqXNqP9Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -1,5 +1,5 @@
 ENV: ENC[AES256_GCM,data:k8JWA2ylFV67rw==,iv:U325LE6D9qQyeLrzsUSuS2RfuvC0Cs7uOPMIEU2Srt8=,tag:6smM9EmK9DXjiX21hLVGhQ==,type:str]
-JWT_TTL: ENC[AES256_GCM,data:cvrLpUFc5w==,iv:N7a0koeSfswf+hWvKZi8oiVV6CkON893jzs/Ze7aoVk=,tag:sCx8h90bPkMdSLY+rSJ7Kw==,type:str]
+JWT_TTL: ENC[AES256_GCM,data:lszlKI+tNA==,iv:xfJmdr4Ng5lm6H2xJZdDHhRI9GRRLOvSaSpz6nAfUkw=,tag:lTiKAnrzP+6uuBeJbd4NwQ==,type:str]
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:AXSXYiGK4Qbdesp5MZWdOjP2XLtfAGqX+5dqC6OwBO0yOIj84egT6mtm8kqA5ipSgb/Y3J8zxuACT1eIFQBgOk+9gPARHB6f2azi5P0WhbqzuQ0dKgGu8P6bme+qWccqjvi1U877XTkXNKw=,iv:bVxlvHgIODlWsoig3QRoq90WEjPWsykQYSsJucVLkJE=,tag:NGyMnSdb9QKn9aHsv/DcDQ==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:6jzt2e62Q+n9+3uRL1s2gIynoA==,iv:DxMf4XlnULYkNTvqXD0IbjCLGqdRIy7FP0NvxWMxWSg=,tag:8WiJV2DQlYsBhGi3TgkAZw==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:4pO1PsQVLpChXNYbKcH55KS1CQFMvlOE5NSVJyElxPI=,iv:/CfUOa9QkOtRUSHRnHZO/6twxYSKl9+MjkRbBkGOk9c=,tag:SRQih+gbUA2wvpYY8oFssw==,type:str]
@@ -63,8 +63,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-13T20:59:56Z"
-    mac: ENC[AES256_GCM,data:z6RTrDBOxCWBcvxtPwynGJnR4SOfkJT3s1mzlMd73PrEauV32FzuFNzEJXgXni4QnaINR2P5UYcmjWr7dCAGX5LwgAt+4xBoI4qYrX1DAhr2FCUxF6g2IrgeQFHOsFl2mpLMw++OJVljK7s3K7+DeSaYwzCZTGBgyv83PMVb9X8=,iv:cXPDnJeDGXJiLHC3R2fseY/1KBrMUVgC/N10RaaFz48=,tag:Xcx7f7DscpCzA32IZznhIA==,type:str]
+    lastmodified: "2023-02-17T19:31:55Z"
+    mac: ENC[AES256_GCM,data:NdHHZquJ6DgLYMZPirmqLX1rRzTHXL2mbZRgkj2z3lHLckE40a8vSuzawzSSZ9+atDnzFaiT1iD2h7K1gjhaUBqkC9gZIUkJmL5OolsKLicjIlS0QM4b+q/4SmGsImY3+cuGr9WAnPXJmha+JTgcgQqc1ST/Cy8IuzTQ+l4kYZ4=,iv:jxrHVeOKfmCmgvwLDUGz2K0dU3C9w/PKbGLWjnhYINc=,tag:RIofKHgH8uDnr6ZJacfP+A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -3,7 +3,6 @@ JWT_TTL: ENC[AES256_GCM,data:lszlKI+tNA==,iv:xfJmdr4Ng5lm6H2xJZdDHhRI9GRRLOvSaSp
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:AXSXYiGK4Qbdesp5MZWdOjP2XLtfAGqX+5dqC6OwBO0yOIj84egT6mtm8kqA5ipSgb/Y3J8zxuACT1eIFQBgOk+9gPARHB6f2azi5P0WhbqzuQ0dKgGu8P6bme+qWccqjvi1U877XTkXNKw=,iv:bVxlvHgIODlWsoig3QRoq90WEjPWsykQYSsJucVLkJE=,tag:NGyMnSdb9QKn9aHsv/DcDQ==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:6jzt2e62Q+n9+3uRL1s2gIynoA==,iv:DxMf4XlnULYkNTvqXD0IbjCLGqdRIy7FP0NvxWMxWSg=,tag:8WiJV2DQlYsBhGi3TgkAZw==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:4pO1PsQVLpChXNYbKcH55KS1CQFMvlOE5NSVJyElxPI=,iv:/CfUOa9QkOtRUSHRnHZO/6twxYSKl9+MjkRbBkGOk9c=,tag:SRQih+gbUA2wvpYY8oFssw==,type:str]
-JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:VQcB6H+5S7mT2RKEYgWOj5xM0QE=,iv:snzyqIGZuMNUh0TWUts5vqfrcI8kDHHdxtwxAEkTPuk=,tag:oWMrScJx0xYR4vLRoE71dg==,type:str]
 PREMIUM_CONTRACT_ADDRESS: ENC[AES256_GCM,data:cqMA/2lufayYk8X25f8NCJZ4NHKi9c4OJDfPJdgKyjrSxLCNO9uK1AgMox+Sqr0ymtQzpz1WgpVjLTsaKGA=,iv:IInvsMSWccf9s+gBLGfI2QlQcKbSpdFNOYH0UgyPeG8=,tag:0JL4dPmqfclj0790/hCaxQ==,type:str]
 CONTRACT_ADDRESSES: ENC[AES256_GCM,data:kznef1LHz2OnBjHB1b9qnVgB6GyJ6cE3ApNkuiuyobEx+5WlB5PESL3M67qTvTeai+KKe3RaLgaPDw21o9lPe8p0FZmXZ2bzGoLkfv8I1IPlM6VaiYhQUIqDfKcMjJS3hc1SRvkEEJ5iCNALxA==,iv:lbJ8W1eEf0XAb4Ozq2I+UB2wghHbVikAj3UnQQ0Ojng=,tag:frT49H/Gh+QQ2bsVa2UEeA==,type:str]
 RPC_URL: ENC[AES256_GCM,data:sjRSfJierr3OHkcYuV7X87s0te3lQZsSnwdSLIEzavKug7a30oDYWRIcJ2HGIGAE2lkyl/h/eGpb9ge5Onyj9Uy8cmH3,iv:JhhtyttIIrSK9Uu3IKjMJURdjMvHaz5gVr3sqyr0Okc=,tag:h+SOwV42WTnp4UTtkl0kcg==,type:str]
@@ -63,8 +62,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-17T19:31:55Z"
-    mac: ENC[AES256_GCM,data:NdHHZquJ6DgLYMZPirmqLX1rRzTHXL2mbZRgkj2z3lHLckE40a8vSuzawzSSZ9+atDnzFaiT1iD2h7K1gjhaUBqkC9gZIUkJmL5OolsKLicjIlS0QM4b+q/4SmGsImY3+cuGr9WAnPXJmha+JTgcgQqc1ST/Cy8IuzTQ+l4kYZ4=,iv:jxrHVeOKfmCmgvwLDUGz2K0dU3C9w/PKbGLWjnhYINc=,tag:RIofKHgH8uDnr6ZJacfP+A==,type:str]
+    lastmodified: "2023-02-17T19:37:37Z"
+    mac: ENC[AES256_GCM,data:bFT6ClWsV79Fvksjf52W+ayziH35HnKlfqPRZxQba8A2udXyz7PisIrq+Su23vPpjurz22IGKSzxRkPOAFHmHvtmZfUjfAWd8QR8ydFrFUY395PSuZK24rGPBr4lC7Hv1LNNgQQJp8tCQ+pLNhb9qWTN0Q2xx9xD486KymFMOrQ=,iv:a/I5tiO3nsJnkWBBJ8P7+9I/05oObDMtu89mhlmxSkc=,tag:HdH1g9LBRgd5lBwuVNISBg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/emails-server-env.yaml
+++ b/secrets/prod/emails-server-env.yaml
@@ -2,7 +2,6 @@ ENV: ENC[AES256_GCM,data:XUjOhJJA+racCA==,iv:Af0kF9adn3ZVH6tRTSO9l2+RTFokV8FTvmA
 JWT_TTL: ENC[AES256_GCM,data:OZmABecM,iv:a8OywtiwZRKV4EAfHLU7wBz5uL/cR4GnnFiRhZrAnko=,tag:gRP2RlC3HmqNCJNFHPRSAg==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:3azHTlbCEq7B1LUFUD6IllF/+A==,iv:PbAcxC7zu8MIz16lOqx9b1KReBphHSS50BAMT9ncIHM=,tag:nhvPqV9Ji9nZc87Ll6ILhQ==,type:str]
 JWT_SECRET: ENC[AES256_GCM,data:WeE1Ro/fVMCbCZQDF3bNO5OXttZH/ln1KfevKAtAVDE=,iv:Px4ja+FZhNBroap8+7rtWbFsib3OANcOV1nCUlOFPDY=,tag:SA4Ek+9jeG+JL1Y4WX9fvQ==,type:str]
-JWT_SECRET_ROTATING_OUT: ENC[AES256_GCM,data:4OuTyQR4/z4dTfCvu22K+RpxemI=,iv:tXH6dJQOb3ZwHNbi8dRkODxROnk3lM2kHaceNS29rBA=,tag:DIjyEgbQRWrGkU6yRDL14g==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:GZs0jN2Sw1IflX6HgGKsOCDgtWlvZJdrEbcV5/HDzNPt0SJnYSBNlaEH6ePV0K9b11PTcphN,iv:AAcasC2b5B6aNasXVSM/O2HqowFM3jAaB+Psiu/9Rk4=,tag:iaf0uIgXf5MBPybvXsJyNw==,type:str]
 POSTGRES_IP: ENC[AES256_GCM,data:wWmPQC8qOEFREg3/CA==,iv:EWhatNuQra7zr8zPDG6W/cX20tpC6Fbuqk2PX0arE8A=,tag:6KOokCWHbI/Prl9cHRb7jw==,type:str]
 POSTGRES_PORT: ENC[AES256_GCM,data:yj3p3w==,iv:1YTQlAFOef9asMJRDtfcEbOopvE7ca9fE5pFUrRwxac=,tag:I9i32ukbYzwGb+EEfhUZQQ==,type:str]
@@ -27,8 +26,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-01T03:45:39Z"
-    mac: ENC[AES256_GCM,data:7Std/fKh0Ww7d+hQki1+HuMdaO/LPa+g8pITEqYta0L4ryFO4PrcwhbP5wq9DRf09sRoz6enkR9KK54y2yRVESkz4d4isuh/jex2t5HzdHhYsRdkneB0SSg3GBwCvRzUQeAU0OAS2iwBXiGuJe55848RXLu+c3ZLH20eDz3loQc=,iv:y5LyDsR3SNHipPuMPXdwAlsugGfdmib1UmFjeHj3XW4=,tag:ldxzA36XZsLde6VIL2jYRQ==,type:str]
+    lastmodified: "2023-02-17T19:37:44Z"
+    mac: ENC[AES256_GCM,data:3JimCy9X7QJ1mXSCPf0oz79HMFlU8nh22AhOXqdMJICVKtjzKT64LONeK8Jx9URg5HhknNRTb1rFgtBN2RuO4qL6LL6l2w5v3R5cZCq6a67hQ2OxZFAF+qrbRKmBhu1gVRi9O3otM29bg0+pwqNvF+wOltAoGlvQY11Ctmg445g=,iv:ks4hLhgJSTSGGRYCKHPZ7OF0wjKdoZBTWFCEKeADrcg=,tag:ARHQoFfa83cCaY3r+DhqRA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
- Bump JWT expiration to 4 weeks
- Remove the JWT migration path I added a few weeks ago. The goal was to start issuing tokens with a new key while allowing tokens issued with the old key to remain valid. At this point, all JWTs issued with the old key should be expired, so we can drop support for it.