### PR TITLE
fallback for ipfs gateway

### DIFF
--- a/indexer/core.go
+++ b/indexer/core.go
@@ -120,6 +120,7 @@ func SetDefaults() {
 	viper.SetDefault("RPC_URL", "")
 	viper.SetDefault("IPFS_URL", "https://gallery.infura-ipfs.io")
 	viper.SetDefault("IPFS_API_URL", "https://ipfs.infura.io:5001")
+	viper.SetDefault("FALLBACK_IPFS_URL", "https://ipfs.io")
 	viper.SetDefault("IPFS_PROJECT_ID", "")
 	viper.SetDefault("IPFS_PROJECT_SECRET", "")
 	viper.SetDefault("CHAIN", 0)

--- a/secrets/dev/app-dev-indexer.yaml
+++ b/secrets/dev/app-dev-indexer.yaml
@@ -16,7 +16,8 @@ env_variables:
     POSTGRES_DB: ENC[AES256_GCM,data:dWb536SluwU=,iv:IxitJRhNi9W9Nao4YALgR8kvUosOnzwonmckisVuzGk=,tag:vUxctaIaae5/0r5qPCS8vg==,type:str]
     POSTGRES_PASSWORD: ENC[AES256_GCM,data:OMC9hzQfJnJRJd0uyCzxrA==,iv:2ZJGAmSGCSj9GYCqeD5Y02nRldDDdOMmliVQASofmfE=,tag:ZRjJLhThrgrylSc2rQYUvQ==,type:str]
     SENTRY_DSN: ENC[AES256_GCM,data:uGQVPI389g603X93/85W6bAT/tNouPFaGBxz+MFOpYndsCWvZR+OpVQerab1GtZu1XWihQ65LvLsmsspRi4hStIDBX/WjAm+apU=,iv:Hlr1uKacyVy3InRWTsVNqT2O42RH7yjuZtf8E22lyEw=,tag:UrXEtFzC8hZ71JguAIoHaA==,type:str]
-    SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:Zw==,iv:s3EKoO4HwB4VfaZRjideqZBWvRYGonhF/D9/4lNuiaU=,tag:fk9Mvhc2CMLAL6jHzu8WqQ==,type:float]
+    SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:MQ==,iv:vHMPv6X0DPRcre/lmdek0Rnqw9Yk9jQ/DX7Azh65eiI=,tag:y2pAPIDq5wrU957uPqYvfg==,type:int]
+    FALLBACK_IPFS_URL: ENC[AES256_GCM,data:J2geibWIdS8xo2ZO35Z5jeo1Re5UlwStzLikcmuXJm0y2b2o,iv:r6LPKONiVTtz0DAK0cRzxcFPr5Gs5JYqULewPnlbBOk=,tag:UQHROMKdI7AkVHYPNu8xyw==,type:str]
 instance_class: ENC[AES256_GCM,data:YR4=,iv:0/asoZfhCondwnpHmL7D5eo2yjrExozqNIG3UdBCGEI=,tag:o40nnZXU+AP2Hde3YlW/8Q==,type:str]
 manual_scaling:
     instances: ENC[AES256_GCM,data:yw==,iv:026s3tZVak7NMBJibe4tc1oNx9J4lnWtx/2m4GjE0i8=,tag:NacoUp/bJISWBzz111xd/A==,type:int]
