### PR TITLE
Change sort order of shared followers and communities order 

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -1570,37 +1570,37 @@ select contracts.id, contracts.deleted, contracts.version, contracts.created_at,
 from owned_contracts a, owned_contracts b, contracts
 left join marketplace_contracts on contracts.id = marketplace_contracts.contract_id
 where a.user_id = $1
-	and b.user_id = $2
-	and a.contract_id = b.contract_id
-	and a.contract_id = contracts.id
+  and b.user_id = $2
+  and a.contract_id = b.contract_id
+  and a.contract_id = contracts.id
   and marketplace_contracts.contract_id is null
   and contracts.name is not null
   and contracts.name != ''
   and contracts.name != 'Unidentified contract'
-	and (
-    a.displayed,
-    b.displayed,
-    a.owned_count,
-    contracts.id
-  ) < (
-    $3,
-    $4,
-    $5::int,
-    $6
-  )
-	and (
+  and (
     a.displayed,
     b.displayed,
     a.owned_count,
     contracts.id
   ) > (
+    $3,
+    $4,
+    $5::int,
+    $6
+  )
+  and (
+    a.displayed,
+    b.displayed,
+    a.owned_count,
+    contracts.id
+  ) < (
     $7,
     $8,
     $9::int,
     $10
   )
-order by case when $11::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end asc,
-        case when not $11::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end desc
+order by case when $11::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end desc,
+        case when not $11::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end asc
 limit $12
 `
 
@@ -1732,10 +1732,10 @@ where a.follower = $1
 	and a.deleted = false
 	and b.deleted = false
 	and users.deleted = false
-  and (a.created_at, users.id) < ($3, $4)
-  and (a.created_at, users.id) > ($5, $6)
-order by case when $7::bool then (a.created_at, users.id) end asc,
-        case when not $7::bool then (a.created_at, users.id) end desc
+  and (a.created_at, users.id) > ($3, $4)
+  and (a.created_at, users.id) < ($5, $6)
+order by case when $7::bool then (a.created_at, users.id) end desc,
+        case when not $7::bool then (a.created_at, users.id) end asc
 limit $8
 `
 

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -152,9 +152,9 @@ select count(*)
 from owned_contracts a, owned_contracts b, contracts
 left join marketplace_contracts on contracts.id = marketplace_contracts.contract_id
 where a.user_id = $1
-	and b.user_id = $2
-	and a.contract_id = b.contract_id
-	and a.contract_id = contracts.id
+  and b.user_id = $2
+  and a.contract_id = b.contract_id
+  and a.contract_id = contracts.id
   and marketplace_contracts.contract_id is null
   and contracts.name is not null
   and contracts.name != ''

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -919,10 +919,10 @@ where a.follower = @follower
 	and a.deleted = false
 	and b.deleted = false
 	and users.deleted = false
-  and (a.created_at, users.id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
-  and (a.created_at, users.id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
-order by case when sqlc.arg('paging_forward')::bool then (a.created_at, users.id) end asc,
-        case when not sqlc.arg('paging_forward')::bool then (a.created_at, users.id) end desc
+  and (a.created_at, users.id) > (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
+  and (a.created_at, users.id) < (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
+order by case when sqlc.arg('paging_forward')::bool then (a.created_at, users.id) end desc,
+        case when not sqlc.arg('paging_forward')::bool then (a.created_at, users.id) end asc
 limit sqlc.arg('limit');
 
 -- name: CountSharedFollows :one
@@ -953,7 +953,7 @@ where a.user_id = @user_a_id
     b.displayed,
     a.owned_count,
     contracts.id
-  ) < (
+  ) > (
     sqlc.arg('cur_before_displayed_by_user_a'),
     sqlc.arg('cur_before_displayed_by_user_b'),
     sqlc.arg('cur_before_owned_count')::int,
@@ -964,14 +964,14 @@ where a.user_id = @user_a_id
     b.displayed,
     a.owned_count,
     contracts.id
-  ) > (
+  ) < (
     sqlc.arg('cur_after_displayed_by_user_a'),
     sqlc.arg('cur_after_displayed_by_user_b'),
     sqlc.arg('cur_after_owned_count')::int,
     sqlc.arg('cur_after_contract_id')
   )
-order by case when sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end asc,
-        case when not sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end desc
+order by case when sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end desc,
+        case when not sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end asc
 limit sqlc.arg('limit');
 
 -- name: CountSharedContracts :one

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -674,10 +674,12 @@ func (api UserAPI) SharedFollowers(ctx context.Context, userID persist.DBID, bef
 		return time.Time{}, "", fmt.Errorf("node is not a db.GetSharedFollowersBatchPaginateRow")
 	}
 
-	paginator := timeIDPaginator{
-		QueryFunc:  queryFunc,
-		CursorFunc: cursorFunc,
-		CountFunc:  countFunc,
+	paginator := sharedFollowersPaginator{
+		timeIDPaginator{
+			QueryFunc:  queryFunc,
+			CursorFunc: cursorFunc,
+			CountFunc:  countFunc,
+		},
 	}
 
 	results, pageInfo, err := paginator.paginate(before, after, first, last)


### PR DESCRIPTION
This PR changes the sort order of shared followers and shared communities to descending when paging forward, and ascending when paging in reverse.