### PR TITLE
Use dataloaders when getting tokens by IDs

### DIFF
--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -180,11 +180,15 @@ func (api TokenAPI) GetTokensByContractIdPaginate(ctx context.Context, contractI
 }
 
 func (api TokenAPI) GetTokensByIDs(ctx context.Context, tokenIDs []persist.DBID) ([]db.Token, error) {
-	ids := make([]string, len(tokenIDs))
-	for i, t := range tokenIDs {
-		ids[i] = t.String()
+	tokens, errs := api.loaders.TokenByTokenID.LoadAll(tokenIDs)
+	foundTokens := tokens[:0]
+	for i, t := range tokens {
+		if errs[i] == nil {
+			foundTokens = append(foundTokens, t)
+		}
 	}
-	return api.queries.GetTokensByIDs(ctx, ids)
+
+	return foundTokens, nil
 }
 
 // GetNewTokensByFeedEventID returns new tokens added to a collection from an event.

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -185,6 +185,8 @@ func (api TokenAPI) GetTokensByIDs(ctx context.Context, tokenIDs []persist.DBID)
 	for i, t := range tokens {
 		if errs[i] == nil {
 			foundTokens = append(foundTokens, t)
+		} else if _, ok := errs[i].(persist.ErrTokenNotFoundByID); !ok {
+			return []db.Token{}, errs[i]
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue where tokens would otherwise be loaded twice as part of the `newTokens` resolve in a feed event.