### PR TITLE
get contract metadata using batch api

### DIFF
--- a/indexer/core.go
+++ b/indexer/core.go
@@ -61,7 +61,7 @@ func coreInit(fromBlock, toBlock *uint64, quietLogs, enableRPC bool) (*gin.Engin
 		rpcEnabled = true
 	}
 
-	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(env.GetInt("CHAIN")), defaultTransferEvents, nil, fromBlock, toBlock)
+	i := newIndexer(ethClient, &http.Client{Timeout: 10 * time.Minute}, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(env.GetInt("CHAIN")), defaultTransferEvents, nil, fromBlock, toBlock)
 
 	router := gin.Default()
 
@@ -110,7 +110,7 @@ func coreInitServer(quietLogs, enableRPC bool) *gin.Engine {
 	queueChan := make(chan processTokensInput)
 	t := newThrottler()
 
-	i := newIndexer(ethClient, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(env.GetInt("CHAIN")), defaultTransferEvents, nil, nil, nil)
+	i := newIndexer(ethClient, &http.Client{Timeout: 10 * time.Minute}, ipfsClient, arweaveClient, s, tokenRepo, contractRepo, addressFilterRepo, persist.Chain(env.GetInt("CHAIN")), defaultTransferEvents, nil, nil, nil)
 
 	go processMissingMetadata(ctx, queueChan, tokenRepo, contractRepo, ipfsClient, ethClient, arweaveClient, s, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), t)
 	return handlersInitServer(router, queueChan, tokenRepo, contractRepo, ethClient, ipfsClient, arweaveClient, s, i)
@@ -136,6 +136,7 @@ func SetDefaults() {
 	viper.SetDefault("SENTRY_DSN", "")
 	viper.SetDefault("IMGIX_API_KEY", "")
 	viper.SetDefault("VERSION", "")
+	viper.SetDefault("ALCHEMY_API_URL", "")
 	viper.AutomaticEnv()
 }
 

--- a/indexer/hook.go
+++ b/indexer/hook.go
@@ -2,16 +2,17 @@ package indexer
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
 type DBHook[T any] func(ctx context.Context, it []T) error
 
