### PR TITLE
keywords but simplified

### DIFF
--- a/indexer/t__integration_test.go
+++ b/indexer/t__integration_test.go
@@ -78,8 +78,7 @@ func TestIndexLogs_Success(t *testing.T) {
 		predicted, _ = persist.SniffMediaType(imageData)
 		mediaTypeHasExpectedType(t, a, nil, persist.MediaTypeImage, predicted)
 
-		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
 		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeImage, med.MediaType)
 		a.Empty(med.ThumbnailURL)
 		a.NotEmpty(med.MediaURL)
@@ -97,8 +96,7 @@ func TestIndexLogs_Success(t *testing.T) {
 		metadata, err := rpc.GetMetadataFromURI(ctx, uri, ipfsShell, arweaveClient)
 		mediaHasContent(t, a, err, metadata)
 
-		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
 		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeSVG, med.MediaType)
 		a.Empty(med.ThumbnailURL)
 		a.Contains(med.MediaURL.String(), "https://")

--- a/publicapi/contract.go
+++ b/publicapi/contract.go
@@ -127,18 +127,9 @@ func (api ContractAPI) RefreshOwnersAsync(ctx context.Context, contractID persis
 		return err
 	}
 
-	contract, err := api.loaders.ContractByContractID.Load(contractID)
-	if err != nil {
-		return err
-	}
-
-	im, anim := contract.Chain.BaseKeywords()
-
 	in := task.TokenProcessingContractTokensMessage{
-		ContractID:        contractID,
-		Imagekeywords:     im,
-		Animationkeywords: anim,
-		ForceRefresh:      forceRefresh,
+		ContractID:   contractID,
+		ForceRefresh: forceRefresh,
 	}
 	return task.CreateTaskForContractOwnerProcessing(ctx, in, api.taskClient)
 }

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -507,14 +507,12 @@ func (p *Provider) sendTokensToTokenProcessing(ctx context.Context, userID persi
 	})
 }
 
-func (p *Provider) processMedialessToken(ctx context.Context, tokenID persist.TokenID, contractAddress persist.Address, chain persist.Chain, ownerAddress persist.Address, imageKeywords, animationKeywords []string) error {
+func (p *Provider) processMedialessToken(ctx context.Context, tokenID persist.TokenID, contractAddress persist.Address, chain persist.Chain, ownerAddress persist.Address) error {
 	input := map[string]interface{}{
-		"token_id":           tokenID,
-		"contract_address":   contractAddress,
-		"chain":              chain,
-		"owner_address":      ownerAddress,
-		"image_keywords":     imageKeywords,
-		"animation_keywords": animationKeywords,
+		"token_id":         tokenID,
+		"contract_address": contractAddress,
+		"chain":            chain,
+		"owner_address":    ownerAddress,
 	}
 	asJSON, err := json.Marshal(input)
 	if err != nil {
@@ -767,8 +765,7 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 					return err
 				}
 
-				image, anim := ti.Chain.BaseKeywords()
-				err = p.processMedialessToken(ctx, ti.TokenID, ti.ContractAddress, ti.Chain, refreshedToken.OwnerAddress, image, anim)
+				err = p.processMedialessToken(ctx, ti.TokenID, ti.ContractAddress, ti.Chain, refreshedToken.OwnerAddress)
 				if err != nil {
 					return err
 				}

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -727,8 +727,8 @@ func makeTempMedia(ctx context.Context, tokenID persist.TokenID, contract persis
 	med := persist.Media{
 		MediaType: persist.MediaTypeSyncing,
 	}
-	imKeywords, animKeywords := persist.ChainTezos.BaseKeywords()
-	img, anim := media.FindImageAndAnimationURLs(ctx, tokenID, contract, agnosticMetadata, "", media.TezAnimationKeywords(imKeywords), media.TezImageKeywords(animKeywords), false)
+
+	img, anim := media.FindImageAndAnimationURLs(ctx, tokenID, contract, persist.ChainTezos, agnosticMetadata, "", false)
 	if persist.TokenURI(anim).Type() == persist.URITypeIPFS {
 		removedIPFS := strings.Replace(anim, "ipfs://", "", 1)
 		removedIPFS = strings.Replace(removedIPFS, "ipfs/", "", 1)
@@ -858,7 +858,8 @@ func IsSigned(ctx context.Context, token multichain.ChainAgnosticToken) bool {
 // The tzkt API sometimes returns completely empty metadata, in which case we want to fallback
 // to an alternative provider.
 func ContainsTezosKeywords(ctx context.Context, token multichain.ChainAgnosticToken) bool {
-	imageKeywords, animationKeywords := persist.ChainTezos.BaseKeywords()
+
+	imageKeywords, animationKeywords := media.KeywordsFor(token.TokenID, token.ContractAddress, persist.ChainTezos)
 	for field, val := range token.TokenMetadata {
 
 		for _, keyword := range imageKeywords {

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -469,16 +469,6 @@ func (c Chain) NormalizeAddress(addr Address) string {
 	}
 }
 
-// BaseKeywords are the keywords that are default for discovering media for a given chain
-func (c Chain) BaseKeywords() (image []string, anim []string) {
-	switch c {
-	case ChainTezos:
-		return []string{"displayUri", "image", "thumbnailUri", "artifactUri", "uri"}, []string{"artifactUri", "displayUri", "uri", "image"}
-	default:
-		return []string{"image"}, []string{"animation", "video"}
-	}
-}
-
 // Value implements the driver.Valuer interface for the Chain type
 func (c Chain) Value() (driver.Value, error) {
 	return c, nil

--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -37,10 +37,8 @@ type TokenProcessingUserMessage struct {
 }
 
 type TokenProcessingContractTokensMessage struct {
-	ContractID        persist.DBID `json:"contract_id" binding:"required"`
-	Imagekeywords     []string     `json:"image_keywords" binding:"required"`
-	Animationkeywords []string     `json:"animation_keywords" binding:"required"`
-	ForceRefresh      bool         `json:"force_refresh"`
+	ContractID   persist.DBID `json:"contract_id" binding:"required"`
+	ForceRefresh bool         `json:"force_refresh"`
 }
 
 // DeepRefreshMessage is the input message to the indexer-api for deep refreshes


### PR DESCRIPTION
Changes:

- **Changed** token processing handlers to not accept keywords and instead use shared code to determine the keywords for a given change (given that it is always just a few switch statements for what chain and contract it is)