### PR TITLE
increase reliability of storage upload

### DIFF
--- a/cmd/optimization_backfill/main.go
+++ b/cmd/optimization_backfill/main.go
@@ -145,9 +145,9 @@ func main() {
 			default:
 
 				func() {
-					timeoutContext, cancel := context.WithTimeout(ctx, 30*time.Second)
+					ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 					defer cancel()
-					dims, err := getMediaDimensions(timeoutContext, media.MediaURL.String())
+					dims, err := getMediaDimensions(ctx, media.MediaURL.String())
 					if err != nil {
 						logrus.Errorf("failed to get dimensions for %s: %s", media.MediaURL, err)
 						return

--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -66,12 +66,12 @@ func getTokenMetadata(nftRepository persist.TokenRepository, ipfsClient *shell.S
 			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
-		loggerCtx := logger.NewContextWithFields(c, logrus.Fields{
+		ctx := logger.NewContextWithFields(c, logrus.Fields{
 			"tokenID":         input.TokenID,
 			"contractAddress": input.ContractAddress,
 		})
 
-		ctx, cancel := context.WithTimeout(loggerCtx, time.Minute*10)
+		ctx, cancel := context.WithTimeout(ctx, time.Minute*10)
 		defer cancel()
 
 		curTokens, err := nftRepository.GetByTokenIdentifiers(ctx, input.TokenID, input.ContractAddress, -1, 0)

--- a/indexer/nfts.go
+++ b/indexer/nfts.go
@@ -66,12 +66,12 @@ func getTokenMetadata(nftRepository persist.TokenRepository, ipfsClient *shell.S
 			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
-		ctx := logger.NewContextWithFields(c, logrus.Fields{
+		loggerCtx := logger.NewContextWithFields(c, logrus.Fields{
 			"tokenID":         input.TokenID,
 			"contractAddress": input.ContractAddress,
 		})
 
-		ctx, cancel := context.WithTimeout(ctx, time.Minute*10)
+		ctx, cancel := context.WithTimeout(loggerCtx, time.Minute*10)
 		defer cancel()
 
 		curTokens, err := nftRepository.GetByTokenIdentifiers(ctx, input.TokenID, input.ContractAddress, -1, 0)

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -1174,7 +1174,7 @@ func newObjectWriter(ctx context.Context, client *storage.Client, bucket, fileNa
 	writer := client.Bucket(bucket).Object(fileName).NewWriter(ctx)
 	writer.ObjectAttrs.ContentType = contentType
 	writer.ObjectAttrs.CacheControl = "no-cache, no-store"
-	writer.ChunkSize = 8 * 1024 * 1024 // Recommended ChunkSize is a multiple of 256 KB (e.g., 8 MB)
+	writer.ChunkSize = 8 * 1024 * 1024 // 8MB
 	return writer
 }
 

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -1181,8 +1181,15 @@ func newObjectWriter(ctx context.Context, client *storage.Client, bucket, fileNa
 	}
 	writer.ObjectAttrs.CacheControl = "no-cache, no-store"
 	writer.ChunkSize = 8 * 1024 * 1024 // 8MB
-	if contentLength != nil && int(*contentLength) < writer.ChunkSize {
-		writer.ChunkSize = int(*contentLength)
+	if contentLength != nil {
+		cl := *contentLength
+		if cl < 4*1024*1024 {
+			writer.ChunkSize = int(cl)
+		} else if cl > 32*1024*1024 {
+			writer.ChunkSize = 8 * 1024 * 1024
+		} else {
+			writer.ChunkSize = 4 * 1024 * 1024
+		}
 	}
 	return writer
 }

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -933,6 +933,7 @@ outer:
 	if !mediaType.IsValid() {
 		timeBeforeSniff := time.Now()
 		bytesToSniff, _ := reader.Headers()
+		var contentType = util.ToPointer("")
 		mediaType, *contentType = persist.SniffMediaType(bytesToSniff)
 		logger.For(pCtx).Infof("sniffed media type for %s: %s in %s", truncateString(mediaURL, 50), mediaType, time.Since(timeBeforeSniff))
 	}

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -173,7 +173,7 @@ func MakePreviewsForMetadata(pCtx context.Context, metadata persist.TokenMetadat
 
 	deleteCtx, cancel := context.WithTimeout(pCtx, 25*time.Second)
 
-	p := pool.New().WithMaxGoroutines(4).WithContext(deleteCtx)
+	p := pool.New().WithContext(deleteCtx)
 
 	// if nothing was cached in the image step and the image step did process an image type, delete the now stale cached image
 	if !imgResult.cached && imgResult.mediaType.IsImageLike() {

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -1180,15 +1180,13 @@ func newObjectWriter(ctx context.Context, client *storage.Client, bucket, fileNa
 		writer.ObjectAttrs.ContentType = *contentType
 	}
 	writer.ObjectAttrs.CacheControl = "no-cache, no-store"
-	writer.ChunkSize = 8 * 1024 * 1024 // 8MB
+	writer.ChunkSize = 4 * 1024 * 1024 // 4MB
 	if contentLength != nil {
 		cl := *contentLength
 		if cl < 4*1024*1024 {
 			writer.ChunkSize = int(cl)
 		} else if cl > 32*1024*1024 {
 			writer.ChunkSize = 8 * 1024 * 1024
-		} else {
-			writer.ChunkSize = 4 * 1024 * 1024
 		}
 	}
 	return writer

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/redis"
 	"github.com/mikeydub/go-gallery/service/task"
+	"github.com/sourcegraph/conc"
 
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	"github.com/gammazero/workerpool"
@@ -359,15 +360,15 @@ func (p *Provider) SyncTokens(ctx context.Context, userID persist.DBID, chains [
 		}
 	}
 
-	wg := sync.WaitGroup{}
+	wg := conc.WaitGroup{}
 	for c, a := range chainsToAddresses {
 		logger.For(ctx).Infof("syncing chain %d tokens for user %s wallets %s", c, user.Username, a)
 		chain := c
 		addresses := a
-		wg.Add(len(addresses))
 		for _, addr := range addresses {
-			go func(addr persist.Address, chain persist.Chain) {
-				defer wg.Done()
+			addr := addr
+			chain := chain
+			wg.Go(func() {
 				start := time.Now()
 				providers, err := p.getProvidersForChain(chain)
 				if err != nil {
@@ -376,11 +377,12 @@ func (p *Provider) SyncTokens(ctx context.Context, userID persist.DBID, chains [
 				}
 
 				tokenFetchers := getChainProvidersForTask[tokensOwnerFetcher](providers)
-				subWg := &sync.WaitGroup{}
+				subWg := &conc.WaitGroup{}
 				for i, p := range tokenFetchers {
-					subWg.Add(1)
-					go func(fetcher tokensOwnerFetcher, priority int) {
-						defer subWg.Done()
+					fetcher := p
+					priority := i
+
+					subWg.Go(func() {
 						tokens, contracts, err := fetcher.GetTokensByWalletAddress(ctx, addr, 0, 0)
 						if err != nil {
 							errChan <- err
@@ -391,11 +393,11 @@ func (p *Provider) SyncTokens(ctx context.Context, userID persist.DBID, chains [
 
 						incomingTokens <- chainTokens{chain: chain, tokens: tokens, priority: priority}
 						incomingContracts <- chainContracts{chain: chain, contracts: contracts, priority: priority}
-					}(p, i)
+					})
 				}
 				subWg.Wait()
 				logger.For(ctx).Debugf("updated media for user %s wallet %s in %s", user.Username, addr, time.Since(start))
-			}(addr, chain)
+			})
 		}
 	}
 

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -210,7 +210,7 @@ func newHTTPClientForRPC(continueTrace bool, spanOptions ...sentry.SpanOption) *
 	})
 
 	return &http.Client{
-		Timeout: time.Second * defaultHTTPTimeout,
+		Timeout: 0,
 		Transport: tracing.NewTracingTransport(&http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs: pool,

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -52,7 +52,7 @@ func init() {
 }
 
 const (
-	defaultHTTPTimeout             = 30
+	defaultHTTPTimeout             = 600
 	defaultHTTPKeepAlive           = 600
 	defaultHTTPMaxIdleConns        = 100
 	defaultHTTPMaxIdleConnsPerHost = 100
@@ -164,13 +164,14 @@ func (h metricsHandler) Log(r *log.Record) error {
 // NewIPFSShell returns an IPFS shell
 func NewIPFSShell() *shell.Shell {
 	sh := shell.NewShellWithClient(env.GetString("IPFS_API_URL"), newClientForIPFS(env.GetString("IPFS_PROJECT_ID"), env.GetString("IPFS_PROJECT_SECRET"), false))
-	sh.SetTimeout(time.Minute * 2)
+	sh.SetTimeout(defaultHTTPTimeout * time.Second)
 	return sh
 }
 
 // newHTTPClientForIPFS returns an http.Client configured with default settings intended for IPFS calls.
 func newClientForIPFS(projectID, projectSecret string, continueOnly bool) *http.Client {
 	return &http.Client{
+		Timeout: defaultHTTPTimeout * time.Second,
 		Transport: authTransport{
 			RoundTripper:  tracing.NewTracingTransport(http.DefaultTransport, continueOnly),
 			ProjectID:     projectID,
@@ -337,8 +338,6 @@ func RetryGetTokenContractMetadata(ctx context.Context, contractAddress persist.
 // GetMetadataFromURI parses and returns the NFT metadata for a given token URI
 func GetMetadataFromURI(ctx context.Context, turi persist.TokenURI, ipfsClient *shell.Shell, arweaveClient *goar.Client) (persist.TokenMetadata, error) {
 
-	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
-	defer cancel()
 	var meta persist.TokenMetadata
 	err := DecodeMetadataFromURI(ctx, turi, &meta, ipfsClient, arweaveClient)
 	if err != nil {

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
+	"github.com/sourcegraph/conc/pool"
 
 	"cloud.google.com/go/storage"
 	"github.com/everFinance/goar"
-	"github.com/gammazero/workerpool"
 	"github.com/gin-gonic/gin"
 	shell "github.com/ipfs/go-ipfs-api"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -50,7 +50,7 @@ func processMediaForUsersTokensOfChain(mc *multichain.Provider, tokenRepo *postg
 		}
 		defer throttler.Unlock(ctx, input.UserID.String())
 
-		wp := workerpool.New(100)
+		wp := pool.New().WithMaxGoroutines(50).WithContext(ctx)
 		for _, tokenID := range input.TokenIDs {
 			t, err := tokenRepo.GetByID(ctx, tokenID)
 			if err != nil {
@@ -63,17 +63,21 @@ func processMediaForUsersTokensOfChain(mc *multichain.Provider, tokenRepo *postg
 				logger.For(ctx).Errorf("Error getting contract: %s", err)
 			}
 
-			wp.Submit(func() {
+			wp.Go(func(ctx context.Context) error {
 				key := fmt.Sprintf("%s-%s-%d", t.TokenID, contract.Address, t.Chain)
 				imageKeywords, animationKeywords := t.Chain.BaseKeywords()
 				err := processToken(ctx, key, t, contract.Address, "", mc, ethClient, ipfsClient, arweaveClient, stg, tokenBucket, tokenRepo, imageKeywords, animationKeywords, false)
 				if err != nil {
+
 					logger.For(c).Errorf("Error processing token: %s", err)
+
+					return err
 				}
+				return nil
 			})
 		}
 
-		wp.StopWait()
+		wp.Wait()
 		logger.For(ctx).Infof("Processing Media: %s - Finished", input.UserID)
 
 		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
@@ -133,24 +137,24 @@ func processToken(c context.Context, key string, t persist.TokenGallery, contrac
 		"chain":           t.Chain,
 	})
 	totalTime := time.Now()
-	ctx, cancel := context.WithTimeout(ctx, time.Hour)
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute*10)
 	defer cancel()
 
 	newMetadata := t.TokenMetadata
 
 	if len(newMetadata) == 0 || forceRefresh {
-		mcMetadata, err := mc.GetTokenMetadataByTokenIdentifiers(ctx, contractAddress, t.TokenID, ownerAddress, t.Chain)
+		mcMetadata, err := mc.GetTokenMetadataByTokenIdentifiers(timeoutCtx, contractAddress, t.TokenID, ownerAddress, t.Chain)
 		if err != nil {
-			logger.For(ctx).Errorf("error getting metadata from chain: %s", err)
+			logger.For(timeoutCtx).Errorf("error getting metadata from chain: %s", err)
 		} else if mcMetadata != nil && len(mcMetadata) > 0 {
-			logger.For(ctx).Infof("got metadata from chain: %v", mcMetadata)
+			logger.For(timeoutCtx).Infof("got metadata from chain: %v", mcMetadata)
 			newMetadata = mcMetadata
 		}
 	}
 
 	image, animation := media.KeywordsForChain(t.Chain, imageKeywords, animationKeywords)
 
-	name, description := media.FindNameAndDescription(ctx, newMetadata)
+	name, description := media.FindNameAndDescription(timeoutCtx, newMetadata)
 
 	if name == "" {
 		name = t.Name.String()
@@ -161,18 +165,18 @@ func processToken(c context.Context, key string, t persist.TokenGallery, contrac
 	}
 
 	totalTimeOfMedia := time.Now()
-	newMedia, err := media.MakePreviewsForMetadata(ctx, newMetadata, contractAddress, persist.TokenID(t.TokenID.String()), t.TokenURI, t.Chain, ipfsClient, arweaveClient, stg, tokenBucket, image, animation)
+	newMedia, err := media.MakePreviewsForMetadata(timeoutCtx, newMetadata, contractAddress, persist.TokenID(t.TokenID.String()), t.TokenURI, t.Chain, ipfsClient, arweaveClient, stg, tokenBucket, image, animation)
 	if err != nil {
-		logger.For(ctx).Errorf("error processing media for %s: %s", key, err)
+		logger.For(timeoutCtx).Errorf("error processing media for %s: %s", key, err)
 		newMedia = persist.Media{
 			MediaType: persist.MediaTypeUnknown,
 		}
 	}
-	logger.For(ctx).Infof("processing media took %s", time.Since(totalTimeOfMedia))
+	logger.For(timeoutCtx).Infof("processing media took %s", time.Since(totalTimeOfMedia))
 
 	// Don't replace existing usable media if tokenprocessing failed to get new media
 	if t.Media.IsServable() && !newMedia.IsServable() {
-		logger.For(ctx).Debugf("not replacing existing media for %s: cur %v new %v", key, t.Media.IsServable(), newMedia.IsServable())
+		logger.For(timeoutCtx).Debugf("not replacing existing media for %s: cur %v new %v", key, t.Media.IsServable(), newMedia.IsServable())
 		return nil
 	}
 
@@ -187,12 +191,12 @@ func processToken(c context.Context, key string, t persist.TokenGallery, contrac
 		Description: persist.NullString(description),
 		LastUpdated: persist.LastUpdatedTime{},
 	}
-	if err := tokenRepo.UpdateByTokenIdentifiersUnsafe(ctx, t.TokenID, contractAddress, t.Chain, up); err != nil {
-		logger.For(ctx).Errorf("error updating media for %s-%s-%d: %s", t.TokenID, contractAddress, t.Chain, err)
+	if err := tokenRepo.UpdateByTokenIdentifiersUnsafe(timeoutCtx, t.TokenID, contractAddress, t.Chain, up); err != nil {
+		logger.For(timeoutCtx).Errorf("error updating media for %s-%s-%d: %s", t.TokenID, contractAddress, t.Chain, err)
 		return err
 	}
 
-	logger.For(ctx).Infof("total processing took %s", time.Since(totalTime))
+	logger.For(timeoutCtx).Infof("total processing took %s", time.Since(totalTime))
 	return nil
 }
 

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -86,3 +86,20 @@ func RetryQueryWithRetry(ctx context.Context, c *graphql.Client, query any, vars
 	}
 	return ErrOutOfRetries
 }
+
+func RetryFunc(ctx context.Context, f func(ctx context.Context) error, shouldRetry func(error) bool, r Retry) error {
+	var err error
+	for i := 0; i < r.Tries; i++ {
+		err = f(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if !shouldRetry(err) {
+			return err
+		}
+
+		r.Sleep(i)
+	}
+	return ErrOutOfRetries
+}


### PR DESCRIPTION
Changes:

- **Changed** storage writer to use a smaller chunk size and retry with the retry mechanism specified by [this doc on GCP](https://cloud.google.com/storage/docs/json_api/v1/status-codes)
- **Changed** RPC http client to use no timeout (this client is always used and should always be used with requests that hold contexts, the request context should be used for timing out, not the http timeout e.g. `http.NewRequestWithContext` then `defaultHTTPClient.Do`) 
- **Changed** some workerpools into the more efficient and reliable `sourcegraph/conc` pools.