### PR TITLE
Skip remap for IPFS gateways

### DIFF
--- a/service/media/media.go
+++ b/service/media/media.go
@@ -359,7 +359,7 @@ func getRawMedia(pCtx context.Context, mediaType persist.MediaType, name, vURL, 
 
 func remapPaths(mediaURL string) string {
 	switch persist.TokenURI(mediaURL).Type() {
-	case persist.URITypeIPFS, persist.URITypeIPFSAPI, persist.URITypeIPFSGateway:
+	case persist.URITypeIPFS, persist.URITypeIPFSAPI:
 		path := util.GetURIPath(mediaURL, false)
 		return fmt.Sprintf("%s/ipfs/%s", viper.GetString("IPFS_URL"), path)
 	case persist.URITypeArweave:
@@ -596,13 +596,6 @@ func downloadAndCache(pCtx context.Context, mediaURL, name, ipfsPrefix string, i
 		"contentType": contentType,
 	})
 	logger.For(pCtx).Infof("predicted media type from '%s' as '%s' with length %s in %s", mediaURL, mediaType, util.InByteSizeFormat(uint64(contentLength)), time.Since(timeBeforePredict))
-
-	if mediaType != persist.MediaTypeHTML && asURI.Type() == persist.URITypeIPFSGateway {
-		indexAfterGateway := strings.Index(asURI.String(), "/ipfs/")
-		path := asURI.String()[indexAfterGateway+len("/ipfs/"):]
-		asURI = persist.TokenURI(fmt.Sprintf("ipfs://%s", path))
-		logger.For(pCtx).Infof("converted '%s' to '%s'", mediaURL, asURI)
-	}
 
 outer:
 	switch mediaType {

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -490,9 +490,8 @@ func GetDataFromURIAsReader(ctx context.Context, turi persist.TokenURI, ipfsClie
 		buf := bytes.NewBuffer(util.RemoveBOM(decoded))
 
 		return util.NewFileHeaderReader(buf), nil
-	case persist.URITypeIPFS, persist.URITypeIPFSGateway:
+	case persist.URITypeIPFS:
 		path := util.GetURIPath(asString, true)
-
 		resp, err := GetIPFSResponse(ctx, ipfsClient, path)
 		if err != nil {
 			return nil, err
@@ -512,8 +511,7 @@ func GetDataFromURIAsReader(ctx context.Context, turi persist.TokenURI, ipfsClie
 		}
 		buf := bytes.NewBuffer(util.RemoveBOM(bs))
 		return util.NewFileHeaderReader(buf), nil
-	case persist.URITypeHTTP:
-
+	case persist.URITypeHTTP, persist.URITypeIPFSGateway:
 		req, err := http.NewRequestWithContext(ctx, "GET", asString, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error creating request: %s", err)


### PR DESCRIPTION
**Background**:
I noticed for MakersPlace that media is served from their IPFS gateway:
https://ipfsgateway.makersplace.com/ipfs/QmV7Zk9joyNpoi8Q8ZPZL6ywoTyRhbXevYUYvWEXLcovCt

The raw IPFS URI would be:
ipfs://QmV7Zk9joyNpoi8Q8ZPZL6ywoTyRhbXevYUYvWEXLcovCt

And mapped to our gateway would be:
https://gallery.infura-ipfs.io/ipfs/QmV7Zk9joyNpoi8Q8ZPZL6ywoTyRhbXevYUYvWEXLcovCt

Only the MakersPlace URL loads, but the IPFS URI and our gateway times out. I think it's safe to assume that if media doesn't load from the original gateway then its unlikely to load from our gateway unless their gateway is actually down. I think in those cases we would want to actually use our own gateway, but we don't have a mechanism to retry yet since we only have a single timeout per token.
