### PR TITLE
only use valid thumbnail for animation like media

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -1174,12 +1174,12 @@ func tokensToNewDedupedTokens(ctx context.Context, tokens []chainTokens, contrac
 			if !seen {
 				seenTokens[ti] = candidateToken
 			} else if !existingToken.Media.IsServable() && candidateToken.Media.IsServable() {
-				if persist.TokenURI(existingToken.Media.ThumbnailURL).IsRenderable() && !persist.TokenURI(candidateToken.Media.ThumbnailURL).IsRenderable() {
+				if existingToken.Media.MediaType.IsAnimationLike() && persist.TokenURI(existingToken.Media.ThumbnailURL).IsRenderable() && !persist.TokenURI(candidateToken.Media.ThumbnailURL).IsRenderable() {
 					candidateToken.Media.ThumbnailURL = existingToken.Media.ThumbnailURL
 				}
 				seenTokens[ti] = candidateToken
 			} else if existingToken.Media.IsServable() {
-				if !persist.TokenURI(existingToken.Media.ThumbnailURL).IsRenderable() && persist.TokenURI(candidateToken.Media.ThumbnailURL).IsRenderable() {
+				if candidateToken.Media.MediaType.IsAnimationLike() && !persist.TokenURI(existingToken.Media.ThumbnailURL).IsRenderable() && persist.TokenURI(candidateToken.Media.ThumbnailURL).IsRenderable() {
 					existingToken.Media.ThumbnailURL = candidateToken.Media.ThumbnailURL
 				}
 				seenTokens[ti] = existingToken


### PR DESCRIPTION
Changes:

- **Added** check to ensure that we only replace valid thumbnails for media types that need thumbnails