@@ -31,8 +32,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-01-19T14:21:44Z"
-    mac: ENC[AES256_GCM,data:R7VQAAVlXywzRkIDBicYVz0sqRk2K4QD5ET4Z64lapOVeK/gHr7lRg6Xshj1bJhTKaqy7XtBp8W/pek/sIY83Kw5QHeit5+c4mjrRQ7d6EiNdSWdchPLQ8hxXm+Zag1+xtZrWWRVYuAe9udxZqxRNg3aj8InWnx6w6xCsWjdaj8=,iv:BgUCE57WAJQLhdIlTa8paC7ft21TEK9TFC9ND6glPVk=,tag:bAMdqxkb+Jy9l6P0P+Ri8A==,type:str]
+    lastmodified: "2023-04-07T20:11:20Z"
+    mac: ENC[AES256_GCM,data:Pi6zZa8Y1UOL+pOD2kTZ6nJrz/sdPeJx9ICHEmMJj1y0EG5OOzAKOTdW9PzeCcHB3KR1BKkrM5+2k74rPY2EgdGUp647r0JYuclLoFXwCzQzhSUzAXyx2DDsxIdoFnsTa0sbT6BqIVuu4+lkW0Yiuy68lBNj5H+EXWXTfsCfkSc=,iv:NPOKr2jrndze7wIsEXR8SEzUpwg8deavIsSEytRsl+c=,tag:bEyl2vqOW3WMVGqWJ4trRw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -57,6 +57,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:4/6bSFy2d4oLjEgqvwxpXPjHp9jWOhjyqW
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:oKFLpj5latuzmCHUKLCw9RPt/VmCQDmbHHD8RUD/i+akiksH3Al60ptQ2YtlTO8R3e8k7ySGmm08zD3Ti9o122sZt9mBxqkgqw==,iv:crqH+kuUkK9Df4PFbiXLAaLBapOyaR1t1w6ZoJ+7Akw=,tag:NyZWCau0en7tLynKgb+5mQ==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:UuHwPIj7dHbsTZpes/LnD1SCLOY6DUtd/TErdldIAC8=,iv:mBx9bAg7KRYS4VdkRz9x6a5MigsHLJ/BL7E/1YLbEnM=,tag:XxOdw3EjMgZCyCS2J/WewQ==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:Q5U/rsXuLFtlIqEBsA3pF/KVMDltMd6ArkCtD8nyE3c=,iv:1l46FiXIedCbnl72kAAFnCshRpf/7IPiOD6S3s9UdFk=,tag:4SKOPAJiwt8m7L9+tEGGVw==,type:str]
+FALLBACK_IPFS_URL: ENC[AES256_GCM,data:7NRmSkpptPP1tE1xDlygfTw70tqc3a9+lpKrzV37doCkxdTu,iv:5KRKS5oeYQPyC5tfH+vudosWVS4n/oKKK/kN6S67iIc=,tag:n9IaoDE0wuux6XnVZTsFaQ==,type:str]
 GCLOUD_FEEDBOT_TASK_QUEUE: ENC[AES256_GCM,data:mkruCDQD7dIdNtJAqHG9VFUZRny/9NmY1FVdgoB6svcUxYYR7wOA92ksQskhKiftiwtLTNXKStJEr53eOw==,iv:K9IO77Q2hPCh8dgI18XyBSIJt/r9mVohEJ0MyRxkysY=,tag:NeqzpnnXuxf6gJkb+GmNGw==,type:str]
 sops:
     kms: []
@@ -67,8 +68,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-06T20:38:17Z"
-    mac: ENC[AES256_GCM,data:p1O4AkOtua8K2eaLM1uGRHN2rsQ2uEkwXQSzgvREhO1DCZ73ksWdPe+S0Cc/OfxmUCMNLnauraEMdDPVlolZLKyoCq4Wt7IirGp6G+I07Zklnf+7WodjBSCm0fVJU5lg3EKB3EkXnU3VqOkXsau3q4QPLP1YDaSHAEJSnp3/fXY=,iv:dKZj2Zwy08ciOwvfzIfuWLStMJR1Kdo7q56o+EGxbW4=,tag:63cqsJXSYCKvfR2qKtbMdw==,type:str]
+    lastmodified: "2023-04-07T20:12:00Z"
+    mac: ENC[AES256_GCM,data:3cEZaB+oNxTh8eHI7sIR+kDKngm9euUINAUXJ5bawPqXFXyBmwmxhrJ8fZj11iNAOcLcDgpwri5SS0gTemag03Ww7y2LuXXtMgA/f3C9F80S8a0W5rs7naGpqMbsA2T9UJHBBN9QmGHVdzTZEejFCHxnWC1MMvam/osO2IMRHlo=,iv:7H8QfXoG5r7CqKZKcTruseBab9sB01pT9xvQHeYVSgw=,tag:iLWZwcLi48A1B5ZH6I1Z5g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -31,6 +31,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:LyMmdnDJFb8J+IIirhxgyxpnt9SD+ovgQ+
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:2UQG+XdUTUJyKN/Pqzbr9lwsMK6LgQ0w6RIABW0AJ9cfiRKfRUfI12jsxdPUsFni2iDTzUUkrRYmVTLogUPttSSOItC+c+AidA==,iv:z1sdLMlu4x9BY4Haikocg5URwh0vcZGr4mz1rtBcj9c=,tag:Hrh5trTAEipJAFS0+tRSng==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:/uXGQ8AtiJ++fGJUngC6EcjBVuSJBNbp8g7yWcEMG9U=,iv:WdVJGHWQPDB4HAkqgCkKWqON9OsURBQixJG5Tc0eHoU=,tag:LgHf3JUslmtFPHV1PJvyNQ==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:RlpUUwAGFdbl2iF/WpJtKhz07/e5crKjzlVTeieOTZs=,iv:nwc5p/quTfMueloGzBAzEMz/ipbZ+hEF7VfuRy28IDE=,tag:7GiecjhouJhsrUfzq0Xgqg==,type:str]
+FALLBACK_IPFS_URL: ENC[AES256_GCM,data:Ho3ZYGLpsRh9qgAgInOnUgQscfn/mnBgNl1y5rcp/onQkrZd,iv:O0QWly+fiaQrcclaWx+0sX0+VJE/Ex23VqClP5dxxz4=,tag:Fd/dlF4LvFPmCjaeAESY9w==,type:str]
 FRONTEND_APQ_UPLOAD_AUTH_TOKEN: ENC[AES256_GCM,data:ZILBnusB44G4Pjr2FciMPA0UG8ZorPjr4a+wEoRA,iv:7bESHVXi8uUuGGQpPGhlT/+amGG07TNZSN9p0y+GGEs=,tag:LczHWZvOyxsRz6sHCkfd0Q==,type:str]
 sops:
     kms: []
