### PR TITLE
Fix missing OS tokens bug

### DIFF
--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -430,7 +430,7 @@ func validateNFTs(c context.Context, input ValidateWalletNFTsInput, tokenReposit
 		output.Message += newMsg
 	}
 
-	openseaAssets, err := opensea.FetchAssetsForWallet(c, input.Wallet, "", 0, nil)
+	openseaAssets, err := opensea.FetchAssetsForWallet(c, input.Wallet)
 	if err != nil {
 		return ValidateUsersNFTsOutput{}, err
 	}

--- a/indexer/refresh/refresh.go
+++ b/indexer/refresh/refresh.go
@@ -300,11 +300,11 @@ func loadFromFile(path string) (*bloom.BloomFilter, error) {
 	}
 
 	f, err := os.Open(path)
-	defer f.Close()
-
 	if err != nil {
 		return nil, err
 	}
+
+	defer f.Close()
 
 	var bf bloom.BloomFilter
 	bf.ReadFrom(f)

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -231,7 +231,7 @@ func downloadMediaFromURL(ctx context.Context, storageClient *storage.Client, ar
 		case errGeneratingThumbnail:
 			resultCh <- cacheResult{mediaType, cached, err}
 		case *googleapi.Error:
-			panic(caught) // Bomb out if we can't access the bucket
+			panic(fmt.Errorf("googleAPI error %s: %s", caught, err))
 		default:
 			logger.For(ctx).Error(err)
 			sentryutil.ReportError(ctx, err)

--- a/util/response.go
+++ b/util/response.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -37,4 +38,13 @@ func GetErrFromResp(res *http.Response) error {
 	errResp := map[string]interface{}{}
 	json.NewDecoder(res.Body).Decode(&errResp)
 	return fmt.Errorf("unexpected status: %s | err: %v ", res.Status, errResp)
+}
+
+// BodyAsError returns the HTTP body as an error
+func BodyAsError(res *http.Response) error {
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("%s", body)
 }


### PR DESCRIPTION
There's an issue with the OpenSea API where it doesn't seem to return all tokens if only the owner address is used in the query. Including the owner address and the contract address seems to get around this issue. This PR also wraps calls to OpenSea with retries so that requests retry and backoff if we get rate-limited. It also refactors the pagination to use a loop vs recursion which makes it a little simpler to read (at least for me!)