### PR TITLE
Make sure tokenprocessing (and other services) can find a Sentry hub

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -66,7 +66,7 @@ func AddTo(ctx *gin.Context, disableDataloaderCaching bool, notif *notifications
 
 // DispatchDelayed sends the event to all of its registered handlers.
 func DispatchDelayed(ctx context.Context, event db.Event) error {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	sender := For(gc)
 
 	if _, handable := sender.registry[delayedKey][event.Action]; !handable {
@@ -87,7 +87,7 @@ func DispatchDelayed(ctx context.Context, event db.Event) error {
 
 // DispatchImmediate flushes the event immediately to its registered handlers.
 func DispatchImmediate(ctx context.Context, events []db.Event) (*db.FeedEvent, error) {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	sender := For(gc)
 
 	for _, e := range events {
@@ -127,7 +127,7 @@ func DispatchImmediate(ctx context.Context, events []db.Event) (*db.FeedEvent, e
 
 // DispatchGroup flushes the event group immediately to its registered handlers.
 func DispatchGroup(ctx context.Context, groupID string, action persist.Action, caption *string) (*db.FeedEvent, error) {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	sender := For(gc)
 
 	if _, handable := sender.registry[groupKey][action]; !handable {
@@ -164,7 +164,7 @@ func DispatchGroup(ctx context.Context, groupID string, action persist.Action, c
 }
 
 func For(ctx context.Context) *eventSender {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	return gc.Value(eventSenderContextKey).(*eventSender)
 }
 

--- a/graphql/resolver/handlers.go
+++ b/graphql/resolver/handlers.go
@@ -76,7 +76,7 @@ func MutationCachingHandler(newPublicAPI func(context.Context, bool) *publicapi.
 		}
 
 		// Get the request context so dataloaders will add their traces to the request span
-		gc := util.GinContextFromContext(ctx)
+		gc := util.MustGetGinContext(ctx)
 		requestContext := gc.Request.Context()
 
 		// Get or create a new public API with caching disabled, and push it to our context
@@ -161,7 +161,7 @@ func ExperimentalDirectiveHandler() func(ctx context.Context, obj interface{}, n
 
 func FrontendBuildAuthDirectiveHandler() func(ctx context.Context, obj interface{}, next gqlgen.Resolver) (res interface{}, err error) {
 	return func(ctx context.Context, obj interface{}, next gqlgen.Resolver) (res interface{}, err error) {
-		gc := util.GinContextFromContext(ctx)
+		gc := util.MustGetGinContext(ctx)
 
 		authError := model.ErrNotAuthorized{
 			Message: "Not authorized",
@@ -197,7 +197,7 @@ func FrontendBuildAuthDirectiveHandler() func(ctx context.Context, obj interface
 func AuthRequiredDirectiveHandler() func(ctx context.Context, obj interface{}, next gqlgen.Resolver) (res interface{}, err error) {
 
 	return func(ctx context.Context, obj interface{}, next gqlgen.Resolver) (res interface{}, err error) {
-		gc := util.GinContextFromContext(ctx)
+		gc := util.MustGetGinContext(ctx)
 
 		makeErrNotAuthorized := func(e string, c model.AuthorizationError) model.ErrNotAuthorized {
 			return model.ErrNotAuthorized{
@@ -370,7 +370,7 @@ func RequestReporter(schema *ast.Schema, log bool, trace bool) func(ctx context.
 		// Unique ID to make finding this particular log entry easy
 		locatorID := ksuid.New().String()
 
-		gc := util.GinContextFromContext(ctx)
+		gc := util.MustGetGinContext(ctx)
 		oc := gqlgen.GetOperationContext(ctx)
 		operationName := getOperationName(oc)
 		operationType := getOperationType(oc)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -133,8 +133,16 @@ func ErrLogger() gin.HandlerFunc {
 // See: https://gqlgen.com/recipes/gin/
 func GinContextToContext() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Add the Gin context to the request context, because some of our handlers (e.g. GraphQL)
+		// only receive the request context, not the Gin context
 		ctx := context.WithValue(c.Request.Context(), util.GinContextKey, c)
 		c.Request = c.Request.WithContext(ctx)
+
+		// Also add the Gin context to itself, just to ensure that this function works
+		// even when called from a handler that is using the Gin context (or one derived
+		// from it) in the first place
+		c.Set(util.GinContextKey, c)
+
 		c.Next()
 	}
 }

--- a/publicapi/gallery.go
+++ b/publicapi/gallery.go
@@ -617,7 +617,7 @@ func (api GalleryAPI) ViewGallery(ctx context.Context, galleryID persist.DBID) (
 		return db.Gallery{}, err
 	}
 
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 
 	if auth.GetUserAuthedFromCtx(gc) {
 		userID, err := getAuthenticatedUserID(ctx)
@@ -656,7 +656,7 @@ func (api GalleryAPI) ViewGallery(ctx context.Context, galleryID persist.DBID) (
 }
 
 func getExternalID(ctx context.Context) *string {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	if ip := net.ParseIP(gc.ClientIP()); ip != nil && !ip.IsPrivate() {
 		hash := sha256.New()
 		hash.Write([]byte(env.GetString("BACKEND_SECRET") + ip.String()))

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -110,12 +110,12 @@ func For(ctx context.Context) *PublicAPI {
 	}
 
 	// If not, fall back to the one added to the gin context
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	return gc.Value(apiContextKey).(*PublicAPI)
 }
 
 func getAuthenticatedUserID(ctx context.Context) (persist.DBID, error) {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	authError := auth.GetAuthErrorFromCtx(gc)
 
 	if authError != nil {

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -48,12 +48,12 @@ type UserAPI struct {
 }
 
 func (api UserAPI) GetLoggedInUserId(ctx context.Context) persist.DBID {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	return auth.GetUserIDFromCtx(gc)
 }
 
 func (api UserAPI) IsUserLoggedIn(ctx context.Context) bool {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	return auth.GetUserAuthedFromCtx(gc)
 }
 
@@ -396,7 +396,7 @@ func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authentica
 		}
 	}
 
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	err = api.queries.AddPiiAccountCreationInfo(ctx, db.AddPiiAccountCreationInfoParams{
 		UserID:    userID,
 		IpAddress: gc.ClientIP(),

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -284,7 +284,7 @@ func NewMagicLinkClient() *magicclient.API {
 
 // Login logs in a user with a given authentication scheme
 func Login(pCtx context.Context, authenticator Authenticator) (persist.DBID, error) {
-	gc := util.GinContextFromContext(pCtx)
+	gc := util.MustGetGinContext(pCtx)
 
 	authResult, err := authenticator.Authenticate(pCtx)
 	if err != nil {
@@ -307,7 +307,7 @@ func Login(pCtx context.Context, authenticator Authenticator) (persist.DBID, err
 }
 
 func Logout(pCtx context.Context) {
-	gc := util.GinContextFromContext(pCtx)
+	gc := util.MustGetGinContext(pCtx)
 	SetAuthStateForCtx(gc, "", ErrNoCookie)
 	SetJWTCookie(gc, "")
 }

--- a/service/auth/retool.go
+++ b/service/auth/retool.go
@@ -14,7 +14,7 @@ import (
 var errRetoolUnauthorized = errors.New("not authorized")
 
 func RetoolAuthorized(ctx context.Context) error {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 
 	parts := strings.SplitN(gc.GetHeader("Authorization"), "Basic ", 2)
 	if len(parts) != 2 {

--- a/service/mediamapper/mediamapper.go
+++ b/service/mediamapper/mediamapper.go
@@ -43,7 +43,7 @@ func AddTo(c *gin.Context) {
 }
 
 func For(ctx context.Context) *MediaMapper {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	return gc.Value(contextKey).(*MediaMapper)
 }
 

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -75,7 +75,7 @@ func AddTo(ctx *gin.Context, notificationHandlers *NotificationHandlers) {
 }
 
 func For(ctx context.Context) *NotificationHandlers {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	return gc.Value(NotificationHandlerContextKey).(*NotificationHandlers)
 }
 

--- a/service/recommend/recommend.go
+++ b/service/recommend/recommend.go
@@ -24,7 +24,7 @@ func AddTo(c *gin.Context, r *Recommender) {
 }
 
 func For(ctx context.Context) *Recommender {
-	gc := util.GinContextFromContext(ctx)
+	gc := util.MustGetGinContext(ctx)
 	return gc.Value(contextKey).(*Recommender)
 }
 

--- a/service/sentry/sentry.go
+++ b/service/sentry/sentry.go
@@ -37,7 +37,7 @@ var logToSentryLevel = map[logrus.Level]sentry.Level{
 var sentryTrailLimit = 8
 
 func ReportRemappedError(ctx context.Context, originalErr error, remappedErr interface{}) {
-	hub := sentry.GetHubFromContext(ctx)
+	hub := SentryHubFromContext(ctx)
 	if hub == nil {
 		logger.For(ctx).Warnln("could not report error to Sentry because hub is nil")
 		return
@@ -135,7 +135,7 @@ func SetEventContext(scope *sentry.Scope, actorID, subjectID persist.DBID, actio
 // NewSentryHubGinContext returns a new Gin context with a cloned hub of the original context's hub.
 // The hub is added to the context's request so that the sentrygin middleware is able to find it.
 func NewSentryHubGinContext(ctx context.Context) *gin.Context {
-	cpy := util.GinContextFromContext(ctx).Copy()
+	cpy := util.MustGetGinContext(ctx).Copy()
 
 	if hub := SentryHubFromContext(cpy); hub != nil {
 		cpy.Request = cpy.Request.WithContext(sentry.SetHubOnContext(cpy.Request.Context(), hub.Clone()))
@@ -155,10 +155,7 @@ func NewSentryHubContext(ctx context.Context) context.Context {
 }
 
 // SentryHubFromContext gets a Hub from the supplied context, or from an underlying
-// gin.Context if one is available. NOTE: once gin 1.7.8 is released, this method can
-// be removed in favor of sentry's default "sentry.GetHubFromContext" method, as gin 1.7.8
-// will automatically check the request context for a value if it isn't found in the gin
-// context.
+// gin.Context if one is available.
 func SentryHubFromContext(ctx context.Context) *sentry.Hub {
 	// Get a hub via Sentry's standard mechanism if possible
 	if hub := sentry.GetHubFromContext(ctx); hub != nil {
@@ -166,9 +163,15 @@ func SentryHubFromContext(ctx context.Context) *sentry.Hub {
 	}
 
 	// Otherwise, see if there's a hub stored on the gin context
-	gc := util.GinContextFromContext(ctx)
-	if hub := sentrygin.GetHubFromContext(gc); hub != nil {
-		return hub
+	if gc := util.GetGinContext(ctx); gc != nil {
+		if hub := sentrygin.GetHubFromContext(gc); hub != nil {
+			return hub
+		}
+
+		// If not, try to get it from the request context
+		if hub := sentry.GetHubFromContext(gc.Request.Context()); hub != nil {
+			return hub
+		}
 	}
 
 	return nil

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -87,7 +87,7 @@ type MergeUsersInput struct {
 // CreateUser creates a new user
 func CreateUser(pCtx context.Context, authenticator auth.Authenticator, username string, email *persist.Email, bio, galleryName, galleryDesc, galleryPos string, userRepo *postgres.UserRepository,
 	galleryRepo *postgres.GalleryRepository, mp *multichain.Provider) (userID persist.DBID, galleryID persist.DBID, err error) {
-	gc := util.GinContextFromContext(pCtx)
+	gc := util.MustGetGinContext(pCtx)
 
 	authResult, err := authenticator.Authenticate(pCtx)
 	if err != nil {


### PR DESCRIPTION
The `tokenprocessing` service was failing to report some errors to Sentry because retrieving a `sentry.Hub` from the available `context` was failing. This happens because of an annoying context split: each request has a `gin.Context` and an `http.Request.Context`. When using GraphQL, gqlgen passes the `http.Request.Context` to resolvers. In other scenarios (like token processing), we may pass the `gin.Context` to handlers. The existing flow was only set up to find a Sentry hub from a `http.Request.Context`; this PR adds handling to retrieve the Sentry hub from a `gin.Context` as well.

**Notable change:** `util.GinContextFromContext` has been renamed to `util.MustGetGinContext`, which is a more idiomatic golang way to say "get this or panic." There's also a new variant, `util.GetGinContext`, which will return nil instead of panicking. We'll still want to use the panic version for most purposes, since the lack of a Gin context usually indicates that something is very wrong, but there are some scenarios (like our Sentry handling) where the existence of a Gin context should be optional (e.g. maybe we want to call Sentry from a service that doesn't handle HTTP requests and doesn't use Gin, and that shouldn't cause a panic).