-func newContractHooks(repo persist.ContractRepository) []DBHook[persist.Contract] {
+func newContractHooks(repo persist.ContractRepository, httpClient *http.Client) []DBHook[persist.Contract] {
 	return []DBHook[persist.Contract]{
 		func(ctx context.Context, it []persist.Contract) error {
-			return repo.BulkUpsert(ctx, it)
+			return repo.BulkUpsert(ctx, fillContractFields(ctx, it, repo, httpClient))
 		},
 	}
 }

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1,10 +1,13 @@
 package indexer
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/big"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,15 +30,18 @@ import (
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer/refresh"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/multichain/alchemy"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/tracing"
+	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
 )
 
 func init() {
 	env.RegisterValidation("GCLOUD_TOKEN_CONTENT_BUCKET", "required")
+	env.RegisterValidation("ALCHEMY_API_URL", "required")
 }
 
 const (
@@ -110,6 +116,7 @@ type indexer struct {
 	ipfsClient        *shell.Shell
 	arweaveClient     *goar.Client
 	storageClient     *storage.Client
+	httpClient        *http.Client
 	tokenRepo         persist.TokenRepository
 	contractRepo      persist.ContractRepository
 	addressFilterRepo refresh.AddressFilterRepository
@@ -137,7 +144,7 @@ type indexer struct {
 }
 
 // newIndexer sets up an indexer for retrieving the specified events that will process tokens
-func newIndexer(ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenRepo persist.TokenRepository, contractRepo persist.ContractRepository, addressFilterRepo refresh.AddressFilterRepository, pChain persist.Chain, pEvents []eventHash, getLogsFunc getLogsFunc, startingBlock, maxBlock *uint64) *indexer {
+func newIndexer(ethClient *ethclient.Client, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenRepo persist.TokenRepository, contractRepo persist.ContractRepository, addressFilterRepo refresh.AddressFilterRepository, pChain persist.Chain, pEvents []eventHash, getLogsFunc getLogsFunc, startingBlock, maxBlock *uint64) *indexer {
 	if rpcEnabled && ethClient == nil {
 		panic("RPC is enabled but an ethClient wasn't provided!")
 	}
@@ -147,6 +154,7 @@ func newIndexer(ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveCli
 		ipfsClient:        ipfsClient,
 		arweaveClient:     arweaveClient,
 		storageClient:     storageClient,
+		httpClient:        httpClient,
 		tokenRepo:         tokenRepo,
 		contractRepo:      contractRepo,
 		addressFilterRepo: addressFilterRepo,
@@ -165,7 +173,7 @@ func newIndexer(ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveCli
 
 		getLogsFunc: getLogsFunc,
 
-		contractDBHooks: newContractHooks(contractRepo),
+		contractDBHooks: newContractHooks(contractRepo, httpClient),
 		tokenDBHooks:    newTokenHooks(),
 	}
 
@@ -802,37 +810,91 @@ func contractsPluginReceiver(cur contractAtBlock, inc contractAtBlock) contractA
 	return inc
 }
 
-func fillContractFields(ctx context.Context, contractRepo persist.ContractRepository, ethClient *ethclient.Client, contractAddress persist.EthereumAddress, lastSyncedBlock persist.BlockNumber, seenContracts *sync.Map) persist.Contract {
-	c := persist.Contract{
-		Address:     contractAddress,
-		LatestBlock: lastSyncedBlock,
-	}
+type alchemyContractMetadata struct {
+	Address  persist.EthereumAddress  `json:"address"`
+	Metadata alchemy.ContractMetadata `json:"contractMetadata"`
+}
 
-	if it, ok := seenContracts.Load(contractAddress); ok {
-		return it.(persist.Contract)
-	}
+func fillContractFields(ctx context.Context, contracts []persist.Contract, contractRepo persist.ContractRepository, httpClient *http.Client) []persist.Contract {
 
-	cur, err := contractRepo.GetByAddress(ctx, contractAddress)
-	if err == nil && (cur.Name != "" || cur.Symbol != "") {
-		c.Name = cur.Name
-		c.Symbol = cur.Symbol
-	} else {
-		cMetadata, err := rpc.GetTokenContractMetadata(ctx, contractAddress, ethClient)
+	result := make([]persist.Contract, 0, len(contracts))
+
+	contractsNotInDB := util.Filter(contracts, func(c persist.Contract) bool {
+		_, err := contractRepo.GetByAddress(ctx, c.Address)
 		if err != nil {
-			logEntry := logger.For(ctx).WithError(err).WithFields(logrus.Fields{
-				"contractAddress": contractAddress,
-				"rpcCall":         "eth_call",
-			})
-			logEthCallRPCError(logEntry, err, "error getting contract metadata")
-		} else {
-			c.Name = persist.NullString(cMetadata.Name)
-			c.Symbol = persist.NullString(cMetadata.Symbol)
+			logger.For(ctx).WithError(err).Errorf("Error getting contract %s from db", c.Address)
 		}
+		return err != nil
+	}, true)
+
+	// process contracts in batches of 100
+	for i := 0; i < len(contractsNotInDB); i += 100 {
+		end := i + 100
+		if end > len(contracts) {
+			end = len(contracts)
+		}
+		batch := contracts[i:end]
+
+		cToAddr := make(map[string]persist.Contract)
+		for _, c := range batch {
+			cToAddr[c.Address.String()] = c
+		}
+
+		addresses := util.MapKeys(cToAddr)
+
+		// get contract metadata
+
+		u := fmt.Sprintf("%s/getContractMetadataBatch", env.GetString("ALCHEMY_API_URL"))
+
+		in := map[string][]string{"contractAddresses": addresses}
+		inAsJSON, err := json.Marshal(in)
+		if err != nil {
+			logger.For(ctx).WithError(err).Error("Failed to marshal contract metadata request")
+			continue
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewBuffer(inAsJSON))
+		if err != nil {
+			logger.For(ctx).WithError(err).Error("Failed to create contract metadata request")
+			continue
+		}
+
+		req.Header.Add("accept", "application/json")
+		req.Header.Add("content-type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			logger.For(ctx).WithError(err).Error("Failed to execute contract metadata request")
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			bodyAsBytes, _ := ioutil.ReadAll(resp.Body)
+			logger.For(ctx).Errorf("Failed to execute contract metadata request: %s status: %s (url: %s) (input: %s) ", string(bodyAsBytes), resp.Status, u, string(inAsJSON))
+			continue
+		}
+
+		var out []alchemyContractMetadata
+		err = json.NewDecoder(resp.Body).Decode(&out)
+		if err != nil {
+			logger.For(ctx).WithError(err).Error("Failed to decode contract metadata response")
+			continue
+		}
+
+		for _, c := range out {
+			contract := cToAddr[c.Address.String()]
+			contract.Name = persist.NullString(c.Metadata.Name)
+			contract.Symbol = persist.NullString(c.Metadata.Symbol)
+			result = append(result, contract)
+		}
+
+		logger.For(ctx).Infof("Fetched metadata for %d contracts", len(out))
+
 	}
 
-	seenContracts.Store(contractAddress, c)
+	logger.For(ctx).Infof("Fetched metadata for %d contracts starting with %d contracts", len(result), len(contracts))
 
-	return c
+	return result
 }
 
 // HELPER FUNCS ---------------------------------------------------------------

--- a/indexer/plugin.go
+++ b/indexer/plugin.go
@@ -146,30 +146,16 @@ func newContractsPlugin(ctx context.Context, contractRepo persist.ContractReposi
 				child := span.StartChild("plugin.ownerPlugin")
 				child.Description = "handleMessage"
 
-				if rpcEnabled {
-
-					contract := fillContractFields(ctx, contractRepo, ethClient, msg.transfer.ContractAddress, msg.transfer.BlockNumber, seenContracts)
-					out <- contractAtBlock{
-						ti: msg.key,
-						boi: blockchainOrderInfo{
-							blockNumber: msg.transfer.BlockNumber,
-							txIndex:     msg.transfer.TxIndex,
-						},
-						contract: contract,
-					}
-
-				} else {
-					out <- contractAtBlock{
-						ti: msg.key,
-						boi: blockchainOrderInfo{
-							blockNumber: msg.transfer.BlockNumber,
-							txIndex:     msg.transfer.TxIndex,
-						},
-						contract: persist.Contract{
-							Address:     msg.transfer.ContractAddress,
-							LatestBlock: msg.transfer.BlockNumber,
-						},
-					}
+				out <- contractAtBlock{
+					ti: msg.key,
+					boi: blockchainOrderInfo{
+						blockNumber: msg.transfer.BlockNumber,
+						txIndex:     msg.transfer.TxIndex,
+					},
+					contract: persist.Contract{
+						Address:     msg.transfer.ContractAddress,
+						LatestBlock: msg.transfer.BlockNumber,
+					},
 				}
 
 				tracing.FinishSpan(child)

--- a/indexer/t__utils_test.go
+++ b/indexer/t__utils_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"math/big"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/ethereum/go-ethereum/common"
@@ -78,7 +80,7 @@ func newMockIndexer(db *sql.DB, pool *pgxpool.Pool) *indexer {
 	storageClient := newStorageClient(context.Background())
 	bucket := storageClient.Bucket(env.GetString("GCLOUD_TOKEN_LOGS_BUCKET"))
 
-	i := newIndexer(ethClient, nil, nil, nil, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), refresh.AddressFilterRepository{Bucket: bucket}, persist.ChainETH, defaultTransferEvents, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
+	i := newIndexer(ethClient, &http.Client{Timeout: 10 * time.Minute}, nil, nil, nil, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), refresh.AddressFilterRepository{Bucket: bucket}, persist.ChainETH, defaultTransferEvents, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
 		transferAgainLogs := []types.Log{{
 			Address:     common.HexToAddress("0x0c2ee19b2a89943066c2dc7f1bddcc907f614033"),
 			Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash(testAddress), common.HexToHash("0x0000000000000000000000008914496dc01efcc49a2fa340331fb90969b6f1d2"), common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000d9")},

--- a/secrets/local/local/app-local-indexer-server.yaml
+++ b/secrets/local/local/app-local-indexer-server.yaml
@@ -1,7 +1,8 @@
 #ENC[AES256_GCM,data:8zgEEHBLWgSSWwbZjxNVCM3FvmLR9gPdgA0WefIPzIsoWioeTUoVVILBDkAMPtF/aw==,iv:E2rtefZaRAEkqiJZN3cc0hr/cUk1HF79IINmR+O73Gc=,tag:Ufi4/EEqzkxbvq8ksTLYig==,type:comment]
-RPC_URL: ENC[AES256_GCM,data:K/5wDSl5nM4QPO+ppJLoYWjL8zTGOIQJSE/0z16dFCSNFoIOT9sSv+CWHsX5ewdeRQjqU+EW3enjcOixUK+CF/YM4R+J,iv:5cjfhKy7dqS0ATfZ00FGNVKOse/XSJbJM21Wfcu82c4=,tag:7Qj66OZoRNtOW/b7k2Bjdw==,type:str]
+RPC_URL: ENC[AES256_GCM,data:8SV7/oeQByiURXDR/qMlbl2/PU0Zxb2Sy9Apwunsn8ZbpjVgPnpqjmJgYaH802EYl0J6LoLydmKg3NAr+3rB9uvk1P41,iv:1MimQ5FOtPD7EBepPycCz0UYaSVbv3ox6j8g9tUV8CE=,tag:05XtWhvd/ZK9NUNf6S9Jpg==,type:str]
 IMGIX_API_KEY: ENC[AES256_GCM,data:xeBmuCi2hcY6akGUqRyotYmQV4+un1k56GmWRa5pVbQToAzAkHkwEINUeevu02xVbvIzHqaGBPne5KHib1zTuPtd9Q==,iv:pVNrkQtCmPppoxoo8O5jNxMDPpvThpdV3c2ZaIkfbCk=,tag:lFWyC8N+5IN6FL2XhWARuA==,type:str]
 IPFS_PROJECT_ID: ENC[AES256_GCM,data:gBkA5TZiWdk59RVjZ8cDi/xTg9DCZ8TIsSBM,iv:o0Oamk/i/CDkxTXxSG5Fp5awZqIPpCgXc2217XBaaGQ=,tag:AQE3sWkHmKKgkQI4fFtang==,type:str]
+ALCHEMY_API_URL: ENC[AES256_GCM,data:z2csIf/wJatB/zq9gwCbAXTr2UGDF+soFQQa2Fm//TNP/jDiFFct7BIsMZoVvBkWgdortDO0NvUdO21j+hhkBmIjTlK4Brn7xQ==,iv:Z8T4zp/WXsRmEQpAB6JMhhBqrqIaaEem+bHiR+vYMQY=,tag:CydL9fKpXsUK3BnysEifXg==,type:str]
 IPFS_PROJECT_SECRET: ENC[AES256_GCM,data:dqdtL+KL0Kfb1ahqNLECV+Bt6brdHTYsg+krCxKdKU0=,iv:yZCgCU05kJRhqUbv+BpHKu7MWxYH4AIuk1wkSbh/Sxw=,tag:hffGpFBC70NGTaSS6ntSwQ==,type:str]
 sops:
     kms: []
@@ -12,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:50:54Z"
-    mac: ENC[AES256_GCM,data:sXYuUTCfx9Dy/qMipiokGNp2DIPvP47n1hcNlB2+iDvSK62RgRw05itqS4XZE+p6+Dh3RZw13PADNTyf5J+AoMpqSUfCBHjaFdd5ej0Q6gwIU3dwB+DEko2KpBA07sVei9huhCjdv3ebN8IBABuFwbkRU3Bge+PxKgXkMWV4AIU=,iv:IFG/l/WY0l7VCDSiuVtd1EkPLI4bojh3bWuzCHT/ULA=,tag:C37Jk0PnTtnjhXFoPygrFg==,type:str]
+    lastmodified: "2023-04-06T23:21:42Z"
+    mac: ENC[AES256_GCM,data:cLDdzarclp79+6eDm2PUqCJcIOg3YZhGjhHvPWZdJ8i19XUfvQi4fAxH4nDOAR0sCm7ImpKMBGw/oJ++t49JGVis5h0NXxl9SdFVlQ4ZhTGli+8ulySKIajHZhXhw4+yUXdBHgGg6B9ozfePgXanPZnf4KM85qhUZVsr/IcjyJM=,iv:GqeByxia1aHI7PU4T08qWTyyJAxcuvxnCXdGR/unN3Y=,tag:uV6zAOTIrDPF28goGnm3qg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-indexer.yaml
+++ b/secrets/local/local/app-local-indexer.yaml
@@ -1,5 +1,6 @@
 #ENC[AES256_GCM,data:D3AQBa661kIGgj01GPvwobbaAp59ckg7drNVJmqrLZY8S90uCGvuI/SNb5/wF2UW8A==,iv:/TaktXubseVaJwnZWBcqOm1ApjWl5i8hDgEohEWdJD0=,tag:jjDK1ln192dbb3x6gl/3kg==,type:comment]
-RPC_URL: ENC[AES256_GCM,data:k28gHaERpowHLIcXmoiIAFujRrrMF/vixs4zXXVlb0r0DQzz9SjnlVdp6OLaBIMh86eVHAvv5lhxjdGUeZ741oDA98Vl,iv:t5PQ1AeUZK+OGLRz6hz7hYES9jt2C28uNMqctHMbf2g=,tag:7PS8Jx8IC5tdvnw1JITb1A==,type:str]
+RPC_URL: ENC[AES256_GCM,data:Y2pnbV4J5cP/y32QzjGEatUeOkB5cdlacyzzW4HbhyaIk/gwFXLrG2wKLhL0/BiH33KNJ9Yfny1ZKgjoskrMch+vejDf,iv:aeCqv3cbH1x0GQ0eNKl3oKlrYQUSYqHqYL32kXloOp8=,tag:46GVSXyUhAbVlU6y4If/0w==,type:str]
+ALCHEMY_API_URL: ENC[AES256_GCM,data:r8hM1msbRkBqf+kupSt2bDspJ+mGW7HotF8E/Td/wOlsUhDF2X0cgi+4Ta4sbUDqAfVXlbFV5dc6Q/VGIdVmG2ZDCFDrASiEcQ==,iv:4dOSUYljDKS+1hHEWDkAfK5eJ+laiYumbXFzLAV/Sgw=,tag:xHZPrUXm3MON5csv50cWXA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -9,8 +10,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:51:00Z"
-    mac: ENC[AES256_GCM,data:Xr47hbfyB9p60QVhD5cmkL4U7R0nGSSILEKGDb7IFpOqrr4BL8m40mBMA1ZKzYnEqekyVO/NDqvj3E+nIz+M0DSygGWYx+hbo6r0ocF/NLzOS7J+VkgEbqNrBtwJ+vnRgOlgA8bRNu81Qhygu90414nrJkVOA5sDts48zMs1Gks=,iv:jqq89MSwxhb+u5GRurmq0W7nGzmoIS2aP0szSRPrV+4=,tag:jEAW4BJjZ0+CJr2Vv90hag==,type:str]
+    lastmodified: "2023-04-06T23:21:25Z"
+    mac: ENC[AES256_GCM,data:szzjTrRph6uPPtJpN843ebxAWwin4beMxUuSSKMcaWgyMrTDLcgiB8PX7LfcBPvCKqoyMdC2VdUNypWHUJhkVE8AxCKMJ0jU2U6RFFkiMtq8nmziCqPmviKPKmnKr9N0Ize+nR+vSrM+mAEM4C0CeqBssw4Xu3dl+UbTHGffOsM=,iv:HirB62wXnO8NJZg7WZuQFfOUl1LT21c0Kmq4YkC/bfc=,tag:uUbfoGSP7aYxizo8NHNhhg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/app-prod-indexer.yaml
+++ b/secrets/prod/app-prod-indexer.yaml
@@ -21,6 +21,7 @@ env_variables:
     ALLOWED_ORIGINS: ENC[AES256_GCM,data:RD7ltQwL+EcgSoVY5pRTrhhgdjNpQgb7DRKdRI9r1wcyiun/lVKR7wUL1iTOsg==,iv:mbpxg9oQ8iLPC6B8bCVSBuCCcY3Z8UQcivdSgZUWeOA=,tag:uRjRjJRx9KjdRB01uIQzeg==,type:str]
     SENTRY_DSN: ENC[AES256_GCM,data:s+HoPAsieu8wXoMvK44NoeQ2vfX8G9BxDoikPvN5SIqS6FULxSjym2RTXumJlj6cwhg/eqIeFO55RH2MF3Mei8QZdligaVmj/C8=,iv:bGhksn8cxG/liOq0eNIKWtTSbg8shGBXlIKq9jFwjfg=,tag:sXCq6I3jEL6Fc3LLSEVxdA==,type:str]
     SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:ze12,iv:4xSFhS8LuU4EQGSTBT4dGTvFEzSShZmvT11Cspb273E=,tag:/CfFi5hdyAeBdqLAiP3cMw==,type:float]
+    ALCHEMY_API_URL: ENC[AES256_GCM,data:1Tht9LCUgOTdcvbAxgIkHjFvv6QrngMr3RrpVQ73n0V17f4yt5eyawMFZRe7T0nkSj9iRslbWRlEeIhCQW3HzYeN9P9jSI1PpQ==,iv:y/p6dyPMB+JuQNdn/q5TfMO19CRmHv7YwOKvMaFlwLA=,tag:CUqqxtoVWL7FkxG6QywBPA==,type:str]
 instance_class: ENC[AES256_GCM,data:9as=,iv:1eTTEMkRHYjGelVnSieaPvFIJniRUs/UMpb6306wM6M=,tag:fznnEO0rNZc0oCkGnrBpDQ==,type:str]
 manual_scaling:
     instances: ENC[AES256_GCM,data:4w==,iv:7S4ZubKWjrGjEsmjbq4hkvEQrT3f0EcdyYcRDh+GSK0=,tag:aypO6og/2WInfcz5Qzj0gQ==,type:int]
@@ -35,8 +36,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-06T19:24:28Z"
-    mac: ENC[AES256_GCM,data:6IJi6bvjppVpPfEiwBCTHvNPTbgNoqMj+qD9DZ9SE+HdTPedSkZElm5vV7/h1gBTU4YumPAAeTVaxexSLT3wpkfI0J/BWc7pGHGNqZAAmNH2T3VN7tXAI1ogZntIWYOpbm87EvvRyvJGEF5HMnNOJ0TxA+anAZz593+JI6zj93k=,iv:rpMEHi67SP3mWjQ1UPeDdy48C1rmoDAEfhYELPVOyXg=,tag:PVAI+l/C4IiZP0c7zmcFeg==,type:str]
+    lastmodified: "2023-04-06T23:22:16Z"
+    mac: ENC[AES256_GCM,data:yGhmv6+AOMQp93WUaAyRWmDsC+hFsW9E8wqtV74gPo1Sq+ai3f7bG31o6Hd3S5shl/B+ycKVVQ6r4XbSnO3bNSb2LnxYRRnZaw1evLEWeHlWCxV6OSTx/4gKqufn43pBzwSt+u4Xum5/S4o/SIBrQTMeZaKijfM8r12NDAv7Cuo=,iv:SknCLKxbsp22hKHNO3DcjJZclf7viTJDChtQ2gIZbY8=,tag:FGfCmwcCs86C2JO8LGMcNQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/local/app-prod-indexer-server.yaml
+++ b/secrets/prod/local/app-prod-indexer-server.yaml
@@ -8,6 +8,7 @@ IPFS_PROJECT_ID: ENC[AES256_GCM,data:W1wRmF71KZkeooEDiiO0728dZ46duGnVMoP/,iv:EuH
 IPFS_PROJECT_SECRET: ENC[AES256_GCM,data:ck99tg0re/8GL5iDjCK0WH3ofYmOK/450kczN114Las=,iv:lUnWZAULc0CFUMfklvfatR3ww7uZcZ4KXO/i+qkSPsc=,tag:efz7Bxwl4Azu73KuXiD9yg==,type:str]
 GCLOUD_TOKEN_LOGS_BUCKET: ENC[AES256_GCM,data:C//34woVq3I5ucviO9g6/BPm1w==,iv:yB/4/cXEueR+wYO1rBsFRI6CTD9BBu7jAV9IEq4QnP0=,tag:XmIpPwCD6nntqpDzazcpkA==,type:str]
 GCLOUD_TOKEN_CONTENT_BUCKET: ENC[AES256_GCM,data:bOwusFszqEg/9IVJ5uVO5Kf2,iv:vIfQc7SQZuzt5O4N2c51bIHHmYQZY+Vmnapq69DvYlY=,tag:OJuHKUKSMRuqhyr77UBPtg==,type:str]
+ALCHEMY_API_URL: ENC[AES256_GCM,data:Fx3fb8N2pakbSnA4ZvyZ9BzEM301VNc9DNESbKG3nXRtGHRTv5O6r0g2LcEV5VK8XP0+NAtbVift3+y+w1edHlKA1KrCMKlwDA==,iv:HwnuVPLhbl5pLhreZq0ZCJbMnKr/8hZDSL3azoBTG1E=,tag:D5s/Et9Nx6ACZIDo+yCRHQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -17,8 +18,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T15:46:42Z"
-    mac: ENC[AES256_GCM,data:7thNRKS3e1V+CxE1zhYrslwaQD6hb/2xu9N4+rVBrkSXek9Bky78Zp2uthskCpcOqzVT9CQTvkGhdaYME2PKal7etsLAp5enLOVVyN2fItn+JfkFK5SCGqNqwf8Wmbi4JFpCyzGLBhBsBQQ0ZRzncdsP8ZYCiaBUc/RbxpTSUFQ=,iv:HvMdXzZsNU0TkZd4pB3hEut8cklgouedX8KCu2oLL+g=,tag:PBRW53yFrx9QMGPXAOCBHg==,type:str]
+    lastmodified: "2023-04-06T23:22:44Z"
+    mac: ENC[AES256_GCM,data:7tfSDIn8ddtEyb06Hro94yiegbMm5lr2bOnRmLb6IUEkeHj7orT7ILmP5X3pPZqX72CpxRfcJR61IlgsLlYq+hH6+qiBZGPZI2lBEZdsxSlI0op4pZshY2+HSOT5bBZ+uYzdxj5eUo0Rv40TBPc51tLVnFzevNJryD3IJF89oxY=,iv:R0y3/pMvUqlmqgkceuWnAtZsoqG4wQTFLhAAnqWAWcQ=,tag:2ZGLvYHvAZtfTiU/yJauUA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/local/app-prod-indexer.yaml
+++ b/secrets/prod/local/app-prod-indexer.yaml
@@ -15,6 +15,7 @@ POSTGRES_PASSWORD: ENC[AES256_GCM,data:O9mxbXvvKelgsFQbUo4=,iv:w8wjo26P0Wri9236n
 ALLOWED_ORIGINS: ENC[AES256_GCM,data:qaZyXiM8C0npXdAxzHuiuXCMNDySHNwrvQ1KvJbpLGYU1FO5L5vgiGUI+wqBKQ==,iv:J9STW+F15VRMHA6Gk+43Qef/Qe26NfaecImtt/SuTXE=,tag:iwW3y569HjjxvtxdhGhnjA==,type:str]
 SENTRY_DSN: ENC[AES256_GCM,data:EUbUxY9d+HSpGXyj0ilYhmllAqVRXCdWBTElADuqMy/hYAg/YvWUd55DIZ6eXrQhPAPwZ/MhuPgZC6SbhyA4N/6B3dIteXueDUc=,iv:R181PyiMz6Zzi+jUk7d9iOHFyS7O+MhzhLE6KDowgs0=,tag:YUNYPLX70ezlYJ9Nzdz+MQ==,type:str]
 SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:lihG,iv:5oUZ9iaajfKCvBAz1bHjwPmbRgLe76xYzDwsLkf85Ec=,tag:aN66Fx0TP+HQWFMJhiskUw==,type:float]
+ALCHEMY_API_URL: ENC[AES256_GCM,data:szvjhxb8giFgSZ7DRvnkAQx3Ej0fkKNn6DEOJXUfhSzChfYqooEPP8vqVYyn/HH1hSG2NtuzAe9W65EdBj3EX13kbC1H2QFFnQ==,iv:FspuwpQpi+SRFYp4Na2ZSLH1JPC07gPXf6+s5O+6n4U=,tag:kXcGD9dNEBC7mOTXJzutBQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -24,8 +25,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-06T19:41:30Z"
-    mac: ENC[AES256_GCM,data:QoIXH28V2BRO/OUE5fwr+Z9t+d8Ca89adgE/YtUQUMpp8JnOR/hmAYIXhSG5wOOjn+p7oEQCEvpMKBN7Z6xzH7WBtkbLEL+yd132HQXpeXDx3f754qjVCfoNY4WjaP9LhhXiEEKhsbbes3/XTNLq2fRyorlOiXCPD5iVqnkJ0RI=,iv:hwKsmceWjqAfbjNgKO6/bJWI/8FJFDmI/l9IxmxjMAg=,tag:9NJCDZpHCOQyBIrvmuGMsw==,type:str]
+    lastmodified: "2023-04-06T23:22:30Z"
+    mac: ENC[AES256_GCM,data:P4QdE/s7k8WcKHmbpXTq/57KcZeQ4Omq35igZdGkTQDKlWibHDFGk+dFfsrvOepSzjeOtsq97QS1XrOMARH4ovJD1h1Iy8mLUXv0qKb1gUfHcq6jzAvy+lCLUXdH4wxXWvOSLbNanoPpM/A8f07YeBlXJc8xae+5mdqe8nhAPxY=,iv:g7g3k8tnjHA2Uwqkz2r5AyBtNF+X75r5jJjt4eVAqVc=,tag:PrUYjP7hwtJJMLgXX/HVjQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
Changes:

- **Added** a batch call for contract metadata to only use a few compute units per pipeline 