### PR TITLE
Fix `go generate`

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -1,12 +1,12 @@
 # Where are all the schema files located? globs are supported eg  src/**/*.graphqls
 schema:
-  - graphql/schema/*.graphql
+  - graphql/schema/schema.graphql
 
 # Where should the generated server code go?
 exec:
   filename: graphql/generated/generated.go
   package: generated
-  
+
 federation:
  filename: graphql/generated/federation.go
  package: generated

--- a/graphql/genqlient.yaml
+++ b/graphql/genqlient.yaml
@@ -1,6 +1,8 @@
 # Default genqlient config; for full documentation see:
 # https://github.com/Khan/genqlient/blob/main/docs/genqlient.yaml
-schema: schema/schema.graphql
+schema:
+  - schema/schema.graphql
+  - schema/federation.graphql
 package: graphql_test
 optional: pointer
 bindings:

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -1,3 +1,4 @@
+//go:generate go get github.com/Khan/genqlient/generate@v0.5.0
 //go:generate go run github.com/Khan/genqlient
 package graphql_test
 

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -1,4 +1,4 @@
-//go:generate go get github.com/Khan/genqlient/generate@v0.5.0
+//go:generate go get github.com/Khan/genqlient/generate
 //go:generate go run github.com/Khan/genqlient
 package graphql_test
 

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -7,7 +7,6 @@ package graphql
 import (
 	"context"
 	"fmt"
-	"github.com/mikeydub/go-gallery/service/mediamapper"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
@@ -16,6 +15,7 @@ import (
 	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/emails"
+	"github.com/mikeydub/go-gallery/service/mediamapper"
 	"github.com/mikeydub/go-gallery/service/persist"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/util"

--- a/graphql/schema/federation.graphql
+++ b/graphql/schema/federation.graphql
@@ -1,0 +1,45 @@
+# ⚠️ This definition must be created dynamically! The union
+#   must include every object type in the schema that uses
+#   the @key directive (i.e., all federated entities).
+union _Entity
+
+scalar _Any
+scalar FieldSet
+scalar link__Import
+
+enum link__Purpose {
+    """
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    `EXECUTION` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+}
+
+type _Service {
+    sdl: String!
+}
+
+extend type Query {
+    _entities(representations: [_Any!]!): [_Entity]!
+    _service: _Service!
+}
+
+directive @external on FIELD_DEFINITION | OBJECT
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @composeDirective(name: String!) repeatable on SCHEMA
+directive @interfaceObject on OBJECT
+
+# This definition is required only for libraries that don't support
+# GraphQL's built-in `extend` keyword
+directive @extends on OBJECT | INTERFACE


### PR DESCRIPTION
`genqlclient` and `gqlgen` aren't playing nice together. Since we added federation support, `gqlgen` automatically injects some schema stuff for us that `genqlclient` doesn't know about. 

I've fixed this by vendoring the federation schema and telling `genqlclient` about it explicitly.

I also fixed the issue with the missing go dep by adding `go get xxx` to `go:generate` as recommended by this thread https://github.com/99designs/gqlgen/issues/1483#issuecomment-949023482