### PR TITLE
Add additional details to owned_contracts view

### DIFF
--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -223,11 +223,13 @@ type Notification struct {
 }
 
 type OwnedContract struct {
-	UserID      persist.DBID
-	ContractID  persist.DBID
-	OwnedCount  int64
-	Displayed   bool
-	LastUpdated time.Time
+	UserID         persist.DBID
+	UserCreatedAt  time.Time
+	ContractID     persist.DBID
+	OwnedCount     int64
+	DisplayedCount int64
+	Displayed      bool
+	LastUpdated    time.Time
 }
 
 type PiiForUser struct {
@@ -280,6 +282,13 @@ type RecommendationResult struct {
 	CreatedAt         time.Time
 	LastUpdated       time.Time
 	Deleted           bool
+}
+
+type ScrubbedPiiForUser struct {
+	UserID          persist.DBID
+	PiiEmailAddress persist.Email
+	Deleted         bool
+	PiiSocials      persist.Socials
 }
 
 type Token struct {

--- a/db/migrations/core/000069_add_scrubbed_pii_views.up.sql
+++ b/db/migrations/core/000069_add_scrubbed_pii_views.up.sql
@@ -47,3 +47,5 @@ create view scrubbed_pii.for_users as (
             join scrubbed_email_address e on e.user_id = p.user_id
             join scrubbed_socials s on s.user_id = p.user_id
 );
+
+set role to access_rw;

--- a/db/migrations/core/000070_update_owned_contracts_view.up.sql
+++ b/db/migrations/core/000070_update_owned_contracts_view.up.sql
@@ -54,7 +54,7 @@ create materialized view owned_contracts as (
       owned_contracts.contract_id,
       owned_contracts.owned_count,
       coalesce(displayed_contracts.displayed_count, 0) as displayed_count,
-      displayed_contracts.displayed_count is not null as displayed,
+      (displayed_contracts.displayed_count is not null)::bool as displayed,
       now()::timestamptz as last_updated
   from owned_contracts
     left join displayed_contracts on

--- a/db/migrations/core/000070_update_owned_contracts_view.up.sql
+++ b/db/migrations/core/000070_update_owned_contracts_view.up.sql
@@ -23,8 +23,7 @@ create materialized view owned_contracts as (
       users.id,
       contracts.id
   ),
-  displayed_contracts as (
-    with displayed_tokens as (
+  displayed_tokens as (
       select
         owned_contracts.user_id,
         owned_contracts.contract_id,
@@ -42,11 +41,12 @@ create materialized view owned_contracts as (
         owned_contracts.user_id,
         owned_contracts.contract_id,
         tokens.id
-    )
+  ),
+  displayed_contracts as (
     select user_id, contract_id, count(token_id) as displayed_count from displayed_tokens
-      group by
-        user_id,
-        contract_id
+    group by
+      user_id,
+      contract_id
   )
   select
       owned_contracts.user_id,

--- a/db/migrations/core/000070_update_owned_contracts_view.up.sql
+++ b/db/migrations/core/000070_update_owned_contracts_view.up.sql
@@ -1,0 +1,69 @@
+begin;
+
+drop materialized view if exists owned_contracts;
+create materialized view owned_contracts as (
+    with owned_contracts as (
+    select
+      users.id as user_id,
+      users.created_at as user_created_at,
+      contracts.id as contract_id,
+      count(tokens.id) as owned_count
+    from users
+    join tokens on
+      tokens.deleted = false
+      and users.id = tokens.owner_user_id
+      and coalesce(tokens.is_user_marked_spam, false) = false
+    join contracts on
+      contracts.deleted = false
+      and tokens.contract = contracts.id
+    where
+      users.deleted = false
+      and users.universal = false
+    group by
+      users.id,
+      contracts.id
+  ),
+  displayed_contracts as (
+    with displayed_tokens as (
+      select
+        owned_contracts.user_id,
+        owned_contracts.contract_id,
+        tokens.id as token_id
+      from owned_contracts, galleries, collections, tokens
+      where
+        galleries.deleted = false
+        and collections.deleted = false
+        and galleries.owner_user_id = owned_contracts.user_id
+        and collections.owner_user_id = owned_contracts.user_id
+        and tokens.owner_user_id = owned_contracts.user_id
+        and tokens.contract = owned_contracts.contract_id
+        and tokens.id = any(collections.nfts)
+      group by
+        owned_contracts.user_id,
+        owned_contracts.contract_id,
+        tokens.id
+    )
+    select user_id, contract_id, count(token_id) as displayed_count from displayed_tokens
+      group by
+        user_id,
+        contract_id
+  )
+  select
+      owned_contracts.user_id,
+      owned_contracts.user_created_at,
+      owned_contracts.contract_id,
+      owned_contracts.owned_count,
+      coalesce(displayed_contracts.displayed_count, 0) as displayed_count,
+      displayed_contracts.displayed_count is not null as displayed,
+      now()::timestamptz as last_updated
+  from owned_contracts
+    left join displayed_contracts on
+      displayed_contracts.user_id = owned_contracts.user_id and
+      displayed_contracts.contract_id = owned_contracts.contract_id
+);
+
+create unique index owned_contracts_user_contract_idx on owned_contracts(user_id, contract_id);
+create index owned_contracts_user_displayed_idx on owned_contracts(user_id, displayed);
+create index owned_contracts_user_created_at_idx on owned_contracts(user_created_at);
+
+commit;


### PR DESCRIPTION
## What's new?

The `owned_contracts` view now contains additional columns for `user_created_at` and `displayed_count`. I kept the `displayed` bool because I think it's more convenient for indexing, and there's no danger of it getting out of sync with the `displayed_count` column since this is a materialized view and can't be edited manually.

@jarrel-b I had previously mentioned getting rid of the `tokens.is_user_marked_spam` check, but honestly, I don't think it'd make a meaningful difference for my purposes, so I left it in!