@@ -41,8 +42,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-06T20:38:21Z"
-    mac: ENC[AES256_GCM,data:io08ZkYgWqPZ6Z0rXxLP8XZGMbq841ZZktNt32E3I7TtmKxrmTVd0o6PoFekInoOKp6iWuAdwfgCQPQaFf3yOo7R7zm6Ruiaic7cJ9hQUMSWcCoUTvwRklO02AekTO6MpdvZTDj1zQpn/rhMH49Ong5zzsJlRBzA6tTcovnuWz0=,iv:HDNOo32XU4npwERmrQPCkqxXodLDe4vurUkWtu0vL80=,tag:JZo4wMKNlmMaZl0TthnD2w==,type:str]
+    lastmodified: "2023-04-07T20:12:29Z"
+    mac: ENC[AES256_GCM,data:DMr23B/MN/S/019+90hNlwfuMrFP0nfY4DO4Z9PgeXXq3g53i/Z1OiOeUmJElzP8wLa4xC4g+jYayzwJGXkNcuk2/VNhxSy+7Mre8LgM/eGEQIVNW4zNbGu8tVpLO+eVhtKfEhhe55G3mLh00T0iVPglVledCAKwdn4vXUf4ubw=,iv:6TRYlKOafIiOK2SR1JB3jmhX2YWADlFGZ7f3/t2z45o=,tag:XtXO7E5ubLd79X2HNH7D2w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-tokenprocessing.yaml
+++ b/secrets/dev/local/app-dev-tokenprocessing.yaml
@@ -18,6 +18,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:v2bRIj9dNEO4LrJi5RXOzpM0k3B1sVEccz
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:XYTC5e8aJ50nfOiwz5nl/UeUiAkP5LIeTv2B/UfoJA168q13hrGAyhZevjeq7UqXFPaCBzNmsm9ApH2WFBXsylf1VPFbHVTkOw==,iv:9GPVpaAe6O8l5GYs5maFJFS7Gtwk3kvNRhxhvshUGL0=,tag:ZxiXAOE2AnAE+IJOAcSHBw==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:NtM4/h1x6NZC+qkecn1RgCuPFKbjeugeO2fHELuMeuU=,iv:VERLmg/lW93M6tSL8LR73Hk2tcS4/MUqFv0c4HuYyGA=,tag:03KEzruRSkNF2+6a3S7w3w==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:41cTcNjbCy2IQvrx8g5TfWvQJz62hQh9pfGkmz8NTWE=,iv:P7Am2MGhUYIOH9sl8aNljcw8uRc8JUO/zJpWqnVmmEI=,tag:nKY3jK4TOVGHWWmMxHQNrg==,type:str]
+FALLBACK_IPFS_URL: ENC[AES256_GCM,data:j/jhOYi+afwkUofoUs9X+oOjtqqWtLyTTLMWeVi5mGCP9C1/,iv:JGgC8klk1ofJ2y669+gLPWY6T1Mv08bh1cE5QsTzAeE=,tag:5gHoZfe02hGJXKypZKCZjg==,type:str]
 RPC_URL: ENC[AES256_GCM,data:gVCI5ASCPQYpE5i2FdmR5oYBONQPVz80Y6MvmLudIPtDllro1Q9pARKJ9RkTBxVGAzWybzcvxV7haTBtdrCNJyBkpSEs,iv:aFwlmQ2BVrYvYZHFbVCetQMBmKcTEAEXzeMkNTyaHbc=,tag:pgpjUseyo5HWrw91UdxSHQ==,type:str]
 sops:
     kms: []
