### PR TITLE
Create scrubbed views of PII tables

### DIFF
--- a/db/migrations/core/000068_add_scrubbed_pii_schema.up.sql
+++ b/db/migrations/core/000068_add_scrubbed_pii_schema.up.sql
@@ -1,0 +1,23 @@
+/* {% require_sudo %} */
+
+create schema if not exists scrubbed_pii;
+alter schema scrubbed_pii owner to access_rw_pii;
+
+-- All access levels get read access to scrubbed_pii views, but only access_rw_pii can create
+-- or modify views. In practical terms, access_rw_pii can set up scrubbed views that query pii
+-- tables but don't return any actual pii, and other access levels can query (but not modify)
+-- those views.
+grant usage on schema scrubbed_pii to access_ro;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant select on tables to access_ro;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant usage on sequences to access_ro;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant execute on functions to access_ro;
+
+grant usage on schema scrubbed_pii to access_rw;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant select on tables to access_rw;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant usage on sequences to access_rw;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant execute on functions to access_rw;
+
+grant usage on schema scrubbed_pii to access_ro_pii;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant select on tables to access_ro_pii;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant usage on sequences to access_ro_pii;
+alter default privileges for role access_rw_pii in schema scrubbed_pii grant execute on functions to access_ro_pii;

--- a/db/migrations/core/000069_add_scrubbed_pii_views.up.sql
+++ b/db/migrations/core/000069_add_scrubbed_pii_views.up.sql
@@ -1,0 +1,47 @@
+set role to access_rw_pii;
+
+create view scrubbed_pii.for_users as (
+    -- includes social data when display = true, otherwise makes a dummy id and omits metadata
+    with scrubbed_socials as (
+        with socials as (
+            select user_id, (jsonb_each(pii_socials)).* from pii.for_users
+        ),
+
+        scrubbed as (
+            select user_id, key as k,
+            case
+                when (socials.value -> 'display')::bool then socials.value
+                else '{"display":false, "metadata":{}}'::jsonb ||
+                    jsonb_build_object('provider', socials.value -> 'provider') ||
+                    jsonb_build_object('id', users.username_idempotent || '-dummy-id')
+            end as v
+            from socials join users on socials.user_id = users.id
+        ),
+
+        aggregated as (
+            select user_id, jsonb_object_agg(k, v) as socials
+                from scrubbed
+                group by user_id
+        )
+
+        select for_users.user_id, coalesce(aggregated.socials, '{}'::jsonb) as scrubbed_socials from pii.for_users
+            left join aggregated on aggregated.user_id = for_users.user_id
+    ),
+
+    -- <username>@dummy-email.gallery.so for users who have email addresses, null otherwise
+    scrubbed_email_address as (
+        select u.id as user_id,
+               case
+                   when p.pii_email_address is not null then u.username_idempotent || '@dummy-email.gallery.so'
+               end as scrubbed_address from users u, pii.for_users p
+        where u.id = p.user_id
+    )
+
+    -- Doing this limit 0 union ensures we have appropriate column types for our view
+    (select * from pii.for_users limit 0)
+    union all
+    select p.user_id, e.scrubbed_address, p.deleted, s.scrubbed_socials
+        from pii.for_users p
+            join scrubbed_email_address e on e.user_id = p.user_id
+            join scrubbed_socials s on s.user_id = p.user_id
+);


### PR DESCRIPTION
We often want to know aggregate stats about PII (e.g. how many users have email addresses set) without needing to know the actual PII itself. This PR sets up a `scrubbed_pii` schema to facilitate these queries, using views to return a scrubbed view of a PII table.

Initially, the only view is `scrubbed_pii.for_users`, but it's easy to add more!