### PR TITLE
indexer checks at the end of each pipeline that tokens exist for each log

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -813,7 +813,7 @@ func (i *indexer) pollNewLogs(ctx context.Context, transfersChan chan<- []transf
 
 	logger.For(ctx).Infof("Processed logs from %d to %d.", i.lastSyncedChunk, mostRecentBlock)
 
-	i.lastSyncedChunk = mostRecentBlock
+	i.updateLastSynced(mostRecentBlock - (mostRecentBlock % blocksPerLogsCall))
 
 	logsToCheckAgainst <- resultLogs
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -417,7 +417,7 @@ func (i *indexer) checkTokensExistForLogs(ctx context.Context, logs []types.Log)
 						return
 					}
 					if balance.Cmp(big.NewInt(0)) == 0 {
-						logger.For(ctx).Errorf("balance of ERC1155 token is 0, skipping check")
+						logger.For(ctx).Debugf("balance of ERC1155 token is 0, skipping check")
 						return
 					}
 				}

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -437,7 +437,7 @@ func (i *indexer) listenForNewBlocks(ctx context.Context) {
 	defer sentryutil.RecoverAndRaise(ctx)
 
 	for {
-		<-time.After(time.Minute * 2)
+		<-time.After(time.Minute * 12)
 		finalBlockUint, err := rpc.RetryGetBlockNumber(ctx, i.ethClient)
 		if err != nil {
 			panic(fmt.Sprintf("error getting block number: %s", err))

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -453,7 +453,7 @@ func (i *indexer) listenForNewBlocks(ctx context.Context) {
 	defer sentryutil.RecoverAndRaise(ctx)
 
 	for {
-		<-time.After(time.Minute * 12)
+		<-time.After(time.Second*12*time.Duration(blocksPerLogsCall) + time.Minute)
 		finalBlockUint, err := rpc.RetryGetBlockNumber(ctx, i.ethClient)
 		if err != nil {
 			panic(fmt.Sprintf("error getting block number: %s", err))

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -853,14 +853,14 @@ outer:
 		}
 
 		if err := thumbnailAndCache(pCtx, videoURL, bucket, name, storageClient); err != nil {
-			return mediaType, false, err
+			logger.For(pCtx).Warnf("could not create thumbnail for %s: %s", name, err)
 		}
 
 		if err := createLiveRenderAndCache(pCtx, videoURL, bucket, name, storageClient); err != nil {
 			logger.For(pCtx).Warnf("could not create live render for %s: %s", name, err)
 		}
 
-		logger.For(pCtx).Infof("cached video and thumbnail for %s in %s", name, time.Since(timeBeforeCache))
+		logger.For(pCtx).Infof("cached video for %s in %s", name, time.Since(timeBeforeCache))
 		return persist.MediaTypeVideo, true, nil
 	case persist.MediaTypeSVG:
 		timeBeforeCache := time.Now()

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -490,7 +490,7 @@ func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.A
 }
 
 // WalletCreated runs whenever a new wallet is created
-func (d *Provider) WalletCreated(ctx context.Context, wallet persist.Address, all bool) error {
+func (d *Provider) WalletCreated(ctx context.Context, userID persist.DBID, wallet persist.Address, walletType persist.WalletType) error {
 	input := task.ValidateNFTsMessage{OwnerAddress: persist.EthereumAddress(wallet.String())}
 
 	return task.CreateTaskForWalletValidation(ctx, input, d.taskClient)

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -28,6 +28,7 @@ import (
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/mikeydub/go-gallery/util"
+	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -491,6 +492,9 @@ func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.A
 
 // WalletCreated runs whenever a new wallet is created
 func (d *Provider) WalletCreated(ctx context.Context, userID persist.DBID, wallet persist.Address, walletType persist.WalletType) error {
+	if viper.GetString("ENV") == "local" {
+		return nil
+	}
 	input := task.ValidateNFTsMessage{OwnerAddress: persist.EthereumAddress(wallet.String())}
 
 	return task.CreateTaskForWalletValidation(ctx, input, d.taskClient)

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -152,7 +152,7 @@ type verifier interface {
 
 type walletHooker interface {
 	// WalletCreated is called when a wallet is created
-	WalletCreated(context.Context, persist.DBID, persist.Address, persist.WalletType, persist.Chain) error
+	WalletCreated(context.Context, persist.DBID, persist.Address, persist.WalletType) error
 }
 
 // tokensFetcher supports fetching tokens for syncing
@@ -692,7 +692,7 @@ func (d *Provider) RunWalletCreationHooks(ctx context.Context, userID persist.DB
 	for _, provider := range d.Chains[chain] {
 
 		if hooker, ok := provider.(walletHooker); ok {
-			if err := hooker.WalletCreated(ctx, userID, walletAddress, walletType, chain); err != nil {
+			if err := hooker.WalletCreated(ctx, userID, walletAddress, walletType); err != nil {
 				return err
 			}
 		}

--- a/service/persist/postgres/token.go
+++ b/service/persist/postgres/token.go
@@ -110,7 +110,7 @@ func NewTokenRepository(db *sql.DB) *TokenRepository {
 	upsert1155Stmt, err := db.PrepareContext(ctx, `INSERT INTO tokens (ID,MEDIA,TOKEN_TYPE,CHAIN,NAME,DESCRIPTION,TOKEN_ID,TOKEN_URI,QUANTITY,OWNER_ADDRESS,OWNERSHIP_HISTORY,TOKEN_METADATA,CONTRACT_ADDRESS,EXTERNAL_URL,BLOCK_NUMBER,VERSION,CREATED_AT,LAST_UPDATED) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18) ON CONFLICT (TOKEN_ID,CONTRACT_ADDRESS,OWNER_ADDRESS) WHERE TOKEN_TYPE = 'ERC-1155' DO UPDATE SET MEDIA = EXCLUDED.MEDIA,TOKEN_TYPE = EXCLUDED.TOKEN_TYPE,CHAIN = EXCLUDED.CHAIN,NAME = EXCLUDED.NAME,DESCRIPTION = EXCLUDED.DESCRIPTION,TOKEN_URI = EXCLUDED.TOKEN_URI,QUANTITY = EXCLUDED.QUANTITY,OWNER_ADDRESS = EXCLUDED.OWNER_ADDRESS,OWNERSHIP_HISTORY = EXCLUDED.OWNERSHIP_HISTORY,TOKEN_METADATA = EXCLUDED.TOKEN_METADATA,EXTERNAL_URL = EXCLUDED.EXTERNAL_URL,BLOCK_NUMBER = EXCLUDED.BLOCK_NUMBER,VERSION = EXCLUDED.VERSION,CREATED_AT = EXCLUDED.CREATED_AT,LAST_UPDATED = EXCLUDED.LAST_UPDATED;`)
 	checkNoErr(err)
 
-	deleteStmt, err := db.PrepareContext(ctx, `DELETE FROM tokens WHERE TOKEN_ID = $1 AND CONTRACT_ADDRESS = $2 AND OWNER_ADDRESS = $3;`)
+	deleteStmt, err := db.PrepareContext(ctx, `DELETE FROM tokens WHERE TOKEN_ID = $1 AND CONTRACT_ADDRESS = $2 AND OWNER_ADDRESS = $3 and TOKEN_TYPE = $4;`)
 	checkNoErr(err)
 
 	deleteByIDStmt, err := db.PrepareContext(ctx, `DELETE FROM tokens WHERE ID = $1;`)
@@ -366,7 +366,7 @@ func (t *TokenRepository) BulkUpsert(pCtx context.Context, pTokens []persist.Tok
 	for _, token := range erc1155Tokens {
 		if token.Quantity == "" || token.Quantity == "0" || token.Quantity == "<nil>" {
 			logger.For(pCtx).Debugf("Deleting token %s for 0 quantity", persist.NewTokenIdentifiers(persist.Address(token.ContractAddress.String()), token.TokenID, token.Chain))
-			if err := t.deleteTokenUnsafe(pCtx, token.TokenID, token.ContractAddress, token.OwnerAddress); err != nil {
+			if err := t.deleteTokenUnsafe(pCtx, token.TokenID, token.ContractAddress, token.OwnerAddress, token.TokenType); err != nil {
 				return err
 			}
 		}
@@ -458,7 +458,7 @@ func (t *TokenRepository) upsertERC1155Tokens(pCtx context.Context, pTokens []pe
 func (t *TokenRepository) Upsert(pCtx context.Context, pToken persist.Token) error {
 	var err error
 	if pToken.Quantity == "0" {
-		_, err = t.deleteStmt.ExecContext(pCtx, pToken.TokenID, pToken.ContractAddress, pToken.OwnerAddress)
+		_, err = t.deleteStmt.ExecContext(pCtx, pToken.TokenID, pToken.ContractAddress, pToken.OwnerAddress, pToken.TokenType)
 	} else {
 		if pToken.TokenType == persist.TokenTypeERC1155 {
 			_, err = t.upsert1155Stmt.ExecContext(pCtx, persist.GenerateID(), pToken.Media, pToken.TokenType, pToken.Chain, pToken.Name, pToken.Description, pToken.TokenID, pToken.TokenURI, pToken.Quantity, pToken.OwnerAddress, pToken.OwnershipHistory, pToken.TokenMetadata, pToken.ContractAddress, pToken.ExternalURL, pToken.BlockNumber, pToken.Version, pToken.CreationTime, pToken.LastUpdated)
@@ -549,8 +549,8 @@ func (t *TokenRepository) DeleteByID(pCtx context.Context, pID persist.DBID) err
 	return err
 }
 
-func (t *TokenRepository) deleteTokenUnsafe(pCtx context.Context, pTokenID persist.TokenID, pContractAddress, pOwnerAddress persist.EthereumAddress) error {
-	_, err := t.deleteStmt.ExecContext(pCtx, pTokenID, pContractAddress, pOwnerAddress)
+func (t *TokenRepository) deleteTokenUnsafe(pCtx context.Context, pTokenID persist.TokenID, pContractAddress, pOwnerAddress persist.EthereumAddress, pTokenType persist.TokenType) error {
+	_, err := t.deleteStmt.ExecContext(pCtx, pTokenID, pContractAddress, pOwnerAddress, pTokenType)
 	return err
 }
 

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -343,6 +343,7 @@ type TokenRepository interface {
 	UpdateByID(context.Context, DBID, interface{}) error
 	UpdateByTokenIdentifiers(context.Context, TokenID, EthereumAddress, interface{}) error
 	MostRecentBlock(context.Context) (BlockNumber, error)
+	TokenExistsByTokenIdentifiers(context.Context, TokenID, EthereumAddress) (bool, error)
 }
 
 // ErrTokenNotFoundByTokenIdentifiers is an error that is returned when a token is not found by its identifiers (token ID and contract address)

--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -52,7 +52,7 @@ type DeepRefreshMessage struct {
 }
 
 type ValidateNFTsMessage struct {
-	OwnerAddress persist.EthereumAddress `json:"owner_address"`
+	OwnerAddress persist.EthereumAddress `json:"wallet"`
 }
 
 func CreateTaskForFeed(ctx context.Context, scheduleOn time.Time, message FeedMessage, client *gcptasks.Client) error {


### PR DESCRIPTION
Changes:

- **Added** a check at the end of the indexer pipelines that will go through every Ethereum log and ensure that there is a token for the log in the database, logging if not
- **Changed** media processing to not delete videos if thumbnailing fails
- **Changed** wallet hook to match the correct interface definition
- **Changed** polling process in a few ways to simplify things and make everything easier to reason about (and remove chances for race conditions because we were editing a shared struct field from within a goroutine without a mutex): 

1. Only poll in groupings of 50 blocks, just like the indexer does during the catchup process
2. Don't send to transfer processing in groupings of 4, send all together like the indexer does during the catchup process
 