### PR TITLE
Try to group by chain and contract for all Sentry errors from tokenprocessing

### DIFF
--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -186,11 +186,6 @@ func updateMediaProccessingFingerprints(event *sentry.Event, hint *sentry.EventH
 	var mediaErr media.MediaProcessingError
 
 	if errors.As(hint.OriginalException, &mediaErr) {
-		if event.Tags["chain"] == "" || event.Tags["contractAddress"] == "" {
-			return event
-		}
-
-		// Add both errors to the stack
 
 		if mediaErr.AnimationError != nil {
 			event.Exception = append(event.Exception, sentry.Exception{
@@ -212,8 +207,10 @@ func updateMediaProccessingFingerprints(event *sentry.Event, hint *sentry.EventH
 			event.Exception = append(event.Exception[1:], event.Exception[0])
 			event.Exception[len(event.Exception)-1].Type = title
 		}
+	}
 
-		// Group by the chain and contract
+	// Group by the chain and contract
+	if event.Tags["chain"] != "" && event.Tags["contractAddress"] != "" {
 		event.Fingerprint = []string{event.Tags["chain"], event.Tags["contractAddress"]}
 	}
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Bug fix: Group Sentry errors by chain and contract address for all media processing errors in `tokenprocessing/tokenprocessing.go`. Removed an unnecessary check that was previously in place.

> "Errors grouped by chain and contract, unnecessary checks now effaced. Codebase improved, bugs erased."
<!-- end of auto-generated comment: release notes by openai -->