### PR TITLE
Fix OpenSea fetch metadata

### DIFF
--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -446,9 +446,11 @@ func FetchAssetsForTokenIdentifiers(ctx context.Context, contractAddress persist
 func FetchAssetsForTokenIdentifiersAndOwner(ctx context.Context, ownerAddress, contractAddress persist.EthereumAddress, tokenID TokenID) ([]Asset, error) {
 	url := baseURL.JoinPath("assets")
 	setPagingParams(url)
-	setOwner(url, ownerAddress)
 	setContractAddress(url, contractAddress)
 	setTokenID(url, tokenID)
+	if ownerAddress != "" {
+		setOwner(url, ownerAddress)
+	}
 
 	req, err := authRequest(ctx, url.String())
 	if err != nil {


### PR DESCRIPTION
Request from OS we're failing since `ownerAddress` can occasionally be empty.

[Cloud run logs](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22tokenprocessing-v2%22%0Aresource.labels.location%20%3D%20%22us-east1%22%0A%20severity%3E%3DDEFAULT%0A%22Address%20like%20string%22;timeRange=2023-03-28T22:29:09.435Z%2F2023-03-28T22:29:09.435Z--PT24H;cursorTimestamp=2023-03-28T21:47:57.513559420Z?project=gallery-prod-325303)