@@ -28,8 +29,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-06T21:06:29Z"
-    mac: ENC[AES256_GCM,data:tKjUtn9orEiTIeSvaUKAt8Kct8V1oLrybEuIQwYYnRl5agMylsCeFzYNAqpXhVb1G0zMIRhShO7/QIL6wakGEX+SZ7ZrRZIDFUnvPZgl2PFNFlUIggzKDEDa40yvS/6QKt+8F3lwdWA0KvWBKsO00vhNP57iDjBeUjD23FiI8vQ=,iv:lWsMEdl0mAEsgf7Z1jqDrIcugz8/Yk1PQtfQT/e3nrs=,tag:EgyOrhJrShcT/abhXwOCvw==,type:str]
+    lastmodified: "2023-04-07T20:13:56Z"
+    mac: ENC[AES256_GCM,data:wMT/e/pSqg/nFOIAH4ay9jqUTCqbqoSJIJhqm0Qkv+WKpEgB+iIzxq0SGmHsE77z6vJ2fI09LrkU7ikhpdsIm7Aha0eohqyQyxaM8w0f9zbeFO8OKXPfEzjRR0XNyz/c8oQxex35AMsxNTjyugD2WAR1kHC7k/PbcIQ6xG3/Rfs=,iv:54+5qxLHFt3/vnYn5J7Ck+DsLxxacWiDBtVZO9W9bKc=,tag:1bhqClRaerGFiU0qTV9S7g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/tokenprocessing-env.yaml
+++ b/secrets/dev/tokenprocessing-env.yaml
@@ -23,6 +23,7 @@ ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:87b+G2kkXIYfOGRoPtBUCOFKZ2WUgHv/L4/
 ALCHEMY_API_URL: ENC[AES256_GCM,data:iR+hy5kZTN+9PKyjflmBi4V05JLiM8pB7Qu7aBP1BQsglN2pyL0bZCB+3y9NIUin90PoGTpp+sTPRt3VP5wGYEN/qf+j,iv:lhzBKnCqMQIPjsUIIy2lpDNGNPv/ewGcxM+zkXEqJNQ=,tag:EZu1P6AzO32CNitkhzFFDA==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:HLVQemyfRDXiBZibFyj4s/pRfcFod0hVtr+Z69icNaI=,iv:/my3Ad4jqXa3GkMUFHvspY1gwwBsgW7xKYBpPqyw7xo=,tag:iGuR0bC3hWYuBuUcLZbbsQ==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:iNuGav3XdTuTRfmzMr+m+xi1jDlZghZuMUycuxU1Fik=,iv:nH60K+11pnEIGhIQV8Usa+/u1PXEuPQvuAcdTkQTXXk=,tag:mIWI/ByqRmQg7btxjccD4g==,type:str]
+FALLBACK_IPFS_URL: ENC[AES256_GCM,data:8ORFaLEmaTxQexsjsdMHUjsn5ztgafE4aWF4eo0nE65Vujdo,iv:0zlf/R7jzI6R13Em1i0O668SJ9dtTds/RNcoNNx7fU4=,tag:BrPQ5iIVw6LUY5hQHqanoA==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:AJGGUGq3TobBLmzrDFir4xFVUkUqXoBkIgZSjSskMLY=,iv:arxPBf8EGVUJpWv6m+aXmw6+sW5P9YbCuGZIF60zlTw=,tag:N/HrxKu9oawyJaGIYMyJ+g==,type:str]
 sops:
     kms: []
@@ -33,8 +34,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-06T20:41:18Z"
-    mac: ENC[AES256_GCM,data:Au+ZQ/mewk5tnchjOAh9BHLL43UpOLx+dQEnEYN2VhLpWRcw+3mUBNE0kDPXRM6mlXk4cYeCh8sNIJ8Vfjd1qEmg6pfg5iNevraGEb972HlXjTNCqHZsTSvAb6PYiIfs50VETrJKarXEWgm/aNltXOU+4U981qoEQMgEk6Sfqsc=,iv:/LK8rlzz1iBqGaMI+l4beq1mrKtQYz7PKN3jx9InGJg=,tag:9evDB5OH4/qFKNcdKLVumQ==,type:str]
+    lastmodified: "2023-04-07T20:14:03Z"
+    mac: ENC[AES256_GCM,data:4/ZS+TA5M4EJbIpXW6AAb6ggoA97/5bYVnxJXIttkImRrjgYEsNVujmoBtSvDYBj9OguOkko8hvT3Ro6PxEMpWA2FoFKa3YWmk75HE7aQPwtWy5rOGeMwbTTA/QshCGoGtZPs3fFMyK0KdoL38b+lMJ9gAWmS7lQnM9aiS/jxM0=,iv:hQ84UEdqYxH1btWouFMjIQdc0eR0ViVXZJjGl2qQvB0=,tag:d3Wx0+S5rP6TCkaW2wvMIw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-backend.yaml
+++ b/secrets/local/local/app-local-backend.yaml
@@ -29,6 +29,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:+24oDGDLQag/aUv9s0V4cgJs1HrsL18Tey
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:gBSa+668Z1lrPwjq5VJ0vHiPXMukvLj9ay4T2m34wdX0Z/orvEAS5k9HQpdMqaqIENHWjm5uDNMJg0w7gHZSItWk49eIZwp6Yg==,iv:0oTpjbOgryuK+QtploVvXFvL0CKNx9URRswylUP1t9Q=,tag:g6r7gecO+rvLFE6R1iwetA==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:PQ9I9fE8J18u639MwVoKYrLRdhS1edztvFLbVc8Jwvo=,iv:JP61Q3I/gcNdpAuSnnD+TNTLL9zyVNrqYMgyOloJzic=,tag:m0kgCT3SUkH1fe4XEuXa6A==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:HFSgGADftArV6i9aMoNT90ET54CknSrsNp1xdfAEDqs=,iv:14VPi8bN1pFe4+Uy8H8P/1ZVD3SvVUvdRSw16Cb5Bx8=,tag:yiuIS1jx6tEfu+E2lJt6CQ==,type:str]
+FALLBACK_IPFS_URL: ENC[AES256_GCM,data:ZB8he/CU+9N3ZXcQxNH34dbBqhXV2hlWzdIcPV0j+t/rH+zU,iv:thwzVgWpCKKgRWENK5JKSqieq9P7ZBwKxDYrSCtbvPg=,tag:XqVcX9GBYONeZHCKJoUGhg==,type:str]
 TWITTER_CLIENT_SECRET: ENC[AES256_GCM,data:T00FMfxXhWdnndK3F16g9w84VBGPTsIm9+BdjMrapWtj8L25xAQ8yW4paw1g3bobx+U=,iv:ZZTLFcqtpb1WW8k7L7r/rVFA24ViwInVIGsOrEg5vGc=,tag:15rm/S9GDmpVNuhkSVISDg==,type:str]
 sops:
     kms: []
@@ -39,8 +40,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-06T20:38:15Z"
-    mac: ENC[AES256_GCM,data:1S/cmaXiy/zeyWmL7pdirqAFPAbK6ITjqzIJEAJ4aWal1CkS1KzJi+yGkKBW5Hu0SfLFnknPH2AAjRXwYcsIzb4s3bb3OyqieV3EazVzmDDBIQE7mFtTZ08kE9y0H1T1e97whwhf7Ggd/9feJBDLVnA7Le8JHPhccTfISB3pIwU=,iv:F0fHcKkfwQnj1uzRSc6rzWzwYQFu2nzRQYYLdpGUEJM=,tag:6JGg1OLr0KwaIimwesPKiw==,type:str]
+    lastmodified: "2023-04-07T20:11:37Z"
+    mac: ENC[AES256_GCM,data:bb/mLTIg/PU4IZql2LIC8DRy5k9d9LJpOmpp8YHRRJfEWvI5QcnTsv2tOrha/maReygJRwayz9rvD+7zanugdMM6OD0KZ0ByUsasberfwkHeL4qXLbvPv4OoQ6Y1lzVdKIQKBJCdW5l7BrNycxjAn2EGwcejqLWsqvqnL8VKu3g=,iv:T+ACFnS6FrRuz1HlJy9gz2j/YHiwsYXKW7a/LnvKXf0=,tag:9AsUwU3uNbWSxfs+Pf/PyQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -59,6 +59,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:SfM1eD1ColBBGrgpZPjUIhA3sOKVA0opeX
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:Gg27WvtReZAdJWUa9TzYlVIDmie6BWgZXUlfCTvgv5P5aHP6UjHL3qgzpnQfHzN0tXKryEuOQS59CMrYAeFNHsJ9GFB7YGa6eg==,iv:5iIk+hJuNwYxkZkK1Bhkv6XAI/42tsCEY6NGWxVuEOM=,tag:lQf0Uf6T7sOaWh8Zg9LR/g==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:DgHYHTfbVstuUrJcJ6bMrPrlcdQH08HQlpx1E4ofc8k=,iv:QfFS5s6kRRvUrvrLmiWYu1LpHzNvxW1m/WpCvHEkVwM=,tag:SNnJZ9jZUdZICJN+c55VSQ==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:SnIWVVu0ES2b+BT7z8/VwUDeqzaRvzfWWIZ67ozX4k4=,iv:EuLUSIdwnQsaznIVzkRuzr900HPUU46Q0r+JzSEaid8=,tag:3cQgeXK7gw0z/wuu3eIPYQ==,type:str]
+FALLBACK_IPFS_URL: ENC[AES256_GCM,data:OGwAoZE4X95p+O2cPCaBoQuv8t4PQnFza75ra43RS5DUbw2X,iv:raHfpd0IYtGzD5ykemc1c+Ax6/NhavQzyfCXMoUi4YA=,tag:qVMxgKRb1a49xyzp56ZHLQ==,type:str]
 GCLOUD_FEEDBOT_TASK_QUEUE: ENC[AES256_GCM,data:J+HuqMA48Gtjo4Lg9Ca1/lYlqrsyVLUtW49YTcYFC89jOHPe5iSFSIiHrYithJNKjX7/rlI5tVn+c3rEloM=,iv:A8a3komasuhBMx0kmkpXqiRNNEjzXcCvDbDQ2GfTLlU=,tag:L7UtSlo5QD9ZHv9QlLz6lw==,type:str]
 sops:
     kms: []
@@ -69,8 +70,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-06T20:38:05Z"
-    mac: ENC[AES256_GCM,data:fD002en76lW63WiTRe9AahL0VvwRXWry1s55UZCBq9WnSyy+olncnb2iaqWSBWAiCjpwpRuNpzMJJ3QffS2oGHJWQijh4xLpzXSMjnyVYqWPpUgEjz/YvPFBoq7Owfe4Bjjz0GDeUEQxsFoEpTBU+QllHfrGoJKyHBa+wBH0WTI=,iv:tTUm/lZ8Rsb7XqPJYlpmcXbZ2hL+Nu1eUn5KGPwoCvc=,tag:0a1zWQDc5GxdC3D+u/ySDQ==,type:str]
+    lastmodified: "2023-04-07T20:13:01Z"
+    mac: ENC[AES256_GCM,data:UtAYNnUOO/L5OrmzeouuOIUfQQq/ckFEJAZ4Cwt1UwV+9syrggWD4xbXD0JtgAgM8NsNgtC1m+5OdU+w463bfZbbmeIT/Ow2XQ69NNXr9LTKFLX2lYPim3GA6tonARJTnHznkQ48ZRJ3jEuhxVX6jQoyeh1x3rT5k5wwQQw9D5k=,iv:+8Fg7OuJvXnkLkLV6lns5k8hhkaGkVV9XorMmLDmWGA=,tag:bilrZ+wL+SSRrhJyxqdhag==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/local/app-prod-tokenprocessing.yaml
+++ b/secrets/prod/local/app-prod-tokenprocessing.yaml
@@ -8,6 +8,7 @@ IMGIX_API_KEY: ENC[AES256_GCM,data:uqTHn031IhPM8Rab+2hx6PymiGZZKpqKhe5vPnRIDDilG
 INDEXER_HOST: ENC[AES256_GCM,data:vG5wueWWN1Gfs4bXts5fFDtQdZtVpAzbLO7tUwRjVGW88Fherm+9lV7Fgg==,iv:JYkI/YTZwfyH5sR0iEouJgFkDnxM9wz7DeAxRSdSuLc=,tag:PI7YK4dyVmXybIZPPsXv2w==,type:str]
 REDIS_URL: ENC[AES256_GCM,data:BW9xNGUaTkckc0rG+Jc=,iv:WjgMZopuWGnhTz5GhOoZhOum5c3l3rbBaAAP5wrlAHs=,tag:zXhFsVL/j1+ZPTA+E6XaMw==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:BF9/IaglaD+j,iv:MeROv4r3ir4JzwApjP+ODH2sN2g9MevRt4sAxA0vh0Q=,tag:vfqDeMpgjWgFajO4YfQv7w==,type:str]
+FALLBACK_IPFS_URL: ENC[AES256_GCM,data:5Laa4jmOABP7bsGpvFZLdpCUL+ecIHmSHJZfrsB3O+vNu29q,iv:O71bTymjTmTeolZi7aJ9hXgFYpQQIqgkNVJh/EFk6/w=,tag:mo1wpHtaEviq4sFAk2w9Pg==,type:str]
 RPC_URL: ENC[AES256_GCM,data:SDexkJAqQvXGlqKibnf+CefTVr4Hvs2tDoJgdemsDrFPuoBtXzuMVnhYnR5sm3P8uwLUHWfsz6QIwrybjO4eNd33R1cB,iv:iwWl0yXDZvghE+rph+WxK6QKlZTH8bwb6v+7dR0WSqU=,tag:hujev87t3BGeZ68Mty7prQ==,type:str]
 sops:
     kms: []
@@ -18,8 +19,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-03-15T18:16:24Z"
-    mac: ENC[AES256_GCM,data:KfghMVX6oL/vpYT1ddiiqvfkHaNZUkXBViBkgmRiKJRrz2lRZqv8v2kzozh75KEm/k56MUuz8/4MUBVFPSMeDPnVo5ecDq4SmCJ5LsS5xRHe6IrxBLdScyNLmidFLUooP5XR3byL6dH9fC0ZgA/NDwQ7TXQELJYWogTCHnilvgI=,iv:seFkPMj8cugdK5bbNzmcKrC+krbZI1HBwvd/cVuB1nM=,tag:eLWwgofz3bwKzRzA/WBVMg==,type:str]
+    lastmodified: "2023-04-07T20:13:11Z"
+    mac: ENC[AES256_GCM,data:+Kah+KSY5PtcxlrCdqyJUOCIW2pre5lHvd/Pdq/aHMrNyKdjfeNuAW2yJQLjsqlyTSQb5oyIlnH5M+xbqYQlR81/LkiM7Ao1wsMOn7gPymHHQiFl0tiEnVgTdJZl2vvyJgOBFjmPJArYT5A7a3pJXVaF0MMyPpZOk10U41tDktY=,iv:muDEHNpw31qwhbfsgDtlveOM0fNNL0Q8moJEtvBW9gQ=,tag:LaXKZxA1h39Xo7JyvLCoTw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/server/server.go
+++ b/server/server.go
@@ -175,6 +175,7 @@ func SetDefaults() {
 	viper.SetDefault("POSTGRES_PASSWORD", "")
 	viper.SetDefault("POSTGRES_DB", "postgres")
 	viper.SetDefault("IPFS_URL", "https://gallery.infura-ipfs.io")
+	viper.SetDefault("FALLBACK_IPFS_URL", "https://ipfs.io")
 	viper.SetDefault("IPFS_API_URL", "https://ipfs.infura.io:5001")
 	viper.SetDefault("IPFS_PROJECT_ID", "")
 	viper.SetDefault("IPFS_PROJECT_SECRET", "")

--- a/service/multichain/tezos/t__utils_test.go
+++ b/service/multichain/tezos/t__utils_test.go
@@ -30,6 +30,7 @@ func setDefaults() {
 	viper.SetDefault("ENV", "local")
 	viper.SetDefault("PORT", 4000)
 	viper.SetDefault("IPFS_URL", "https://gallery.infura-ipfs.io")
+	viper.SetDefault("FALLBACK_IPFS_URL", "https://ipfs.io")
 	viper.SetDefault("IPFS_API_URL", "https://ipfs.infura.io:5001")
 	viper.SetDefault("IPFS_PROJECT_ID", "")
 	viper.SetDefault("IPFS_PROJECT_SECRET", "")


### PR DESCRIPTION
Changes:

- **Added** an IPFS gateway fallback


Created a cloud run service called `ipfs` that has low specs but can handle cases where our primary gateway fails.