### PR TITLE
Revert OS changes

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -625,21 +625,19 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contr
 		return nil, nil
 	}
 
-	for _, provider := range d.Chains[chain] {
+	var metadata persist.TokenMetadata
+	var err error
 
+	for _, provider := range d.Chains[chain] {
 		if metadataFetcher, ok := provider.(tokenMetadataFetcher); ok {
-			metadata, err := metadataFetcher.GetTokenMetadataByTokenIdentifiers(ctx, ChainAgnosticIdentifiers{ContractAddress: contractAddress, TokenID: tokenID}, ownerAddress)
-			if err != nil {
-				return nil, err
-			}
-			if metadata != nil && len(metadata) > 0 {
+			metadata, err = metadataFetcher.GetTokenMetadataByTokenIdentifiers(ctx, ChainAgnosticIdentifiers{ContractAddress: contractAddress, TokenID: tokenID}, ownerAddress)
+			if err == nil && len(metadata) > 0 {
 				return metadata, nil
 			}
 		}
-
 	}
 
-	return nil, nil
+	return metadata, err
 }
 
 // DeepRefresh re-indexes a user's wallets.

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -386,19 +386,9 @@ func verifySignature(pSignatureStr string,
 }
 
 func FetchAssetsForWallet(ctx context.Context, address persist.EthereumAddress) ([]Asset, error) {
-	collections, err := FetchCollectionsForAddress(ctx, address)
-	if err != nil {
-		return nil, err
-	}
-
 	url := baseURL.JoinPath("assets")
 	setPagingParams(url)
 	setOwner(url, address)
-	for _, collection := range collections {
-		for _, contract := range collection.PrimaryAssetContracts {
-			addContractAddress(url, contract.Address)
-		}
-	}
 
 	req, err := authRequest(ctx, url.String())
 	if err != nil {
@@ -595,7 +585,7 @@ func assetsToTokens(ctx context.Context, ownerAddress persist.Address, assetsCha
 					case "ERC1155":
 						tokenType = persist.TokenTypeERC1155
 					default:
-						errChan <- fmt.Errorf("unknown token type: %s", nft.Contract.ContractSchemaName)
+						logger.For(ctx).Warnf("unknown token type: %s", nft.Contract.ContractSchemaName)
 						return
 					}
 


### PR DESCRIPTION
* Removes including the contract_address in the query param to OS
* Doesn't return if we get an unsupported token type from OS
* Tries to get the first valid metadata from the providers