### PR TITLE
Use pg_cron to refresh search relevance tables

### DIFF
--- a/db/migrations/core/000067_add_schedule_search_relevance.up.sql
+++ b/db/migrations/core/000067_add_schedule_search_relevance.up.sql
@@ -1,0 +1,4 @@
+-- Not sure if it matters in practical terms, but stagger these so we're not computing a bunch of stuff at the same time
+select cron.schedule('5 * * * *', 'refresh materialized view concurrently user_relevance with data');
+select cron.schedule('10 * * * *', 'refresh materialized view concurrently gallery_relevance with data');
+select cron.schedule('15 * * * *', 'refresh materialized view concurrently contract_relevance with data');


### PR DESCRIPTION
Now that pg_cron is up and running, it's time to keep our search relevance tables up to date. Thanks @jarrel-b!

This PR refreshes the `user_relevance`, `contract_relevance`, and `gallery_relevance` tables every hour, and staggers the start times (:05, :10, :15) to avoid running a bunch of operations at the same time.