### PR TITLE
Benny/env reliability

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -34,7 +34,7 @@ func CoreInit(pqClient *sql.DB) *gin.Engine {
 
 	log.SetReportCaller(true)
 
-	if env.Get[string](context.Background(), "ENV") != "production" {
+	if env.GetString(context.Background(), "ENV") != "production" {
 		log.SetLevel(log.DebugLevel)
 		gin.SetMode(gin.DebugMode)
 	}
@@ -44,7 +44,7 @@ func CoreInit(pqClient *sql.DB) *gin.Engine {
 
 	var s *storage.Client
 	var err error
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		s, err = storage.NewClient(context.Background())
 	} else {
 		s, err = storage.NewClient(context.Background(), option.WithCredentialsJSON(util.LoadEncryptedServiceKey("./secrets/prod/service-key.json")))

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -18,10 +18,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-func init() {
-	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
-}
-
 // Init initializes the server
 func Init() {
 	setDefaults()

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"net/http"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/util"
 
 	"cloud.google.com/go/storage"
@@ -16,6 +17,10 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/api/option"
 )
+
+func init() {
+	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
+}
 
 // Init initializes the server
 func Init() {
@@ -33,7 +38,7 @@ func CoreInit(pqClient *sql.DB) *gin.Engine {
 
 	log.SetReportCaller(true)
 
-	if viper.GetString("ENV") != "production" {
+	if env.Get[string](context.Background(), "ENV") != "production" {
 		log.SetLevel(log.DebugLevel)
 		gin.SetMode(gin.DebugMode)
 	}
@@ -43,7 +48,7 @@ func CoreInit(pqClient *sql.DB) *gin.Engine {
 
 	var s *storage.Client
 	var err error
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		s, err = storage.NewClient(context.Background())
 	} else {
 		s, err = storage.NewClient(context.Background(), option.WithCredentialsJSON(util.LoadEncryptedServiceKey("./secrets/prod/service-key.json")))

--- a/admin/nft.go
+++ b/admin/nft.go
@@ -58,7 +58,7 @@ type RefreshNFTsInput struct {
 // }
 
 // func ownsGeneral(ethClient *ethclient.Client) gin.HandlerFunc {
-// 	general, err := contracts.NewIERC1155Caller(common.HexToAddress(viper.GetString("GENERAL_ADDRESS")), ethClient)
+// 	general, err := contracts.NewIERC1155Caller(common.HexToAddress(env.Get[string](ctx, "GENERAL_ADDRESS")), ethClient)
 // 	if err != nil {
 // 		panic(err)
 // 	}

--- a/admin/nft.go
+++ b/admin/nft.go
@@ -58,7 +58,7 @@ type RefreshNFTsInput struct {
 // }
 
 // func ownsGeneral(ethClient *ethclient.Client) gin.HandlerFunc {
-// 	general, err := contracts.NewIERC1155Caller(common.HexToAddress(env.Get[string](ctx, "GENERAL_ADDRESS")), ethClient)
+// 	general, err := contracts.NewIERC1155Caller(common.HexToAddress(env.GetString(ctx, "GENERAL_ADDRESS")), ethClient)
 // 	if err != nil {
 // 		panic(err)
 // 	}

--- a/admin/snapshot.go
+++ b/admin/snapshot.go
@@ -8,10 +8,14 @@ import (
 
 	storage "cloud.google.com/go/storage"
 	"github.com/gin-gonic/gin"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("SNAPSHOT_BUCKET", []string{"required"})
+}
 
 var rwMutex = &sync.RWMutex{}
 
@@ -55,14 +59,14 @@ func updateSnapshot(stg *storage.Client) gin.HandlerFunc {
 }
 
 func getSnapshotReader(c context.Context, stg *storage.Client) (*storage.Reader, error) {
-	r, err := stg.Bucket(viper.GetString("SNAPSHOT_BUCKET")).Object("snapshot.json").NewReader(c)
+	r, err := stg.Bucket(env.Get[string](c, "SNAPSHOT_BUCKET")).Object("snapshot.json").NewReader(c)
 	if err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 func writeSnapshot(c context.Context, stg *storage.Client, snapshot []string) error {
-	obj := stg.Bucket(viper.GetString("SNAPSHOT_BUCKET")).Object("snapshot.json")
+	obj := stg.Bucket(env.Get[string](c, "SNAPSHOT_BUCKET")).Object("snapshot.json")
 	obj.Delete(c)
 	w := obj.NewWriter(c)
 	w.CacheControl = "no-store"
@@ -77,4 +81,16 @@ func writeSnapshot(c context.Context, stg *storage.Client, snapshot []string) er
 	}
 
 	return nil
+}
+
+func dedupeTags(tags []string) []string {
+	seen := make(map[string]bool)
+	var deduped []string
+	for _, tag := range tags {
+		if !seen[tag] {
+			seen[tag] = true
+			deduped = append(deduped, tag)
+		}
+	}
+	return deduped
 }

--- a/admin/snapshot.go
+++ b/admin/snapshot.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("SNAPSHOT_BUCKET", []string{"required"})
+	env.RegisterValidation("SNAPSHOT_BUCKET", []string{"required"})
 }
 
 var rwMutex = &sync.RWMutex{}
@@ -59,14 +59,14 @@ func updateSnapshot(stg *storage.Client) gin.HandlerFunc {
 }
 
 func getSnapshotReader(c context.Context, stg *storage.Client) (*storage.Reader, error) {
-	r, err := stg.Bucket(env.Get[string](c, "SNAPSHOT_BUCKET")).Object("snapshot.json").NewReader(c)
+	r, err := stg.Bucket(env.GetString(c, "SNAPSHOT_BUCKET")).Object("snapshot.json").NewReader(c)
 	if err != nil {
 		return nil, err
 	}
 	return r, nil
 }
 func writeSnapshot(c context.Context, stg *storage.Client, snapshot []string) error {
-	obj := stg.Bucket(env.Get[string](c, "SNAPSHOT_BUCKET")).Object("snapshot.json")
+	obj := stg.Bucket(env.GetString(c, "SNAPSHOT_BUCKET")).Object("snapshot.json")
 	obj.Delete(c)
 	w := obj.NewWriter(c)
 	w.CacheControl = "no-store"
@@ -81,16 +81,4 @@ func writeSnapshot(c context.Context, stg *storage.Client, snapshot []string) er
 	}
 
 	return nil
-}
-
-func dedupeTags(tags []string) []string {
-	seen := make(map[string]bool)
-	var deduped []string
-	for _, tag := range tags {
-		if !seen[tag] {
-			seen[tag] = true
-			deduped = append(deduped, tag)
-		}
-	}
-	return deduped
 }

--- a/admin/snapshot.go
+++ b/admin/snapshot.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("SNAPSHOT_BUCKET", []string{"required"})
+	env.RegisterValidation("SNAPSHOT_BUCKET", "required")
 }
 
 var rwMutex = &sync.RWMutex{}

--- a/cmd/data/farcaster/farcaster.go
+++ b/cmd/data/farcaster/farcaster.go
@@ -8,12 +8,18 @@ import (
 	"time"
 
 	farcaster "github.com/ertan/go-farcaster/pkg"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
+	env.RegisterEnvValidation("FARCASTER_MNEMONIC", []string{"required"})
+}
 
 /*
 {
@@ -74,7 +80,7 @@ func main() {
 	}
 
 	apiUrl := "https://api.warpcast.com"
-	mnemonic := viper.GetString("FARCASTER_MNEMONIC")
+	mnemonic := env.Get[string](ctx, "FARCASTER_MNEMONIC")
 	fc := farcaster.NewFarcasterClient(apiUrl, mnemonic, "")
 
 	results := []farcastGalleryAcc{}
@@ -140,7 +146,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/data/farcaster/farcaster.go
+++ b/cmd/data/farcaster/farcaster.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("FARCASTER_MNEMONIC", []string{"required"})
+	env.RegisterValidation("FARCASTER_MNEMONIC", []string{"required"})
 }
 
 /*
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	apiUrl := "https://api.warpcast.com"
-	mnemonic := env.Get[string](ctx, "FARCASTER_MNEMONIC")
+	mnemonic := env.GetString(ctx, "FARCASTER_MNEMONIC")
 	fc := farcaster.NewFarcasterClient(apiUrl, mnemonic, "")
 
 	results := []farcastGalleryAcc{}
@@ -145,7 +145,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/data/farcaster/farcaster.go
+++ b/cmd/data/farcaster/farcaster.go
@@ -17,7 +17,6 @@ import (
 )
 
 func init() {
-
 	env.RegisterEnvValidation("FARCASTER_MNEMONIC", []string{"required"})
 }
 

--- a/cmd/data/farcaster/farcaster.go
+++ b/cmd/data/farcaster/farcaster.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("FARCASTER_MNEMONIC", []string{"required"})
+	env.RegisterValidation("FARCASTER_MNEMONIC", "required")
 }
 
 /*

--- a/cmd/data/farcaster/farcaster.go
+++ b/cmd/data/farcaster/farcaster.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
+
 	env.RegisterEnvValidation("FARCASTER_MNEMONIC", []string{"required"})
 }
 

--- a/cmd/data/farcaster/gallery_cards/farcaster.go
+++ b/cmd/data/farcaster/gallery_cards/farcaster.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("FARCASTER_MNEMONIC", []string{"required"})
+	env.RegisterValidation("FARCASTER_MNEMONIC", "required")
 }
 
 type farcastGalleryAcc struct {

--- a/cmd/data/farcaster/gallery_cards/farcaster.go
+++ b/cmd/data/farcaster/gallery_cards/farcaster.go
@@ -11,11 +11,17 @@ import (
 	farcaster "github.com/ertan/go-farcaster/pkg"
 	"github.com/ertan/go-farcaster/pkg/users"
 	"github.com/jackc/pgx/v4"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
+	env.RegisterEnvValidation("FARCASTER_MNEMONIC", []string{"required"})
+}
 
 type farcastGalleryAcc struct {
 	galleryUsername string
@@ -39,7 +45,7 @@ func main() {
 
 	// apiUrl := "https://api.farcaster.xyz"
 	apiUrl := "https://api.warpcast.com"
-	mnemonic := viper.GetString("FARCASTER_MNEMONIC")
+	mnemonic := env.Get[string](ctx, "FARCASTER_MNEMONIC")
 
 	fc := farcaster.NewFarcasterClient(apiUrl, mnemonic, "")
 	fcUsers := []users.User{}
@@ -149,7 +155,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/data/farcaster/gallery_cards/farcaster.go
+++ b/cmd/data/farcaster/gallery_cards/farcaster.go
@@ -19,7 +19,6 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
 	env.RegisterEnvValidation("FARCASTER_MNEMONIC", []string{"required"})
 }
 

--- a/cmd/data/farcaster/gallery_cards/farcaster.go
+++ b/cmd/data/farcaster/gallery_cards/farcaster.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("FARCASTER_MNEMONIC", []string{"required"})
+	env.RegisterValidation("FARCASTER_MNEMONIC", []string{"required"})
 }
 
 type farcastGalleryAcc struct {
@@ -44,7 +44,7 @@ func main() {
 
 	// apiUrl := "https://api.farcaster.xyz"
 	apiUrl := "https://api.warpcast.com"
-	mnemonic := env.Get[string](ctx, "FARCASTER_MNEMONIC")
+	mnemonic := env.GetString(ctx, "FARCASTER_MNEMONIC")
 
 	fc := farcaster.NewFarcasterClient(apiUrl, mnemonic, "")
 	fcUsers := []users.User{}
@@ -154,7 +154,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/data/lens/lens.go
+++ b/cmd/data/lens/lens.go
@@ -16,10 +16,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-func init() {
-	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
-}
-
 /*
 {
   "data": {

--- a/cmd/data/lens/lens.go
+++ b/cmd/data/lens/lens.go
@@ -147,7 +147,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/data/lens/lens.go
+++ b/cmd/data/lens/lens.go
@@ -8,12 +8,17 @@ import (
 	"time"
 
 	"github.com/machinebox/graphql"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
+}
 
 /*
 {
@@ -146,7 +151,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/optimization_backfill/main.go
+++ b/cmd/optimization_backfill/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	var rows pgx.Rows
 
-	if env.Get[string](context.Background(), "CLOUD_RUN_JOB") != "" {
+	if env.GetString(context.Background(), "CLOUD_RUN_JOB") != "" {
 		logrus.Infof("running as cloud run job")
 
 		jobIndex := env.Get[int](ctx, "CLOUD_RUN_TASK_INDEX")
@@ -224,7 +224,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logrus.Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/optimization_backfill/main.go
+++ b/cmd/optimization_backfill/main.go
@@ -58,8 +58,8 @@ func main() {
 	if env.Get[string](context.Background(), "CLOUD_RUN_JOB") != "" {
 		logrus.Infof("running as cloud run job")
 
-		jobIndex := viper.GetInt("CLOUD_RUN_TASK_INDEX")
-		jobCount := viper.GetInt("CLOUD_RUN_TASK_COUNT")
+		jobIndex := env.Get[int](ctx, "CLOUD_RUN_TASK_INDEX")
+		jobCount := env.Get[int](ctx, "CLOUD_RUN_TASK_COUNT")
 
 		// given the totalTokenCount, and the jobCount, we can calculate the offset and limit for this job
 		// we want to evenly distribute the work across the jobs

--- a/cmd/optimization_backfill/main.go
+++ b/cmd/optimization_backfill/main.go
@@ -25,10 +25,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-func init() {
-	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
-}
-
 type updateTokenMedia struct {
 	TokenDBID persist.DBID
 	Media     persist.Media

--- a/cmd/optimization_backfill/main.go
+++ b/cmd/optimization_backfill/main.go
@@ -16,12 +16,17 @@ import (
 
 	"github.com/gammazero/workerpool"
 	"github.com/jackc/pgx/v4"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("ENV", []string{"required", "oneof=local development production"})
+}
 
 type updateTokenMedia struct {
 	TokenDBID persist.DBID
@@ -53,7 +58,7 @@ func main() {
 
 	var rows pgx.Rows
 
-	if viper.GetString("CLOUD_RUN_JOB") != "" {
+	if env.Get[string](context.Background(), "CLOUD_RUN_JOB") != "" {
 		logrus.Infof("running as cloud run job")
 
 		jobIndex := viper.GetInt("CLOUD_RUN_TASK_INDEX")
@@ -222,7 +227,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		logrus.Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"

--- a/cmd/update/main.go
+++ b/cmd/update/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("INDEXER_HOST", []string{"required", "http"})
+	env.RegisterValidation("INDEXER_HOST", "required", "http")
 }
 func main() {
 

--- a/cmd/update/main.go
+++ b/cmd/update/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gammazero/workerpool"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -17,6 +18,9 @@ import (
 	"github.com/spf13/viper"
 )
 
+func init() {
+	env.RegisterEnvValidation("INDEXER_HOST", []string{"required", "http"})
+}
 func main() {
 
 	setDefaults()
@@ -72,7 +76,7 @@ func processAddresses(addresses <-chan persist.Address, wg *sync.WaitGroup) {
 				panic(err)
 			}
 
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/nfts/refresh", viper.GetString("INDEXER_HOST")), bytes.NewBuffer(j))
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/nfts/refresh", env.Get[string](ctx, "INDEXER_HOST")), bytes.NewBuffer(j))
 			if err != nil {
 				logrus.Errorf("error creating req: %s", err)
 				return

--- a/cmd/update/main.go
+++ b/cmd/update/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("INDEXER_HOST", []string{"required", "http"})
+	env.RegisterValidation("INDEXER_HOST", []string{"required", "http"})
 }
 func main() {
 
@@ -76,7 +76,7 @@ func processAddresses(addresses <-chan persist.Address, wg *sync.WaitGroup) {
 				panic(err)
 			}
 
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/nfts/refresh", env.Get[string](ctx, "INDEXER_HOST")), bytes.NewBuffer(j))
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/nfts/refresh", env.GetString(ctx, "INDEXER_HOST")), bytes.NewBuffer(j))
 			if err != nil {
 				logrus.Errorf("error creating req: %s", err)
 				return

--- a/debugtools/debugtools_enabled.go
+++ b/debugtools/debugtools_enabled.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/socialauth"
@@ -22,13 +23,13 @@ const Enabled bool = true
 
 func init() {
 	// An additional safeguard against running debug tools in production
-	if viper.GetString("ENV") == "production" {
+	if env.Get[string](context.Background(), "ENV") == "production" {
 		panic(errors.New("debug tools may not be enabled in a production environment"))
 	}
 }
 
 func (d DebugAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult, error) {
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		return nil, errors.New("DebugAuthenticator may only be used in a local environment")
 	}
 	wallets := make([]auth.AuthenticatedAddress, len(d.ChainAddresses))
@@ -48,7 +49,7 @@ func (d DebugAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult,
 }
 
 func (d DebugSocialAuthenticator) Authenticate(ctx context.Context) (*socialauth.SocialAuthResult, error) {
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		return nil, errors.New("DebugSocialAuthenticator may only be used in a local environment")
 	}
 

--- a/debugtools/debugtools_enabled.go
+++ b/debugtools/debugtools_enabled.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/socialauth"
-	"github.com/spf13/viper"
 )
 
 const Enabled bool = true

--- a/debugtools/debugtools_enabled.go
+++ b/debugtools/debugtools_enabled.go
@@ -22,13 +22,13 @@ const Enabled bool = true
 
 func init() {
 	// An additional safeguard against running debug tools in production
-	if env.Get[string](context.Background(), "ENV") == "production" {
+	if env.GetString(context.Background(), "ENV") == "production" {
 		panic(errors.New("debug tools may not be enabled in a production environment"))
 	}
 }
 
 func (d DebugAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult, error) {
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		return nil, errors.New("DebugAuthenticator may only be used in a local environment")
 	}
 	wallets := make([]auth.AuthenticatedAddress, len(d.ChainAddresses))
@@ -48,7 +48,7 @@ func (d DebugAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult,
 }
 
 func (d DebugSocialAuthenticator) Authenticate(ctx context.Context) (*socialauth.SocialAuthResult, error) {
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		return nil, errors.New("DebugSocialAuthenticator may only be used in a local environment")
 	}
 

--- a/emails/emails.go
+++ b/emails/emails.go
@@ -140,7 +140,7 @@ func initSentry() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
 		Environment:      env.Get[string](context.Background(), "ENV"),
-		TracesSampleRate: viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE"),
+		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
 		Release:          env.Get[string](context.Background(), "VERSION"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {

--- a/emails/jwt.go
+++ b/emails/jwt.go
@@ -1,10 +1,12 @@
 package emails
 
 import (
+	"context"
 	"errors"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/spf13/viper"
 )
@@ -25,7 +27,7 @@ func jwtParse(pJWTtokenStr string) (persist.DBID, string, error) {
 	JWTtoken, err := jwt.ParseWithClaims(pJWTtokenStr,
 		&claims,
 		func(pJWTtoken *jwt.Token) (interface{}, error) {
-			return []byte(viper.GetString("JWT_SECRET")), nil
+			return []byte(env.Get[string](context.Background(), "JWT_SECRET")), nil
 		})
 
 	if err != nil || !JWTtoken.Valid {
@@ -38,7 +40,7 @@ func jwtParse(pJWTtokenStr string) (persist.DBID, string, error) {
 func jwtGenerate(pUserID persist.DBID, email string) (string, error) {
 	issuer := "gallery"
 
-	signingKeyBytesLst := []byte(viper.GetString("JWT_SECRET"))
+	signingKeyBytesLst := []byte(env.Get[string](context.Background(), "JWT_SECRET"))
 
 	creationTimeUNIXint := time.Now().UnixNano() / 1000000000
 	expiresAtUNIXint := creationTimeUNIXint + viper.GetInt64("JWT_TTL") // expire N number of secs from now

--- a/emails/jwt.go
+++ b/emails/jwt.go
@@ -26,7 +26,7 @@ func jwtParse(pJWTtokenStr string) (persist.DBID, string, error) {
 	JWTtoken, err := jwt.ParseWithClaims(pJWTtokenStr,
 		&claims,
 		func(pJWTtoken *jwt.Token) (interface{}, error) {
-			return []byte(env.Get[string](context.Background(), "JWT_SECRET")), nil
+			return []byte(env.GetString(context.Background(), "JWT_SECRET")), nil
 		})
 
 	if err != nil || !JWTtoken.Valid {
@@ -39,7 +39,7 @@ func jwtParse(pJWTtokenStr string) (persist.DBID, string, error) {
 func jwtGenerate(pUserID persist.DBID, email string) (string, error) {
 	issuer := "gallery"
 
-	signingKeyBytesLst := []byte(env.Get[string](context.Background(), "JWT_SECRET"))
+	signingKeyBytesLst := []byte(env.GetString(context.Background(), "JWT_SECRET"))
 
 	creationTimeUNIXint := time.Now().UnixNano() / 1000000000
 	expiresAtUNIXint := creationTimeUNIXint + env.Get[int64](context.Background(), "JWT_TTL") // expire N number of secs from now

--- a/emails/jwt.go
+++ b/emails/jwt.go
@@ -8,7 +8,6 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/spf13/viper"
 )
 
 // this wouldn't be necessary if we were using go 1.18 because we could have the auth.ParseJWT function use generics to return the correct type
@@ -43,7 +42,7 @@ func jwtGenerate(pUserID persist.DBID, email string) (string, error) {
 	signingKeyBytesLst := []byte(env.Get[string](context.Background(), "JWT_SECRET"))
 
 	creationTimeUNIXint := time.Now().UnixNano() / 1000000000
-	expiresAtUNIXint := creationTimeUNIXint + viper.GetInt64("JWT_TTL") // expire N number of secs from now
+	expiresAtUNIXint := creationTimeUNIXint + env.Get[int64](context.Background(), "JWT_TTL") // expire N number of secs from now
 	claims := jwtClaims{
 		pUserID,
 		email,

--- a/emails/send.go
+++ b/emails/send.go
@@ -11,6 +11,7 @@ import (
 	"cloud.google.com/go/pubsub"
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -21,6 +22,12 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 )
+
+func init() {
+	env.RegisterEnvValidation("FROM_EMAIL", []string{"required", "email"})
+	env.RegisterEnvValidation("SENDGRID_VERIFICATION_TEMPLATE_ID", []string{"required"})
+	env.RegisterEnvValidation("PUBSUB_NOTIFICATIONS_EMAILS_SUBSCRIPTION", []string{"required"})
+}
 
 const emailsAtATime = 10_000
 

--- a/emails/send.go
+++ b/emails/send.go
@@ -23,9 +23,9 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("FROM_EMAIL", []string{"required", "email"})
-	env.RegisterValidation("SENDGRID_VERIFICATION_TEMPLATE_ID", []string{"required"})
-	env.RegisterValidation("PUBSUB_NOTIFICATIONS_EMAILS_SUBSCRIPTION", []string{"required"})
+	env.RegisterValidation("FROM_EMAIL", "required", "email")
+	env.RegisterValidation("SENDGRID_VERIFICATION_TEMPLATE_ID", "required")
+	env.RegisterValidation("PUBSUB_NOTIFICATIONS_EMAILS_SUBSCRIPTION", "required")
 }
 
 const emailsAtATime = 10_000

--- a/emails/subscriptions.go
+++ b/emails/subscriptions.go
@@ -19,8 +19,8 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID", []string{"required"})
-	env.RegisterEnvValidation("SENDGRID_API_KEY", []string{"required"})
+	env.RegisterValidation("SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID", []string{"required"})
+	env.RegisterValidation("SENDGRID_API_KEY", []string{"required"})
 }
 
 var emailTypes = []model.EmailUnsubscriptionType{model.EmailUnsubscriptionTypeAll, model.EmailUnsubscriptionTypeNotifications}
@@ -79,9 +79,9 @@ func updateSubscriptions(queries *coredb.Queries) gin.HandlerFunc {
 
 				errGroup.Go(func() error {
 					if input.Unsubs.Notifications {
-						return addEmailToUnsubscribeGroup(c, emailAddress, env.Get[string](c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
+						return addEmailToUnsubscribeGroup(c, emailAddress, env.GetString(c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
 					}
-					return removeEmailFromUnsubscribeGroup(c, emailAddress, env.Get[string](c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
+					return removeEmailFromUnsubscribeGroup(c, emailAddress, env.GetString(c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
 				})
 			default:
 				util.ErrResponse(c, http.StatusBadRequest, fmt.Errorf("unsupported email type: %s", emailType))
@@ -156,7 +156,7 @@ func unsubscribe(queries *coredb.Queries) gin.HandlerFunc {
 			case model.EmailUnsubscriptionTypeNotifications:
 				unsubs.Notifications = true
 				errGroup.Go(func() error {
-					return addEmailToUnsubscribeGroup(c, emailAddress, env.Get[string](c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
+					return addEmailToUnsubscribeGroup(c, emailAddress, env.GetString(c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
 				})
 			default:
 				util.ErrResponse(c, http.StatusBadRequest, fmt.Errorf("unsupported email type: %s", emailType))
@@ -231,7 +231,7 @@ func resubscribe(queries *coredb.Queries) gin.HandlerFunc {
 			case model.EmailUnsubscriptionTypeNotifications:
 				unsubs.Notifications = false
 				errGroup.Go(func() error {
-					return removeEmailFromUnsubscribeGroup(c, emailAddress, env.Get[string](c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
+					return removeEmailFromUnsubscribeGroup(c, emailAddress, env.GetString(c, "SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID"))
 				})
 			default:
 				util.ErrResponse(c, http.StatusBadRequest, fmt.Errorf("unsupported email type: %s", emailType))
@@ -272,7 +272,7 @@ func addEmailToGlobalUnsubscribeGroup(ctx context.Context, email string) error {
 }
 
 func unsubscribeSendgrid(ctx context.Context, email string, url string) error {
-	request := sendgrid.GetRequest(env.Get[string](ctx, "SENDGRID_API_KEY"), url, "https://api.sendgrid.com")
+	request := sendgrid.GetRequest(env.GetString(ctx, "SENDGRID_API_KEY"), url, "https://api.sendgrid.com")
 	request.Method = "POST"
 
 	emails := unsubscribeGroupRecipients{
@@ -308,7 +308,7 @@ func removeEmailFromGlobalUnsubscribeGroup(ctx context.Context, email string) er
 }
 
 func sendSendgridDeleteRequest(ctx context.Context, url string) error {
-	request := sendgrid.GetRequest(env.Get[string](ctx, "SENDGRID_API_KEY"), url, "https://api.sendgrid.com")
+	request := sendgrid.GetRequest(env.GetString(ctx, "SENDGRID_API_KEY"), url, "https://api.sendgrid.com")
 	request.Method = "DELETE"
 
 	response, err := sendgrid.API(request)

--- a/emails/subscriptions.go
+++ b/emails/subscriptions.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -17,6 +18,11 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 )
+
+func init() {
+	env.RegisterEnvValidation("SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID", []string{"required"})
+	env.RegisterEnvValidation("SENDGRID_API_KEY", []string{"required"})
+}
 
 var emailTypes = []model.EmailUnsubscriptionType{model.EmailUnsubscriptionTypeAll, model.EmailUnsubscriptionTypeNotifications}
 

--- a/emails/subscriptions.go
+++ b/emails/subscriptions.go
@@ -19,8 +19,8 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID", []string{"required"})
-	env.RegisterValidation("SENDGRID_API_KEY", []string{"required"})
+	env.RegisterValidation("SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID", "required")
+	env.RegisterValidation("SENDGRID_API_KEY", "required")
 }
 
 var emailTypes = []model.EmailUnsubscriptionType{model.EmailUnsubscriptionTypeAll, model.EmailUnsubscriptionTypeNotifications}

--- a/emails/verify.go
+++ b/emails/verify.go
@@ -13,7 +13,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sendgrid/sendgrid-go"
-	"github.com/spf13/viper"
 )
 
 func init() {
@@ -123,7 +122,7 @@ func verifyEmail(queries *coredb.Queries) gin.HandlerFunc {
 			return
 		}
 
-		err = addEmailToSendgridList(c, userWithPII.PiiEmailAddress.String(), viper.GetString("SENDGRID_DEFAULT_LIST_ID"))
+		err = addEmailToSendgridList(c, userWithPII.PiiEmailAddress.String(), env.Get[string](c, "SENDGRID_DEFAULT_LIST_ID"))
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return
@@ -175,7 +174,7 @@ type sendgridContact struct {
 
 func addEmailToSendgridList(ctx context.Context, email string, listID string) error {
 
-	request := sendgrid.GetRequest(viper.GetString("SENDGRID_API_KEY"), "/v3/marketing/contacts", "https://api.sendgrid.com")
+	request := sendgrid.GetRequest(env.Get[string](ctx, "SENDGRID_API_KEY"), "/v3/marketing/contacts", "https://api.sendgrid.com")
 	request.Method = "PUT"
 
 	contacts := sendgridContacts{
@@ -270,7 +269,7 @@ func validateEmail(ctx context.Context, email persist.Email, source string) (sen
 
 	var result sendgridEmailValidationResult
 
-	request := sendgrid.GetRequest(viper.GetString("SENDGRID_VALIDATION_KEY"), "/v3/validations/email", "https://api.sendgrid.com")
+	request := sendgrid.GetRequest(env.Get[string](ctx, "SENDGRID_VALIDATION_KEY"), "/v3/validations/email", "https://api.sendgrid.com")
 	request.Method = "POST"
 
 	val := sendgridEmailValidation{

--- a/emails/verify.go
+++ b/emails/verify.go
@@ -16,8 +16,8 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("SENDGRID_DEFAULT_LIST_ID", []string{"required"})
-	env.RegisterValidation("SENDGRID_API_KEY", []string{"required"})
+	env.RegisterValidation("SENDGRID_DEFAULT_LIST_ID", "required")
+	env.RegisterValidation("SENDGRID_API_KEY", "required")
 }
 
 type VerifyEmailInput struct {

--- a/emails/verify.go
+++ b/emails/verify.go
@@ -16,8 +16,8 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("SENDGRID_DEFAULT_LIST_ID", []string{"required"})
-	env.RegisterEnvValidation("SENDGRID_API_KEY", []string{"required"})
+	env.RegisterValidation("SENDGRID_DEFAULT_LIST_ID", []string{"required"})
+	env.RegisterValidation("SENDGRID_API_KEY", []string{"required"})
 }
 
 type VerifyEmailInput struct {
@@ -122,7 +122,7 @@ func verifyEmail(queries *coredb.Queries) gin.HandlerFunc {
 			return
 		}
 
-		err = addEmailToSendgridList(c, userWithPII.PiiEmailAddress.String(), env.Get[string](c, "SENDGRID_DEFAULT_LIST_ID"))
+		err = addEmailToSendgridList(c, userWithPII.PiiEmailAddress.String(), env.GetString(c, "SENDGRID_DEFAULT_LIST_ID"))
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return
@@ -174,7 +174,7 @@ type sendgridContact struct {
 
 func addEmailToSendgridList(ctx context.Context, email string, listID string) error {
 
-	request := sendgrid.GetRequest(env.Get[string](ctx, "SENDGRID_API_KEY"), "/v3/marketing/contacts", "https://api.sendgrid.com")
+	request := sendgrid.GetRequest(env.GetString(ctx, "SENDGRID_API_KEY"), "/v3/marketing/contacts", "https://api.sendgrid.com")
 	request.Method = "PUT"
 
 	contacts := sendgridContacts{
@@ -269,7 +269,7 @@ func validateEmail(ctx context.Context, email persist.Email, source string) (sen
 
 	var result sendgridEmailValidationResult
 
-	request := sendgrid.GetRequest(env.Get[string](ctx, "SENDGRID_VALIDATION_KEY"), "/v3/validations/email", "https://api.sendgrid.com")
+	request := sendgrid.GetRequest(env.GetString(ctx, "SENDGRID_VALIDATION_KEY"), "/v3/validations/email", "https://api.sendgrid.com")
 	request.Method = "POST"
 
 	val := sendgridEmailValidation{

--- a/emails/verify.go
+++ b/emails/verify.go
@@ -9,11 +9,17 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("SENDGRID_DEFAULT_LIST_ID", []string{"required"})
+	env.RegisterEnvValidation("SENDGRID_API_KEY", []string{"required"})
+}
 
 type VerifyEmailInput struct {
 	JWT string `json:"jwt" binding:"required"`

--- a/env/env.go
+++ b/env/env.go
@@ -1,0 +1,57 @@
+package env
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/util"
+	"github.com/mikeydub/go-gallery/validate"
+	"github.com/spf13/viper"
+)
+
+// TODO cmd+f and replace "viper.GetString(" with "env.Get[string]("
+
+var validators = map[string][]string{}
+
+var v = validate.WithCustomValidators()
+
+func init() {
+	v.RegisterValidation("required_for_env", RequiredForEnv)
+}
+
+func RegisterEnvValidation(name string, tags []string) {
+	validators[name] = util.Dedupe(append(validators[name], tags...), true)
+}
+
+func Get[T any](ctx context.Context, name string) T {
+	for _, tag := range validators[name] {
+		err := v.Var(name, tag)
+		if err != nil {
+			logger.For(ctx).Errorf("invalid env var: %s, tag: %s, err: %s", name, tag, err.Error())
+		}
+	}
+
+	it, ok := viper.Get(name).(T)
+	if !ok {
+		logger.For(ctx).Errorf("invalid env var: %s, expected type: %T", name, it)
+		return *new(T)
+	}
+
+	return it
+}
+
+var RequiredForEnv validator.Func = func(fl validator.FieldLevel) bool {
+	s := fl.Field().String()
+	if s == "" {
+		return false
+	}
+
+	spl := strings.Split(s, "=")
+	if len(spl) != 2 {
+		return false
+	}
+
+	return spl[1] == Get[string](context.Background(), "ENV")
+}

--- a/env/env.go
+++ b/env/env.go
@@ -20,7 +20,7 @@ func init() {
 	v.RegisterValidation("required_for_env", RequiredForEnv)
 }
 
-func RegisterValidation(name string, tags []string) {
+func RegisterValidation(name string, tags ...string) {
 	validatorsMu.Lock()
 	defer validatorsMu.Unlock()
 	validators[name] = dedupe(append(validators[name], tags...))

--- a/env/env.go
+++ b/env/env.go
@@ -2,27 +2,24 @@ package env
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/mikeydub/go-gallery/service/logger"
-	"github.com/mikeydub/go-gallery/util"
-	"github.com/mikeydub/go-gallery/validate"
 	"github.com/spf13/viper"
 )
 
-// TODO cmd+f and replace "viper.GetString(" with "env.Get[string]("
-
 var validators = map[string][]string{}
 
-var v = validate.WithCustomValidators()
+var v = validator.New()
 
 func init() {
 	v.RegisterValidation("required_for_env", RequiredForEnv)
 }
 
 func RegisterEnvValidation(name string, tags []string) {
-	validators[name] = util.Dedupe(append(validators[name], tags...), true)
+	validators[name] = dedupe(append(validators[name], tags...))
 }
 
 func Get[T any](ctx context.Context, name string) T {
@@ -35,6 +32,9 @@ func Get[T any](ctx context.Context, name string) T {
 
 	it, ok := viper.Get(name).(T)
 	if !ok {
+		if reflect.ValueOf(it).IsZero() {
+			return *new(T)
+		}
 		logger.For(ctx).Errorf("invalid env var: %s, expected type: %T", name, it)
 		return *new(T)
 	}
@@ -54,4 +54,17 @@ var RequiredForEnv validator.Func = func(fl validator.FieldLevel) bool {
 	}
 
 	return spl[1] == Get[string](context.Background(), "ENV")
+}
+
+func dedupe(src []string) []string {
+	result := src[:0]
+
+	seen := make(map[string]bool)
+	for _, x := range src {
+		if !seen[x] {
+			result = append(result, x)
+			seen[x] = true
+		}
+	}
+	return result
 }

--- a/env/env.go
+++ b/env/env.go
@@ -2,7 +2,6 @@ package env
 
 import (
 	"context"
-	"reflect"
 	"strings"
 
 	"github.com/go-playground/validator/v10"
@@ -30,11 +29,12 @@ func Get[T any](ctx context.Context, name string) T {
 		}
 	}
 
+	if !viper.IsSet(name) {
+		return *new(T)
+	}
+
 	it, ok := viper.Get(name).(T)
 	if !ok {
-		if reflect.ValueOf(it).IsZero() {
-			return *new(T)
-		}
 		logger.For(ctx).Errorf("invalid env var: %s, expected type: %T", name, it)
 		return *new(T)
 	}

--- a/event/event.go
+++ b/event/event.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/mikeydub/go-gallery/env"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/task"
-	"github.com/spf13/viper"
 
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	"github.com/gin-gonic/gin"
@@ -319,7 +319,7 @@ func (h feedHandler) handleDelayed(ctx context.Context, persistedEvent db.Event)
 		return nil
 	}
 
-	scheduleOn := persistedEvent.CreatedAt.Add(time.Duration(viper.GetInt("GCLOUD_FEED_BUFFER_SECS")) * time.Second)
+	scheduleOn := persistedEvent.CreatedAt.Add(time.Duration(env.Get[int](ctx, "GCLOUD_FEED_BUFFER_SECS")) * time.Second)
 	return task.CreateTaskForFeed(ctx, scheduleOn, task.FeedMessage{ID: persistedEvent.ID}, h.tc)
 }
 

--- a/feed/event.go
+++ b/feed/event.go
@@ -6,12 +6,12 @@ import (
 	"time"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/mikeydub/go-gallery/service/tracing"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -87,7 +87,7 @@ func NewEventBuilder(queries *db.Queries) *EventBuilder {
 		eventRepo:         &postgres.EventRepository{Queries: queries},
 		feedRepo:          &postgres.FeedRepository{Queries: queries},
 		feedBlocklistRepo: &postgres.FeedBlocklistRepository{Queries: queries},
-		windowSize:        viper.GetDuration("FEED_WINDOW_SIZE") * time.Second,
+		windowSize:        env.Get[time.Duration](context.Background(), "FEED_WINDOW_SIZE") * time.Second,
 	}
 }
 
@@ -210,7 +210,7 @@ func (b *EventBuilder) createUserFollowedUsersFeedEvent(ctx context.Context, eve
 	if event.GroupID.String != "" {
 		events, err = b.eventRepo.Queries.GetEventsInGroup(ctx, event.GroupID)
 	} else {
-		events, err = b.eventRepo.EventsInWindow(ctx, event.ID, viper.GetInt("FEED_WINDOW_SIZE"), persist.ActionList{event.Action}, false)
+		events, err = b.eventRepo.EventsInWindow(ctx, event.ID, env.Get[int](ctx, "FEED_WINDOW_SIZE"), persist.ActionList{event.Action}, false)
 	}
 	if err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func (b *EventBuilder) createGalleryUpdatedFeedEvent(ctx context.Context, event 
 	if event.GroupID.String != "" {
 		events, err = b.queries.GetEventsInGroup(ctx, event.GroupID)
 	} else {
-		events, err = b.eventRepo.EventsInWindowForGallery(ctx, event.ID, event.GalleryID, viper.GetInt("FEED_WINDOW_SIZE"), groupingConfig[persist.ActionGalleryUpdated], false)
+		events, err = b.eventRepo.EventsInWindowForGallery(ctx, event.ID, event.GalleryID, env.Get[int](ctx, "FEED_WINDOW_SIZE"), groupingConfig[persist.ActionGalleryUpdated], false)
 	}
 	if err != nil {
 		return nil, err

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -35,7 +35,7 @@ func coreInit(pgx *pgxpool.Pool) *gin.Engine {
 	router := gin.Default()
 	router.Use(middleware.ErrLogger(), middleware.Sentry(true), middleware.Tracing())
 
-	if env.Get[string](context.Background(), "ENV") != "production" {
+	if env.GetString(context.Background(), "ENV") != "production" {
 		gin.SetMode(gin.DebugMode)
 	}
 
@@ -58,14 +58,14 @@ func setDefaults() {
 	viper.SetDefault("GAE_VERSION", "")
 	viper.AutomaticEnv()
 
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		util.VarNotSetTo("SENTRY_DSN", "")
 		util.VarNotSetTo("GAE_VERSION", "")
 	}
 }
 
 func initSentry() {
-	if env.Get[string](context.Background(), "ENV") == "local" {
+	if env.GetString(context.Background(), "ENV") == "local" {
 		logger.For(nil).Info("skipping sentry init")
 		return
 	}
@@ -73,8 +73,8 @@ func initSentry() {
 	logger.For(nil).Info("initializing sentry...")
 
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
-		Environment:      env.Get[string](context.Background(), "ENV"),
+		Dsn:              env.GetString(context.Background(), "SENTRY_DSN"),
+		Environment:      env.GetString(context.Background(), "ENV"),
 		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -75,7 +75,7 @@ func initSentry() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
 		Environment:      env.Get[string](context.Background(), "ENV"),
-		TracesSampleRate: viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE"),
+		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			event = auth.ScrubEventCookies(event, hint)

--- a/feed/feed.go
+++ b/feed/feed.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v4/pgxpool"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -34,7 +35,7 @@ func coreInit(pgx *pgxpool.Pool) *gin.Engine {
 	router := gin.Default()
 	router.Use(middleware.ErrLogger(), middleware.Sentry(true), middleware.Tracing())
 
-	if viper.GetString("ENV") != "production" {
+	if env.Get[string](context.Background(), "ENV") != "production" {
 		gin.SetMode(gin.DebugMode)
 	}
 
@@ -57,14 +58,14 @@ func setDefaults() {
 	viper.SetDefault("GAE_VERSION", "")
 	viper.AutomaticEnv()
 
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		util.VarNotSetTo("SENTRY_DSN", "")
 		util.VarNotSetTo("GAE_VERSION", "")
 	}
 }
 
 func initSentry() {
-	if viper.GetString("ENV") == "local" {
+	if env.Get[string](context.Background(), "ENV") == "local" {
 		logger.For(nil).Info("skipping sentry init")
 		return
 	}
@@ -72,8 +73,8 @@ func initSentry() {
 	logger.For(nil).Info("initializing sentry...")
 
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              viper.GetString("SENTRY_DSN"),
-		Environment:      viper.GetString("ENV"),
+		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
+		Environment:      env.Get[string](context.Background(), "ENV"),
 		TracesSampleRate: viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {

--- a/feed/handler.go
+++ b/feed/handler.go
@@ -28,7 +28,7 @@ func taskRequired() gin.HandlerFunc {
 		}
 
 		creds := c.Request.Header.Get("Authorization")
-		if creds != "Basic "+env.Get[string](context.Background(), "FEED_SECRET") {
+		if creds != "Basic "+env.GetString(context.Background(), "FEED_SECRET") {
 			c.AbortWithError(http.StatusOK, errors.New("unauthorized request"))
 			return
 		}

--- a/feed/handler.go
+++ b/feed/handler.go
@@ -1,13 +1,14 @@
 package feed
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	"github.com/gin-gonic/gin"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
-	"github.com/spf13/viper"
+	"github.com/mikeydub/go-gallery/env"
 )
 
 // TaskRequired checks that the request came from Cloud Tasks.
@@ -27,7 +28,7 @@ func taskRequired() gin.HandlerFunc {
 		}
 
 		creds := c.Request.Header.Get("Authorization")
-		if creds != "Basic "+viper.GetString("FEED_SECRET") {
+		if creds != "Basic "+env.Get[string](context.Background(), "FEED_SECRET") {
 			c.AbortWithError(http.StatusOK, errors.New("unauthorized request"))
 			return
 		}

--- a/feedbot/discord.go
+++ b/feedbot/discord.go
@@ -8,19 +8,19 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/spf13/viper"
+	"github.com/mikeydub/go-gallery/env"
 )
 
 func prepareRequest(ctx context.Context, body []byte) (*http.Request, error) {
-	url := fmt.Sprintf("%s/channels/%s/messages", viper.GetString("DISCORD_API"), viper.GetString("CHANNEL_ID"))
+	url := fmt.Sprintf("%s/channels/%s/messages", env.Get[string](ctx, "DISCORD_API"), env.Get[string](ctx, "CHANNEL_ID"))
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", "Bot "+viper.GetString("BOT_TOKEN"))
-	req.Header.Set("User-Agent", viper.GetString("AGENT_NAME"))
+	req.Header.Set("Authorization", "Bot "+env.Get[string](ctx, "BOT_TOKEN"))
+	req.Header.Set("User-Agent", env.Get[string](ctx, "AGENT_NAME"))
 	req.Header.Set("Content-Type", "application/json")
 	return req, nil
 }

--- a/feedbot/discord.go
+++ b/feedbot/discord.go
@@ -12,15 +12,15 @@ import (
 )
 
 func prepareRequest(ctx context.Context, body []byte) (*http.Request, error) {
-	url := fmt.Sprintf("%s/channels/%s/messages", env.Get[string](ctx, "DISCORD_API"), env.Get[string](ctx, "CHANNEL_ID"))
+	url := fmt.Sprintf("%s/channels/%s/messages", env.GetString(ctx, "DISCORD_API"), env.GetString(ctx, "CHANNEL_ID"))
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Set("Authorization", "Bot "+env.Get[string](ctx, "BOT_TOKEN"))
-	req.Header.Set("User-Agent", env.Get[string](ctx, "AGENT_NAME"))
+	req.Header.Set("Authorization", "Bot "+env.GetString(ctx, "BOT_TOKEN"))
+	req.Header.Set("User-Agent", env.GetString(ctx, "AGENT_NAME"))
 	req.Header.Set("Content-Type", "application/json")
 	return req, nil
 }

--- a/feedbot/feedbot.go
+++ b/feedbot/feedbot.go
@@ -31,9 +31,9 @@ func coreInit() *gin.Engine {
 	router := gin.Default()
 	router.Use(middleware.ErrLogger(), middleware.Sentry(true), middleware.Tracing())
 
-	gql := graphql.NewClient(env.Get[string](context.Background(), "GALLERY_API"), http.DefaultClient)
+	gql := graphql.NewClient(env.GetString(context.Background(), "GALLERY_API"), http.DefaultClient)
 
-	if env.Get[string](context.Background(), "ENV") != "production" {
+	if env.GetString(context.Background(), "ENV") != "production" {
 		gin.SetMode(gin.DebugMode)
 	}
 
@@ -54,13 +54,13 @@ func setDefaults() {
 	viper.AutomaticEnv()
 
 	util.VarNotSetTo("BOT_TOKEN", "")
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		util.VarNotSetTo("SENTRY_DSN", "")
 	}
 }
 
 func initSentry() {
-	if env.Get[string](context.Background(), "ENV") == "local" {
+	if env.GetString(context.Background(), "ENV") == "local" {
 		logger.For(nil).Info("skipping sentry init")
 		return
 	}
@@ -68,8 +68,8 @@ func initSentry() {
 	logger.For(nil).Info("initializing sentry...")
 
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
-		Environment:      env.Get[string](context.Background(), "ENV"),
+		Dsn:              env.GetString(context.Background(), "SENTRY_DSN"),
+		Environment:      env.GetString(context.Background(), "ENV"),
 		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {

--- a/feedbot/feedbot.go
+++ b/feedbot/feedbot.go
@@ -70,7 +70,7 @@ func initSentry() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
 		Environment:      env.Get[string](context.Background(), "ENV"),
-		TracesSampleRate: viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE"),
+		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			event = sentryutil.ScrubEventHeaders(event, hint)

--- a/feedbot/handler.go
+++ b/feedbot/handler.go
@@ -1,13 +1,14 @@
 package feedbot
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/shurcooL/graphql"
-	"github.com/spf13/viper"
 )
 
 type errBadTaskRequest struct {
@@ -35,7 +36,7 @@ func TaskRequired() gin.HandlerFunc {
 		}
 
 		creds := c.Request.Header.Get("Authorization")
-		if creds != "Basic "+viper.GetString("FEEDBOT_SECRET") {
+		if creds != "Basic "+env.Get[string](context.Background(), "FEEDBOT_SECRET") {
 			c.AbortWithError(http.StatusOK, errors.New("unauthorized request"))
 			return
 		}

--- a/feedbot/handler.go
+++ b/feedbot/handler.go
@@ -36,7 +36,7 @@ func TaskRequired() gin.HandlerFunc {
 		}
 
 		creds := c.Request.Header.Get("Authorization")
-		if creds != "Basic "+env.Get[string](context.Background(), "FEEDBOT_SECRET") {
+		if creds != "Basic "+env.GetString(context.Background(), "FEEDBOT_SECRET") {
 			c.AbortWithError(http.StatusOK, errors.New("unauthorized request"))
 			return
 		}

--- a/feedbot/post.go
+++ b/feedbot/post.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"html"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/shurcooL/graphql"
-	"github.com/spf13/viper"
 )
 
 type PostRenderSender struct {
@@ -326,7 +326,7 @@ func (s *PostSender) Send(ctx context.Context, post string) error {
 }
 
 func userURL(username string) string {
-	return fmt.Sprintf("%s/%s", viper.GetString("GALLERY_HOST"), username)
+	return fmt.Sprintf("%s/%s", env.Get[string](context.Background(), "GALLERY_HOST"), username)
 }
 
 func collectionURL(username, collectionID string) string {

--- a/feedbot/post.go
+++ b/feedbot/post.go
@@ -326,7 +326,7 @@ func (s *PostSender) Send(ctx context.Context, post string) error {
 }
 
 func userURL(username string) string {
-	return fmt.Sprintf("%s/%s", env.Get[string](context.Background(), "GALLERY_HOST"), username)
+	return fmt.Sprintf("%s/%s", env.GetString(context.Background(), "GALLERY_HOST"), username)
 }
 
 func collectionURL(username, collectionID string) string {

--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"reflect"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/publicapi"
 
 	gqlgen "github.com/99designs/gqlgen/graphql"
@@ -26,7 +27,6 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/segmentio/ksuid"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vektah/gqlparser/v2/validator"
@@ -186,7 +186,7 @@ func FrontendBuildAuthDirectiveHandler() func(ctx context.Context, obj interface
 		password := usernameAndPasswordParts[1]
 		passwordBytes := []byte(password)
 
-		if cmp := subtle.ConstantTimeCompare([]byte(viper.GetString("FRONTEND_APQ_UPLOAD_AUTH_TOKEN")), passwordBytes); cmp != 1 {
+		if cmp := subtle.ConstantTimeCompare([]byte(env.Get[string](ctx, "FRONTEND_APQ_UPLOAD_AUTH_TOKEN")), passwordBytes); cmp != 1 {
 			return authError, nil
 		}
 
@@ -240,10 +240,11 @@ func AuthRequiredDirectiveHandler() func(ctx context.Context, obj interface{}, n
 }
 
 func RestrictEnvironmentDirectiveHandler() func(ctx context.Context, obj interface{}, next gqlgen.Resolver, allowed []string) (res interface{}, err error) {
-	env := viper.GetString("ENV")
+
 	restrictionErr := errors.New("schema restriction: functionality not allowed in the current environment")
 
 	return func(ctx context.Context, obj interface{}, next gqlgen.Resolver, allowed []string) (res interface{}, err error) {
+		env := env.Get[string](ctx, "ENV")
 		for _, allowedEnv := range allowed {
 			if strings.EqualFold(env, allowedEnv) {
 				return next(ctx)

--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -186,7 +186,7 @@ func FrontendBuildAuthDirectiveHandler() func(ctx context.Context, obj interface
 		password := usernameAndPasswordParts[1]
 		passwordBytes := []byte(password)
 
-		if cmp := subtle.ConstantTimeCompare([]byte(env.Get[string](ctx, "FRONTEND_APQ_UPLOAD_AUTH_TOKEN")), passwordBytes); cmp != 1 {
+		if cmp := subtle.ConstantTimeCompare([]byte(env.GetString(ctx, "FRONTEND_APQ_UPLOAD_AUTH_TOKEN")), passwordBytes); cmp != 1 {
 			return authError, nil
 		}
 
@@ -242,9 +242,9 @@ func AuthRequiredDirectiveHandler() func(ctx context.Context, obj interface{}, n
 func RestrictEnvironmentDirectiveHandler() func(ctx context.Context, obj interface{}, next gqlgen.Resolver, allowed []string) (res interface{}, err error) {
 
 	restrictionErr := errors.New("schema restriction: functionality not allowed in the current environment")
-
+	env := env.GetString(context.Background(), "ENV")
 	return func(ctx context.Context, obj interface{}, next gqlgen.Resolver, allowed []string) (res interface{}, err error) {
-		env := env.Get[string](ctx, "ENV")
+
 		for _, allowedEnv := range allowed {
 			if strings.EqualFold(env, allowedEnv) {
 				return next(ctx)

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gammazero/workerpool"
 	"github.com/magiclabs/magic-admin-go/token"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/service/emails"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -23,7 +24,6 @@ import (
 	"github.com/mikeydub/go-gallery/validate"
 
 	"github.com/mikeydub/go-gallery/debugtools"
-	"github.com/spf13/viper"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/publicapi"
@@ -180,7 +180,7 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 	authApi := publicapi.For(ctx).Auth
 
 	if debugtools.Enabled {
-		if viper.GetString("ENV") == "local" && m.Debug != nil {
+		if env.Get[string](ctx, "ENV") == "local" && m.Debug != nil {
 			return authApi.NewDebugAuthenticator(ctx, *m.Debug)
 		}
 	}
@@ -209,7 +209,7 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 func (r *Resolver) socialAuthMechanismToAuthenticator(ctx context.Context, m model.SocialAuthMechanism) (socialauth.Authenticator, error) {
 
 	if debugtools.Enabled {
-		if viper.GetString("ENV") == "local" && m.Debug != nil {
+		if env.Get[string](ctx, "ENV") == "local" && m.Debug != nil {
 			return debugtools.NewDebugSocialAuthenticator(m.Debug.Provider, m.Debug.ID, map[string]interface{}{"username": m.Debug.Username}), nil
 		}
 	}

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -183,7 +183,7 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 	authApi := publicapi.For(ctx).Auth
 
 	if debugtools.Enabled {
-		if env.Get[string](ctx, "ENV") == "local" && m.Debug != nil {
+		if env.GetString(ctx, "ENV") == "local" && m.Debug != nil {
 			return authApi.NewDebugAuthenticator(ctx, *m.Debug)
 		}
 	}
@@ -212,7 +212,7 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 func (r *Resolver) socialAuthMechanismToAuthenticator(ctx context.Context, m model.SocialAuthMechanism) (socialauth.Authenticator, error) {
 
 	if debugtools.Enabled {
-		if env.Get[string](ctx, "ENV") == "local" && m.Debug != nil {
+		if env.GetString(ctx, "ENV") == "local" && m.Debug != nil {
 			return debugtools.NewDebugSocialAuthenticator(m.Debug.Provider, m.Debug.ID, map[string]interface{}{"username": m.Debug.Username}), nil
 		}
 	}

--- a/indexer/cmd/root.go
+++ b/indexer/cmd/root.go
@@ -51,7 +51,7 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("[from-block] must be less than [to-block]")
 		}
 
-		if !cmd.Flags().Lookup("to-block").Changed && (!enableRPC && env.Get[string](cmd.Context(), "ENV") != "production") {
+		if !cmd.Flags().Lookup("to-block").Changed && (!enableRPC && env.GetString(cmd.Context(), "ENV") != "production") {
 			return fmt.Errorf("`flags in group [from-block, to-block] must all be set when [enable-rpc] is not set")
 		}
 

--- a/indexer/cmd/root.go
+++ b/indexer/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer"
 	"github.com/mikeydub/go-gallery/service/logger"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
@@ -11,7 +12,6 @@ import (
 	"google.golang.org/appengine"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var (
@@ -51,7 +51,7 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("[from-block] must be less than [to-block]")
 		}
 
-		if !cmd.Flags().Lookup("to-block").Changed && (!enableRPC && viper.GetString("ENV") != "production") {
+		if !cmd.Flags().Lookup("to-block").Changed && (!enableRPC && env.Get[string](cmd.Context(), "ENV") != "production") {
 			return fmt.Errorf("`flags in group [from-block, to-block] must all be set when [enable-rpc] is not set")
 		}
 

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -61,7 +61,7 @@ func coreInit(fromBlock, toBlock *uint64, quietLogs, enableRPC bool) (*gin.Engin
 		rpcEnabled = true
 	}
 
-	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(viper.GetInt("CHAIN")), defaultTransferEvents, nil, fromBlock, toBlock)
+	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(env.Get[int](context.Background(), "CHAIN")), defaultTransferEvents, nil, fromBlock, toBlock)
 
 	router := gin.Default()
 
@@ -110,7 +110,7 @@ func coreInitServer(quietLogs, enableRPC bool) *gin.Engine {
 	queueChan := make(chan processTokensInput)
 	t := newThrottler()
 
-	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(viper.GetInt("CHAIN")), defaultTransferEvents, nil, nil, nil)
+	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(env.Get[int](ctx, "CHAIN")), defaultTransferEvents, nil, nil, nil)
 
 	go processMissingMetadata(ctx, queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), t)
 	return handlersInitServer(router, queueChan, tokenRepo, contractRepo, ethClient, ipfsClient, arweaveClient, s, i)
@@ -178,7 +178,7 @@ func initSentry() {
 			if ctx.Span.Op == rpc.GethSocketOpName {
 				return sentry.UniformTracesSampler(0.01).Sample(ctx)
 			}
-			return sentry.UniformTracesSampler(viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE")).Sample(ctx)
+			return sentry.UniformTracesSampler(env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE")).Sample(ctx)
 		}),
 		Release:          env.Get[string](context.Background(), "VERSION"),
 		AttachStacktrace: true,

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -46,7 +46,7 @@ func coreInit(fromBlock, toBlock *uint64, quietLogs, enableRPC bool) (*gin.Engin
 	logger.SetLoggerOptions(func(logger *logrus.Logger) {
 		logger.AddHook(sentryutil.SentryLoggerHook)
 		logger.SetLevel(logrus.InfoLevel)
-		if env.Get[string](context.Background(), "ENV") != "production" && !quietLogs {
+		if env.GetString(context.Background(), "ENV") != "production" && !quietLogs {
 			logger.SetLevel(logrus.DebugLevel)
 		}
 	})
@@ -57,7 +57,7 @@ func coreInit(fromBlock, toBlock *uint64, quietLogs, enableRPC bool) (*gin.Engin
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()
 
-	if env.Get[string](context.Background(), "ENV") == "production" || enableRPC {
+	if env.GetString(context.Background(), "ENV") == "production" || enableRPC {
 		rpcEnabled = true
 	}
 
@@ -67,7 +67,7 @@ func coreInit(fromBlock, toBlock *uint64, quietLogs, enableRPC bool) (*gin.Engin
 
 	router.Use(middleware.GinContextToContext(), middleware.Sentry(true), middleware.Tracing(), middleware.HandleCORS(), middleware.ErrLogger())
 
-	if env.Get[string](context.Background(), "ENV") != "production" {
+	if env.GetString(context.Background(), "ENV") != "production" {
 		gin.SetMode(gin.DebugMode)
 	}
 
@@ -81,7 +81,7 @@ func coreInitServer(quietLogs, enableRPC bool) *gin.Engine {
 	logger.InitWithGCPDefaults()
 	logger.SetLoggerOptions(func(logger *logrus.Logger) {
 		logger.SetLevel(logrus.InfoLevel)
-		if env.Get[string](ctx, "ENV") != "production" && !quietLogs {
+		if env.GetString(ctx, "ENV") != "production" && !quietLogs {
 			logger.SetLevel(logrus.DebugLevel)
 		}
 	})
@@ -92,7 +92,7 @@ func coreInitServer(quietLogs, enableRPC bool) *gin.Engine {
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()
 
-	if env.Get[string](ctx, "ENV") == "production" || enableRPC {
+	if env.GetString(ctx, "ENV") == "production" || enableRPC {
 		rpcEnabled = true
 	}
 
@@ -100,7 +100,7 @@ func coreInitServer(quietLogs, enableRPC bool) *gin.Engine {
 
 	router.Use(middleware.GinContextToContext(), middleware.Sentry(true), middleware.Tracing(), middleware.HandleCORS(), middleware.ErrLogger())
 
-	if env.Get[string](ctx, "ENV") != "production" {
+	if env.GetString(ctx, "ENV") != "production" {
 		gin.SetMode(gin.DebugMode)
 		logrus.SetLevel(logrus.DebugLevel)
 	}
@@ -112,7 +112,7 @@ func coreInitServer(quietLogs, enableRPC bool) *gin.Engine {
 
 	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(env.Get[int](ctx, "CHAIN")), defaultTransferEvents, nil, nil, nil)
 
-	go processMissingMetadata(ctx, queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), t)
+	go processMissingMetadata(ctx, queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, env.GetString(ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), t)
 	return handlersInitServer(router, queueChan, tokenRepo, contractRepo, ethClient, ipfsClient, arweaveClient, s, i)
 }
 
@@ -140,7 +140,7 @@ func SetDefaults() {
 }
 
 func LoadConfigFile(service string, manualEnv string) {
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 		return
 	}
@@ -149,14 +149,14 @@ func LoadConfigFile(service string, manualEnv string) {
 
 func ValidateEnv() {
 	util.VarNotSetTo("RPC_URL", "")
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		util.VarNotSetTo("SENTRY_DSN", "")
 	}
 }
 
 func newRepos(storageClient *storage.Client) (persist.TokenRepository, persist.ContractRepository, refresh.AddressFilterRepository) {
 	pgClient := postgres.MustCreateClient()
-	return postgres.NewTokenRepository(pgClient), postgres.NewContractRepository(pgClient), refresh.AddressFilterRepository{Bucket: storageClient.Bucket(env.Get[string](context.Background(), "GCLOUD_TOKEN_LOGS_BUCKET"))}
+	return postgres.NewTokenRepository(pgClient), postgres.NewContractRepository(pgClient), refresh.AddressFilterRepository{Bucket: storageClient.Bucket(env.GetString(context.Background(), "GCLOUD_TOKEN_LOGS_BUCKET"))}
 }
 
 func newThrottler() *throttle.Locker {
@@ -164,7 +164,7 @@ func newThrottler() *throttle.Locker {
 }
 
 func initSentry() {
-	if env.Get[string](context.Background(), "ENV") == "local" {
+	if env.GetString(context.Background(), "ENV") == "local" {
 		logger.For(nil).Info("skipping sentry init")
 		return
 	}
@@ -172,15 +172,15 @@ func initSentry() {
 	logger.For(nil).Info("initializing sentry...")
 
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:         env.Get[string](context.Background(), "SENTRY_DSN"),
-		Environment: env.Get[string](context.Background(), "ENV"),
+		Dsn:         env.GetString(context.Background(), "SENTRY_DSN"),
+		Environment: env.GetString(context.Background(), "ENV"),
 		TracesSampler: sentry.TracesSamplerFunc(func(ctx sentry.SamplingContext) sentry.Sampled {
 			if ctx.Span.Op == rpc.GethSocketOpName {
 				return sentry.UniformTracesSampler(0.01).Sample(ctx)
 			}
 			return sentry.UniformTracesSampler(env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE")).Sample(ctx)
 		}),
-		Release:          env.Get[string](context.Background(), "VERSION"),
+		Release:          env.GetString(context.Background(), "VERSION"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			event = auth.ScrubEventCookies(event, hint)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("GCLOUD_TOKEN_CONTENT_BUCKET", []string{"required"})
+	env.RegisterValidation("GCLOUD_TOKEN_CONTENT_BUCKET", "required")
 }
 
 const (

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	shell "github.com/ipfs/go-ipfs-api"
 	"github.com/mikeydub/go-gallery/contracts"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer/refresh"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -32,8 +33,11 @@ import (
 	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("GCLOUD_TOKEN_CONTENT_BUCKET", []string{"required"})
+}
 
 const (
 	// transferEventHash represents the keccak256 hash of Transfer(address,address,uint256)
@@ -222,7 +226,7 @@ func newIndexer(ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveCli
 		dbMu:              &sync.Mutex{},
 		stateMu:           &sync.Mutex{},
 
-		tokenBucket: viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"),
+		tokenBucket: env.Get[string](context.Background(), "GCLOUD_TOKEN_CONTENT_BUCKET"),
 
 		chain: pChain,
 
@@ -420,7 +424,7 @@ func (i *indexer) fetchLogs(ctx context.Context, startingBlock persist.BlockNumb
 
 func (i *indexer) defaultGetLogs(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
 	var logsTo []types.Log
-	reader, err := i.storageClient.Bucket(viper.GetString("GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%d-%d", curBlock, nextBlock)).NewReader(ctx)
+	reader, err := i.storageClient.Bucket(env.Get[string](ctx, "GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%d-%d", curBlock, nextBlock)).NewReader(ctx)
 	if err != nil {
 		logger.For(ctx).WithError(err).Warn("error getting logs from GCP")
 	} else {
@@ -1130,7 +1134,7 @@ func transfersToTransfersAtBlock(transfers []rpc.Transfer) []transfersAtBlock {
 
 func saveLogsInBlockRange(ctx context.Context, curBlock, nextBlock string, logsTo []types.Log, storageClient *storage.Client) {
 	logger.For(ctx).Infof("Saving logs in block range %s to %s", curBlock, nextBlock)
-	obj := storageClient.Bucket(viper.GetString("GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%s-%s", curBlock, nextBlock))
+	obj := storageClient.Bucket(env.Get[string](ctx, "GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%s-%s", curBlock, nextBlock))
 	obj.Delete(ctx)
 	storageWriter := obj.NewWriter(ctx)
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -36,7 +36,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("GCLOUD_TOKEN_CONTENT_BUCKET", []string{"required"})
+	env.RegisterValidation("GCLOUD_TOKEN_CONTENT_BUCKET", []string{"required"})
 }
 
 const (
@@ -223,7 +223,7 @@ func newIndexer(ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveCli
 		dbMu:              &sync.Mutex{},
 		stateMu:           &sync.Mutex{},
 
-		tokenBucket: env.Get[string](context.Background(), "GCLOUD_TOKEN_CONTENT_BUCKET"),
+		tokenBucket: env.GetString(context.Background(), "GCLOUD_TOKEN_CONTENT_BUCKET"),
 
 		chain: pChain,
 
@@ -487,7 +487,7 @@ func (i *indexer) fetchLogs(ctx context.Context, startingBlock persist.BlockNumb
 
 func (i *indexer) defaultGetLogs(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
 	var logsTo []types.Log
-	reader, err := i.storageClient.Bucket(env.Get[string](ctx, "GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%d-%d", curBlock, nextBlock)).NewReader(ctx)
+	reader, err := i.storageClient.Bucket(env.GetString(ctx, "GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%d-%d", curBlock, nextBlock)).NewReader(ctx)
 	if err != nil {
 		logger.For(ctx).WithError(err).Warn("error getting logs from GCP")
 	} else {
@@ -1297,7 +1297,7 @@ func transfersToTransfersAtBlock(transfers []rpc.Transfer) []transfersAtBlock {
 
 func saveLogsInBlockRange(ctx context.Context, curBlock, nextBlock string, logsTo []types.Log, storageClient *storage.Client) {
 	logger.For(ctx).Infof("Saving logs in block range %s to %s", curBlock, nextBlock)
-	obj := storageClient.Bucket(env.Get[string](ctx, "GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%s-%s", curBlock, nextBlock))
+	obj := storageClient.Bucket(env.GetString(ctx, "GCLOUD_TOKEN_LOGS_BUCKET")).Object(fmt.Sprintf("%s-%s", curBlock, nextBlock))
 	obj.Delete(ctx)
 	storageWriter := obj.NewWriter(ctx)
 

--- a/indexer/refresh/refresh.go
+++ b/indexer/refresh/refresh.go
@@ -112,7 +112,7 @@ func NewBlockFilterManager(ctx context.Context, sc *storage.Client) *BlockFilter
 		blocksPerLogFile: DefaultConfig.BlocksPerCachedLog,
 		chunkSize:        DefaultConfig.ChunkSize,
 		fetchWorkerSize:  DefaultConfig.ChunkWorkerSize,
-		repo:             &AddressFilterRepository{sc.Bucket(env.Get[string](ctx, "GCLOUD_TOKEN_LOGS_BUCKET"))},
+		repo:             &AddressFilterRepository{sc.Bucket(env.GetString(ctx, "GCLOUD_TOKEN_LOGS_BUCKET"))},
 		fetchers:         make(map[persist.BlockNumber]*filterFetcher),
 		baseDir:          baseDir,
 		mu:               &mu,

--- a/indexer/refresh/refresh.go
+++ b/indexer/refresh/refresh.go
@@ -11,9 +11,9 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/bits-and-blooms/bloom"
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
-	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -112,7 +112,7 @@ func NewBlockFilterManager(ctx context.Context, sc *storage.Client) *BlockFilter
 		blocksPerLogFile: DefaultConfig.BlocksPerCachedLog,
 		chunkSize:        DefaultConfig.ChunkSize,
 		fetchWorkerSize:  DefaultConfig.ChunkWorkerSize,
-		repo:             &AddressFilterRepository{sc.Bucket(viper.GetString("GCLOUD_TOKEN_LOGS_BUCKET"))},
+		repo:             &AddressFilterRepository{sc.Bucket(env.Get[string](ctx, "GCLOUD_TOKEN_LOGS_BUCKET"))},
 		fetchers:         make(map[persist.BlockNumber]*filterFetcher),
 		baseDir:          baseDir,
 		mu:               &mu,

--- a/indexer/t__integration_test.go
+++ b/indexer/t__integration_test.go
@@ -79,7 +79,7 @@ func TestIndexLogs_Success(t *testing.T) {
 		mediaTypeHasExpectedType(t, a, nil, persist.MediaTypeImage, predicted)
 
 		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, env.GetString(ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
 		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeImage, med.MediaType)
 		a.Empty(med.ThumbnailURL)
 		a.NotEmpty(med.MediaURL)
@@ -98,7 +98,7 @@ func TestIndexLogs_Success(t *testing.T) {
 		mediaHasContent(t, a, err, metadata)
 
 		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, env.GetString(ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
 		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeSVG, med.MediaType)
 		a.Empty(med.ThumbnailURL)
 		a.Contains(med.MediaURL.String(), "https://")

--- a/indexer/t__integration_test.go
+++ b/indexer/t__integration_test.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,7 +79,7 @@ func TestIndexLogs_Success(t *testing.T) {
 		mediaTypeHasExpectedType(t, a, nil, persist.MediaTypeImage, predicted)
 
 		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
 		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeImage, med.MediaType)
 		a.Empty(med.ThumbnailURL)
 		a.NotEmpty(med.MediaURL)
@@ -98,7 +98,7 @@ func TestIndexLogs_Success(t *testing.T) {
 		mediaHasContent(t, a, err, metadata)
 
 		image, animation := media.KeywordsForChain(persist.ChainETH, imageKeywords, animationKeywords)
-		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
+		med, err := media.MakePreviewsForMetadata(ctx, metadata, persist.Address(token.ContractAddress), token.TokenID, uri, persist.ChainETH, ipfsShell, arweaveClient, stg, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"), image, animation)
 		mediaTypeHasExpectedType(t, a, err, persist.MediaTypeSVG, med.MediaType)
 		a.Empty(med.ThumbnailURL)
 		a.Contains(med.MediaURL.String(), "https://")

--- a/indexer/t__utils_test.go
+++ b/indexer/t__utils_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	migrate "github.com/mikeydub/go-gallery/db"
 	"github.com/mikeydub/go-gallery/docker"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer/refresh"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/option"
 )
@@ -76,7 +76,7 @@ func newMockIndexer(db *sql.DB, pool *pgxpool.Pool) *indexer {
 	rpcEnabled = true
 	ethClient := rpc.NewEthSocketClient()
 	storageClient := newStorageClient(context.Background())
-	bucket := storageClient.Bucket(viper.GetString("GCLOUD_TOKEN_LOGS_BUCKET"))
+	bucket := storageClient.Bucket(env.Get[string](context.Background(), "GCLOUD_TOKEN_LOGS_BUCKET"))
 
 	i := newIndexer(ethClient, nil, nil, nil, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), refresh.AddressFilterRepository{Bucket: bucket}, persist.ChainETH, defaultTransferEvents, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
 		transferAgainLogs := []types.Log{{

--- a/indexer/t__utils_test.go
+++ b/indexer/t__utils_test.go
@@ -76,7 +76,7 @@ func newMockIndexer(db *sql.DB, pool *pgxpool.Pool) *indexer {
 	rpcEnabled = true
 	ethClient := rpc.NewEthSocketClient()
 	storageClient := newStorageClient(context.Background())
-	bucket := storageClient.Bucket(env.Get[string](context.Background(), "GCLOUD_TOKEN_LOGS_BUCKET"))
+	bucket := storageClient.Bucket(env.GetString(context.Background(), "GCLOUD_TOKEN_LOGS_BUCKET"))
 
 	i := newIndexer(ethClient, nil, nil, nil, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), refresh.AddressFilterRepository{Bucket: bucket}, persist.ChainETH, defaultTransferEvents, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
 		transferAgainLogs := []types.Log{{

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -9,12 +9,12 @@ import (
 )
 
 func IsOriginAllowed(requestOrigin string) bool {
-	if env.Get[string](context.Background(), "ENV") == "local" {
+	if env.GetString(context.Background(), "ENV") == "local" {
 		return true
 	}
-	allowedOrigins := strings.Split(env.Get[string](context.Background(), "ALLOWED_ORIGINS"), ",")
+	allowedOrigins := strings.Split(env.GetString(context.Background(), "ALLOWED_ORIGINS"), ",")
 
-	if util.ContainsString(allowedOrigins, requestOrigin) || util.ContainsString([]string{"sandbox"}, strings.ToLower(env.Get[string](context.Background(), "ENV"))) || (util.ContainsString([]string{"development"}, strings.ToLower(env.Get[string](context.Background(), "ENV"))) && strings.HasSuffix(requestOrigin, "-gallery-so.vercel.app")) {
+	if util.ContainsString(allowedOrigins, requestOrigin) || util.ContainsString([]string{"sandbox"}, strings.ToLower(env.GetString(context.Background(), "ENV"))) || (util.ContainsString([]string{"development"}, strings.ToLower(env.GetString(context.Background(), "ENV"))) && strings.HasSuffix(requestOrigin, "-gallery-so.vercel.app")) {
 		return true
 	}
 

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -1,19 +1,20 @@
 package middleware
 
 import (
+	"context"
 	"strings"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 func IsOriginAllowed(requestOrigin string) bool {
-	if viper.GetString("ENV") == "local" {
+	if env.Get[string](context.Background(), "ENV") == "local" {
 		return true
 	}
-	allowedOrigins := strings.Split(viper.GetString("ALLOWED_ORIGINS"), ",")
+	allowedOrigins := strings.Split(env.Get[string](context.Background(), "ALLOWED_ORIGINS"), ",")
 
-	if util.ContainsString(allowedOrigins, requestOrigin) || util.ContainsString([]string{"sandbox"}, strings.ToLower(viper.GetString("ENV"))) || (util.ContainsString([]string{"development"}, strings.ToLower(viper.GetString("ENV"))) && strings.HasSuffix(requestOrigin, "-gallery-so.vercel.app")) {
+	if util.ContainsString(allowedOrigins, requestOrigin) || util.ContainsString([]string{"sandbox"}, strings.ToLower(env.Get[string](context.Background(), "ENV"))) || (util.ContainsString([]string{"development"}, strings.ToLower(env.Get[string](context.Background(), "ENV"))) && strings.HasSuffix(requestOrigin, "-gallery-so.vercel.app")) {
 		return true
 	}
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -28,7 +28,7 @@ type errUserDoesNotHaveRequiredNFT struct {
 // AdminRequired is a middleware that checks if the user is authenticated as an admin
 func AdminRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if c.GetHeader("Authorization") != env.Get[string](c, "ADMIN_PASS") {
+		if c.GetHeader("Authorization") != env.GetString(c, "ADMIN_PASS") {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, util.ErrorResponse{Error: "Unauthorized"})
 			return
 		}
@@ -57,7 +57,7 @@ func AddAuthToContext() gin.HandlerFunc {
 			return
 		}
 
-		userID, err := auth.JWTParse(jwt, env.Get[string](c, "JWT_SECRET"))
+		userID, err := auth.JWTParse(jwt, env.GetString(c, "JWT_SECRET"))
 		auth.SetAuthStateForCtx(c, userID, err)
 
 		// If we have a successfully authenticated user, add their ID to all subsequent logging

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	sentrygin "github.com/getsentry/sentry-go/gin"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/tracing"
@@ -16,7 +17,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 var mixpanelDistinctIDs = map[string]string{}
@@ -28,7 +28,7 @@ type errUserDoesNotHaveRequiredNFT struct {
 // AdminRequired is a middleware that checks if the user is authenticated as an admin
 func AdminRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if c.GetHeader("Authorization") != viper.GetString("ADMIN_PASS") {
+		if c.GetHeader("Authorization") != env.Get[string](c, "ADMIN_PASS") {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, util.ErrorResponse{Error: "Unauthorized"})
 			return
 		}
@@ -57,7 +57,7 @@ func AddAuthToContext() gin.HandlerFunc {
 			return
 		}
 
-		userID, err := auth.JWTParse(jwt, viper.GetString("JWT_SECRET"))
+		userID, err := auth.JWTParse(jwt, env.Get[string](c, "JWT_SECRET"))
 		auth.SetAuthStateForCtx(c, userID, err)
 
 		// If we have a successfully authenticated user, add their ID to all subsequent logging

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -6,6 +6,7 @@ import (
 
 	magicclient "github.com/magiclabs/magic-admin-go/client"
 	"github.com/magiclabs/magic-admin-go/token"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -17,7 +18,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/spf13/viper"
 )
 
 type AuthAPI struct {
@@ -46,7 +46,7 @@ func (api AuthAPI) NewNonceAuthenticator(chainAddress persist.ChainPubKey, nonce
 }
 
 func (api AuthAPI) NewDebugAuthenticator(ctx context.Context, debugParams model.DebugAuth) (auth.Authenticator, error) {
-	if !debugtools.Enabled || viper.GetString("ENV") != "local" {
+	if !debugtools.Enabled || env.Get[string](ctx, "ENV") != "local" {
 		return nil, fmt.Errorf("debug auth is only allowed in local environments with debugtools enabled")
 	}
 

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -46,7 +46,7 @@ func (api AuthAPI) NewNonceAuthenticator(chainAddress persist.ChainPubKey, nonce
 }
 
 func (api AuthAPI) NewDebugAuthenticator(ctx context.Context, debugParams model.DebugAuth) (auth.Authenticator, error) {
-	if !debugtools.Enabled || env.Get[string](ctx, "ENV") != "local" {
+	if !debugtools.Enabled || env.GetString(ctx, "ENV") != "local" {
 		return nil, fmt.Errorf("debug auth is only allowed in local environments with debugtools enabled")
 	}
 

--- a/publicapi/card.go
+++ b/publicapi/card.go
@@ -30,7 +30,7 @@ type CardAPI struct {
 
 func (api *CardAPI) MintPremiumCardToWallet(ctx context.Context, input model.MintPremiumCardToWalletInput) (string, error) {
 
-	cardAddress := env.Get[string](ctx, "PREMIUM_CONTRACT_ADDRESS")
+	cardAddress := env.GetString(ctx, "PREMIUM_CONTRACT_ADDRESS")
 
 	cards, err := contracts.NewPremiumCards(common.HexToAddress(cardAddress), api.ethClient)
 	if err != nil {
@@ -42,8 +42,8 @@ func (api *CardAPI) MintPremiumCardToWallet(ctx context.Context, input model.Min
 		return "", fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
-	if chainID.Cmp(big.NewInt(1)) == 0 && env.Get[string](ctx, "ENV") == "production" {
-		privateKey := env.Get[string](ctx, "ETH_PRIVATE_KEY")
+	if chainID.Cmp(big.NewInt(1)) == 0 && env.GetString(ctx, "ENV") == "production" {
+		privateKey := env.GetString(ctx, "ETH_PRIVATE_KEY")
 
 		key, err := crypto.HexToECDSA(privateKey)
 		if err != nil {

--- a/publicapi/card.go
+++ b/publicapi/card.go
@@ -7,11 +7,11 @@ import (
 	"math/big"
 
 	"github.com/mikeydub/go-gallery/contracts"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -30,7 +30,7 @@ type CardAPI struct {
 
 func (api *CardAPI) MintPremiumCardToWallet(ctx context.Context, input model.MintPremiumCardToWalletInput) (string, error) {
 
-	cardAddress := viper.GetString("PREMIUM_CONTRACT_ADDRESS")
+	cardAddress := env.Get[string](ctx, "PREMIUM_CONTRACT_ADDRESS")
 
 	cards, err := contracts.NewPremiumCards(common.HexToAddress(cardAddress), api.ethClient)
 	if err != nil {
@@ -42,8 +42,8 @@ func (api *CardAPI) MintPremiumCardToWallet(ctx context.Context, input model.Min
 		return "", fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
-	if chainID.Cmp(big.NewInt(1)) == 0 && viper.GetString("ENV") == "production" {
-		privateKey := viper.GetString("ETH_PRIVATE_KEY")
+	if chainID.Cmp(big.NewInt(1)) == 0 && env.Get[string](ctx, "ENV") == "production" {
+		privateKey := env.Get[string](ctx, "ETH_PRIVATE_KEY")
 
 		key, err := crypto.HexToECDSA(privateKey)
 		if err != nil {

--- a/publicapi/gallery.go
+++ b/publicapi/gallery.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/validate"
-	"github.com/spf13/viper"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-playground/validator/v10"
@@ -659,7 +659,7 @@ func getExternalID(ctx context.Context) *string {
 	gc := util.GinContextFromContext(ctx)
 	if ip := net.ParseIP(gc.ClientIP()); ip != nil && !ip.IsPrivate() {
 		hash := sha256.New()
-		hash.Write([]byte(viper.GetString("BACKEND_SECRET") + ip.String()))
+		hash.Write([]byte(env.Get[string](ctx, "BACKEND_SECRET") + ip.String()))
 		res, _ := hash.(encoding.BinaryMarshaler).MarshalBinary()
 		externalID := base64.StdEncoding.EncodeToString(res)
 		return &externalID

--- a/publicapi/gallery.go
+++ b/publicapi/gallery.go
@@ -659,7 +659,7 @@ func getExternalID(ctx context.Context) *string {
 	gc := util.GinContextFromContext(ctx)
 	if ip := net.ParseIP(gc.ClientIP()); ip != nil && !ip.IsPrivate() {
 		hash := sha256.New()
-		hash.Write([]byte(env.Get[string](ctx, "BACKEND_SECRET") + ip.String()))
+		hash.Write([]byte(env.GetString(ctx, "BACKEND_SECRET") + ip.String()))
 		res, _ := hash.(encoding.BinaryMarshaler).MarshalBinary()
 		externalID := base64.StdEncoding.EncodeToString(res)
 		return &externalID

--- a/publicapi/merch.go
+++ b/publicapi/merch.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	"github.com/mikeydub/go-gallery/contracts"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/validate"
-	"github.com/spf13/viper"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/storage"
@@ -69,7 +69,7 @@ func (api MerchAPI) GetMerchTokens(ctx context.Context, address persist.Address)
 		return nil, err
 	}
 
-	merchAddress := viper.GetString("MERCH_CONTRACT_ADDRESS")
+	merchAddress := env.Get[string](ctx, "MERCH_CONTRACT_ADDRESS")
 
 	tokens, err := api.multichainProvider.GetTokensOfContractForWallet(ctx, persist.Address(merchAddress), persist.NewChainAddress(address, persist.ChainETH), 0, 0)
 	if err != nil {
@@ -155,7 +155,7 @@ func (api MerchAPI) GetMerchTokenByTokenID(ctx context.Context, tokenID persist.
 		return nil, err
 	}
 
-	merchAddress := viper.GetString("MERCH_CONTRACT_ADDRESS")
+	merchAddress := env.Get[string](ctx, "MERCH_CONTRACT_ADDRESS")
 
 	token, err := api.queries.GetTokenByTokenIdentifiers(ctx, db.GetTokenByTokenIdentifiersParams{
 		TokenHex:        tokenID,
@@ -243,7 +243,7 @@ func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.Tok
 
 	// check if user owns tokens
 
-	merchAddress := viper.GetString("MERCH_CONTRACT_ADDRESS")
+	merchAddress := env.Get[string](ctx, "MERCH_CONTRACT_ADDRESS")
 
 	mer, err := contracts.NewMerch(common.HexToAddress(merchAddress), api.ethClient)
 	if err != nil {
@@ -282,8 +282,8 @@ func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.Tok
 		return nil, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
-	if chainID.Cmp(big.NewInt(1)) == 0 && viper.GetString("ENV") == "production" {
-		privateKey := viper.GetString("ETH_PRIVATE_KEY")
+	if chainID.Cmp(big.NewInt(1)) == 0 && env.Get[string](ctx, "ENV") == "production" {
+		privateKey := env.Get[string](ctx, "ETH_PRIVATE_KEY")
 
 		key, err := crypto.HexToECDSA(privateKey)
 		if err != nil {

--- a/publicapi/merch.go
+++ b/publicapi/merch.go
@@ -69,7 +69,7 @@ func (api MerchAPI) GetMerchTokens(ctx context.Context, address persist.Address)
 		return nil, err
 	}
 
-	merchAddress := env.Get[string](ctx, "MERCH_CONTRACT_ADDRESS")
+	merchAddress := env.GetString(ctx, "MERCH_CONTRACT_ADDRESS")
 
 	tokens, err := api.multichainProvider.GetTokensOfContractForWallet(ctx, persist.Address(merchAddress), persist.NewChainAddress(address, persist.ChainETH), 0, 0)
 	if err != nil {
@@ -155,7 +155,7 @@ func (api MerchAPI) GetMerchTokenByTokenID(ctx context.Context, tokenID persist.
 		return nil, err
 	}
 
-	merchAddress := env.Get[string](ctx, "MERCH_CONTRACT_ADDRESS")
+	merchAddress := env.GetString(ctx, "MERCH_CONTRACT_ADDRESS")
 
 	token, err := api.queries.GetTokenByTokenIdentifiers(ctx, db.GetTokenByTokenIdentifiersParams{
 		TokenHex:        tokenID,
@@ -243,7 +243,7 @@ func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.Tok
 
 	// check if user owns tokens
 
-	merchAddress := env.Get[string](ctx, "MERCH_CONTRACT_ADDRESS")
+	merchAddress := env.GetString(ctx, "MERCH_CONTRACT_ADDRESS")
 
 	mer, err := contracts.NewMerch(common.HexToAddress(merchAddress), api.ethClient)
 	if err != nil {
@@ -282,8 +282,8 @@ func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.Tok
 		return nil, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
-	if chainID.Cmp(big.NewInt(1)) == 0 && env.Get[string](ctx, "ENV") == "production" {
-		privateKey := env.Get[string](ctx, "ETH_PRIVATE_KEY")
+	if chainID.Cmp(big.NewInt(1)) == 0 && env.GetString(ctx, "ENV") == "production" {
+		privateKey := env.GetString(ctx, "ETH_PRIVATE_KEY")
 
 		key, err := crypto.HexToECDSA(privateKey)
 		if err != nil {

--- a/publicapi/misc.go
+++ b/publicapi/misc.go
@@ -3,6 +3,8 @@ package publicapi
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 
 	"cloud.google.com/go/storage"
@@ -12,7 +14,6 @@ import (
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/spf13/viper"
 )
 
 type MiscAPI struct {
@@ -27,10 +28,10 @@ type MiscAPI struct {
 func (api MiscAPI) GetGeneralAllowlist(ctx context.Context) ([]persist.EthereumAddress, error) {
 	// Nothing to validate
 
-	bucket := viper.GetString("SNAPSHOT_BUCKET")
+	bucket := env.Get[string](ctx, "SNAPSHOT_BUCKET")
 	logger.For(ctx).Infof("Proxying snapshot from bucket %s", bucket)
 
-	obj := api.storageClient.Bucket(viper.GetString("SNAPSHOT_BUCKET")).Object("snapshot.json")
+	obj := api.storageClient.Bucket(env.Get[string](ctx, "SNAPSHOT_BUCKET")).Object("snapshot.json")
 
 	r, err := obj.NewReader(ctx)
 	if err != nil {

--- a/publicapi/misc.go
+++ b/publicapi/misc.go
@@ -28,10 +28,10 @@ type MiscAPI struct {
 func (api MiscAPI) GetGeneralAllowlist(ctx context.Context) ([]persist.EthereumAddress, error) {
 	// Nothing to validate
 
-	bucket := env.Get[string](ctx, "SNAPSHOT_BUCKET")
+	bucket := env.GetString(ctx, "SNAPSHOT_BUCKET")
 	logger.For(ctx).Infof("Proxying snapshot from bucket %s", bucket)
 
-	obj := api.storageClient.Bucket(env.Get[string](ctx, "SNAPSHOT_BUCKET")).Object("snapshot.json")
+	obj := api.storageClient.Bucket(env.GetString(ctx, "SNAPSHOT_BUCKET")).Object("snapshot.json")
 
 	r, err := obj.NewReader(ctx)
 	if err != nil {

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -207,7 +207,7 @@ func (api UserAPI) GetUsersWithTrait(ctx context.Context, trait string) ([]db.Us
 }
 
 func (api *UserAPI) GetUserRolesByUserID(ctx context.Context, userID persist.DBID) ([]persist.Role, error) {
-	address, tokenIDs := parseAddressTokens(env.Get[string](ctx, "PREMIUM_CONTRACT_ADDRESS"))
+	address, tokenIDs := parseAddressTokens(env.GetString(ctx, "PREMIUM_CONTRACT_ADDRESS"))
 	return api.queries.GetUserRolesByUserId(ctx, db.GetUserRolesByUserIdParams{
 		UserID:                userID,
 		MembershipAddress:     persist.Address(address),

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/jackc/pgtype"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/recommend"
 	"github.com/mikeydub/go-gallery/service/socialauth"
 	"github.com/mikeydub/go-gallery/service/user"
-	"github.com/spf13/viper"
 
 	"cloud.google.com/go/storage"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -207,7 +207,7 @@ func (api UserAPI) GetUsersWithTrait(ctx context.Context, trait string) ([]db.Us
 }
 
 func (api *UserAPI) GetUserRolesByUserID(ctx context.Context, userID persist.DBID) ([]persist.Role, error) {
-	address, tokenIDs := parseAddressTokens(viper.GetString("PREMIUM_CONTRACT_ADDRESS"))
+	address, tokenIDs := parseAddressTokens(env.Get[string](ctx, "PREMIUM_CONTRACT_ADDRESS"))
 	return api.queries.GetUserRolesByUserId(ctx, db.GetUserRolesByUserIdParams{
 		UserID:                userID,
 		MembershipAddress:     persist.Address(address),

--- a/server/handler.go
+++ b/server/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/graphql/apq"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/recommend"
@@ -43,7 +44,6 @@ import (
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/throttle"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 func handlersInit(router *gin.Engine, repos *postgres.Repositories, queries *db.Queries, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, mcProvider *multichain.Provider, throttler *throttle.Locker, taskClient *cloudtasks.Client, pub *pubsub.Client, lock *redislock.Client, secrets *secretmanager.Client, graphqlAPQCache *redis.Cache, feedCache *redis.Cache, socialCache *redis.Cache, magicClient *magicclient.API, recommender *recommend.Recommender) *gin.Engine {
@@ -112,7 +112,7 @@ func graphqlHandler(repos *postgres.Repositories, queries *db.Queries, ethClient
 
 	// Request/response logging is spammy in a local environment and can typically be better handled via browser debug tools.
 	// It might be worth logging top-level queries and mutations in a single log line, though.
-	enableLogging := viper.GetString("ENV") != "local"
+	enableLogging := env.Get[string](context.Background(), "ENV") != "local"
 
 	h.AroundOperations(graphql.RequestReporter(schema.Schema(), enableLogging, true))
 	h.AroundResponses(graphql.ResponseReporter(enableLogging, true))

--- a/server/handler.go
+++ b/server/handler.go
@@ -112,7 +112,7 @@ func graphqlHandler(repos *postgres.Repositories, queries *db.Queries, ethClient
 
 	// Request/response logging is spammy in a local environment and can typically be better handled via browser debug tools.
 	// It might be worth logging top-level queries and mutations in a single log line, though.
-	enableLogging := env.Get[string](context.Background(), "ENV") != "local"
+	enableLogging := env.GetString(context.Background(), "ENV") != "local"
 
 	h.AroundOperations(graphql.RequestReporter(schema.Schema(), enableLogging, true))
 	h.AroundResponses(graphql.ResponseReporter(enableLogging, true))

--- a/server/server.go
+++ b/server/server.go
@@ -256,7 +256,7 @@ func initSentry() {
 		MaxSpans:         100000,
 		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
 		Environment:      env.Get[string](context.Background(), "ENV"),
-		TracesSampleRate: viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE"),
+		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
 		Release:          env.Get[string](context.Background(), "GAE_VERSION"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {

--- a/server/server.go
+++ b/server/server.go
@@ -49,8 +49,8 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("TOKEN_PROCESSING_URL", []string{"required"})
-	env.RegisterValidation("INDEXER_HOST", []string{"required"})
+	env.RegisterValidation("TOKEN_PROCESSING_URL", "required")
+	env.RegisterValidation("INDEXER_HOST", "required")
 }
 
 // Init initializes the server

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	sentry "github.com/getsentry/sentry-go"
 	shell "github.com/ipfs/go-ipfs-api"
 	magicclient "github.com/magiclabs/magic-admin-go/client"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/validate"
 	"github.com/sirupsen/logrus"
@@ -46,6 +47,11 @@ import (
 	"github.com/mikeydub/go-gallery/service/throttle"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("TOKEN_PROCESSING_URL", []string{"required"})
+	env.RegisterEnvValidation("INDEXER_HOST", []string{"required"})
+}
 
 // Init initializes the server
 func Init() {
@@ -107,7 +113,7 @@ func ClientInit(ctx context.Context) *Clients {
 func CoreInit(c *Clients, provider *multichain.Provider, recommender *recommend.Recommender) *gin.Engine {
 	logger.For(nil).Info("initializing server...")
 
-	if viper.GetString("ENV") != "production" {
+	if env.Get[string](context.Background(), "ENV") != "production" {
 		gin.SetMode(gin.DebugMode)
 		logrus.SetLevel(logrus.DebugLevel)
 	}
@@ -138,7 +144,7 @@ func CoreInit(c *Clients, provider *multichain.Provider, recommender *recommend.
 func newSecretsClient() *secretmanager.Client {
 	options := []option.ClientOption{}
 
-	if viper.GetString("ENV") == "local" {
+	if env.Get[string](context.Background(), "ENV") == "local" {
 		fi, err := util.LoadEncryptedServiceKeyOrError("./secrets/dev/service-key-dev.json")
 		if err != nil {
 			logger.For(nil).WithError(err).Error("error finding service key, running without secrets client")
@@ -216,7 +222,7 @@ func SetDefaults() {
 
 	viper.AutomaticEnv()
 
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"
@@ -227,7 +233,7 @@ func SetDefaults() {
 		util.LoadEncryptedEnvFile(envFile)
 	}
 
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		util.VarNotSetTo("IMGIX_SECRET", "")
 		util.VarNotSetTo("ADMIN_PASS", "TEST_ADMIN_PASS")
 		util.VarNotSetTo("SENTRY_DSN", "")
@@ -239,7 +245,7 @@ func SetDefaults() {
 }
 
 func initSentry() {
-	if viper.GetString("ENV") == "local" {
+	if env.Get[string](context.Background(), "ENV") == "local" {
 		logger.For(nil).Info("skipping sentry init")
 		return
 	}
@@ -248,10 +254,10 @@ func initSentry() {
 
 	err := sentry.Init(sentry.ClientOptions{
 		MaxSpans:         100000,
-		Dsn:              viper.GetString("SENTRY_DSN"),
-		Environment:      viper.GetString("ENV"),
+		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
+		Environment:      env.Get[string](context.Background(), "ENV"),
 		TracesSampleRate: viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE"),
-		Release:          viper.GetString("GAE_VERSION"),
+		Release:          env.Get[string](context.Background(), "GAE_VERSION"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			event = auth.ScrubEventCookies(event, hint)
@@ -268,16 +274,16 @@ func initSentry() {
 func NewMultichainProvider(c *Clients) *multichain.Provider {
 	ethChain := persist.ChainETH
 	overrides := multichain.ChainOverrideMap{persist.ChainPOAP: &ethChain}
-	ethProvider := eth.NewProvider(viper.GetString("INDEXER_HOST"), c.HTTPClient, c.EthClient, c.TaskClient)
+	ethProvider := eth.NewProvider(env.Get[string](context.Background(), "INDEXER_HOST"), c.HTTPClient, c.EthClient, c.TaskClient)
 	openseaProvider := opensea.NewProvider(c.EthClient, c.HTTPClient)
 	tezosProvider := multichain.FallbackProvider{
-		Primary:  tezos.NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_URL"), c.HTTPClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET")),
-		Fallback: tezos.NewObjktProvider(viper.GetString("IPFS_URL")),
+		Primary:  tezos.NewProvider(env.Get[string](context.Background(), "TEZOS_API_URL"), env.Get[string](context.Background(), "TOKEN_PROCESSING_URL"), env.Get[string](context.Background(), "IPFS_URL"), c.HTTPClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.Get[string](context.Background(), "GCLOUD_TOKEN_CONTENT_BUCKET")),
+		Fallback: tezos.NewObjktProvider(env.Get[string](context.Background(), "IPFS_URL")),
 		Eval: func(ctx context.Context, token multichain.ChainAgnosticToken) bool {
 			return tezos.IsSigned(ctx, token) && tezos.ContainsTezosKeywords(ctx, token)
 		},
 	}
-	poapProvider := poap.NewProvider(c.HTTPClient, viper.GetString("POAP_API_KEY"), viper.GetString("POAP_AUTH_TOKEN"))
+	poapProvider := poap.NewProvider(c.HTTPClient, env.Get[string](context.Background(), "POAP_API_KEY"), env.Get[string](context.Background(), "POAP_AUTH_TOKEN"))
 	cache := redis.NewCache(redis.CommunitiesDB)
 	return multichain.NewProvider(context.Background(), c.Repos, c.Queries, cache, c.TaskClient,
 		overrides,

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -279,7 +279,7 @@ func (e MagicLinkAuthenticator) Authenticate(pCtx context.Context) (*AuthResult,
 }
 
 func NewMagicLinkClient() *magicclient.API {
-	return magicclient.New(env.Get[string](context.Background(), "MAGIC_LINK_SECRET_KEY"), magic.NewDefaultClient())
+	return magicclient.New(env.GetString(context.Background(), "MAGIC_LINK_SECRET_KEY"), magic.NewDefaultClient())
 }
 
 // Login logs in a user with a given authentication scheme
@@ -418,7 +418,7 @@ func SetJWTCookie(c *gin.Context, token string) {
 
 	clientIsLocalhost := c.Request.Header.Get("Origin") == "http://localhost:3000"
 
-	if env.Get[string](context.Background(), "ENV") != "production" || clientIsLocalhost {
+	if env.GetString(context.Background(), "ENV") != "production" || clientIsLocalhost {
 		mode = http.SameSiteNoneMode
 		domain = ""
 		httpOnly = false

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/magiclabs/magic-admin-go"
 	magicclient "github.com/magiclabs/magic-admin-go/client"
 	"github.com/magiclabs/magic-admin-go/token"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -20,7 +21,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 // TODO: ExternalWallet? Something to denote "wallet, but not part of our ecosystem"
@@ -279,7 +279,7 @@ func (e MagicLinkAuthenticator) Authenticate(pCtx context.Context) (*AuthResult,
 }
 
 func NewMagicLinkClient() *magicclient.API {
-	return magicclient.New(viper.GetString("MAGIC_LINK_SECRET_KEY"), magic.NewDefaultClient())
+	return magicclient.New(env.Get[string](context.Background(), "MAGIC_LINK_SECRET_KEY"), magic.NewDefaultClient())
 }
 
 // Login logs in a user with a given authentication scheme
@@ -418,7 +418,7 @@ func SetJWTCookie(c *gin.Context, token string) {
 
 	clientIsLocalhost := c.Request.Header.Get("Origin") == "http://localhost:3000"
 
-	if viper.GetString("ENV") != "production" || clientIsLocalhost {
+	if env.Get[string](context.Background(), "ENV") != "production" || clientIsLocalhost {
 		mode = http.SameSiteNoneMode
 		domain = ""
 		httpOnly = false

--- a/service/auth/jwt.go
+++ b/service/auth/jwt.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/spf13/viper"
 )
@@ -66,7 +67,7 @@ func JWTGeneratePipeline(pCtx context.Context, pUserID persist.DBID) (string, er
 
 func jwtGenerate(pIssuerStr string, pUserID persist.DBID) (string, error) {
 
-	signingKeyBytesLst := []byte(viper.GetString("JWT_SECRET"))
+	signingKeyBytesLst := []byte(env.Get[string](context.Background(), "JWT_SECRET"))
 
 	creationTimeUNIXint := time.Now().UnixNano() / 1000000000
 	expiresAtUNIXint := creationTimeUNIXint + viper.GetInt64("JWT_TTL") // expire N number of secs from now

--- a/service/auth/jwt.go
+++ b/service/auth/jwt.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/spf13/viper"
 )
 
 type jwtClaims struct {
@@ -70,7 +69,7 @@ func jwtGenerate(pIssuerStr string, pUserID persist.DBID) (string, error) {
 	signingKeyBytesLst := []byte(env.Get[string](context.Background(), "JWT_SECRET"))
 
 	creationTimeUNIXint := time.Now().UnixNano() / 1000000000
-	expiresAtUNIXint := creationTimeUNIXint + viper.GetInt64("JWT_TTL") // expire N number of secs from now
+	expiresAtUNIXint := creationTimeUNIXint + env.Get[int64](context.Background(), "JWT_TTL") // expire N number of secs from now
 	claims := jwtClaims{
 		pUserID,
 		jwt.StandardClaims{

--- a/service/auth/jwt.go
+++ b/service/auth/jwt.go
@@ -66,7 +66,7 @@ func JWTGeneratePipeline(pCtx context.Context, pUserID persist.DBID) (string, er
 
 func jwtGenerate(pIssuerStr string, pUserID persist.DBID) (string, error) {
 
-	signingKeyBytesLst := []byte(env.Get[string](context.Background(), "JWT_SECRET"))
+	signingKeyBytesLst := []byte(env.GetString(context.Background(), "JWT_SECRET"))
 
 	creationTimeUNIXint := time.Now().UnixNano() / 1000000000
 	expiresAtUNIXint := creationTimeUNIXint + env.Get[int64](context.Background(), "JWT_TTL") // expire N number of secs from now

--- a/service/auth/retool.go
+++ b/service/auth/retool.go
@@ -34,7 +34,7 @@ func RetoolAuthorized(ctx context.Context) error {
 	password := usernameAndPasswordParts[1]
 	passwordBytes := []byte(password)
 
-	if cmp := subtle.ConstantTimeCompare([]byte(env.Get[string](ctx, "RETOOL_AUTH_TOKEN")), passwordBytes); cmp != 1 {
+	if cmp := subtle.ConstantTimeCompare([]byte(env.GetString(ctx, "RETOOL_AUTH_TOKEN")), passwordBytes); cmp != 1 {
 		return errRetoolUnauthorized
 	}
 

--- a/service/auth/retool.go
+++ b/service/auth/retool.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 var errRetoolUnauthorized = errors.New("not authorized")
@@ -34,7 +34,7 @@ func RetoolAuthorized(ctx context.Context) error {
 	password := usernameAndPasswordParts[1]
 	passwordBytes := []byte(password)
 
-	if cmp := subtle.ConstantTimeCompare([]byte(viper.GetString("RETOOL_AUTH_TOKEN")), passwordBytes); cmp != 1 {
+	if cmp := subtle.ConstantTimeCompare([]byte(env.Get[string](ctx, "RETOOL_AUTH_TOKEN")), passwordBytes); cmp != 1 {
 		return errRetoolUnauthorized
 	}
 

--- a/service/emails/emails.go
+++ b/service/emails/emails.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("EMAILS_HOST", []string{"required"})
+	env.RegisterValidation("EMAILS_HOST", []string{"required"})
 }
 
 func VerifyEmail(ctx context.Context, token string) (emails.VerifyEmailOutput, error) {
@@ -29,7 +29,7 @@ func VerifyEmail(ctx context.Context, token string) (emails.VerifyEmailOutput, e
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/verify", env.Get[string](ctx, "EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/verify", env.GetString(ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return emails.VerifyEmailOutput{}, err
 	}
@@ -57,7 +57,7 @@ func VerifyEmail(ctx context.Context, token string) (emails.VerifyEmailOutput, e
 func PreverifyEmail(ctx context.Context, email persist.Email, source string) (emails.PreverifyEmailOutput, error) {
 	var result emails.PreverifyEmailOutput
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/preverify?email=%s&source=%s", env.Get[string](ctx, "EMAILS_HOST"), email, source), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/preverify?email=%s&source=%s", env.GetString(ctx, "EMAILS_HOST"), email, source), nil)
 	if err != nil {
 		return result, err
 	}
@@ -94,7 +94,7 @@ func UnsubscribeByJWT(ctx context.Context, jwt string, unsubTypes []model.EmailU
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/unsubscribe", env.Get[string](ctx, "EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/unsubscribe", env.GetString(ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func UpdateUnsubscriptionsByUserID(ctx context.Context, userID persist.DBID, uns
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/subscriptions", env.Get[string](ctx, "EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/subscriptions", env.GetString(ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func RequestVerificationEmail(ctx context.Context, userID persist.DBID) error {
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/send/verification", env.Get[string](ctx, "EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/send/verification", env.GetString(ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return err
 	}

--- a/service/emails/emails.go
+++ b/service/emails/emails.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("EMAILS_HOST", []string{"required"})
+	env.RegisterValidation("EMAILS_HOST", "required")
 }
 
 func VerifyEmail(ctx context.Context, token string) (emails.VerifyEmailOutput, error) {

--- a/service/emails/emails.go
+++ b/service/emails/emails.go
@@ -8,11 +8,15 @@ import (
 	"net/http"
 
 	"github.com/mikeydub/go-gallery/emails"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("EMAILS_HOST", []string{"required"})
+}
 
 func VerifyEmail(ctx context.Context, token string) (emails.VerifyEmailOutput, error) {
 	input := emails.VerifyEmailInput{
@@ -25,7 +29,7 @@ func VerifyEmail(ctx context.Context, token string) (emails.VerifyEmailOutput, e
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/verify", viper.GetString("EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/verify", env.Get[string](ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return emails.VerifyEmailOutput{}, err
 	}
@@ -53,7 +57,7 @@ func VerifyEmail(ctx context.Context, token string) (emails.VerifyEmailOutput, e
 func PreverifyEmail(ctx context.Context, email persist.Email, source string) (emails.PreverifyEmailOutput, error) {
 	var result emails.PreverifyEmailOutput
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/preverify?email=%s&source=%s", viper.GetString("EMAILS_HOST"), email, source), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/preverify?email=%s&source=%s", env.Get[string](ctx, "EMAILS_HOST"), email, source), nil)
 	if err != nil {
 		return result, err
 	}
@@ -90,7 +94,7 @@ func UnsubscribeByJWT(ctx context.Context, jwt string, unsubTypes []model.EmailU
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/unsubscribe", viper.GetString("EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/unsubscribe", env.Get[string](ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return err
 	}
@@ -122,7 +126,7 @@ func UpdateUnsubscriptionsByUserID(ctx context.Context, userID persist.DBID, uns
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/subscriptions", viper.GetString("EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/subscriptions", env.Get[string](ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return err
 	}
@@ -152,7 +156,7 @@ func RequestVerificationEmail(ctx context.Context, userID persist.DBID) error {
 
 	buf := bytes.NewBuffer(body)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/send/verification", viper.GetString("EMAILS_HOST")), buf)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/send/verification", env.Get[string](ctx, "EMAILS_HOST")), buf)
 	if err != nil {
 		return err
 	}

--- a/service/logger/logger.go
+++ b/service/logger/logger.go
@@ -6,10 +6,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 const loggerContextKey = "logger.logger"

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -41,7 +41,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("IPFS_URL", []string{"required"})
+	env.RegisterValidation("IPFS_URL", []string{"required"})
 }
 
 var errAlreadyHasMedia = errors.New("token already has preview and thumbnail URLs")
@@ -84,7 +84,7 @@ var postfixesToMediaTypes = map[string]mediaWithContentType{
 func NewStorageClient(ctx context.Context) *storage.Client {
 	opts := append([]option.ClientOption{}, option.WithScopes([]string{storage.ScopeFullControl}...))
 
-	if env.Get[string](ctx, "ENV") == "local" {
+	if env.GetString(ctx, "ENV") == "local" {
 		fi, err := util.LoadEncryptedServiceKeyOrError("./secrets/dev/service-key-dev.json")
 		if err != nil {
 			logger.For(ctx).WithError(err).Error("failed to find service key file (local), running without storage client")
@@ -548,7 +548,7 @@ func remapPaths(mediaURL string) string {
 	switch persist.TokenURI(mediaURL).Type() {
 	case persist.URITypeIPFS, persist.URITypeIPFSAPI:
 		path := util.GetURIPath(mediaURL, false)
-		return fmt.Sprintf("%s/ipfs/%s", env.Get[string](context.Background(), "IPFS_URL"), path)
+		return fmt.Sprintf("%s/ipfs/%s", env.GetString(context.Background(), "IPFS_URL"), path)
 	case persist.URITypeArweave:
 		path := util.GetURIPath(mediaURL, false)
 		return fmt.Sprintf("https://arweave.net/%s", path)

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -41,7 +41,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("IPFS_URL", []string{"required"})
+	env.RegisterValidation("IPFS_URL", "required")
 }
 
 var errAlreadyHasMedia = errors.New("token already has preview and thumbnail URLs")

--- a/service/mediamapper/mediamapper.go
+++ b/service/mediamapper/mediamapper.go
@@ -66,7 +66,7 @@ func newWidthParam(width int) imgix.IxParam {
 }
 
 func NewMediaMapper() *MediaMapper {
-	token := env.Get[string](context.Background(), "IMGIX_SECRET")
+	token := env.GetString(context.Background(), "IMGIX_SECRET")
 	if token == "" {
 		// panic(errors.New("IMGIX_SECRET must be set in order to generate image URLs"))
 		logger.For(nil).Error("IMGIX_SECRET must be set in order to generate image URLs")
@@ -218,7 +218,7 @@ func PurgeImage(ctx context.Context, u string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+env.Get[string](ctx, "IMGIX_API_KEY"))
+	req.Header.Set("Authorization", "Bearer "+env.GetString(ctx, "IMGIX_API_KEY"))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/service/mediamapper/mediamapper.go
+++ b/service/mediamapper/mediamapper.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/imgix/imgix-go/v2"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 const contextKey = "mediamapper.instance"
@@ -66,7 +66,7 @@ func newWidthParam(width int) imgix.IxParam {
 }
 
 func NewMediaMapper() *MediaMapper {
-	token := viper.GetString("IMGIX_SECRET")
+	token := env.Get[string](context.Background(), "IMGIX_SECRET")
 	if token == "" {
 		// panic(errors.New("IMGIX_SECRET must be set in order to generate image URLs"))
 		logger.For(nil).Error("IMGIX_SECRET must be set in order to generate image URLs")
@@ -218,7 +218,7 @@ func PurgeImage(ctx context.Context, u string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/vnd.api+json")
-	req.Header.Set("Authorization", "Bearer "+viper.GetString("IMGIX_API_KEY"))
+	req.Header.Set("Authorization", "Bearer "+env.Get[string](ctx, "IMGIX_API_KEY"))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/service/membership/alchemy.go
+++ b/service/membership/alchemy.go
@@ -32,7 +32,7 @@ type indexerTokenResponse struct {
 }
 
 // func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress persist.Address) ([]persist.Address, error) {
-// 	alchemyURL := env.Get[string](ctx, "CONTRACT_INTERACTION_URL") + "/getOwnersForToken"
+// 	alchemyURL := env.GetString(ctx, "CONTRACT_INTERACTION_URL") + "/getOwnersForToken"
 
 // 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s?contractAddress=%s&tokenId=%s", alchemyURL, contractAddress, fmt.Sprintf("0x0%s", tid)), nil)
 // 	if err != nil {
@@ -54,7 +54,7 @@ type indexerTokenResponse struct {
 // }
 
 // func getTokenMetadata(ctx context.Context, tid persist.TokenID, contractAddress persist.Address, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client) (alchemyNFTMetadata, error) {
-// 	alchemyURL := env.Get[string](ctx, "CONTRACT_INTERACTION_URL") + "/getNFTMetadata"
+// 	alchemyURL := env.GetString(ctx, "CONTRACT_INTERACTION_URL") + "/getNFTMetadata"
 
 // 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s?contractAddress=%s&tokenId=%s", alchemyURL, contractAddress, tid), nil)
 // 	if err != nil {
@@ -96,7 +96,7 @@ type indexerTokenResponse struct {
 // }
 
 func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress persist.EthereumAddress) ([]persist.EthereumAddress, error) {
-	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s", env.Get[string](ctx, "INDEXER_HOST"), tid, contractAddress)
+	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s", env.GetString(ctx, "INDEXER_HOST"), tid, contractAddress)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -125,7 +125,7 @@ func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress
 }
 
 func getTokenMetadata(ctx context.Context, tid persist.TokenID, contractAddress persist.EthereumAddress, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client) (alchemyNFTMetadata, error) {
-	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s&limit=1", env.Get[string](ctx, "INDEXER_HOST"), tid, contractAddress)
+	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s&limit=1", env.GetString(ctx, "INDEXER_HOST"), tid, contractAddress)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/service/membership/alchemy.go
+++ b/service/membership/alchemy.go
@@ -9,9 +9,9 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/everFinance/goar"
 	shell "github.com/ipfs/go-ipfs-api"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 type alchemyGetOwnersForTokensResponse struct {
@@ -32,7 +32,7 @@ type indexerTokenResponse struct {
 }
 
 // func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress persist.Address) ([]persist.Address, error) {
-// 	alchemyURL := viper.GetString("CONTRACT_INTERACTION_URL") + "/getOwnersForToken"
+// 	alchemyURL := env.Get[string](ctx, "CONTRACT_INTERACTION_URL") + "/getOwnersForToken"
 
 // 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s?contractAddress=%s&tokenId=%s", alchemyURL, contractAddress, fmt.Sprintf("0x0%s", tid)), nil)
 // 	if err != nil {
@@ -54,7 +54,7 @@ type indexerTokenResponse struct {
 // }
 
 // func getTokenMetadata(ctx context.Context, tid persist.TokenID, contractAddress persist.Address, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client) (alchemyNFTMetadata, error) {
-// 	alchemyURL := viper.GetString("CONTRACT_INTERACTION_URL") + "/getNFTMetadata"
+// 	alchemyURL := env.Get[string](ctx, "CONTRACT_INTERACTION_URL") + "/getNFTMetadata"
 
 // 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s?contractAddress=%s&tokenId=%s", alchemyURL, contractAddress, tid), nil)
 // 	if err != nil {
@@ -96,7 +96,7 @@ type indexerTokenResponse struct {
 // }
 
 func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress persist.EthereumAddress) ([]persist.EthereumAddress, error) {
-	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s", viper.GetString("INDEXER_HOST"), tid, contractAddress)
+	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s", env.Get[string](ctx, "INDEXER_HOST"), tid, contractAddress)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -125,7 +125,7 @@ func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress
 }
 
 func getTokenMetadata(ctx context.Context, tid persist.TokenID, contractAddress persist.EthereumAddress, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client) (alchemyNFTMetadata, error) {
-	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s&limit=1", viper.GetString("INDEXER_HOST"), tid, contractAddress)
+	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s&limit=1", env.Get[string](ctx, "INDEXER_HOST"), tid, contractAddress)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -98,7 +98,7 @@ func OpenseaFetchMembershipCards(contractAddress persist.EthereumAddress, tokenI
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("X-API-KEY", env.Get[string](context.Background(), "OPENSEA_API_KEY"))
+	req.Header.Set("X-API-KEY", env.GetString(context.Background(), "OPENSEA_API_KEY"))
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -3,9 +3,11 @@ package membership
 import (
 	"context"
 	"fmt"
-	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"net/http"
 	"time"
+
+	"github.com/mikeydub/go-gallery/env"
+	"github.com/mikeydub/go-gallery/service/persist/postgres"
 
 	"github.com/mikeydub/go-gallery/service/logger"
 
@@ -17,7 +19,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/multichain/opensea"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 // MembershipTierIDs is a list of all membership tiers
@@ -97,7 +98,7 @@ func OpenseaFetchMembershipCards(contractAddress persist.EthereumAddress, tokenI
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("X-API-KEY", viper.GetString("OPENSEA_API_KEY"))
+	req.Header.Set("X-API-KEY", env.Get[string](context.Background(), "OPENSEA_API_KEY"))
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -492,7 +492,7 @@ func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.A
 
 // WalletCreated runs whenever a new wallet is created
 func (d *Provider) WalletCreated(ctx context.Context, userID persist.DBID, wallet persist.Address, walletType persist.WalletType) error {
-	if env.Get[string](ctx, "ENV") == "local" {
+	if env.GetString(ctx, "ENV") == "local" {
 		return nil
 	}
 	input := task.ValidateNFTsMessage{OwnerAddress: persist.EthereumAddress(wallet.String())}

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/mikeydub/go-gallery/contracts"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer"
 	"github.com/mikeydub/go-gallery/indexer/refresh"
 	"github.com/mikeydub/go-gallery/service/auth"
@@ -28,7 +29,6 @@ import (
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -492,7 +492,7 @@ func (d *Provider) ValidateTokensForWallet(ctx context.Context, wallet persist.A
 
 // WalletCreated runs whenever a new wallet is created
 func (d *Provider) WalletCreated(ctx context.Context, userID persist.DBID, wallet persist.Address, walletType persist.WalletType) error {
-	if viper.GetString("ENV") == "local" {
+	if env.Get[string](ctx, "ENV") == "local" {
 		return nil
 	}
 	input := task.ValidateNFTsMessage{OwnerAddress: persist.EthereumAddress(wallet.String())}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -11,10 +11,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/redis"
 	"github.com/mikeydub/go-gallery/service/task"
-	"github.com/spf13/viper"
 
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	"github.com/gammazero/workerpool"
@@ -23,6 +23,10 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
 )
+
+func init() {
+	env.RegisterEnvValidation("TOKEN_PROCESSING_URL", []string{"required"})
+}
 
 const staleCommunityTime = time.Minute * 30
 
@@ -520,7 +524,7 @@ func (p *Provider) processMedialessToken(ctx context.Context, tokenID persist.To
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", viper.GetString("TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", env.Get[string](ctx, "TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
 	if err != nil {
 		return err
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("TOKEN_PROCESSING_URL", []string{"required"})
+	env.RegisterValidation("TOKEN_PROCESSING_URL", "required")
 }
 
 const staleCommunityTime = time.Minute * 30

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -25,7 +25,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("TOKEN_PROCESSING_URL", []string{"required"})
+	env.RegisterValidation("TOKEN_PROCESSING_URL", []string{"required"})
 }
 
 const staleCommunityTime = time.Minute * 30
@@ -524,7 +524,7 @@ func (p *Provider) processTokenMedia(ctx context.Context, tokenID persist.TokenI
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", env.Get[string](ctx, "TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", env.GetString(ctx, "TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
 	if err != nil {
 		return err
 	}

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	env.RegisterEnvValidation("OPENSEA_API_KEY", []string{"required"})
+	env.RegisterValidation("OPENSEA_API_KEY", []string{"required"})
 }
 
 var baseURL, _ = url.Parse("https://api.opensea.io/api/v1")
@@ -735,7 +735,7 @@ func authRequest(ctx context.Context, url string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("X-API-KEY", env.Get[string](ctx, "OPENSEA_API_KEY"))
+	req.Header.Set("X-API-KEY", env.GetString(ctx, "OPENSEA_API_KEY"))
 	return req, nil
 }
 

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	env.RegisterValidation("OPENSEA_API_KEY", []string{"required"})
+	env.RegisterValidation("OPENSEA_API_KEY", "required")
 }
 
 var baseURL, _ = url.Parse("https://api.opensea.io/api/v1")

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/gammazero/workerpool"
 	"github.com/mikeydub/go-gallery/contracts"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/media"
@@ -27,8 +28,11 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
+
+func init() {
+	env.RegisterEnvValidation("OPENSEA_API_KEY", []string{"required"})
+}
 
 var baseURL, _ = url.Parse("https://api.opensea.io/api/v1")
 
@@ -741,7 +745,7 @@ func authRequest(ctx context.Context, url string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("X-API-KEY", viper.GetString("OPENSEA_API_KEY"))
+	req.Header.Set("X-API-KEY", env.Get[string](ctx, "OPENSEA_API_KEY"))
 	return req, nil
 }
 

--- a/service/multichain/tezos/t__get_tokens_test.go
+++ b/service/multichain/tezos/t__get_tokens_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
-	"github.com/spf13/viper"
 )
 
 func TestGetTokensForWallet_Success(t *testing.T) {
@@ -20,7 +19,7 @@ func TestGetTokensForWallet_Success(t *testing.T) {
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()
 	storage := newStorageClient(ctx)
-	p := NewProvider(env.Get[string](ctx, "TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_GATEWAY_URL"), http.DefaultClient, ipfsClient, arweaveClient, storage, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
+	p := NewProvider(env.Get[string](ctx, "TEZOS_API_URL"), env.Get[string](ctx, "TOKEN_PROCESSING_URL"), env.Get[string](ctx, "IPFS_GATEWAY_URL"), http.DefaultClient, ipfsClient, arweaveClient, storage, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"))
 
 	powerUsers := []persist.Address{"tz1hyNv7RBzNPGLpKfdwHRc6NhLW6VbzXP3N", "tz1YHsinBJHMj1YFN7UrCsVAgTcaJCH86PjK", "tz1bPMztWzs449CuEmVTY3BprhHMtm4NUQPJ"}
 

--- a/service/multichain/tezos/t__get_tokens_test.go
+++ b/service/multichain/tezos/t__get_tokens_test.go
@@ -19,7 +19,7 @@ func TestGetTokensForWallet_Success(t *testing.T) {
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()
 	storage := newStorageClient(ctx)
-	p := NewProvider(env.Get[string](ctx, "TEZOS_API_URL"), env.Get[string](ctx, "TOKEN_PROCESSING_URL"), env.Get[string](ctx, "IPFS_GATEWAY_URL"), http.DefaultClient, ipfsClient, arweaveClient, storage, env.Get[string](ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"))
+	p := NewProvider(env.GetString(ctx, "TEZOS_API_URL"), env.GetString(ctx, "TOKEN_PROCESSING_URL"), env.GetString(ctx, "IPFS_GATEWAY_URL"), http.DefaultClient, ipfsClient, arweaveClient, storage, env.GetString(ctx, "GCLOUD_TOKEN_CONTENT_BUCKET"))
 
 	powerUsers := []persist.Address{"tz1hyNv7RBzNPGLpKfdwHRc6NhLW6VbzXP3N", "tz1YHsinBJHMj1YFN7UrCsVAgTcaJCH86PjK", "tz1bPMztWzs449CuEmVTY3BprhHMtm4NUQPJ"}
 

--- a/service/multichain/tezos/t__get_tokens_test.go
+++ b/service/multichain/tezos/t__get_tokens_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/spf13/viper"
@@ -19,7 +20,7 @@ func TestGetTokensForWallet_Success(t *testing.T) {
 	ipfsClient := rpc.NewIPFSShell()
 	arweaveClient := rpc.NewArweaveClient()
 	storage := newStorageClient(ctx)
-	p := NewProvider(viper.GetString("TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_GATEWAY_URL"), http.DefaultClient, ipfsClient, arweaveClient, storage, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
+	p := NewProvider(env.Get[string](ctx, "TEZOS_API_URL"), viper.GetString("TOKEN_PROCESSING_URL"), viper.GetString("IPFS_GATEWAY_URL"), http.DefaultClient, ipfsClient, arweaveClient, storage, viper.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
 
 	powerUsers := []persist.Address{"tz1hyNv7RBzNPGLpKfdwHRc6NhLW6VbzXP3N", "tz1YHsinBJHMj1YFN7UrCsVAgTcaJCH86PjK", "tz1bPMztWzs449CuEmVTY3BprhHMtm4NUQPJ"}
 

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -13,10 +13,10 @@ import (
 	"github.com/googleapis/gax-go/v2/apierror"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc/codes"
 )
 
@@ -282,7 +282,7 @@ func (n *NotificationHandlers) subscribe(ctx context.Context, topic, name string
 }
 
 func (n *NotificationHandlers) receiveNewNotificationsFromPubSub() {
-	sub, err := n.subscribe(context.Background(), viper.GetString("PUBSUB_TOPIC_NEW_NOTIFICATIONS"), fmt.Sprintf("new-notifications-%s", persist.GenerateID()))
+	sub, err := n.subscribe(context.Background(), env.Get[string](context.Background(), "PUBSUB_TOPIC_NEW_NOTIFICATIONS"), fmt.Sprintf("new-notifications-%s", persist.GenerateID()))
 	if err != nil {
 		logger.For(nil).Errorf("error creating updated notifications subscription: %s", err)
 		panic(err)
@@ -323,7 +323,7 @@ func (n *NotificationHandlers) receiveNewNotificationsFromPubSub() {
 }
 
 func (n *NotificationHandlers) receiveUpdatedNotificationsFromPubSub() {
-	sub, err := n.subscribe(context.Background(), viper.GetString("PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"), fmt.Sprintf("updated-notifications-%s", persist.GenerateID()))
+	sub, err := n.subscribe(context.Background(), env.Get[string](context.Background(), "PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"), fmt.Sprintf("updated-notifications-%s", persist.GenerateID()))
 	if err != nil {
 		logger.For(nil).Errorf("error creating updated notifications subscription: %s", err)
 		panic(err)
@@ -373,7 +373,7 @@ func insertAndPublishNotif(ctx context.Context, notif db.Notification, queries *
 	if err != nil {
 		return err
 	}
-	t := ps.Topic(viper.GetString("PUBSUB_TOPIC_NEW_NOTIFICATIONS"))
+	t := ps.Topic(env.Get[string](ctx, "PUBSUB_TOPIC_NEW_NOTIFICATIONS"))
 	result := t.Publish(ctx, &pubsub.Message{
 		Data: marshalled,
 	})
@@ -419,7 +419,7 @@ func updateAndPublishNotif(ctx context.Context, notif db.Notification, mostRecen
 	if err != nil {
 		return err
 	}
-	t := ps.Topic(viper.GetString("PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"))
+	t := ps.Topic(env.Get[string](ctx, "PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"))
 	result := t.Publish(ctx, &pubsub.Message{
 		Data: marshalled,
 	})

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -282,7 +282,7 @@ func (n *NotificationHandlers) subscribe(ctx context.Context, topic, name string
 }
 
 func (n *NotificationHandlers) receiveNewNotificationsFromPubSub() {
-	sub, err := n.subscribe(context.Background(), env.Get[string](context.Background(), "PUBSUB_TOPIC_NEW_NOTIFICATIONS"), fmt.Sprintf("new-notifications-%s", persist.GenerateID()))
+	sub, err := n.subscribe(context.Background(), env.GetString(context.Background(), "PUBSUB_TOPIC_NEW_NOTIFICATIONS"), fmt.Sprintf("new-notifications-%s", persist.GenerateID()))
 	if err != nil {
 		logger.For(nil).Errorf("error creating updated notifications subscription: %s", err)
 		panic(err)
@@ -323,7 +323,7 @@ func (n *NotificationHandlers) receiveNewNotificationsFromPubSub() {
 }
 
 func (n *NotificationHandlers) receiveUpdatedNotificationsFromPubSub() {
-	sub, err := n.subscribe(context.Background(), env.Get[string](context.Background(), "PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"), fmt.Sprintf("updated-notifications-%s", persist.GenerateID()))
+	sub, err := n.subscribe(context.Background(), env.GetString(context.Background(), "PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"), fmt.Sprintf("updated-notifications-%s", persist.GenerateID()))
 	if err != nil {
 		logger.For(nil).Errorf("error creating updated notifications subscription: %s", err)
 		panic(err)
@@ -373,7 +373,7 @@ func insertAndPublishNotif(ctx context.Context, notif db.Notification, queries *
 	if err != nil {
 		return err
 	}
-	t := ps.Topic(env.Get[string](ctx, "PUBSUB_TOPIC_NEW_NOTIFICATIONS"))
+	t := ps.Topic(env.GetString(ctx, "PUBSUB_TOPIC_NEW_NOTIFICATIONS"))
 	result := t.Publish(ctx, &pubsub.Message{
 		Data: marshalled,
 	})
@@ -419,7 +419,7 @@ func updateAndPublishNotif(ctx context.Context, notif db.Notification, mostRecen
 	if err != nil {
 		return err
 	}
-	t := ps.Topic(env.Get[string](ctx, "PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"))
+	t := ps.Topic(env.GetString(ctx, "PUBSUB_TOPIC_UPDATED_NOTIFICATIONS"))
 	result := t.Publish(ctx, &pubsub.Message{
 		Data: marshalled,
 	})

--- a/service/persist/postgres/postgres.go
+++ b/service/persist/postgres/postgres.go
@@ -67,9 +67,9 @@ func (c *connectionParams) toConnectionString() string {
 	//	return numNotEmpty
 	//}
 	//
-	//dbServerCa := env.Get[string](ctx, "POSTGRES_SERVER_CA")
-	//dbClientKey := env.Get[string](ctx, "POSTGRES_CLIENT_KEY")
-	//dbClientCert := env.Get[string](ctx, "POSTGRES_CLIENT_CERT")
+	//dbServerCa := env.GetString(ctx, "POSTGRES_SERVER_CA")
+	//dbClientKey := env.GetString(ctx, "POSTGRES_CLIENT_KEY")
+	//dbClientCert := env.GetString(ctx, "POSTGRES_CLIENT_CERT")
 	//
 	//numSSLParams := countNonEmptyStrings(dbServerCa, dbClientKey, dbClientCert)
 	//if numSSLParams == 0 {
@@ -84,10 +84,10 @@ func (c *connectionParams) toConnectionString() string {
 func newConnectionParamsFromEnv() connectionParams {
 	ctx := context.Background()
 	return connectionParams{
-		user:     env.Get[string](ctx, "POSTGRES_USER"),
-		password: env.Get[string](ctx, "POSTGRES_PASSWORD"),
-		dbname:   env.Get[string](ctx, "POSTGRES_DB"),
-		host:     env.Get[string](ctx, "POSTGRES_HOST"),
+		user:     env.GetString(ctx, "POSTGRES_USER"),
+		password: env.GetString(ctx, "POSTGRES_PASSWORD"),
+		dbname:   env.GetString(ctx, "POSTGRES_DB"),
+		host:     env.GetString(ctx, "POSTGRES_HOST"),
 		port:     env.Get[int](ctx, "POSTGRES_PORT"),
 	}
 }

--- a/service/persist/postgres/postgres.go
+++ b/service/persist/postgres/postgres.go
@@ -19,7 +19,6 @@ import (
 	// register postgres driver
 	_ "github.com/jackc/pgx/v4/stdlib"
 	// _ "github.com/lib/pq"
-	"github.com/spf13/viper"
 )
 
 type ErrRoleDoesNotExist struct {
@@ -89,7 +88,7 @@ func newConnectionParamsFromEnv() connectionParams {
 		password: env.Get[string](ctx, "POSTGRES_PASSWORD"),
 		dbname:   env.Get[string](ctx, "POSTGRES_DB"),
 		host:     env.Get[string](ctx, "POSTGRES_HOST"),
-		port:     viper.GetInt("POSTGRES_PORT"),
+		port:     env.Get[int](ctx, "POSTGRES_PORT"),
 	}
 }
 

--- a/service/persist/postgres/postgres.go
+++ b/service/persist/postgres/postgres.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/jackc/pgx/v4"
@@ -67,9 +68,9 @@ func (c *connectionParams) toConnectionString() string {
 	//	return numNotEmpty
 	//}
 	//
-	//dbServerCa := viper.GetString("POSTGRES_SERVER_CA")
-	//dbClientKey := viper.GetString("POSTGRES_CLIENT_KEY")
-	//dbClientCert := viper.GetString("POSTGRES_CLIENT_CERT")
+	//dbServerCa := env.Get[string](ctx, "POSTGRES_SERVER_CA")
+	//dbClientKey := env.Get[string](ctx, "POSTGRES_CLIENT_KEY")
+	//dbClientCert := env.Get[string](ctx, "POSTGRES_CLIENT_CERT")
 	//
 	//numSSLParams := countNonEmptyStrings(dbServerCa, dbClientKey, dbClientCert)
 	//if numSSLParams == 0 {
@@ -82,11 +83,12 @@ func (c *connectionParams) toConnectionString() string {
 }
 
 func newConnectionParamsFromEnv() connectionParams {
+	ctx := context.Background()
 	return connectionParams{
-		user:     viper.GetString("POSTGRES_USER"),
-		password: viper.GetString("POSTGRES_PASSWORD"),
-		dbname:   viper.GetString("POSTGRES_DB"),
-		host:     viper.GetString("POSTGRES_HOST"),
+		user:     env.Get[string](ctx, "POSTGRES_USER"),
+		password: env.Get[string](ctx, "POSTGRES_PASSWORD"),
+		dbname:   env.Get[string](ctx, "POSTGRES_DB"),
+		host:     env.Get[string](ctx, "POSTGRES_HOST"),
 		port:     viper.GetInt("POSTGRES_PORT"),
 	}
 }

--- a/service/pubsub/gcp/pubsub.go
+++ b/service/pubsub/gcp/pubsub.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/util"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/spf13/viper"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -26,10 +26,10 @@ func NewPubSub(pCtx context.Context, opts ...option.ClientOption) (*PubSub, erro
 
 func NewClient(ctx context.Context) *pubsub.Client {
 	options := []option.ClientOption{}
-	projectID := viper.GetString("GOOGLE_CLOUD_PROJECT")
+	projectID := env.Get[string](ctx, "GOOGLE_CLOUD_PROJECT")
 
-	if viper.GetString("ENV") == "local" {
-		if host := viper.GetString("PUBSUB_EMULATOR_HOST"); host != "" {
+	if env.Get[string](ctx, "ENV") == "local" {
+		if host := env.Get[string](ctx, "PUBSUB_EMULATOR_HOST"); host != "" {
 			projectID = "gallery-local"
 			options = append(
 				options,

--- a/service/pubsub/gcp/pubsub.go
+++ b/service/pubsub/gcp/pubsub.go
@@ -26,10 +26,10 @@ func NewPubSub(pCtx context.Context, opts ...option.ClientOption) (*PubSub, erro
 
 func NewClient(ctx context.Context) *pubsub.Client {
 	options := []option.ClientOption{}
-	projectID := env.Get[string](ctx, "GOOGLE_CLOUD_PROJECT")
+	projectID := env.GetString(ctx, "GOOGLE_CLOUD_PROJECT")
 
-	if env.Get[string](ctx, "ENV") == "local" {
-		if host := env.Get[string](ctx, "PUBSUB_EMULATOR_HOST"); host != "" {
+	if env.GetString(ctx, "ENV") == "local" {
+		if host := env.GetString(ctx, "PUBSUB_EMULATOR_HOST"); host != "" {
 			projectID = "gallery-local"
 			options = append(
 				options,

--- a/service/redis/redis.go
+++ b/service/redis/redis.go
@@ -58,8 +58,8 @@ func GetNameForDatabase(databaseId int) string {
 func NewClient(db int) *redis.Client {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	redisURL := env.Get[string](ctx, "REDIS_URL")
-	redisPass := env.Get[string](ctx, "REDIS_PASS")
+	redisURL := env.GetString(ctx, "REDIS_URL")
+	redisPass := env.GetString(ctx, "REDIS_PASS")
 	client := redis.NewClient(&redis.Options{
 		Addr:     redisURL,
 		Password: redisPass,

--- a/service/redis/redis.go
+++ b/service/redis/redis.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/bsm/redislock"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/tracing"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/spf13/viper"
 )
 
 type ErrKeyNotFound struct {
@@ -58,8 +58,8 @@ func GetNameForDatabase(databaseId int) string {
 func NewClient(db int) *redis.Client {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	redisURL := viper.GetString("REDIS_URL")
-	redisPass := viper.GetString("REDIS_PASS")
+	redisURL := env.Get[string](ctx, "REDIS_URL")
+	redisPass := env.Get[string](ctx, "REDIS_PASS")
 	client := redis.NewClient(&redis.Options{
 		Addr:     redisURL,
 		Password: redisPass,

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -94,7 +94,7 @@ func NewEthClient() *ethclient.Client {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	rpcClient, err := rpc.DialContext(ctx, env.Get[string](ctx, "RPC_URL"))
+	rpcClient, err := rpc.DialContext(ctx, env.GetString(ctx, "RPC_URL"))
 	if err != nil {
 		panic(err)
 	}
@@ -105,12 +105,12 @@ func NewEthClient() *ethclient.Client {
 
 // NewEthHTTPClient returns a new http client with request tracing enabled
 func NewEthHTTPClient() *ethclient.Client {
-	if !strings.HasPrefix(env.Get[string](context.Background(), "RPC_URL"), "http") {
+	if !strings.HasPrefix(env.GetString(context.Background(), "RPC_URL"), "http") {
 		return NewEthClient()
 	}
 
 	httpClient := newHTTPClientForRPC(false, sentryutil.TransactionNameSafe("gethRPC"))
-	rpcClient, err := rpc.DialHTTPWithClient(env.Get[string](context.Background(), "RPC_URL"), httpClient)
+	rpcClient, err := rpc.DialHTTPWithClient(env.GetString(context.Background(), "RPC_URL"), httpClient)
 	if err != nil {
 		panic(err)
 	}
@@ -120,7 +120,7 @@ func NewEthHTTPClient() *ethclient.Client {
 
 // NewEthSocketClient returns a new websocket client with request tracing enabled
 func NewEthSocketClient() *ethclient.Client {
-	if !strings.HasPrefix(env.Get[string](context.Background(), "RPC_URL"), "wss") {
+	if !strings.HasPrefix(env.GetString(context.Background(), "RPC_URL"), "wss") {
 		return NewEthClient()
 	}
 
@@ -158,7 +158,7 @@ func (h metricsHandler) Log(r *log.Record) error {
 
 // NewIPFSShell returns an IPFS shell
 func NewIPFSShell() *shell.Shell {
-	sh := shell.NewShellWithClient(env.Get[string](context.Background(), "IPFS_API_URL"), newClientForIPFS(env.Get[string](context.Background(), "IPFS_PROJECT_ID"), env.Get[string](context.Background(), "IPFS_PROJECT_SECRET"), false))
+	sh := shell.NewShellWithClient(env.GetString(context.Background(), "IPFS_API_URL"), newClientForIPFS(env.GetString(context.Background(), "IPFS_PROJECT_ID"), env.GetString(context.Background(), "IPFS_PROJECT_SECRET"), false))
 	sh.SetTimeout(time.Minute * 2)
 	return sh
 }
@@ -647,7 +647,7 @@ func GetIPFSResponse(pCtx context.Context, ipfsClient *shell.Shell, path string)
 
 	// Via HTTP gateway
 	go func() {
-		url := fmt.Sprintf("%s/ipfs/%s", env.Get[string](pCtx, "IPFS_URL"), path)
+		url := fmt.Sprintf("%s/ipfs/%s", env.GetString(pCtx, "IPFS_URL"), path)
 		req, err := http.NewRequestWithContext(pCtx, "GET", url, nil)
 		if err != nil {
 			responseCh <- err
@@ -769,7 +769,7 @@ func getContentHeaders(ctx context.Context, url string) (contentType string, con
 
 // GetIPFSHeaders returns the headers for the given IPFS hash
 func GetIPFSHeaders(ctx context.Context, path string) (contentType string, contentLength int64, err error) {
-	url := fmt.Sprintf("%s/ipfs/%s", env.Get[string](ctx, "IPFS_URL"), path)
+	url := fmt.Sprintf("%s/ipfs/%s", env.GetString(ctx, "IPFS_URL"), path)
 	return getContentHeaders(ctx, url)
 }
 

--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	gcptasks "cloud.google.com/go/cloudtasks/apiv2"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 	"google.golang.org/api/option"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
 	"google.golang.org/grpc"
@@ -63,10 +63,10 @@ func CreateTaskForFeed(ctx context.Context, scheduleOn time.Time, message FeedMe
 		"Event ID": message.ID,
 	})
 
-	url := fmt.Sprintf("%s/tasks/feed-event", viper.GetString("FEED_URL"))
+	url := fmt.Sprintf("%s/tasks/feed-event", env.Get[string](ctx, "FEED_URL"))
 	logger.For(ctx).Infof("creating task for feed event %s, scheduling on %s, sending to %s", message.ID, scheduleOn, url)
 
-	queue := viper.GetString("GCLOUD_FEED_QUEUE")
+	queue := env.Get[string](ctx, "GCLOUD_FEED_QUEUE")
 	task := &taskspb.Task{
 		ScheduleTime: timestamppb.New(scheduleOn),
 		MessageType: &taskspb.Task_HttpRequest{
@@ -76,7 +76,7 @@ func CreateTaskForFeed(ctx context.Context, scheduleOn time.Time, message FeedMe
 				Headers: map[string]string{
 					"Content-type":  "application/json",
 					"sentry-trace":  span.TraceID.String(),
-					"Authorization": "Basic " + viper.GetString("FEED_SECRET"),
+					"Authorization": "Basic " + env.Get[string](ctx, "FEED_SECRET"),
 				},
 			},
 		},
@@ -98,17 +98,17 @@ func CreateTaskForFeedbot(ctx context.Context, scheduleOn time.Time, message Fee
 		"Event ID": message.FeedEventID,
 	})
 
-	queue := viper.GetString("GCLOUD_FEEDBOT_TASK_QUEUE")
+	queue := env.Get[string](ctx, "GCLOUD_FEEDBOT_TASK_QUEUE")
 	task := &taskspb.Task{
 		Name:         fmt.Sprintf("%s/tasks/%s", queue, message.FeedEventID.String()),
 		ScheduleTime: timestamppb.New(scheduleOn),
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{
 				HttpMethod: taskspb.HttpMethod_POST,
-				Url:        fmt.Sprintf("%s/tasks/feed-event", viper.GetString("FEEDBOT_URL")),
+				Url:        fmt.Sprintf("%s/tasks/feed-event", env.Get[string](ctx, "FEEDBOT_URL")),
 				Headers: map[string]string{
 					"Content-type":  "application/json",
-					"Authorization": "Basic " + viper.GetString("FEEDBOT_SECRET"),
+					"Authorization": "Basic " + env.Get[string](ctx, "FEEDBOT_SECRET"),
 					"sentry-trace":  span.TraceID.String(),
 				},
 			},
@@ -129,12 +129,12 @@ func CreateTaskForTokenProcessing(ctx context.Context, client *gcptasks.Client, 
 
 	tracing.AddEventDataToSpan(span, map[string]interface{}{"User ID": message.UserID})
 
-	queue := viper.GetString("TOKEN_PROCESSING_QUEUE")
+	queue := env.Get[string](ctx, "TOKEN_PROCESSING_QUEUE")
 	task := &taskspb.Task{
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{
 				HttpMethod: taskspb.HttpMethod_POST,
-				Url:        fmt.Sprintf("%s/media/process", viper.GetString("TOKEN_PROCESSING_URL")),
+				Url:        fmt.Sprintf("%s/media/process", env.Get[string](ctx, "TOKEN_PROCESSING_URL")),
 				Headers: map[string]string{
 					"Content-type": "application/json",
 					"sentry-trace": span.TraceID.String(),
@@ -159,12 +159,12 @@ func CreateTaskForContractOwnerProcessing(ctx context.Context, message TokenProc
 		"Contract ID": message.ContractID,
 	})
 
-	queue := viper.GetString("TOKEN_PROCESSING_QUEUE")
+	queue := env.Get[string](ctx, "TOKEN_PROCESSING_QUEUE")
 	task := &taskspb.Task{
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{
 				HttpMethod: taskspb.HttpMethod_POST,
-				Url:        fmt.Sprintf("%s/owners/process/contract", viper.GetString("TOKEN_PROCESSING_URL")),
+				Url:        fmt.Sprintf("%s/owners/process/contract", env.Get[string](ctx, "TOKEN_PROCESSING_URL")),
 				Headers: map[string]string{
 					"Content-type": "application/json",
 					"sentry-trace": span.TraceID.String(),
@@ -185,12 +185,12 @@ func CreateTaskForDeepRefresh(ctx context.Context, message DeepRefreshMessage, c
 	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForDeepRefresh")
 	defer tracing.FinishSpan(span)
 
-	queue := viper.GetString("GCLOUD_REFRESH_TASK_QUEUE")
+	queue := env.Get[string](ctx, "GCLOUD_REFRESH_TASK_QUEUE")
 	task := &taskspb.Task{
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{
 				HttpMethod: taskspb.HttpMethod_POST,
-				Url:        fmt.Sprintf("%s/tasks/refresh", viper.GetString("INDEXER_HOST")),
+				Url:        fmt.Sprintf("%s/tasks/refresh", env.Get[string](ctx, "INDEXER_HOST")),
 				Headers: map[string]string{
 					"Content-type": "application/json",
 					"sentry-trace": span.TraceID.String(),
@@ -211,12 +211,12 @@ func CreateTaskForWalletValidation(ctx context.Context, message ValidateNFTsMess
 	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForWalletValidate")
 	defer tracing.FinishSpan(span)
 
-	queue := viper.GetString("GCLOUD_WALLET_VALIDATE_QUEUE")
+	queue := env.Get[string](ctx, "GCLOUD_WALLET_VALIDATE_QUEUE")
 	task := &taskspb.Task{
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{
 				HttpMethod: taskspb.HttpMethod_POST,
-				Url:        fmt.Sprintf("%s/nfts/validate", viper.GetString("INDEXER_HOST")),
+				Url:        fmt.Sprintf("%s/nfts/validate", env.Get[string](ctx, "INDEXER_HOST")),
 				Headers: map[string]string{
 					"Content-type": "application/json",
 					"sentry-trace": span.TraceID.String(),
@@ -244,8 +244,8 @@ func NewClient(ctx context.Context) *gcptasks.Client {
 
 	// Configure the client depending on whether or not
 	// the cloud task emulator is used.
-	if viper.GetString("ENV") == "local" {
-		if host := viper.GetString("TASK_QUEUE_HOST"); host != "" {
+	if env.Get[string](ctx, "ENV") == "local" {
+		if host := env.Get[string](ctx, "TASK_QUEUE_HOST"); host != "" {
 			copts = append(
 				copts,
 				option.WithEndpoint(host),

--- a/service/twitter/twitter.go
+++ b/service/twitter/twitter.go
@@ -102,7 +102,7 @@ func (a *API) generateAuthTokenFromCode(ctx context.Context, authCode string) (A
 	q := url.Values{}
 	q.Set("code", authCode)
 	q.Set("grant_type", "authorization_code")
-	q.Set("redirect_uri", env.Get[string](ctx, "TWITTER_AUTH_REDIRECT_URI"))
+	q.Set("redirect_uri", env.GetString(ctx, "TWITTER_AUTH_REDIRECT_URI"))
 	q.Set("code_verifier", "challenge")
 	encoded := q.Encode()
 
@@ -115,7 +115,7 @@ func (a *API) generateAuthTokenFromCode(ctx context.Context, authCode string) (A
 	accessReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(encoded)))
 	accessReq.Header.Set("Accept", "*/*")
 
-	accessReq.SetBasicAuth(env.Get[string](ctx, "TWITTER_CLIENT_ID"), env.Get[string](ctx, "TWITTER_CLIENT_SECRET"))
+	accessReq.SetBasicAuth(env.GetString(ctx, "TWITTER_CLIENT_ID"), env.GetString(ctx, "TWITTER_CLIENT_SECRET"))
 
 	accessResp, err := http.DefaultClient.Do(accessReq)
 	if err != nil {
@@ -155,7 +155,7 @@ func (a *API) generateAuthTokenFromRefresh(ctx context.Context, refreshToken str
 	accessReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(encoded)))
 	accessReq.Header.Set("Accept", "*/*")
 
-	accessReq.SetBasicAuth(env.Get[string](ctx, "TWITTER_CLIENT_ID"), env.Get[string](ctx, "TWITTER_CLIENT_SECRET"))
+	accessReq.SetBasicAuth(env.GetString(ctx, "TWITTER_CLIENT_ID"), env.GetString(ctx, "TWITTER_CLIENT_SECRET"))
 
 	accessResp, err := http.DefaultClient.Do(accessReq)
 	if err != nil {

--- a/service/twitter/twitter.go
+++ b/service/twitter/twitter.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/redis"
 	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/mikeydub/go-gallery/util"
-	"github.com/spf13/viper"
 )
 
 const maxFollowingReturn = 1000
@@ -94,7 +94,7 @@ func (a *API) generateAuthTokenFromCode(ctx context.Context, authCode string) (A
 	q := url.Values{}
 	q.Set("code", authCode)
 	q.Set("grant_type", "authorization_code")
-	q.Set("redirect_uri", viper.GetString("TWITTER_AUTH_REDIRECT_URI"))
+	q.Set("redirect_uri", env.Get[string](ctx, "TWITTER_AUTH_REDIRECT_URI"))
 	q.Set("code_verifier", "challenge")
 	encoded := q.Encode()
 
@@ -107,7 +107,7 @@ func (a *API) generateAuthTokenFromCode(ctx context.Context, authCode string) (A
 	accessReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(encoded)))
 	accessReq.Header.Set("Accept", "*/*")
 
-	accessReq.SetBasicAuth(viper.GetString("TWITTER_CLIENT_ID"), viper.GetString("TWITTER_CLIENT_SECRET"))
+	accessReq.SetBasicAuth(env.Get[string](ctx, "TWITTER_CLIENT_ID"), env.Get[string](ctx, "TWITTER_CLIENT_SECRET"))
 
 	accessResp, err := http.DefaultClient.Do(accessReq)
 	if err != nil {
@@ -147,7 +147,7 @@ func (a *API) generateAuthTokenFromRefresh(ctx context.Context, refreshToken str
 	accessReq.Header.Set("Content-Length", fmt.Sprintf("%d", len(encoded)))
 	accessReq.Header.Set("Accept", "*/*")
 
-	accessReq.SetBasicAuth(viper.GetString("TWITTER_CLIENT_ID"), viper.GetString("TWITTER_CLIENT_SECRET"))
+	accessReq.SetBasicAuth(env.Get[string](ctx, "TWITTER_CLIENT_ID"), env.Get[string](ctx, "TWITTER_CLIENT_SECRET"))
 
 	accessResp, err := http.DefaultClient.Do(accessReq)
 	if err != nil {

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -108,7 +108,7 @@ func initSentry() {
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
 		Environment:      env.Get[string](context.Background(), "ENV"),
-		TracesSampleRate: viper.GetFloat64("SENTRY_TRACES_SAMPLE_RATE"),
+		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
 		Release:          env.Get[string](context.Background(), "VERSION"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -40,7 +40,7 @@ func coreInitServer() *gin.Engine {
 
 	router.Use(middleware.GinContextToContext(), middleware.Sentry(true), middleware.Tracing(), middleware.HandleCORS(), middleware.ErrLogger())
 
-	if env.Get[string](context.Background(), "ENV") != "production" {
+	if env.GetString(context.Background(), "ENV") != "production" {
 		gin.SetMode(gin.DebugMode)
 		logrus.SetLevel(logrus.DebugLevel)
 	}
@@ -51,7 +51,7 @@ func coreInitServer() *gin.Engine {
 	c := server.ClientInit(context.Background())
 	mc := server.NewMultichainProvider(c)
 
-	return handlersInitServer(router, mc, c.Repos, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.Get[string](context.Background(), "GCLOUD_TOKEN_CONTENT_BUCKET"), t)
+	return handlersInitServer(router, mc, c.Repos, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.GetString(context.Background(), "GCLOUD_TOKEN_CONTENT_BUCKET"), t)
 }
 
 func setDefaults() {
@@ -76,7 +76,7 @@ func setDefaults() {
 
 	viper.AutomaticEnv()
 
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 	} else {
 		fi := "local"
@@ -87,7 +87,7 @@ func setDefaults() {
 		util.LoadEncryptedEnvFile(envFile)
 	}
 
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		util.VarNotSetTo("SENTRY_DSN", "")
 		util.VarNotSetTo("VERSION", "")
 	}
@@ -98,7 +98,7 @@ func newThrottler() *throttle.Locker {
 }
 
 func initSentry() {
-	if env.Get[string](context.Background(), "ENV") == "local" {
+	if env.GetString(context.Background(), "ENV") == "local" {
 		logger.For(nil).Info("skipping sentry init")
 		return
 	}
@@ -106,10 +106,10 @@ func initSentry() {
 	logger.For(nil).Info("initializing sentry...")
 
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              env.Get[string](context.Background(), "SENTRY_DSN"),
-		Environment:      env.Get[string](context.Background(), "ENV"),
+		Dsn:              env.GetString(context.Background(), "SENTRY_DSN"),
+		Environment:      env.GetString(context.Background(), "ENV"),
 		TracesSampleRate: env.Get[float64](context.Background(), "SENTRY_TRACES_SAMPLE_RATE"),
-		Release:          env.Get[string](context.Background(), "VERSION"),
+		Release:          env.GetString(context.Background(), "VERSION"),
 		AttachStacktrace: true,
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			event = auth.ScrubEventCookies(event, hint)

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -450,7 +450,7 @@ func FindFirstFieldFromMap(it map[string]interface{}, fields ...string) interfac
 
 // VarNotSetTo panics if an environment variable is not set or set to `emptyVal`.
 func VarNotSetTo(envVar, emptyVal string) {
-	setTo := env.Get[string](context.Background(), envVar)
+	setTo := env.GetString(context.Background(), envVar)
 	if setTo == emptyVal || setTo == "" {
 		panic(fmt.Sprintf("%s must be set", envVar))
 	}
@@ -509,7 +509,7 @@ func ResolveEnvFile(service string, env string) string {
 
 // LoadEncryptedEnvFile configures the environment with the configured input file.
 func LoadEncryptedEnvFile(filePath string) {
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 		return
 	}
@@ -531,7 +531,7 @@ func LoadEncryptedEnvFile(filePath string) {
 
 // LoadEnvFile configures the environment with the configured input file.
 func LoadEnvFile(filePath string) {
-	if env.Get[string](context.Background(), "ENV") != "local" {
+	if env.GetString(context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 		return
 	}

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgtype"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/spf13/viper"
 	"go.mozilla.org/sops/v3/decrypt"
@@ -449,7 +450,7 @@ func FindFirstFieldFromMap(it map[string]interface{}, fields ...string) interfac
 
 // VarNotSetTo panics if an environment variable is not set or set to `emptyVal`.
 func VarNotSetTo(envVar, emptyVal string) {
-	setTo := viper.GetString(envVar)
+	setTo := env.Get[string](context.Background(), envVar)
 	if setTo == emptyVal || setTo == "" {
 		panic(fmt.Sprintf("%s must be set", envVar))
 	}
@@ -508,7 +509,7 @@ func ResolveEnvFile(service string, env string) string {
 
 // LoadEncryptedEnvFile configures the environment with the configured input file.
 func LoadEncryptedEnvFile(filePath string) {
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 		return
 	}
@@ -530,7 +531,7 @@ func LoadEncryptedEnvFile(filePath string) {
 
 // LoadEnvFile configures the environment with the configured input file.
 func LoadEnvFile(filePath string) {
-	if viper.GetString("ENV") != "local" {
+	if env.Get[string](context.Background(), "ENV") != "local" {
 		logger.For(nil).Info("running in non-local environment, skipping environment configuration")
 		return
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -134,6 +135,7 @@ func RegisterCustomValidators(v *validator.Validate) {
 	v.RegisterValidation("chain", ChainValidator)
 	v.RegisterValidation("role", IsValidRole)
 	v.RegisterValidation("created_collections", CreatedCollectionsValidator)
+	v.RegisterValidation("http", HTTPValidator)
 	v.RegisterAlias("collection_name", "max=200")
 	v.RegisterAlias("collection_note", "max=600")
 	v.RegisterAlias("token_note", "max=1200")
@@ -248,6 +250,27 @@ var NonceValidator validator.Func = func(fl validator.FieldLevel) bool {
 		return true
 	}
 	return len(nonce) >= 10 && len(nonce) <= 150
+}
+
+// HTTPValidator validates a string ensuring it is an HTTP url
+var HTTPValidator validator.Func = func(fl validator.FieldLevel) bool {
+	s := fl.Field().String()
+
+	if s == "" {
+		return true
+	}
+
+	_, err := url.ParseRequestURI(s)
+	if err != nil {
+		return false
+	}
+
+	u, err := url.Parse(s)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+
+	return true
 }
 
 // UsernameValidator ensures that usernames are not reserved, are alphanumeric with the exception of underscores and periods, and do not contain consecutive periods or underscores


### PR DESCRIPTION
Changes:

- **Added** new `env.Get[T](context.Context, string)` func for retrieving environment variables (don't use `viper.GetString` anymore)
- **Added** new way to use `init()` funcs to establish runtime validation for environment variables


Examples:

## Getting a string Env var
```
func UpdateUser(ctx context.Context, userID persist.DBID) error {
    specialUserEnvField := env.Get[string](ctx, "USER_ENV_FIELD")
    ...
}
```

## Setting validation
```
func init() {
    env.RegisterEnvValidation("REQUIRED_ENV_VAR", []string{"required", "another_validation_tag_maybe"})
}


func UseRequiredEnvVar(ctx context.Context) error {
    weReallyNeedThisSetHere := env.Get[string](ctx, "REQUIRED_ENV_VAR")
    // if this was not set it will error log it using the logger.For(ctx)
    ...
}
```

