### PR TITLE
Remove metadata check

### DIFF
--- a/secrets/local/local/app-local-tokenprocessing.yaml
+++ b/secrets/local/local/app-local-tokenprocessing.yaml
@@ -5,7 +5,7 @@ IPFS_PROJECT_SECRET: ENC[AES256_GCM,data:YhhIG2LlhYmzDEYELnTsR0zyjWcGm6GN09kC8iZ
 GCLOUD_TOKEN_LOGS_BUCKET: ENC[AES256_GCM,data:1//q6sJN++FN3Ycq8TBIVPdD,iv:l/WezEomyf+fjEosQRxjRjc2ztBvvGxcEyUWUiLHIoE=,tag:rwkchSDeu0yVL49eMXRh0A==,type:str]
 GCLOUD_TOKEN_CONTENT_BUCKET: ENC[AES256_GCM,data:wutTPK740fP4r8WO0PwRKQg=,iv:dyP55Ny3ErUmqrNEbpoltAhDLRfLzBruVsSAEn7jJI8=,tag:Xlw6J6w7J8LgqVtGChYwEQ==,type:str]
 IMGIX_API_KEY: ENC[AES256_GCM,data:mLypOjQG8WRf6vKtMV6w1VbZn5biLu05vhb4lyMU7pBjGvOJBm+ecbVUQn/ruLqM7SF7mHo62dvNSu/PIuKRAcaMKw==,iv:oV6DzXjb+h2kL/i0TwlfpjvWF/J4HkJpDrG7eaJHI5M=,tag:V5PUKDHqfBgP4LdgCKk6MA==,type:str]
-INDEXER_HOST: ENC[AES256_GCM,data:9QDZaR70VvsVaG6xhQvx8C8e8aVy,iv:dT07iYxbgja3aGBqxOi7pF56QcwVkcNZaQN0MTEApFM=,tag:im7O/PTvsqxYxJsl4Z43+g==,type:str]
+INDEXER_HOST: ENC[AES256_GCM,data:5RAAy7ukxWol2ZZ3ZOQits9nkCbD,iv:cxvp/u0iZ6XlSfmg8mTPHeMIDqdHUKlG4QV60kd2OUs=,tag:P3npOvKxh+h2vPk89BG6nA==,type:str]
 #ENC[AES256_GCM,data:lVXNSgfXWQgbDaSqPRqH0+HmnkFOKCDkvddkuCELF577oIgGxhfgSISYpRQKDihgZvUr/7ufbRXmCsylyabRy0W0LwtnADfmqC3PtL9VI1SwRJlZCy6cYIHi,iv:Wd7vvS2L/xxsQfVodagSr/fmrHuezE4n2sT38IkmGAs=,tag:XET+dpieokoiLESU1ONbMw==,type:comment]
 REDIS_URL: ENC[AES256_GCM,data:Btl3GsNm70oSLY4yCyE=,iv:jlHZZK7kE0hjgUx+F4M89RsyJOYVVfl63eRJQQkZVE0=,tag:QE+UEUmdge9ySwYtdRH1CA==,type:str]
 #ENC[AES256_GCM,data:0qYMcBuz2RcyrfSgb3XXMijC/PrtFnA/hdN5Zam1uhAT7jbDqNpQREWJf5sVLQHMncq9Fxn155ObQ/GN0AXjAQorPcQONUNqJ0EjPdlnh5t6S6c=,iv:QcnCDGhi1HM0v50/+ZbnsLM5DhuGkgveHtD6CsbQnQo=,tag:6FA8nMm+YgtMcr+Vsf0mXA==,type:comment]
@@ -20,8 +20,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-02-07T18:30:57Z"
-    mac: ENC[AES256_GCM,data:Aq7HovJ9nnEJbxSupyMO/CKJffG3rniswEmXYuWm1EZ7CUTj2EzzxkBC57/dah1HimkVt8V5AZdajOt4FYSqEhozWjUIB55pIwmzwkrvTT6PPypI+ttlcve3wnj+7kmHRF6RrM60yQBTqFg3bN1qhaKMhieEMNABfC8Z4T3oqZU=,iv:8GliTAMRJzDMKB19naUmGLBkNv5TYDAmbidFgtVB9WE=,tag:ZOmR++cJZ5A5lZY1rmGOsg==,type:str]
+    lastmodified: "2023-03-15T18:16:26Z"
+    mac: ENC[AES256_GCM,data:Y4Et9iRyO7lUhUOOlLYwg5bLhkJo241FH2JGvMKd3QyrVj7WYBisqrpcX9XfnpFiRYJtr9830ZpKhNEt4wp7F4pYkUJZsbJ4HG06DheR/7gIHbHlbpHVe/wO7RzLrem4QXXmZhCK63ejRJXlYwR6G6wnDSiKXAoz/GpO5vJ08mY=,iv:ss9NSLKo1GRfvjO85Us/S6F+nB998mgKhZCBSLtX6O4=,tag:hwq2mVJcBRe1eMBUBF7bow==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/local/app-prod-tokenprocessing.yaml
+++ b/secrets/prod/local/app-prod-tokenprocessing.yaml
@@ -1,23 +1,14 @@
-ENV: ENC[AES256_GCM,data:sVdVbyU=,iv:Y80wpb7nwwHO5/zCyvKgaY3wZrTz1kqOWld6UPSFBSw=,tag:ukeOBX6YVl9CA2sWceOb/w==,type:str]
 IPFS_URL: ENC[AES256_GCM,data:qqWAs6tFmh+P4fPkN83PUyXa+Fn4G69fAdzcOzQQ,iv:ZGYwFN/bRts9N9mheftV0bHa5gcm0TW3LssMCjEW2GA=,tag:izzXJHf4PkW4zP9XJ5lM7A==,type:str]
 IPFS_API_URL: ENC[AES256_GCM,data:D/eTu9c4o0/G5GyUYszqTA6IEtgrlHToIOVG,iv:h//iHCXw/MSweSR8zGY3YGRfkVw5Y9/AxB5DXqvWT0M=,tag:WGkn4/SzyuIo4a5KdAHvXw==,type:str]
 IPFS_PROJECT_ID: ENC[AES256_GCM,data:11zeltdEwTPPi79NXhPQfOP6VyoRdHMo1UuL,iv:owB+g8k9cZ8Lyhsr+ZeX/NMHhAhv3iaPGr9bInIdFEY=,tag:D6RQ8amU+yNVNanuq0Ap0Q==,type:str]
 IPFS_PROJECT_SECRET: ENC[AES256_GCM,data:5Krd6/n3kzC+Ebl1MFAWT1gmPFmdVks0SjDMH4ixX/8=,iv:6toSKeAL10hLEMcBsmWkIDbTSFYvPUxCpUDd6aRZ+Qw=,tag:WAg30klUdZ6xNdAwYbbdAg==,type:str]
-GCLOUD_TOKEN_LOGS_BUCKET: ENC[AES256_GCM,data:1glD/a2+yVAU+Y9aNqoBJHFl2w==,iv:dFHyQb3eff1Rn4ArtJOF68FjBz7wFzBs+PRhL3e0AAE=,tag:0FTJRo1D1UL4Gyv3jvuiBw==,type:str]
-GCLOUD_TOKEN_CONTENT_BUCKET: ENC[AES256_GCM,data:PhitL0lIYEnhYAdIkwFxKwJf,iv:HF79NPp/ZweNEjDsOqga0FwwK6EOEAxEpzbL/CnGwO4=,tag:v/OjL8/aNnkPvfk4k3u8yg==,type:str]
-POSTGRES_HOST: ENC[AES256_GCM,data:BF9/IaglaD+j,iv:MeROv4r3ir4JzwApjP+ODH2sN2g9MevRt4sAxA0vh0Q=,tag:vfqDeMpgjWgFajO4YfQv7w==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:RQ4/mg==,iv:NEds3QgQyIbhSr+qDaMCB5EaJsh/EnrBF9O0gvxjmy0=,tag:QTmdEc0NjXjXA7vZ0l9/TQ==,type:str]
-POSTGRES_DB: ENC[AES256_GCM,data:j/tapU+Fb7M=,iv:TIPldVAbkTYKXLY44PEl5tJKaTm10Ejp3v+WwEk1dj4=,tag:skwpR9Ea04m1G58WTpHg5A==,type:str]
-POSTGRES_USER: ENC[AES256_GCM,data:5Ec2ojUvLLGTqcmqaMt/,iv:QnzYsDoBC7wmfYIvfr6OLQrBCZWS6kwqC5sfzD+Xx00=,tag:vBR8NcCPmdEYQq0KXweiGw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:SNsEEovj4xfE9duCv39xhqMPjFV9plBeSIROLdDmqM4=,iv:nmDHCuKF6KVqpAOKs09D5qWZzUPsNu1sX0JTI5RhWsI=,tag:agh1Y1Vq/azeEHzChP9YRQ==,type:str]
-REDIS_URL: ENC[AES256_GCM,data:BW9xNGUaTkckc0rG+Jc=,iv:WjgMZopuWGnhTz5GhOoZhOum5c3l3rbBaAAP5wrlAHs=,tag:zXhFsVL/j1+ZPTA+E6XaMw==,type:str]
-SENTRY_DSN: ENC[AES256_GCM,data:BxYk67DTnbPpLjMJxOvSu1IEtAUlLHeAcbvkqUq820cKPHf47XR+ACSqe2JxYAAqfEgCoXQYrCLiOV7z4ETd/o0ZFo/D/QsQ33Y=,iv:82T2sYKB76M8NPsj/2SgisvEfV8sbrTkHZrrtXcJk0g=,tag:QV17XRYHsBjJTH/nGYNKZg==,type:str]
-SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:LToK,iv:xBIAcvDedIrpUMy3y+/XZGu0HNjZsoSzL+ekxiq1H+o=,tag:MglsDDZfCsloSf3RZwZSUQ==,type:str]
+GCLOUD_TOKEN_LOGS_BUCKET: ENC[AES256_GCM,data:/DbibSgBMSdFoNNKy1A5C3C/,iv:M+avpitY7btLxhX55+XiLM7MsIh8OnoHZ/lshQoYHoY=,tag:OmgsTl0QhxJXZXwqyuCIsw==,type:str]
+GCLOUD_TOKEN_CONTENT_BUCKET: ENC[AES256_GCM,data:iVm6pqp1NZnAWrsDS4v/Qak=,iv:Vj1Rf3xM09hsONCQxxravdY+oFXjxB6xMpfsk8Wm48M=,tag:dn1Vrzn5zr7Wb4dwO/Cz2A==,type:str]
 IMGIX_API_KEY: ENC[AES256_GCM,data:uqTHn031IhPM8Rab+2hx6PymiGZZKpqKhe5vPnRIDDilGSezbmIy7N4b37mfUqwqKsTK9XEb4qKGdicjkgYtVW4ICA==,iv:u/qijLXqbLqup+nh/mjQjwtl2uJvhH/Hv224ghkNwdw=,tag:NBAX1/MUODZP7a58LGNyXQ==,type:str]
-INDEXER_HOST: ENC[AES256_GCM,data:el27OD4ntS+6RiTnpECyR+mVwLWn,iv:0S+rUUSPfmv4DXDrpX3iRu2rUxwfzcJptry9LH39KsQ=,tag:Ze1SxWAFQwsX9Dyq4qaNaQ==,type:str]
+INDEXER_HOST: ENC[AES256_GCM,data:vG5wueWWN1Gfs4bXts5fFDtQdZtVpAzbLO7tUwRjVGW88Fherm+9lV7Fgg==,iv:JYkI/YTZwfyH5sR0iEouJgFkDnxM9wz7DeAxRSdSuLc=,tag:PI7YK4dyVmXybIZPPsXv2w==,type:str]
+REDIS_URL: ENC[AES256_GCM,data:BW9xNGUaTkckc0rG+Jc=,iv:WjgMZopuWGnhTz5GhOoZhOum5c3l3rbBaAAP5wrlAHs=,tag:zXhFsVL/j1+ZPTA+E6XaMw==,type:str]
+POSTGRES_HOST: ENC[AES256_GCM,data:BF9/IaglaD+j,iv:MeROv4r3ir4JzwApjP+ODH2sN2g9MevRt4sAxA0vh0Q=,tag:vfqDeMpgjWgFajO4YfQv7w==,type:str]
 RPC_URL: ENC[AES256_GCM,data:SDexkJAqQvXGlqKibnf+CefTVr4Hvs2tDoJgdemsDrFPuoBtXzuMVnhYnR5sm3P8uwLUHWfsz6QIwrybjO4eNd33R1cB,iv:iwWl0yXDZvghE+rph+WxK6QKlZTH8bwb6v+7dR0WSqU=,tag:hujev87t3BGeZ68Mty7prQ==,type:str]
-OPENSEA_API_KEY: ENC[AES256_GCM,data:E/7zAX6LGQBNmHXZvdfcxOVJ2FyPunNhYvZCdzSu7sw=,iv:C10zXwvtA+q1oYayPbxRTc2xqjaCcZQEpXfRakov6AE=,tag:7atdecdr9rHjKwH21kOWHQ==,type:str]
-VERSION: ENC[AES256_GCM,data:bA==,iv:w0Y+LMV40CTr8y7QUF8Kk/0Es716Ul99+f1B8SLNwms=,tag:9x0r3+APlk15psBTrQPwNA==,type:int]
 sops:
     kms: []
     gcp_kms:
@@ -27,8 +18,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-13T21:34:53Z"
-    mac: ENC[AES256_GCM,data:hGwg6Jc0SzLHAh+qX/VwmZgADBymoJaYEcEwzsw0lOIeKTEAr1l786jWQfU7JiokR5x3uJq/StbRPeLKKGewieYwdHsYd+Dm00ejkWZSaszpGU3+xOsDA2dfJE6+rcW2wKajTTzXgP+Xtj3j2DZ08fuWE89ngg9kpGuXTK8fQj4=,iv:uB2A/ju4tV1kVevenL8w75JGNzrIAPHPUVSuET/L1FE=,tag:NXA0zbNeB5yDHnp+3syPvA==,type:str]
+    lastmodified: "2023-03-15T18:16:24Z"
+    mac: ENC[AES256_GCM,data:KfghMVX6oL/vpYT1ddiiqvfkHaNZUkXBViBkgmRiKJRrz2lRZqv8v2kzozh75KEm/k56MUuz8/4MUBVFPSMeDPnVo5ecDq4SmCJ5LsS5xRHe6IrxBLdScyNLmidFLUooP5XR3byL6dH9fC0ZgA/NDwQ7TXQELJYWogTCHnilvgI=,iv:seFkPMj8cugdK5bbNzmcKrC+krbZI1HBwvd/cVuB1nM=,tag:eLWwgofz3bwKzRzA/WBVMg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -424,7 +424,7 @@ func (p *Provider) prepTokensForTokenProcessing(ctx context.Context, tokensFromP
 		}
 		// There's no available media for the token at this point, so set the state to syncing
 		// so we can show the loading state instead of a broken token while tokenprocessing handles it.
-		if !providerTokens[i].Media.IsServable() && len(providerTokens[i].TokenMetadata) > 0 {
+		if !providerTokens[i].Media.IsServable() {
 			providerTokens[i].Media = persist.Media{MediaType: persist.MediaTypeSyncing}
 		}
 	}


### PR DESCRIPTION
Removes the metadata check for when a token is set to the syncing state. If a token has usable media, we'll choose to display that while it gets processed. 