### PR TITLE
create user inside tx

### DIFF
--- a/adminapi/admin.go
+++ b/adminapi/admin.go
@@ -127,7 +127,7 @@ func (api *AdminAPI) AddWalletToUserUnchecked(ctx context.Context, username stri
 		}, nil
 	}
 
-	return user.AddWalletToUser(ctx, u.ID, chainAddress, authenticator{authMethod}, api.repos.UserRepository, api.repos.WalletRepository, api.multichain)
+	return user.AddWalletToUser(ctx, u.ID, chainAddress, authenticator{authMethod}, api.repos.UserRepository, api.multichain)
 }
 
 func requireRetoolAuthorized(ctx context.Context) {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -89,6 +89,20 @@ func (q *Queries) AddUserRoles(ctx context.Context, arg AddUserRolesParams) erro
 	return err
 }
 
+const addWalletToUserByID = `-- name: AddWalletToUserByID :exec
+update users set wallets = array_append(wallets, $1::varchar) where id = $2
+`
+
+type AddWalletToUserByIDParams struct {
+	WalletID string
+	UserID   persist.DBID
+}
+
+func (q *Queries) AddWalletToUserByID(ctx context.Context, arg AddWalletToUserByIDParams) error {
+	_, err := q.db.Exec(ctx, addWalletToUserByID, arg.WalletID, arg.UserID)
+	return err
+}
+
 const blockUserFromFeed = `-- name: BlockUserFromFeed :exec
 INSERT INTO feed_blocklist (id, user_id, action) VALUES ($1, $2, $3)
 `
@@ -855,6 +869,15 @@ func (q *Queries) DeleteCollections(ctx context.Context, ids []string) error {
 	return err
 }
 
+const deleteUserByID = `-- name: DeleteUserByID :exec
+update users set deleted = true where id = $1
+`
+
+func (q *Queries) DeleteUserByID(ctx context.Context, id persist.DBID) error {
+	_, err := q.db.Exec(ctx, deleteUserByID, id)
+	return err
+}
+
 const deleteUserRoles = `-- name: DeleteUserRoles :exec
 update user_roles set deleted = true, last_updated = now() where user_id = $1 and role = any($2)
 `
@@ -866,6 +889,15 @@ type DeleteUserRolesParams struct {
 
 func (q *Queries) DeleteUserRoles(ctx context.Context, arg DeleteUserRolesParams) error {
 	_, err := q.db.Exec(ctx, deleteUserRoles, arg.UserID, arg.Roles)
+	return err
+}
+
+const deleteWalletByID = `-- name: DeleteWalletByID :exec
+update wallets set deleted = true, last_updated = now() where id = $1
+`
+
+func (q *Queries) DeleteWalletByID(ctx context.Context, id persist.DBID) error {
+	_, err := q.db.Exec(ctx, deleteWalletByID, id)
 	return err
 }
 
@@ -2850,6 +2882,35 @@ func (q *Queries) GetUserByUsername(ctx context.Context, username string) (User,
 	return i, err
 }
 
+const getUserByWalletID = `-- name: GetUserByWalletID :one
+select id, deleted, version, last_updated, created_at, username, username_idempotent, wallets, bio, traits, universal, notification_settings, email_verified, email_unsubscriptions, featured_gallery, primary_wallet_id, user_experiences from users where array[$1::varchar]::varchar[] <@ wallets and deleted = false
+`
+
+func (q *Queries) GetUserByWalletID(ctx context.Context, wallet string) (User, error) {
+	row := q.db.QueryRow(ctx, getUserByWalletID, wallet)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.Deleted,
+		&i.Version,
+		&i.LastUpdated,
+		&i.CreatedAt,
+		&i.Username,
+		&i.UsernameIdempotent,
+		&i.Wallets,
+		&i.Bio,
+		&i.Traits,
+		&i.Universal,
+		&i.NotificationSettings,
+		&i.EmailVerified,
+		&i.EmailUnsubscriptions,
+		&i.FeaturedGallery,
+		&i.PrimaryWalletID,
+		&i.UserExperiences,
+	)
+	return i, err
+}
+
 const getUserExperiencesByUserID = `-- name: GetUserExperiencesByUserID :one
 select user_experiences from users where id = $1
 `
