### PR TITLE
find metadata anyway on indexer, fallback to opensea

### DIFF
--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -183,7 +183,7 @@ func getTokenMetadata(nftRepository persist.TokenRepository, ipfsClient *shell.S
 			return
 		}
 
-		if len(curTokens) == 0 {
+		if len(curTokens) == 0 && input.OwnerAddress != "" {
 			t, err := manuallyIndexToken(c, input.TokenID, input.ContractAddress, input.OwnerAddress, ethClient, nftRepository)
 			if err != nil {
 				logger.For(ctx).Error(ctx, "error manually indexing token", err)

--- a/secrets/dev/local/app-dev-tokenprocessing.yaml
+++ b/secrets/dev/local/app-dev-tokenprocessing.yaml
@@ -10,8 +10,8 @@ POSTGRES_DB: ENC[AES256_GCM,data:nEf+pFTAhlk=,iv:Tz6K3k8rqAMV7mFJyiHBmjjPVA839FV
 POSTGRES_USER: ENC[AES256_GCM,data:eQ/HqIZjKx9y1QGwUZAU,iv:h3mEWFmfiZY0vfcE6Xba//s/h2FsyujIl5G9T9+FXmY=,tag:uZKVRPxCTlCULOOd4s7iaQ==,type:str]
 POSTGRES_PASSWORD: ENC[AES256_GCM,data:Usi4/eSc889GPD3Vk69HuBM317G9SMG5hq5VOwO2sIU=,iv:3ZrWp3eJBlwkVtXrWCxwKybtxfBzRoGrlZLx9nKZn5E=,tag:T/ixt0+WcmLKbw1aAmsD6g==,type:str]
 IMGIX_API_KEY: ENC[AES256_GCM,data:jVsVr44tCUYGW2X+gqmJ+u4KM4jQTvEB0t5EloiIo4Oo71SEZwN3XWnJjL1p6O8IWe1qTYPihMwL5+BHPp9LWgShvw==,iv:ddBBDWwxN9ZxrTjU8WQWX4nCse4ImpE+87YorRU/Ups=,tag:Nvf/lsWiWnXQKLCHHR1UdQ==,type:str]
+INDEXER_HOST: ENC[AES256_GCM,data:eTXaGaO2mqUl3Q++8ExkgrQI/sny,iv:Pd+y3QpPMytHeZ9pqw9YvWeX6PBvE23FG6RxLC0MuTY=,tag:l/Aq4N+L7TkCfLU8BEL/pA==,type:str]
 RPC_URL: ENC[AES256_GCM,data:gVCI5ASCPQYpE5i2FdmR5oYBONQPVz80Y6MvmLudIPtDllro1Q9pARKJ9RkTBxVGAzWybzcvxV7haTBtdrCNJyBkpSEs,iv:aFwlmQ2BVrYvYZHFbVCetQMBmKcTEAEXzeMkNTyaHbc=,tag:pgpjUseyo5HWrw91UdxSHQ==,type:str]
-INDEXER_HOST: ENC[AES256_GCM,data:zB4PO1wEfcohZDeh+JqmZPKXNI4sCHIp8Qsuf40TrWb6omirZ1vZcxngaA==,iv:g7kGKhSEEArw4F0awa/xxcj2JCc1XIWKOmZMELc/TlY=,tag:bHNdXmMbfS7z673f2A1Xzg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -21,8 +21,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-02T20:07:55Z"
-    mac: ENC[AES256_GCM,data:6jGUsfzOP5A7WGO3iRaGDD2Pf2gcvX3shposDpCf+9fuTYUCsvz4+9IbZ99C78OQ3Jy8ILTaX+L8GWBt2Gk7IlCvLP6VgbvDRnbSO+kTMQzXkKNQ/yAdbW86PnIxJnygGCWC9ZpqW1c0U5ZtP5nInvMqr0L/E/w2RBj5L3nrpJU=,iv:OlECsEqXxqC9msoDkBqmOmubOF4GDB7DY9/+1+Wu4iw=,tag:Nbhmxmqx6AtSvQNDc303xw==,type:str]
+    lastmodified: "2023-03-13T21:35:09Z"
+    mac: ENC[AES256_GCM,data:fiWtDrzDwW09ocvkRrNbeR/VpirU1jcJfmzBY4jkn3B/WlMK1htvu7xLEk8bsCy3ICYPNlJRUXIx6JKg8kZ9n/1i8tCuWJcbPCQulgpZH6qDuego0pu76GSk9nwRGn8dthpJEoxAZRcrFvlm7TH3TUE1q1p7ExZxZ/o6I8paznA=,iv:jDtz8Iru5b3fdeA3LnJ1gX+qxNR8yXjMqYyzdgSrsS8=,tag:4ra18R2X2zg3lLNeBJu6BQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/local/app-prod-tokenprocessing.yaml
+++ b/secrets/prod/local/app-prod-tokenprocessing.yaml
@@ -14,7 +14,7 @@ REDIS_URL: ENC[AES256_GCM,data:BW9xNGUaTkckc0rG+Jc=,iv:WjgMZopuWGnhTz5GhOoZhOum5
 SENTRY_DSN: ENC[AES256_GCM,data:BxYk67DTnbPpLjMJxOvSu1IEtAUlLHeAcbvkqUq820cKPHf47XR+ACSqe2JxYAAqfEgCoXQYrCLiOV7z4ETd/o0ZFo/D/QsQ33Y=,iv:82T2sYKB76M8NPsj/2SgisvEfV8sbrTkHZrrtXcJk0g=,tag:QV17XRYHsBjJTH/nGYNKZg==,type:str]
 SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:LToK,iv:xBIAcvDedIrpUMy3y+/XZGu0HNjZsoSzL+ekxiq1H+o=,tag:MglsDDZfCsloSf3RZwZSUQ==,type:str]
 IMGIX_API_KEY: ENC[AES256_GCM,data:uqTHn031IhPM8Rab+2hx6PymiGZZKpqKhe5vPnRIDDilGSezbmIy7N4b37mfUqwqKsTK9XEb4qKGdicjkgYtVW4ICA==,iv:u/qijLXqbLqup+nh/mjQjwtl2uJvhH/Hv224ghkNwdw=,tag:NBAX1/MUODZP7a58LGNyXQ==,type:str]
-INDEXER_HOST: ENC[AES256_GCM,data:LRgaKtqa6JplWmZBRfLsiVVjNlpa9NtKmlnRQ67Q5Nu/+UPdzcC6lTYOdw==,iv:CU8M3lDTQsxK4vZQSFuR3EaVoy0T+q37OwHtnOr8tOU=,tag:oTaC103NBLt32l1W4ZerZg==,type:str]
+INDEXER_HOST: ENC[AES256_GCM,data:el27OD4ntS+6RiTnpECyR+mVwLWn,iv:0S+rUUSPfmv4DXDrpX3iRu2rUxwfzcJptry9LH39KsQ=,tag:Ze1SxWAFQwsX9Dyq4qaNaQ==,type:str]
 RPC_URL: ENC[AES256_GCM,data:SDexkJAqQvXGlqKibnf+CefTVr4Hvs2tDoJgdemsDrFPuoBtXzuMVnhYnR5sm3P8uwLUHWfsz6QIwrybjO4eNd33R1cB,iv:iwWl0yXDZvghE+rph+WxK6QKlZTH8bwb6v+7dR0WSqU=,tag:hujev87t3BGeZ68Mty7prQ==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:E/7zAX6LGQBNmHXZvdfcxOVJ2FyPunNhYvZCdzSu7sw=,iv:C10zXwvtA+q1oYayPbxRTc2xqjaCcZQEpXfRakov6AE=,tag:7atdecdr9rHjKwH21kOWHQ==,type:str]
 VERSION: ENC[AES256_GCM,data:bA==,iv:w0Y+LMV40CTr8y7QUF8Kk/0Es716Ul99+f1B8SLNwms=,tag:9x0r3+APlk15psBTrQPwNA==,type:int]
@@ -27,8 +27,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-10T20:22:15Z"
-    mac: ENC[AES256_GCM,data:yJlTU9k2BGLAgOV1pdSU2Ix7vkmzBb9JE5RAzKJ7A2FJNGvUleafRomjl4EmJo/Fq8X+9mcXXVSjeKO7L5rdoTgupm70GVixfF8fckntn14VbRdIjOBfQf6wDeTgM49z0nEUON0ZoO81qfUuQNUgU05OLnpIM3Ml51oNf5KJOA0=,iv:Wo8/RwMoc/K0gEnqGcW2UlmUqoI7jWHYkpHk5AftIOk=,tag:ZGw5AvJWF+/G3ovCEMr/Pg==,type:str]
+    lastmodified: "2023-03-13T21:34:53Z"
+    mac: ENC[AES256_GCM,data:hGwg6Jc0SzLHAh+qX/VwmZgADBymoJaYEcEwzsw0lOIeKTEAr1l786jWQfU7JiokR5x3uJq/StbRPeLKKGewieYwdHsYd+Dm00ejkWZSaszpGU3+xOsDA2dfJE6+rcW2wKajTTzXgP+Xtj3j2DZ08fuWE89ngg9kpGuXTK8fQj4=,iv:uB2A/ju4tV1kVevenL8w75JGNzrIAPHPUVSuET/L1FE=,tag:NXA0zbNeB5yDHnp+3syPvA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -857,7 +857,7 @@ outer:
 		}
 
 		if err := createLiveRenderAndCache(pCtx, videoURL, bucket, name, storageClient); err != nil {
-			return mediaType, false, err
+			logger.For(pCtx).Warnf("could not create live render for %s: %s", name, err)
 		}
 
 		logger.For(pCtx).Infof("cached video and thumbnail for %s in %s", name, time.Since(timeBeforeCache))

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -262,7 +262,7 @@ func getAuxilaryMedia(pCtx context.Context, name, tokenBucket string, storageCli
 
 	res = remapMedia(res)
 
-	res.Dimensions, err = getMediaDimensions(res.MediaURL.String())
+	res.Dimensions, err = getMediaDimensions(pCtx, res.MediaURL.String())
 	if err != nil {
 		logger.For(pCtx).Errorf("failed to get dimensions for %s: %v", name, err)
 	}
@@ -306,7 +306,7 @@ func getGIFMedia(pCtx context.Context, name, tokenBucket string, storageClient *
 
 	res = remapMedia(res)
 
-	res.Dimensions, err = getMediaDimensions(res.MediaURL.String())
+	res.Dimensions, err = getMediaDimensions(pCtx, res.MediaURL.String())
 	if err != nil {
 		logger.For(pCtx).Errorf("failed to get dimensions for %s: %v", name, err)
 	}
@@ -441,7 +441,7 @@ func getImageMedia(pCtx context.Context, name, tokenBucket string, storageClient
 
 	res = remapMedia(res)
 
-	res.Dimensions, err = getMediaDimensions(res.MediaURL.String())
+	res.Dimensions, err = getMediaDimensions(pCtx, res.MediaURL.String())
 	if err != nil {
 		logger.For(pCtx).Errorf("failed to get dimensions for %s: %v", name, err)
 	}
@@ -539,7 +539,7 @@ func getRawMedia(pCtx context.Context, mediaType persist.MediaType, name, vURL, 
 
 	res = remapMedia(res)
 
-	dimensions, err := getMediaDimensions(res.MediaURL.String())
+	dimensions, err := getMediaDimensions(pCtx, res.MediaURL.String())
 	if err != nil {
 		logger.For(pCtx).Errorf("failed to get dimensions for %s: %v", name, err)
 	}
@@ -1015,9 +1015,9 @@ func (e errNoStreams) Error() string {
 	return fmt.Sprintf("no streams in %s: %s", e.url, e.err)
 }
 
-func getMediaDimensions(url string) (persist.Dimensions, error) {
+func getMediaDimensions(ctx context.Context, url string) (persist.Dimensions, error) {
 	outBuf := &bytes.Buffer{}
-	c := exec.Command("ffprobe", "-show_streams", url, "-print_format", "json")
+	c := exec.CommandContext(ctx, "ffprobe", "-hide_banner", "-loglevel", "error", "-show_streams", url, "-print_format", "json")
 	c.Stderr = os.Stderr
 	c.Stdout = outBuf
 	err := c.Run()
@@ -1028,11 +1028,11 @@ func getMediaDimensions(url string) (persist.Dimensions, error) {
 	var d dimensions
 	err = json.Unmarshal(outBuf.Bytes(), &d)
 	if err != nil {
-		return persist.Dimensions{}, errNoStreams{url: url, err: err}
+		return persist.Dimensions{}, fmt.Errorf("failed to unmarshal ffprobe output: %w", err)
 	}
 
 	if len(d.Streams) == 0 {
-		return persist.Dimensions{}, errNoStreams{url: url}
+		return persist.Dimensions{}, fmt.Errorf("no streams found in ffprobe output: %w", err)
 	}
 
 	dims := persist.Dimensions{}
@@ -1048,7 +1048,7 @@ func getMediaDimensions(url string) (persist.Dimensions, error) {
 		break
 	}
 
-	logger.For(nil).Debugf("got dimensions %+v for %s", dims, url)
+	logrus.Debugf("got dimensions %+v for %s", dims, url)
 	return dims, nil
 }
 

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -87,7 +87,11 @@ func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Ad
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID
 func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/nfts/get/metadata?contract_address=%s&token_id=%s&address=%s", d.indexerBaseURL, ti.ContractAddress, ti.TokenID, ownerAddress), nil)
+	url := fmt.Sprintf("%s/nfts/get/metadata?contract_address=%s&token_id=%s", d.indexerBaseURL, ti.ContractAddress, ti.TokenID)
+	if ownerAddress != "" {
+		url = fmt.Sprintf("%s&address=%s", url, ownerAddress)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -86,8 +86,8 @@ func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Ad
 }
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID
-func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contractAddress persist.Address, tokenID persist.TokenID) (persist.TokenMetadata, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/nfts/get/metadata?contract_address=%s&token_id=%s", d.indexerBaseURL, contractAddress, tokenID), nil)
+func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/nfts/get/metadata?contract_address=%s&token_id=%s&address=%s", d.indexerBaseURL, ti.ContractAddress, ti.TokenID, ownerAddress), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -186,7 +186,7 @@ type deepRefresher interface {
 
 // tokenMetadataFetcher supports fetching token metadata
 type tokenMetadataFetcher interface {
-	GetTokenMetadataByTokenIdentifiers(ctx context.Context, contractAddress persist.Address, tokenID persist.TokenID) (persist.TokenMetadata, error)
+	GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error)
 }
 
 type ChainOverrideMap = map[persist.Chain]*persist.Chain
@@ -621,7 +621,7 @@ func (p *Provider) GetTokensOfContractForWallet(ctx context.Context, contractAdd
 }
 
 // GetTokenMetadataByTokenIdentifiers will get the metadata for a given token identifier
-func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contractAddress persist.Address, tokenID persist.TokenID, chain persist.Chain) (persist.TokenMetadata, error) {
+func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contractAddress persist.Address, tokenID persist.TokenID, ownerAddress persist.Address, chain persist.Chain) (persist.TokenMetadata, error) {
 	if _, ok := d.Chains[chain]; !ok {
 		return nil, nil
 	}
@@ -629,7 +629,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contr
 	for _, provider := range d.Chains[chain] {
 
 		if metadataFetcher, ok := provider.(tokenMetadataFetcher); ok {
-			metadata, err := metadataFetcher.GetTokenMetadataByTokenIdentifiers(ctx, contractAddress, tokenID)
+			metadata, err := metadataFetcher.GetTokenMetadataByTokenIdentifiers(ctx, ChainAgnosticIdentifiers{ContractAddress: contractAddress, TokenID: tokenID}, ownerAddress)
 			if err != nil {
 				return nil, err
 			}

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -820,7 +820,15 @@ func GetTokenURI(ctx context.Context, pTokenType persist.TokenType, pContractAdd
 		return persist.TokenURI(strings.ReplaceAll(turi, "\x00", "")), nil
 
 	default:
-		return "", fmt.Errorf("unknown token type: %s", pTokenType)
+		if tokenURI, err := GetTokenURI(ctx, persist.TokenTypeERC721, pContractAddress, pTokenID, ethClient); err == nil {
+			return tokenURI, nil
+		}
+
+		if tokenURI, err := GetTokenURI(ctx, persist.TokenTypeERC1155, pContractAddress, pTokenID, ethClient); err == nil {
+			return tokenURI, nil
+		}
+
+		return "", fmt.Errorf("unsupported token type: %s", pTokenType)
 	}
 }
 

--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -13,7 +13,7 @@ import (
 
 func handlersInitServer(router *gin.Engine, mc *multichain.Provider, repos *postgres.Repositories, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, tokenBucket string, throttler *throttle.Locker) *gin.Engine {
 	mediaGroup := router.Group("/media")
-	mediaGroup.POST("/process", processMediaForUsersTokensOfChain(mc, repos.TokenRepository, repos.ContractRepository, ethClient, ipfsClient, arweaveClient, stg, tokenBucket, throttler))
+	mediaGroup.POST("/process", processMediaForUsersTokensOfChain(mc, repos.TokenRepository, repos.ContractRepository, repos.WalletRepository, ethClient, ipfsClient, arweaveClient, stg, tokenBucket, throttler))
 	mediaGroup.POST("/process/token", processMediaForToken(mc, repos.TokenRepository, repos.UserRepository, repos.WalletRepository, ethClient, ipfsClient, arweaveClient, stg, tokenBucket, throttler))
 	ownersGroup := router.Group("/owners")
 	ownersGroup.POST("/process/contract", processOwnersForContractTokens(mc, repos.ContractRepository, throttler))


### PR DESCRIPTION
Changes:

- **Added** token metadata fetcher to opensea provider
- **Added** manual index step to indexer API metadata fetcher
- **Changed** indexer API metadata fetcher to not return when a token is not found, and instead continue the process of finding metadata using the blockchain