### PR TITLE
Fix syncing bug and only process new tokens on syncs

### DIFF
--- a/indexer/core.go
+++ b/indexer/core.go
@@ -127,7 +127,7 @@ func SetDefaults() {
 	viper.SetDefault("GCLOUD_TOKEN_CONTENT_BUCKET", "dev-token-content")
 	viper.SetDefault("POSTGRES_HOST", "0.0.0.0")
 	viper.SetDefault("POSTGRES_PORT", 5433)
-	viper.SetDefault("POSTGRES_USER", "gallery_backend")
+	viper.SetDefault("POSTGRES_USER", "postgres")
 	viper.SetDefault("POSTGRES_PASSWORD", "")
 	viper.SetDefault("POSTGRES_DB", "postgres")
 	viper.SetDefault("ALLOWED_ORIGINS", "http://localhost:3000")

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -417,7 +417,6 @@ func (p *Provider) prepTokensForTokenProcessing(ctx context.Context, tokensFromP
 	}
 
 	newTokens := make(map[persist.TokenIdentifiers]bool)
-	syncingTokens := make([]persist.DBID, 0, len(providerTokens))
 
 	for i, token := range providerTokens {
 		existingToken, exists := tokenLookup[token.TokenIdentifiers()]
@@ -431,7 +430,6 @@ func (p *Provider) prepTokensForTokenProcessing(ctx context.Context, tokensFromP
 		// so we can show the loading state instead of a broken token while tokenprocessing handles it.
 		if !exists && !token.Media.IsServable() {
 			providerTokens[i].Media = persist.Media{MediaType: persist.MediaTypeSyncing}
-			syncingTokens = append(syncingTokens, token.ID)
 		}
 
 		if !exists {

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -400,15 +400,15 @@ outer:
 	return err
 }
 
-func (p *Provider) prepTokensForTokenProcessing(ctx context.Context, tokensFromProviders []chainTokens, addressToContract map[string]persist.DBID, user persist.User) ([]persist.TokenGallery, error) {
+func (p *Provider) prepTokensForTokenProcessing(ctx context.Context, tokensFromProviders []chainTokens, addressToContract map[string]persist.DBID, user persist.User) ([]persist.TokenGallery, map[persist.TokenIdentifiers]bool, error) {
 	providerTokens, err := tokensToNewDedupedTokens(ctx, tokensFromProviders, addressToContract, user)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	currentTokens, err := p.Repos.TokenRepository.GetByUserID(ctx, user.ID, 0, 0)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	tokenLookup := make(map[persist.TokenIdentifiers]persist.TokenGallery)
@@ -416,28 +416,39 @@ func (p *Provider) prepTokensForTokenProcessing(ctx context.Context, tokensFromP
 		tokenLookup[token.TokenIdentifiers()] = token
 	}
 
+	newTokens := make(map[persist.TokenIdentifiers]bool)
+	syncingTokens := make([]persist.DBID, 0, len(providerTokens))
+
 	for i, token := range providerTokens {
+		existingToken, exists := tokenLookup[token.TokenIdentifiers()]
 		// Add already existing media to the provider token if it exists so that
 		// we can display media for a token while it gets handled by tokenprocessing
-		if dbToken := tokenLookup[token.TokenIdentifiers()]; !token.Media.IsServable() && dbToken.Media.IsServable() {
-			providerTokens[i].Media = dbToken.Media
+		if !token.Media.IsServable() && existingToken.Media.IsServable() {
+			providerTokens[i].Media = existingToken.Media
 		}
+
 		// There's no available media for the token at this point, so set the state to syncing
 		// so we can show the loading state instead of a broken token while tokenprocessing handles it.
-		if !providerTokens[i].Media.IsServable() {
+		if !exists && !token.Media.IsServable() {
 			providerTokens[i].Media = persist.Media{MediaType: persist.MediaTypeSyncing}
+			syncingTokens = append(syncingTokens, token.ID)
+		}
+
+		if !exists {
+			newTokens[token.TokenIdentifiers()] = true
 		}
 	}
 
-	return providerTokens, nil
+	return providerTokens, newTokens, nil
 }
 
 func (p *Provider) processTokensForOwnersOfContract(ctx context.Context, contractID persist.DBID, users map[persist.DBID]persist.User, chainTokensForUsers map[persist.DBID][]chainTokens, addressToContract map[string]persist.DBID) error {
 	tokensToUpsert := make([]persist.TokenGallery, 0, len(chainTokensForUsers)*3)
 	userTokenOffsets := make(map[persist.DBID][2]int)
+	newUserTokens := make(map[persist.DBID]map[persist.TokenIdentifiers]bool)
 
 	for userID, user := range users {
-		tokens, err := p.prepTokensForTokenProcessing(ctx, chainTokensForUsers[userID], addressToContract, user)
+		tokens, newTokens, err := p.prepTokensForTokenProcessing(ctx, chainTokensForUsers[userID], addressToContract, user)
 		if err != nil {
 			return err
 		}
@@ -445,6 +456,7 @@ func (p *Provider) processTokensForOwnersOfContract(ctx context.Context, contrac
 		start := len(tokensToUpsert)
 		tokensToUpsert = append(tokensToUpsert, tokens...)
 		userTokenOffsets[userID] = [2]int{start, start + len(tokens)}
+		newUserTokens[userID] = newTokens
 	}
 
 	persistedTokens, err := p.Repos.TokenRepository.BulkUpsertTokensOfContract(ctx, contractID, tokensToUpsert, false)
@@ -459,7 +471,16 @@ func (p *Provider) processTokensForOwnersOfContract(ctx context.Context, contrac
 
 	errors := make([]error, 0)
 	for userID, offset := range userTokenOffsets {
-		err = p.sendTokensToTokenProcessing(ctx, userID, persistedTokens[offset[0]:offset[1]])
+		start, end := offset[0], offset[1]
+		userTokenIDs := make([]persist.DBID, 0, end-start)
+
+		for _, token := range persistedTokens[start:end] {
+			if newUserTokens[userID][token.TokenIdentifiers()] {
+				userTokenIDs = append(userTokenIDs, token.ID)
+			}
+		}
+
+		err = p.sendTokensToTokenProcessing(ctx, userID, userTokenIDs)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -473,7 +494,7 @@ func (p *Provider) processTokensForOwnersOfContract(ctx context.Context, contrac
 }
 
 func (p *Provider) processTokensForUser(ctx context.Context, tokensFromProviders []chainTokens, addressToContract map[string]persist.DBID, user persist.User, chains []persist.Chain, skipDelete bool) ([]persist.TokenGallery, error) {
-	dedupedTokens, err := p.prepTokensForTokenProcessing(ctx, tokensFromProviders, addressToContract, user)
+	dedupedTokens, newTokens, err := p.prepTokensForTokenProcessing(ctx, tokensFromProviders, addressToContract, user)
 	if err != nil {
 		return nil, err
 	}
@@ -483,27 +504,25 @@ func (p *Provider) processTokensForUser(ctx context.Context, tokensFromProviders
 		return nil, err
 	}
 
-	err = p.sendTokensToTokenProcessing(ctx, user.ID, persistedTokens)
-	return persistedTokens, err
-}
-
-func (p *Provider) sendTokensToTokenProcessing(ctx context.Context, userID persist.DBID, tokens []persist.TokenGallery) error {
-	tokensToProcess := make([]persist.DBID, 0, len(tokens))
-	for _, token := range tokens {
-		// Process net new tokens based on the creation and update time so that new tokens are handled at least once by tokenprocessing.
-		// Also process tokens that are in a syncing state either from this sync or tokens that were left syncing for whatever reason.
-		if (token.CreationTime.Time() == token.LastUpdated.Time()) || token.Media.MediaType == persist.MediaTypeSyncing {
-			tokensToProcess = append(tokensToProcess, token.ID)
+	tokenIDs := make([]persist.DBID, 0, len(newTokens))
+	for _, token := range persistedTokens {
+		if newTokens[token.TokenIdentifiers()] {
+			tokenIDs = append(tokenIDs, token.ID)
 		}
 	}
 
-	if len(tokensToProcess) == 0 {
+	err = p.sendTokensToTokenProcessing(ctx, user.ID, tokenIDs)
+	return persistedTokens, err
+}
+
+func (p *Provider) sendTokensToTokenProcessing(ctx context.Context, userID persist.DBID, tokens []persist.DBID) error {
+	if len(tokens) == 0 {
 		return nil
 	}
 
 	return task.CreateTaskForTokenProcessing(ctx, p.TasksClient, task.TokenProcessingUserMessage{
 		UserID:   userID,
-		TokenIDs: tokensToProcess,
+		TokenIDs: tokens,
 	})
 }
 

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -44,7 +44,8 @@ func processMediaForUsersTokensOfChain(mc *multichain.Provider, tokenRepo *postg
 		ctx := logger.NewContextWithFields(c, logrus.Fields{"userID": input.UserID})
 
 		if err := throttler.Lock(ctx, input.UserID.String()); err != nil {
-			util.ErrResponse(c, http.StatusOK, err)
+			// Reply with a non-200 status so that the message is tried again later on
+			util.ErrResponse(c, http.StatusTooManyRequests, err)
 			return
 		}
 		defer throttler.Unlock(ctx, input.UserID.String())


### PR DESCRIPTION
This PR changes tokenprocessing to reply with a `429` status code when a sync is already in progress for a user. Replying with a non-200 status code will re-queue the message for retry so that tokens that are syncing will eventually get processed again.

This PR also ensures that only newly synced tokens are sent to tokenprocessing so that consecutive syncs don't send the same faulty tokens to tokenprocessing each time.