### PR TITLE
Add sleep to tests

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Khan/genqlient/graphql"
 	genql "github.com/Khan/genqlient/graphql"
@@ -343,6 +344,9 @@ func testUpdateGalleryWithPublish(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, update2Reponse.UpdateGallery)
+
+	// Wait for event handlers to store update events
+	time.Sleep(time.Second)
 
 	// publish
 	publishResponse, err := publishGalleryMutation(context.Background(), c, PublishGalleryInput{
@@ -691,6 +695,9 @@ func testTrendingUsers(t *testing.T) {
 		}
 		return actual
 	}
+
+	// Wait for event handlers to store views
+	time.Sleep(time.Second)
 
 	t.Run("should pull the last 5 days", func(t *testing.T) {
 		actual := getTrending(t, "LAST_5_DAYS")

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -981,10 +981,7 @@ type SearchCommunitiesPayload {
 
 union SearchCommunitiesPayloadOrError = SearchCommunitiesPayload | ErrInvalidInput
 
-union SocialQueriesOrError =
-    SocialQueries
-  | ErrNotAuthorized
-  | ErrNeedsToReconnectSocial
+union SocialQueriesOrError = SocialQueries | ErrNotAuthorized | ErrNeedsToReconnectSocial
 
 type Query {
   node(id: ID!): Node


### PR DESCRIPTION
I originally had the idea to refactor the event dispatcher so that we could patch it so that it will store events immediately for tests. This mostly worked, but it caused issues with the Update -> Publish Gallery flow because it would save each update of that edit group as a feed event which is bad because `group_id` has a unique constraint on the `feed_events` table, and we only want a feed event saved at publish time. Rather than going down that rabbit hole that, I just decided to add sleep to the flaky tests 🤷‍♂️ 