@@ -3689,6 +3750,56 @@ func (q *Queries) HasLaterGroupedEvent(ctx context.Context, arg HasLaterGroupedE
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err
+}
+
+const insertUser = `-- name: InsertUser :exec
+insert into users (id, username, username_idempotent, bio, wallets, universal, email_unsubscriptions, primary_wallet_id) values ($1, $2, $3, $4, $5, $6, $7, $8) returning id
+`
+
+type InsertUserParams struct {
+	ID                   persist.DBID
+	Username             sql.NullString
+	UsernameIdempotent   sql.NullString
+	Bio                  sql.NullString
+	Wallets              persist.WalletList
+	Universal            bool
+	EmailUnsubscriptions persist.EmailUnsubscriptions
+	PrimaryWalletID      persist.DBID
+}
+
+func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) error {
+	_, err := q.db.Exec(ctx, insertUser,
+		arg.ID,
+		arg.Username,
+		arg.UsernameIdempotent,
+		arg.Bio,
+		arg.Wallets,
+		arg.Universal,
+		arg.EmailUnsubscriptions,
+		arg.PrimaryWalletID,
+	)
+	return err
+}
+
+const insertWallet = `-- name: InsertWallet :exec
+insert into wallets (id, address, chain, wallet_type) values ($1, $2, $3, $4)
+`
+
+type InsertWalletParams struct {
+	ID         persist.DBID
+	Address    persist.Address
+	Chain      persist.Chain
+	WalletType persist.WalletType
+}
+
+func (q *Queries) InsertWallet(ctx context.Context, arg InsertWalletParams) error {
+	_, err := q.db.Exec(ctx, insertWallet,
+		arg.ID,
+		arg.Address,
+		arg.Chain,
+		arg.WalletType,
+	)
+	return err
 }
 
 const isActorActionActive = `-- name: IsActorActionActive :one

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -990,3 +990,21 @@ where a.user_id = @user_a_id
 -- name: AddPiiAccountCreationInfo :exec
 insert into pii.account_creation_info (user_id, ip_address, created_at) values (@user_id, @ip_address, now())
   on conflict do nothing;
+
+-- name: GetUserByWalletID :one
+select * from users where array[@wallet::varchar]::varchar[] <@ wallets and deleted = false;
+
+-- name: DeleteUserByID :exec
+update users set deleted = true where id = $1;
+
+-- name: InsertWallet :exec
+insert into wallets (id, address, chain, wallet_type) values ($1, $2, $3, $4);
+
+-- name: DeleteWalletByID :exec
+update wallets set deleted = true, last_updated = now() where id = $1;
+
+-- name: InsertUser :exec
+insert into users (id, username, username_idempotent, bio, wallets, universal, email_unsubscriptions, primary_wallet_id) values ($1, $2, $3, $4, $5, $6, $7, $8) returning id;
+
+-- name: AddWalletToUserByID :exec
+update users set wallets = array_append(wallets, @wallet_id::varchar) where id = @user_id;

--- a/emails/t__utils_test.go
+++ b/emails/t__utils_test.go
@@ -64,27 +64,9 @@ func setupTest(t *testing.T) (*assert.Assertions, *sql.DB, *pgxpool.Pool) {
 	db := postgres.MustCreateClient()
 	pgx := postgres.NewPgxClient()
 
-	seedNotifications(context.Background(), t, coredb.New(pgx), newRepos(db, pgx))
+	seedNotifications(context.Background(), t, coredb.New(pgx), postgres.NewRepositories(db, pgx))
 
 	return assert.New(t), db, pgx
-}
-
-func newRepos(pq *sql.DB, pgx *pgxpool.Pool) *postgres.Repositories {
-	queries := coredb.New(pgx)
-
-	return &postgres.Repositories{
-		UserRepository:        postgres.NewUserRepository(pq, queries, pgx),
-		NonceRepository:       postgres.NewNonceRepository(pq, queries),
-		TokenRepository:       postgres.NewTokenGalleryRepository(pq, queries),
-		CollectionRepository:  postgres.NewCollectionTokenRepository(pq, queries),
-		GalleryRepository:     postgres.NewGalleryRepository(queries),
-		ContractRepository:    postgres.NewContractGalleryRepository(pq, queries),
-		MembershipRepository:  postgres.NewMembershipRepository(pq, queries),
-		EarlyAccessRepository: postgres.NewEarlyAccessRepository(pq, queries),
-		WalletRepository:      postgres.NewWalletRepository(pq, queries),
-		AdmireRepository:      postgres.NewAdmireRepository(queries),
-		CommentRepository:     postgres.NewCommentRepository(pq, queries),
-	}
 }
 
 func seedNotifications(ctx context.Context, t *testing.T, q *coredb.Queries, repos *postgres.Repositories) {

--- a/emails/t__utils_test.go
+++ b/emails/t__utils_test.go
@@ -73,7 +73,7 @@ func newRepos(pq *sql.DB, pgx *pgxpool.Pool) *postgres.Repositories {
 	queries := coredb.New(pgx)
 
 	return &postgres.Repositories{
-		UserRepository:        postgres.NewUserRepository(pq, queries),
+		UserRepository:        postgres.NewUserRepository(pq, queries, pgx),
 		NonceRepository:       postgres.NewNonceRepository(pq, queries),
 		TokenRepository:       postgres.NewTokenGalleryRepository(pq, queries),
 		CollectionRepository:  postgres.NewCollectionTokenRepository(pq, queries),
@@ -90,13 +90,13 @@ func newRepos(pq *sql.DB, pgx *pgxpool.Pool) *postgres.Repositories {
 func seedNotifications(ctx context.Context, t *testing.T, q *coredb.Queries, repos *postgres.Repositories) {
 
 	email := testUser.PiiEmailAddress
-	userID, err := repos.UserRepository.Create(ctx, persist.CreateUserInput{Username: testUser.Username.String, Email: &email, ChainAddress: persist.NewChainAddress("0x8914496dc01efcc49a2fa340331fb90969b6f1d2", persist.ChainETH)})
+	userID, err := repos.UserRepository.Create(ctx, persist.CreateUserInput{Username: testUser.Username.String, Email: &email, ChainAddress: persist.NewChainAddress("0x8914496dc01efcc49a2fa340331fb90969b6f1d2", persist.ChainETH)}, nil)
 	if err != nil {
 		t.Fatalf("failed to create user: %s", err)
 	}
 
 	email2 := testUser2.PiiEmailAddress
-	userID2, err := repos.UserRepository.Create(ctx, persist.CreateUserInput{Username: testUser2.Username.String, Email: &email2, ChainAddress: persist.NewChainAddress("0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5", persist.ChainETH)})
+	userID2, err := repos.UserRepository.Create(ctx, persist.CreateUserInput{Username: testUser2.Username.String, Email: &email2, ChainAddress: persist.NewChainAddress("0x9a3f9764b21adaf3c6fdf6f947e6d3340a3f8ac5", persist.ChainETH)}, nil)
 	if err != nil {
 		t.Fatalf("failed to create user: %s", err)
 	}

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -385,7 +385,7 @@ func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authentica
 	queries := api.queries.WithTx(tx)
 	defer tx.Rollback(ctx)
 
-	userID, galleryID, err = user.CreateUser(ctx, authenticator, username, email, bio, galleryName, galleryDesc, galleryPos, api.repos.UserRepository, api.repos.GalleryRepository, queries, api.multichainProvider)
+	userID, galleryID, err = user.CreateUser(ctx, authenticator, username, email, bio, galleryName, galleryDesc, galleryPos, api.repos.UserRepository, queries, api.multichainProvider)
 	if err != nil {
 		return "", "", err
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -1048,7 +1048,7 @@ func (p *Provider) createUsersForTokens(ctx context.Context, tokens []chainToken
 							Username:     username,
 							ChainAddress: persist.NewChainAddress(t.OwnerAddress, ct.chain),
 							Universal:    true,
-						})
+						}, nil)
 						if err != nil {
 							if _, ok := err.(persist.ErrUsernameNotAvailable); ok {
 								user, err = p.Repos.UserRepository.GetByUsername(ctx, username)

--- a/service/persist/postgres/postgres.go
+++ b/service/persist/postgres/postgres.go
@@ -320,7 +320,7 @@ func NewRepositories(pq *sql.DB, pgx *pgxpool.Pool) *Repositories {
 	return &Repositories{
 		db:                    pq,
 		pool:                  pgx,
-		UserRepository:        NewUserRepository(pq, queries),
+		UserRepository:        NewUserRepository(pq, queries, pgx),
 		NonceRepository:       NewNonceRepository(pq, queries),
 		TokenRepository:       NewTokenGalleryRepository(pq, queries),
 		CollectionRepository:  NewCollectionTokenRepository(pq, queries),

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -103,6 +103,7 @@ func NewUserRepository(db *sql.DB, queries *db.Queries, pgx *pgxpool.Pool) *User
 
 	return &UserRepository{
 		db:             db,
+		pgx:            pgx,
 		queries:        queries,
 		updateInfoStmt: updateInfoStmt,
 

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/util"
 
 	"github.com/lib/pq"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
@@ -19,9 +22,9 @@ import (
 // UserRepository represents a user repository in the postgres database
 type UserRepository struct {
 	db                       *sql.DB
+	pgx                      *pgxpool.Pool
 	queries                  *db.Queries
 	updateInfoStmt           *sql.Stmt
-	createStmt               *sql.Stmt
 	getByIDStmt              *sql.Stmt
 	getByIDsStmt             *sql.Stmt
 	getByWalletIDStmt        *sql.Stmt
@@ -31,10 +34,8 @@ type UserRepository struct {
 	getGalleriesStmt         *sql.Stmt
 	updateCollectionsStmt    *sql.Stmt
 	deleteGalleryStmt        *sql.Stmt
-	createWalletStmt         *sql.Stmt
 	getWalletIDStmt          *sql.Stmt
 	getWalletStmt            *sql.Stmt
-	addWalletStmt            *sql.Stmt
 	removeWalletFromUserStmt *sql.Stmt
 	deleteWalletStmt         *sql.Stmt
 	addFollowerStmt          *sql.Stmt
@@ -45,14 +46,11 @@ type UserRepository struct {
 
 // NewUserRepository creates a new postgres repository for interacting with users
 // TODO joins for users to wallets and wallets to addresses
-func NewUserRepository(db *sql.DB, queries *db.Queries) *UserRepository {
+func NewUserRepository(db *sql.DB, queries *db.Queries, pgx *pgxpool.Pool) *UserRepository {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
 	updateInfoStmt, err := db.PrepareContext(ctx, `UPDATE users SET USERNAME = $2, USERNAME_IDEMPOTENT = $3, LAST_UPDATED = $4, BIO = $5 WHERE ID = $1;`)
-	checkNoErr(err)
-
-	createStmt, err := db.PrepareContext(ctx, `INSERT INTO users (ID, USERNAME, USERNAME_IDEMPOTENT, BIO, WALLETS, UNIVERSAL, EMAIL_UNSUBSCRIPTIONS, PRIMARY_WALLET_ID) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING ID;`)
 	checkNoErr(err)
 
 	getByIDStmt, err := db.PrepareContext(ctx, `SELECT ID,DELETED,VERSION,USERNAME,USERNAME_IDEMPOTENT,BIO,TRAITS,WALLETS,UNIVERSAL,PRIMARY_WALLET_ID,CREATED_AT,LAST_UPDATED FROM users WHERE ID = $1 AND DELETED = false;`)
@@ -82,16 +80,10 @@ func NewUserRepository(db *sql.DB, queries *db.Queries) *UserRepository {
 	deleteGalleryStmt, err := db.PrepareContext(ctx, `UPDATE galleries SET DELETED = true WHERE ID = $1;`)
 	checkNoErr(err)
 
-	createWalletStmt, err := db.PrepareContext(ctx, `INSERT INTO wallets (ID, ADDRESS, CHAIN, WALLET_TYPE) VALUES ($1, $2, $3, $4);`)
-	checkNoErr(err)
-
 	getWalletIDStmt, err := db.PrepareContext(ctx, `SELECT ID FROM wallets WHERE ADDRESS = $1 AND CHAIN = $2 AND DELETED = false;`)
 	checkNoErr(err)
 
 	getWalletStmt, err := db.PrepareContext(ctx, `SELECT ADDRESS,CHAIN,WALLET_TYPE,VERSION,CREATED_AT,LAST_UPDATED FROM wallets WHERE ID = $1 AND DELETED = false;`)
-	checkNoErr(err)
-
-	addWalletStmt, err := db.PrepareContext(ctx, `UPDATE users SET WALLETS = array_append(WALLETS, $1) WHERE ID = $2;`)
 	checkNoErr(err)
 
 	removeWalletFromUserStmt, err := db.PrepareContext(ctx, `UPDATE users SET WALLETS = array_remove(WALLETS, $1) WHERE ID = $2 AND NOT $1 = PRIMARY_WALLET_ID AND $1 = ANY(WALLETS);`)
@@ -110,10 +102,10 @@ func NewUserRepository(db *sql.DB, queries *db.Queries) *UserRepository {
 	checkNoErr(err)
 
 	return &UserRepository{
-		db:                db,
-		queries:           queries,
-		updateInfoStmt:    updateInfoStmt,
-		createStmt:        createStmt,
+		db:             db,
+		queries:        queries,
+		updateInfoStmt: updateInfoStmt,
+
 		getByIDStmt:       getByIDStmt,
 		getByIDsStmt:      getByIDsStmt,
 		getByWalletIDStmt: getByWalletIDStmt,
@@ -124,10 +116,8 @@ func NewUserRepository(db *sql.DB, queries *db.Queries) *UserRepository {
 		getGalleriesStmt:         getGalleriesStmt,
 		updateCollectionsStmt:    updateCollectionsStmt,
 		deleteGalleryStmt:        deleteGalleryStmt,
-		createWalletStmt:         createWalletStmt,
 		getWalletIDStmt:          getWalletIDStmt,
 		getWalletStmt:            getWalletStmt,
-		addWalletStmt:            addWalletStmt,
 		removeWalletFromUserStmt: removeWalletFromUserStmt,
 		deleteWalletStmt:         deleteWalletStmt,
 		addFollowerStmt:          addFollowerStmt,
@@ -179,25 +169,31 @@ func (u *UserRepository) UpdateByID(pCtx context.Context, pID persist.DBID, pUpd
 
 }
 
-func (u *UserRepository) createWalletWithTx(ctx context.Context, tx *sql.Tx, chainAddress persist.ChainAddress, walletType persist.WalletType) (persist.DBID, error) {
-	// Do we already have a wallet with this ChainAddress?
-	var walletID persist.DBID
-	if err := tx.StmtContext(ctx, u.getWalletIDStmt).QueryRowContext(ctx, chainAddress.Address(), chainAddress.Chain()).Scan(&walletID); err != nil && err != sql.ErrNoRows {
-		return "", err
+func (u *UserRepository) createWalletWithTx(ctx context.Context, queries *coredb.Queries, chainAddress persist.ChainAddress, walletType persist.WalletType) (persist.DBID, error) {
+	if queries == nil {
+		queries = u.queries
 	}
 
+	wallet, err := queries.GetWalletByChainAddress(ctx, coredb.GetWalletByChainAddressParams{
+		Address: chainAddress.Address(),
+		Chain:   chainAddress.Chain(),
+	})
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return "", err
+	}
+	walletID := wallet.ID
+
 	if walletID != "" {
-		// If we do have a wallet with this ChainAddress, does it belong to a user?
-		var user persist.User
-		err := tx.StmtContext(ctx, u.getByWalletIDStmt).QueryRowContext(ctx, walletID).Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, pq.Array(&user.Wallets), &user.Bio, &user.Traits, &user.Universal, &user.PrimaryWalletID, &user.CreationTime, &user.LastUpdated)
-		if err != nil && err != sql.ErrNoRows {
+
+		user, err := queries.GetUserByWalletID(ctx, walletID.String())
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 			return "", err
 		}
 
 		// If the wallet belongs to a user, its address can't be used to create a new wallet. Return an error.
 		if user.ID != "" {
 			if user.Universal {
-				_, err = tx.StmtContext(ctx, u.deleteStmt).ExecContext(ctx, user.ID)
+				err = queries.DeleteUserByID(ctx, user.ID)
 				if err != nil {
 					return "", err
 				}
@@ -208,14 +204,23 @@ func (u *UserRepository) createWalletWithTx(ctx context.Context, tx *sql.Tx, cha
 
 		logger.For(ctx).Infof("wallet %s already exists, but is not owned by a user", walletID)
 		// If the wallet exists but doesn't belong to anyone, it should be deleted.
-		if _, err := tx.StmtContext(ctx, u.deleteWalletStmt).ExecContext(ctx, walletID); err != nil {
+
+		err = queries.DeleteWalletByID(ctx, walletID)
+		if err != nil {
 			return "", err
 		}
+
 	}
 
 	newWalletID := persist.GenerateID()
 	// At this point, we know there's no existing wallet in the database with this ChainAddress, so let's make a new one!
-	if _, err := tx.StmtContext(ctx, u.createWalletStmt).ExecContext(ctx, newWalletID, chainAddress.Address(), chainAddress.Chain(), walletType); err != nil {
+	err = queries.InsertWallet(ctx, coredb.InsertWalletParams{
+		ID:         newWalletID,
+		Address:    chainAddress.Address(),
+		Chain:      chainAddress.Chain(),
+		WalletType: walletType,
+	})
+	if err != nil {
 		return "", persist.ErrWalletCreateFailed{
 			ChainAddress: chainAddress,
 			WalletID:     walletID,
@@ -227,37 +232,48 @@ func (u *UserRepository) createWalletWithTx(ctx context.Context, tx *sql.Tx, cha
 }
 
 // Create creates a new user
-func (u *UserRepository) Create(pCtx context.Context, pUser persist.CreateUserInput) (persist.DBID, error) {
-	tx, err := u.db.BeginTx(pCtx, nil)
-	if err != nil {
-		return "", err
+func (u *UserRepository) Create(pCtx context.Context, pUser persist.CreateUserInput, queries *coredb.Queries) (persist.DBID, error) {
+	if queries == nil {
+		tx, err := u.pgx.BeginTx(pCtx, pgx.TxOptions{})
+		if err != nil {
+			return "", err
+		}
+		queries = u.queries.WithTx(tx)
+		defer tx.Rollback(pCtx)
+		defer func() {
+			err := tx.Commit(pCtx)
+			if err != nil {
+				logger.For(pCtx).Errorf("failed to commit transaction: %v", err)
+			}
+		}()
 	}
 
-	defer tx.Rollback()
-
-	var user persist.User
-	err = tx.StmtContext(pCtx, u.getByUsernameStmt).QueryRowContext(pCtx, strings.ToLower(pUser.Username)).Scan(&user.ID, &user.Deleted, &user.Version, &user.Username, &user.UsernameIdempotent, pq.Array(&user.Wallets), &user.Bio, &user.Traits, &user.Universal, &user.PrimaryWalletID, &user.CreationTime, &user.LastUpdated)
+	_, err := queries.GetUserByUsername(pCtx, strings.ToLower(pUser.Username))
 	if err == nil {
 		return "", persist.ErrUsernameNotAvailable{Username: pUser.Username}
 	}
 
-	// If there are no rows returned, the username isn't taken yet
-	if err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return "", err
 	}
 
-	walletID, err := u.createWalletWithTx(pCtx, tx, pUser.ChainAddress, pUser.WalletType)
+	walletID, err := u.createWalletWithTx(pCtx, queries, pUser.ChainAddress, pUser.WalletType)
 	if err != nil {
 		return "", err
 	}
 
-	var id persist.DBID
-	err = tx.StmtContext(pCtx, u.createStmt).QueryRowContext(pCtx, persist.GenerateID(), pUser.Username, strings.ToLower(pUser.Username), pUser.Bio, []persist.DBID{walletID}, pUser.Universal, pUser.EmailNotificationsSettings, walletID).Scan(&id)
+	userID := persist.GenerateID()
+	err = queries.InsertUser(pCtx, coredb.InsertUserParams{
+		ID:                   userID,
+		Username:             util.ToNullString(pUser.Username, true),
+		UsernameIdempotent:   util.ToNullString(strings.ToLower(pUser.Username), true),
+		Bio:                  util.ToNullString(pUser.Bio, true),
+		Wallets:              persist.WalletList{persist.Wallet{ID: walletID}},
+		Universal:            pUser.Universal,
+		EmailUnsubscriptions: pUser.EmailNotificationsSettings,
+		PrimaryWalletID:      walletID,
+	})
 	if err != nil {
-		return "", err
-	}
-
-	if err := tx.Commit(); err != nil {
 		return "", err
 	}
 
@@ -266,16 +282,16 @@ func (u *UserRepository) Create(pCtx context.Context, pUser persist.CreateUserIn
 	// for the time being that these inserts will work. Worst case scenario: the user has
 	// to enter their email address again after successfully creating an account.
 	if pUser.Email != nil {
-		err := u.queries.UpdateUserEmail(pCtx, coredb.UpdateUserEmailParams{
-			UserID:       id,
+		err := queries.UpdateUserEmail(pCtx, coredb.UpdateUserEmailParams{
+			UserID:       userID,
 			EmailAddress: *pUser.Email,
 		})
 		if err != nil {
-			logger.For(pCtx).Errorf("failed to insert email address when creating new user with userID=%s\n", id)
+			logger.For(pCtx).Errorf("failed to insert email address when creating new user with userID=%s\n", userID)
 		}
 	}
 
-	return id, nil
+	return userID, nil
 }
 
 // GetByID gets the user with the given ID
@@ -397,27 +413,32 @@ func (u *UserRepository) GetByEmail(pCtx context.Context, pEmail persist.Email) 
 }
 
 // AddWallet adds an address to user as well as ensures that the wallet and address exists
-func (u *UserRepository) AddWallet(pCtx context.Context, pUserID persist.DBID, pChainAddress persist.ChainAddress, pWalletType persist.WalletType) error {
-	tx, err := u.db.BeginTx(pCtx, nil)
+func (u *UserRepository) AddWallet(pCtx context.Context, pUserID persist.DBID, pChainAddress persist.ChainAddress, pWalletType persist.WalletType, queries *coredb.Queries) error {
+
+	if queries == nil {
+		tx, err := u.pgx.BeginTx(pCtx, pgx.TxOptions{})
+		if err != nil {
+			return err
+		}
+		queries = u.queries.WithTx(tx)
+		defer tx.Rollback(pCtx)
+		defer func() {
+			err := tx.Commit(pCtx)
+			if err != nil {
+				logger.For(pCtx).Errorf("failed to commit transaction: %v", err)
+			}
+		}()
+	}
+
+	walletID, err := u.createWalletWithTx(pCtx, queries, pChainAddress, pWalletType)
 	if err != nil {
 		return err
 	}
 
-	defer tx.Rollback()
-
-	walletID, err := u.createWalletWithTx(pCtx, tx, pChainAddress, pWalletType)
-	if err != nil {
-		return err
-	}
-
-	// Add the new wallet to the user
-	if _, err := tx.StmtContext(pCtx, u.addWalletStmt).ExecContext(pCtx, walletID, pUserID); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return err
-	}
+	queries.AddWalletToUserByID(pCtx, coredb.AddWalletToUserByIDParams{
+		WalletID: walletID.String(),
+		UserID:   pUserID,
+	})
 
 	return nil
 }

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -277,10 +277,6 @@ func (u *UserRepository) Create(pCtx context.Context, pUser persist.CreateUserIn
 		return "", err
 	}
 
-	// TODO: Put this in the above transaction when refactoring UserRepository to use pgx+sqlc.
-	// At the moment, we'd have to mix sql.Tx and pgx.Tx, and it's easier just to assume
-	// for the time being that these inserts will work. Worst case scenario: the user has
-	// to enter their email address again after successfully creating an account.
 	if pUser.Email != nil {
 		err := queries.UpdateUserEmail(pCtx, coredb.UpdateUserEmailParams{
 			UserID:       userID,

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -86,7 +86,7 @@ type MergeUsersInput struct {
 
 // CreateUser creates a new user
 func CreateUser(pCtx context.Context, authenticator auth.Authenticator, username string, email *persist.Email, bio, galleryName, galleryDesc, galleryPos string, userRepo *postgres.UserRepository,
-	galleryRepo *postgres.GalleryRepository, queries *coredb.Queries, mp *multichain.Provider) (userID persist.DBID, galleryID persist.DBID, err error) {
+	queries *coredb.Queries, mp *multichain.Provider) (userID persist.DBID, galleryID persist.DBID, err error) {
 	gc := util.MustGetGinContext(pCtx)
 
 	authResult, err := authenticator.Authenticate(pCtx)
@@ -114,11 +114,6 @@ func CreateUser(pCtx context.Context, authenticator auth.Authenticator, username
 	}
 
 	userID, err = userRepo.Create(pCtx, user, queries)
-	if err != nil {
-		return "", "", err
-	}
-
-	err = mp.RunWalletCreationHooks(pCtx, userID, wallet.ChainAddress.Address(), wallet.WalletType, wallet.ChainAddress.Chain())
 	if err != nil {
 		return "", "", err
 	}
@@ -194,7 +189,7 @@ func AddWalletToUser(pCtx context.Context, pUserID persist.DBID, pChainAddress p
 		return err
 	}
 
-	return mp.RunWalletCreationHooks(pCtx, pUserID, authenticatedAddress.ChainAddress.Address(), authenticatedAddress.WalletType, authenticatedAddress.ChainAddress.Chain())
+	return nil
 }
 
 // RemoveAddressesFromUserToken removes any amount of addresses from a user in the DB


### PR DESCRIPTION
Changes:

- **Changed** the user creation pipeline to use an sqlc queries with an attached transaction so that the user cannot be created in a broken state if any other error occurs down the pipeline.