### PR TITLE
keep track of indexer stats each pipeline

### DIFF
--- a/db/gen/indexerdb/models_gen.go
+++ b/db/gen/indexerdb/models_gen.go
@@ -13,20 +13,21 @@ import (
 )
 
 type BlockchainStatistic struct {
-	ID             persist.DBID
-	Deleted        bool
-	Version        int32
-	CreatedAt      time.Time
-	LastUpdated    time.Time
-	BlockStart     persist.BlockNumber
-	BlockEnd       persist.BlockNumber
-	TotalLogs      sql.NullInt64
-	TotalTransfers sql.NullInt64
-	TotalTokens    sql.NullInt64
-	TotalContracts sql.NullInt64
-	Success        bool
-	ContractStats  pgtype.JSONB
-	TokenStats     pgtype.JSONB
+	ID                    persist.DBID
+	Deleted               bool
+	Version               int32
+	CreatedAt             time.Time
+	LastUpdated           time.Time
+	BlockStart            persist.BlockNumber
+	BlockEnd              persist.BlockNumber
+	TotalLogs             sql.NullInt64
+	TotalTransfers        sql.NullInt64
+	TotalTokens           sql.NullInt64
+	TotalContracts        sql.NullInt64
+	Success               bool
+	ContractStats         pgtype.JSONB
+	TokenStats            pgtype.JSONB
+	ProcessingTimeSeconds sql.NullInt64
 }
 
 type Contract struct {

--- a/db/gen/indexerdb/models_gen.go
+++ b/db/gen/indexerdb/models_gen.go
@@ -12,6 +12,23 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
+type BlockchainStatistic struct {
+	ID             persist.DBID
+	Deleted        bool
+	Version        int32
+	CreatedAt      time.Time
+	LastUpdated    time.Time
+	BlockStart     persist.BlockNumber
+	BlockEnd       persist.BlockNumber
+	TotalLogs      sql.NullInt64
+	TotalTransfers sql.NullInt64
+	TotalTokens    sql.NullInt64
+	TotalContracts sql.NullInt64
+	Success        bool
+	ContractStats  pgtype.JSONB
+	TokenStats     pgtype.JSONB
+}
+
 type Contract struct {
 	ID             persist.DBID
 	Deleted        bool

--- a/db/gen/indexerdb/query.sql.go
+++ b/db/gen/indexerdb/query.sql.go
@@ -69,16 +69,17 @@ func (q *Queries) UpdateStatisticContractStats(ctx context.Context, arg UpdateSt
 }
 
 const updateStatisticSuccess = `-- name: UpdateStatisticSuccess :exec
-update blockchain_statistics set success = $1 where id = $2
+update blockchain_statistics set success = $1, processing_time_seconds = $2 where id = $3
 `
 
 type UpdateStatisticSuccessParams struct {
-	Success bool
-	ID      persist.DBID
+	Success               bool
+	ProcessingTimeSeconds sql.NullInt64
+	ID                    persist.DBID
 }
 
 func (q *Queries) UpdateStatisticSuccess(ctx context.Context, arg UpdateStatisticSuccessParams) error {
-	_, err := q.db.Exec(ctx, updateStatisticSuccess, arg.Success, arg.ID)
+	_, err := q.db.Exec(ctx, updateStatisticSuccess, arg.Success, arg.ProcessingTimeSeconds, arg.ID)
 	return err
 }
 

--- a/db/gen/indexerdb/query.sql.go
+++ b/db/gen/indexerdb/query.sql.go
@@ -7,6 +7,10 @@ package indexerdb
 
 import (
 	"context"
+	"database/sql"
+
+	"github.com/jackc/pgtype"
+	"github.com/mikeydub/go-gallery/service/persist"
 )
 
 const firstContract = `-- name: FirstContract :one
@@ -32,4 +36,105 @@ func (q *Queries) FirstContract(ctx context.Context) (Contract, error) {
 		&i.OwnerAddress,
 	)
 	return i, err
+}
+
+const insertStatistic = `-- name: InsertStatistic :one
+insert into blockchain_statistics (block_start, block_end) values ($1, $2) returning id
+`
+
+type InsertStatisticParams struct {
+	BlockStart persist.BlockNumber
+	BlockEnd   persist.BlockNumber
+}
+
+func (q *Queries) InsertStatistic(ctx context.Context, arg InsertStatisticParams) (persist.DBID, error) {
+	row := q.db.QueryRow(ctx, insertStatistic, arg.BlockStart, arg.BlockEnd)
+	var id persist.DBID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const updateStatisticContractStats = `-- name: UpdateStatisticContractStats :exec
+update blockchain_statistics set contract_stats = $1 where id = $2
+`
+
+type UpdateStatisticContractStatsParams struct {
+	ContractStats pgtype.JSONB
+	ID            persist.DBID
+}
+
+func (q *Queries) UpdateStatisticContractStats(ctx context.Context, arg UpdateStatisticContractStatsParams) error {
+	_, err := q.db.Exec(ctx, updateStatisticContractStats, arg.ContractStats, arg.ID)
+	return err
+}
+
+const updateStatisticSuccess = `-- name: UpdateStatisticSuccess :exec
+update blockchain_statistics set success = $1 where id = $2
+`
+
+type UpdateStatisticSuccessParams struct {
+	Success bool
+	ID      persist.DBID
+}
+
+func (q *Queries) UpdateStatisticSuccess(ctx context.Context, arg UpdateStatisticSuccessParams) error {
+	_, err := q.db.Exec(ctx, updateStatisticSuccess, arg.Success, arg.ID)
+	return err
+}
+
+const updateStatisticTokenStats = `-- name: UpdateStatisticTokenStats :exec
+update blockchain_statistics set token_stats = $1 where id = $2
+`
+
+type UpdateStatisticTokenStatsParams struct {
+	TokenStats pgtype.JSONB
+	ID         persist.DBID
+}
+
+func (q *Queries) UpdateStatisticTokenStats(ctx context.Context, arg UpdateStatisticTokenStatsParams) error {
+	_, err := q.db.Exec(ctx, updateStatisticTokenStats, arg.TokenStats, arg.ID)
+	return err
+}
+
+const updateStatisticTotalLogs = `-- name: UpdateStatisticTotalLogs :exec
+update blockchain_statistics set total_logs = $1 where id = $2
+`
+
+type UpdateStatisticTotalLogsParams struct {
+	TotalLogs sql.NullInt64
+	ID        persist.DBID
+}
+
+func (q *Queries) UpdateStatisticTotalLogs(ctx context.Context, arg UpdateStatisticTotalLogsParams) error {
+	_, err := q.db.Exec(ctx, updateStatisticTotalLogs, arg.TotalLogs, arg.ID)
+	return err
+}
+
+const updateStatisticTotalTokensAndContracts = `-- name: UpdateStatisticTotalTokensAndContracts :exec
+update blockchain_statistics set total_tokens = $1, total_contracts = $2 where id = $3
+`
+
+type UpdateStatisticTotalTokensAndContractsParams struct {
+	TotalTokens    sql.NullInt64
+	TotalContracts sql.NullInt64
+	ID             persist.DBID
+}
+
+func (q *Queries) UpdateStatisticTotalTokensAndContracts(ctx context.Context, arg UpdateStatisticTotalTokensAndContractsParams) error {
+	_, err := q.db.Exec(ctx, updateStatisticTotalTokensAndContracts, arg.TotalTokens, arg.TotalContracts, arg.ID)
+	return err
+}
+
+const updateStatisticTotalTransfers = `-- name: UpdateStatisticTotalTransfers :exec
+update blockchain_statistics set total_transfers = $1 where id = $2
+`
+
+type UpdateStatisticTotalTransfersParams struct {
+	TotalTransfers sql.NullInt64
+	ID             persist.DBID
+}
+
+func (q *Queries) UpdateStatisticTotalTransfers(ctx context.Context, arg UpdateStatisticTotalTransfersParams) error {
+	_, err := q.db.Exec(ctx, updateStatisticTotalTransfers, arg.TotalTransfers, arg.ID)
+	return err
 }

--- a/db/migrations/indexer/000003_stats.up.sql
+++ b/db/migrations/indexer/000003_stats.up.sql
@@ -12,7 +12,8 @@ create table if not exists blockchain_statistics (
     total_contracts bigint,
     success boolean default false not null,
     contract_stats jsonb,
-    token_stats jsonb
+    token_stats jsonb,
+    processing_time_seconds bigint
 );
 
 create unique index if not exists blockchain_statistics_blocks_idx on blockchain_statistics (block_start, block_end) where deleted = false;

--- a/db/migrations/indexer/000003_stats.up.sql
+++ b/db/migrations/indexer/000003_stats.up.sql
@@ -1,0 +1,16 @@
+create table if not exists blockchain_statistics (
+    id character varying(255) PRIMARY KEY,
+    deleted boolean default false not null,
+    version integer default 0 not null,
+    created_at timestamp with time zone default CURRENT_TIMESTAMP not null,
+    last_updated timestamp with time zone default CURRENT_TIMESTAMP not null,
+    block_start bigint not null,
+    block_end bigint not null,
+    total_logs bigint,
+    total_transfers bigint,
+    total_tokens bigint,
+    total_contracts bigint,
+    success boolean default false not null,
+    contract_stats jsonb,
+    token_stats jsonb
+);

--- a/db/migrations/indexer/000003_stats.up.sql
+++ b/db/migrations/indexer/000003_stats.up.sql
@@ -14,3 +14,5 @@ create table if not exists blockchain_statistics (
     contract_stats jsonb,
     token_stats jsonb
 );
+
+create unique index if not exists blockchain_statistics_blocks_idx on blockchain_statistics (block_start, block_end) where deleted = false;

--- a/db/queries/indexer/query.sql
+++ b/db/queries/indexer/query.sql
@@ -15,7 +15,7 @@ update blockchain_statistics set total_transfers = $1 where id = $2;
 update blockchain_statistics set total_tokens = $1, total_contracts = $2 where id = $3;
 
 -- name: UpdateStatisticSuccess :exec
-update blockchain_statistics set success = $1 where id = $2;
+update blockchain_statistics set success = $1, processing_time_seconds = $2 where id = $3;
 
 -- name: UpdateStatisticContractStats :exec
 update blockchain_statistics set contract_stats = $1 where id = $2;

--- a/db/queries/indexer/query.sql
+++ b/db/queries/indexer/query.sql
@@ -1,3 +1,24 @@
 -- name: FirstContract :one
 -- sqlc needs at least one query in order to generate the models.
 SELECT * FROM contracts LIMIT 1;
+
+-- name: InsertStatistic :one
+insert into blockchain_statistics (block_start, block_end) values ($1, $2) returning id;
+
+-- name: UpdateStatisticTotalLogs :exec
+update blockchain_statistics set total_logs = $1 where id = $2;
+
+-- name: UpdateStatisticTotalTransfers :exec
+update blockchain_statistics set total_transfers = $1 where id = $2;
+
+-- name: UpdateStatisticTotalTokensAndContracts :exec
+update blockchain_statistics set total_tokens = $1, total_contracts = $2 where id = $3;
+
+-- name: UpdateStatisticSuccess :exec
+update blockchain_statistics set success = $1 where id = $2;
+
+-- name: UpdateStatisticContractStats :exec
+update blockchain_statistics set contract_stats = $1 where id = $2;
+
+-- name: UpdateStatisticTokenStats :exec
+update blockchain_statistics set token_stats = $1 where id = $2;

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -26,7 +27,9 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/getsentry/sentry-go"
 	shell "github.com/ipfs/go-ipfs-api"
+	"github.com/jackc/pgtype"
 	"github.com/mikeydub/go-gallery/contracts"
+	"github.com/mikeydub/go-gallery/db/gen/indexerdb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer/refresh"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -118,6 +121,7 @@ type indexer struct {
 	ipfsClient        *shell.Shell
 	arweaveClient     *goar.Client
 	storageClient     *storage.Client
+	queries           *indexerdb.Queries
 	tokenRepo         persist.TokenRepository
 	contractRepo      persist.ContractRepository
 	addressFilterRepo refresh.AddressFilterRepository
@@ -146,7 +150,7 @@ type indexer struct {
 }
 
 // newIndexer sets up an indexer for retrieving the specified events that will process tokens
-func newIndexer(ethClient *ethclient.Client, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, tokenRepo persist.TokenRepository, contractRepo persist.ContractRepository, addressFilterRepo refresh.AddressFilterRepository, pChain persist.Chain, pEvents []eventHash, getLogsFunc getLogsFunc, startingBlock, maxBlock *uint64) *indexer {
+func newIndexer(ethClient *ethclient.Client, httpClient *http.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, queries *indexerdb.Queries, tokenRepo persist.TokenRepository, contractRepo persist.ContractRepository, addressFilterRepo refresh.AddressFilterRepository, pChain persist.Chain, pEvents []eventHash, getLogsFunc getLogsFunc, startingBlock, maxBlock *uint64) *indexer {
 	if rpcEnabled && ethClient == nil {
 		panic("RPC is enabled but an ethClient wasn't provided!")
 	}
@@ -161,6 +165,7 @@ func newIndexer(ethClient *ethclient.Client, httpClient *http.Client, ipfsClient
 		storageClient:     storageClient,
 		tokenRepo:         tokenRepo,
 		contractRepo:      contractRepo,
+		queries:           queries,
 		addressFilterRepo: addressFilterRepo,
 		dbMu:              &sync.Mutex{},
 		stateMu:           &sync.Mutex{},
@@ -178,7 +183,7 @@ func newIndexer(ethClient *ethclient.Client, httpClient *http.Client, ipfsClient
 
 		getLogsFunc: getLogsFunc,
 
-		contractDBHooks: newContractHooks(contractRepo, ethClient, httpClient, ownerStats),
+		contractDBHooks: newContractHooks(queries, contractRepo, ethClient, httpClient, ownerStats),
 		tokenDBHooks:    newTokenHooks(),
 
 		mostRecentBlock: 0,
@@ -312,16 +317,26 @@ func (i *indexer) startPipeline(ctx context.Context, start persist.BlockNumber, 
 	plugins := NewTransferPlugins(ctx)
 	enabledPlugins := []chan<- TransferPluginMsg{plugins.contracts.in}
 
+	statsID, err := i.queries.InsertStatistic(ctx, indexerdb.InsertStatisticParams{BlockStart: start, BlockEnd: start + blocksPerLogsCall})
+	if err != nil {
+		panic(err)
+	}
+
 	go func() {
 		ctx := sentryutil.NewSentryHubContext(ctx)
 		span, ctx := tracing.StartSpan(ctx, "indexer.logs", "processLogs")
 		defer tracing.FinishSpan(span)
 
-		logs := i.fetchLogs(ctx, start, topics)
+		logs := i.fetchLogs(ctx, start, topics, statsID)
 		i.processLogs(ctx, transfers, logs)
 	}()
-	go i.processAllTransfers(sentryutil.NewSentryHubContext(ctx), transfers, enabledPlugins)
-	i.processTokens(ctx, plugins.contracts.out)
+	go i.processAllTransfers(sentryutil.NewSentryHubContext(ctx), transfers, enabledPlugins, statsID)
+	i.processTokens(ctx, plugins.contracts.out, statsID)
+
+	err = i.queries.UpdateStatisticSuccess(ctx, indexerdb.UpdateStatisticSuccessParams{ID: statsID, Success: true})
+	if err != nil {
+		panic(err)
+	}
 
 	logger.For(ctx).Warnf("Finished processing %d blocks from block %d in %s", blocksPerLogsCall, start.Uint64(), time.Since(startTime))
 }
@@ -334,9 +349,24 @@ func (i *indexer) startNewBlocksPipeline(ctx context.Context, topics [][]common.
 	plugins := NewTransferPlugins(ctx)
 	enabledPlugins := []chan<- TransferPluginMsg{plugins.contracts.in}
 
-	go i.pollNewLogs(sentryutil.NewSentryHubContext(ctx), transfers, topics)
-	go i.processAllTransfers(sentryutil.NewSentryHubContext(ctx), transfers, enabledPlugins)
-	i.processTokens(ctx, plugins.contracts.out)
+	mostRecentBlock, err := rpc.RetryGetBlockNumber(ctx, i.ethClient)
+	if err != nil {
+		panic(err)
+	}
+
+	if i.lastSyncedChunk+blocksPerLogsCall > mostRecentBlock {
+		logger.For(ctx).Infof("No new blocks to process. Last synced block: %d, most recent block: %d", i.lastSyncedChunk, mostRecentBlock)
+		return
+	}
+
+	statsID, err := i.queries.InsertStatistic(ctx, indexerdb.InsertStatisticParams{BlockStart: persist.BlockNumber(i.lastSyncedChunk), BlockEnd: persist.BlockNumber(mostRecentBlock - (i.mostRecentBlock % blocksPerLogsCall))})
+	if err != nil {
+		panic(err)
+	}
+
+	go i.pollNewLogs(sentryutil.NewSentryHubContext(ctx), transfers, topics, mostRecentBlock, statsID)
+	go i.processAllTransfers(sentryutil.NewSentryHubContext(ctx), transfers, enabledPlugins, statsID)
+	i.processTokens(ctx, plugins.contracts.out, statsID)
 
 }
 
@@ -356,7 +386,7 @@ func (i *indexer) listenForNewBlocks(ctx context.Context) {
 
 // LOGS FUNCS ---------------------------------------------------------------
 
-func (i *indexer) fetchLogs(ctx context.Context, startingBlock persist.BlockNumber, topics [][]common.Hash) []types.Log {
+func (i *indexer) fetchLogs(ctx context.Context, startingBlock persist.BlockNumber, topics [][]common.Hash, statsID persist.DBID) []types.Log {
 	curBlock := startingBlock.BigInt()
 	nextBlock := new(big.Int).Add(curBlock, big.NewInt(int64(blocksPerLogsCall)))
 
@@ -365,6 +395,14 @@ func (i *indexer) fetchLogs(ctx context.Context, startingBlock persist.BlockNumb
 	logsTo, err := i.getLogsFunc(ctx, curBlock, nextBlock, topics)
 	if err != nil {
 		panic(fmt.Sprintf("error getting logs: %s", err))
+	}
+
+	err = i.queries.UpdateStatisticTotalLogs(ctx, indexerdb.UpdateStatisticTotalLogsParams{
+		ID:        statsID,
+		TotalLogs: sql.NullInt64{Int64: int64(len(logsTo)), Valid: true},
+	})
+	if err != nil {
+		panic(err)
 	}
 
 	logger.For(ctx).Infof("Found %d logs at block %d", len(logsTo), curBlock.Uint64())
@@ -638,19 +676,16 @@ func getTokenIdentifiersFromLog(ctx context.Context, log types.Log) ([]tokenIden
 
 }
 
-func (i *indexer) pollNewLogs(ctx context.Context, transfersChan chan<- []transfersAtBlock, topics [][]common.Hash) {
+func (i *indexer) pollNewLogs(ctx context.Context, transfersChan chan<- []transfersAtBlock, topics [][]common.Hash, mostRecentBlock uint64, statsID persist.DBID) {
 	span, ctx := tracing.StartSpan(ctx, "indexer.logs", "pollLogs")
 	defer tracing.FinishSpan(span)
 	defer close(transfersChan)
 	defer recoverAndWait(ctx)
 	defer sentryutil.RecoverAndRaise(ctx)
 
-	mostRecentBlock, err := rpc.RetryGetBlockNumber(ctx, i.ethClient)
-	if err != nil {
-		panic(err)
-	}
-
 	logger.For(ctx).Infof("Subscribing to new logs from block %d starting with block %d", mostRecentBlock, i.lastSyncedChunk)
+
+	totalLogs := &atomic.Int64{}
 
 	wp := workerpool.New(10)
 	// starting at the last chunk that we synced, poll for logs in chunks of blocksPerLogsCall
@@ -680,6 +715,8 @@ func (i *indexer) pollNewLogs(ctx context.Context, transfersChan chan<- []transf
 				return
 			}
 
+			totalLogs.Add(int64(len(logsTo)))
+
 			go saveLogsInBlockRange(ctx, strconv.Itoa(int(curBlock)), strconv.Itoa(int(nextBlock)), logsTo, i.storageClient, i.memoryMu)
 
 			logger.For(ctx).Infof("Found %d logs at block %d", len(logsTo), curBlock)
@@ -696,7 +733,18 @@ func (i *indexer) pollNewLogs(ctx context.Context, transfersChan chan<- []transf
 
 	wp.StopWait()
 
-	logger.For(ctx).Infof("Processed logs from %d to %d.", i.lastSyncedChunk, mostRecentBlock)
+	total := totalLogs.Load()
+
+	err := i.queries.UpdateStatisticTotalLogs(ctx, indexerdb.UpdateStatisticTotalLogsParams{
+		TotalLogs: sql.NullInt64{Int64: total, Valid: true},
+		ID:        statsID,
+	})
+	if err != nil {
+		logger.For(ctx).WithError(err).Error("Failed to update total logs")
+		panic(err)
+	}
+
+	logger.For(ctx).Infof("Processed %d logs from %d to %d.", total, i.lastSyncedChunk, mostRecentBlock)
 
 	i.updateLastSynced(mostRecentBlock - (mostRecentBlock % blocksPerLogsCall))
 
@@ -704,7 +752,7 @@ func (i *indexer) pollNewLogs(ctx context.Context, transfersChan chan<- []transf
 
 // TRANSFERS FUNCS -------------------------------------------------------------
 
-func (i *indexer) processAllTransfers(ctx context.Context, incomingTransfers <-chan []transfersAtBlock, plugins []chan<- TransferPluginMsg) {
+func (i *indexer) processAllTransfers(ctx context.Context, incomingTransfers <-chan []transfersAtBlock, plugins []chan<- TransferPluginMsg, statsID persist.DBID) {
 	span, ctx := tracing.StartSpan(ctx, "indexer.transfers", "processTransfers")
 	defer tracing.FinishSpan(span)
 	defer sentryutil.RecoverAndRaise(ctx)
@@ -715,10 +763,13 @@ func (i *indexer) processAllTransfers(ctx context.Context, incomingTransfers <-c
 	wp := workerpool.New(5)
 
 	logger.For(ctx).Info("Starting to process transfers...")
+	var totatTransfers int64
 	for transfers := range incomingTransfers {
 		if transfers == nil || len(transfers) == 0 {
 			continue
 		}
+
+		totatTransfers += int64(len(transfers))
 
 		submit := transfers
 		wp.Submit(func() {
@@ -729,8 +780,19 @@ func (i *indexer) processAllTransfers(ctx context.Context, incomingTransfers <-c
 			logger.For(ctx).Infof("Processed %d transfers in %s", len(submit), time.Since(timeStart))
 		})
 	}
+
 	logger.For(ctx).Info("Waiting for transfers to finish...")
 	wp.StopWait()
+
+	err := i.queries.UpdateStatisticTotalTransfers(ctx, indexerdb.UpdateStatisticTotalTransfersParams{
+		TotalTransfers: sql.NullInt64{Int64: totatTransfers, Valid: true},
+		ID:             statsID,
+	})
+	if err != nil {
+		logger.For(ctx).WithError(err).Error("Failed to update total transfers")
+		panic(err)
+	}
+
 	logger.For(ctx).Info("Closing field channels...")
 }
 
@@ -755,7 +817,7 @@ func (i *indexer) processTransfers(ctx context.Context, transfers []transfersAtB
 
 // TOKENS FUNCS ---------------------------------------------------------------
 
-func (i *indexer) processTokens(ctx context.Context, contractsOut <-chan contractAtBlock) {
+func (i *indexer) processTokens(ctx context.Context, contractsOut <-chan contractAtBlock, statsID persist.DBID) {
 
 	wg := &sync.WaitGroup{}
 	mu := &sync.Mutex{}
@@ -768,7 +830,12 @@ func (i *indexer) processTokens(ctx context.Context, contractsOut <-chan contrac
 
 	contracts := contractsAtBlockToContracts(contractsMap)
 
-	i.runDBHooks(ctx, contracts, []persist.Token{})
+	i.queries.UpdateStatisticTotalTokensAndContracts(ctx, indexerdb.UpdateStatisticTotalTokensAndContractsParams{
+		TotalContracts: sql.NullInt64{Int64: int64(len(contracts)), Valid: true},
+		ID:             statsID,
+	})
+
+	i.runDBHooks(ctx, contracts, []persist.Token{}, statsID)
 }
 
 func contractsAtBlockToContracts(contractsAtBlock map[persist.EthereumTokenIdentifiers]contractAtBlock) []persist.Contract {
@@ -784,7 +851,7 @@ func contractsAtBlockToContracts(contractsAtBlock map[persist.EthereumTokenIdent
 	return contracts
 }
 
-func (i *indexer) runDBHooks(ctx context.Context, contracts []persist.Contract, tokens []persist.Token) {
+func (i *indexer) runDBHooks(ctx context.Context, contracts []persist.Contract, tokens []persist.Token, statsID persist.DBID) {
 	defer recoverAndWait(ctx)
 
 	wp := workerpool.New(10)
@@ -792,14 +859,14 @@ func (i *indexer) runDBHooks(ctx context.Context, contracts []persist.Contract, 
 	for _, hook := range i.contractDBHooks {
 		hook := hook
 		wp.Submit(func() {
-			hook(ctx, contracts)
+			hook(ctx, contracts, statsID)
 		})
 	}
 
 	for _, hook := range i.tokenDBHooks {
 		hook := hook
 		wp.Submit(func() {
-			hook(ctx, tokens)
+			hook(ctx, tokens, statsID)
 		})
 	}
 
@@ -816,8 +883,10 @@ type alchemyContractMetadata struct {
 	ContractDeployer persist.EthereumAddress  `json:"contractDeployer"`
 }
 
-func fillContractFields(ctx context.Context, contracts []persist.Contract, contractRepo persist.ContractRepository, httpClient *http.Client, ethClient *ethclient.Client, contractOwnerStats *sync.Map, upChan chan<- []persist.Contract) {
+func fillContractFields(ctx context.Context, contracts []persist.Contract, queries *indexerdb.Queries, contractRepo persist.ContractRepository, httpClient *http.Client, ethClient *ethclient.Client, contractOwnerStats *sync.Map, upChan chan<- []persist.Contract, statsID persist.DBID) {
 	defer close(upChan)
+
+	innerPipelineStats := map[any]any{}
 
 	contractsNotInDB := make(chan persist.Contract)
 
@@ -932,12 +1001,36 @@ func fillContractFields(ctx context.Context, contracts []persist.Contract, contr
 				contractOwnerStats.Store(method, total)
 			}
 
+			it, ok = innerPipelineStats[method]
+			if ok {
+				total := it.(int)
+				total++
+				innerPipelineStats[method] = total
+			} else {
+				innerPipelineStats[method] = 1
+			}
+
 			toUp = append(toUp, contract)
 		}
 
 		logger.For(ctx).Infof("Fetched metadata for %d contracts", len(toUp))
 
 		upChan <- toUp
+	}
+
+	marshalled, err := json.Marshal(innerPipelineStats)
+	if err != nil {
+		logger.For(ctx).WithError(err).Error("Failed to marshal inner pipeline stats")
+		panic(err)
+	}
+
+	err = queries.UpdateStatisticContractStats(ctx, indexerdb.UpdateStatisticContractStatsParams{
+		ContractStats: pgtype.JSONB{Bytes: marshalled, Status: pgtype.Present},
+		ID:            statsID,
+	})
+	if err != nil {
+		logger.For(ctx).WithError(err).Error("Failed to update contract stats")
+		panic(err)
 	}
 
 	logger.For(ctx).Infof("Fetched metadata for total %d contracts", len(contracts))

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -333,7 +333,7 @@ func (i *indexer) startPipeline(ctx context.Context, start persist.BlockNumber, 
 	go i.processAllTransfers(sentryutil.NewSentryHubContext(ctx), transfers, enabledPlugins, statsID)
 	i.processTokens(ctx, plugins.contracts.out, statsID)
 
-	err = i.queries.UpdateStatisticSuccess(ctx, indexerdb.UpdateStatisticSuccessParams{ID: statsID, Success: true})
+	err = i.queries.UpdateStatisticSuccess(ctx, indexerdb.UpdateStatisticSuccessParams{ID: statsID, Success: true, ProcessingTimeSeconds: sql.NullInt64{Int64: int64(time.Since(startTime) / time.Second), Valid: true}})
 	if err != nil {
 		panic(err)
 	}

--- a/indexer/t__utils_test.go
+++ b/indexer/t__utils_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/jackc/pgx/v4/pgxpool"
 	migrate "github.com/mikeydub/go-gallery/db"
+	"github.com/mikeydub/go-gallery/db/gen/indexerdb"
 	"github.com/mikeydub/go-gallery/docker"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer/refresh"
@@ -79,8 +80,9 @@ func newMockIndexer(db *sql.DB, pool *pgxpool.Pool) *indexer {
 	ethClient := rpc.NewEthSocketClient()
 	storageClient := newStorageClient(context.Background())
 	bucket := storageClient.Bucket(env.GetString("GCLOUD_TOKEN_LOGS_BUCKET"))
+	queries := indexerdb.New(pool)
 
-	i := newIndexer(ethClient, &http.Client{Timeout: 10 * time.Minute}, nil, nil, nil, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), refresh.AddressFilterRepository{Bucket: bucket}, persist.ChainETH, defaultTransferEvents, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
+	i := newIndexer(ethClient, &http.Client{Timeout: 10 * time.Minute}, nil, nil, nil, queries, postgres.NewTokenRepository(db), postgres.NewContractRepository(db), refresh.AddressFilterRepository{Bucket: bucket}, persist.ChainETH, defaultTransferEvents, func(ctx context.Context, curBlock, nextBlock *big.Int, topics [][]common.Hash) ([]types.Log, error) {
 		transferAgainLogs := []types.Log{{
 			Address:     common.HexToAddress("0x0c2ee19b2a89943066c2dc7f1bddcc907f614033"),
 			Topics:      []common.Hash{common.HexToHash("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"), common.HexToHash(testAddress), common.HexToHash("0x0000000000000000000000008914496dc01efcc49a2fa340331fb90969b6f1d2"), common.HexToHash("0x00000000000000000000000000000000000000000000000000000000000000d9")},

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -19,6 +19,10 @@ sql:
           # Note: to override one of these wildcard entries, add a more specific entry (like some_table.id) above
           - column: "*.id"
             go_type: "github.com/mikeydub/go-gallery/service/persist.DBID"
+          - column: "*.block_start"
+            go_type: "github.com/mikeydub/go-gallery/service/persist.BlockNumber"
+          - column: "*.block_end"
+            go_type: "github.com/mikeydub/go-gallery/service/persist.BlockNumber"
 
   # Backend model gen
   - schema:


### PR DESCRIPTION
Changes:

- **Added** `blockchain_statistics` with information on each pipeline the indexer processes
- **Added** queries for updating and inserting statistical information

What we keep track of:

- Total logs processed
- Total transfers processed
- Total contracts found
- What methods we use for finding contract owner
- Success of pipeline
- Total time taken for pipeline in seconds