### PR TITLE
get owner reliably from the blockchain

### DIFF
--- a/indexer/plugin.go
+++ b/indexer/plugin.go
@@ -289,8 +289,17 @@ func newOwnerPlugin(ctx context.Context, ethClient *ethclient.Client) ownersPlug
 								"tokenIdentifier": msg.key,
 								"block":           msg.transfer.BlockNumber,
 							}).Errorf("error getting owner of %s", msg.key)
+							out <- ownerAtBlock{
+								ti:    msg.key,
+								owner: msg.transfer.To,
+								boi: blockchainOrderInfo{
+									blockNumber: msg.transfer.BlockNumber,
+									txIndex:     msg.transfer.TxIndex,
+								},
+							}
+						} else {
+							out <- owner
 						}
-						out <- owner
 					} else {
 						out <- ownerAtBlock{
 							ti:    msg.key,


### PR DESCRIPTION
Changes:

- **Changed** indexer to get owner directly from the blockchain for ERC-721 tokens just like we do with balances for ERC-1155 tokens

Considerations:

- More calls from alchemy. Given that we tend to use about 5%-15% of our current prepaid units I don't anticipate this being an issue