### PR TITLE
Enable debug tools on dev

### DIFF
--- a/debugtools/debugtools_common.go
+++ b/debugtools/debugtools_common.go
@@ -5,38 +5,48 @@ package debugtools
 
 import (
 	"fmt"
+	"github.com/mikeydub/go-gallery/env"
 
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/socialauth"
 )
 
+func IsDebugEnv() bool {
+	currentEnv := env.GetString("ENV")
+	return currentEnv == "local" || currentEnv == "development" || currentEnv == "sandbox"
+}
+
 type DebugAuthenticator struct {
-	User           *persist.User
-	ChainAddresses []persist.ChainAddress
+	User               *persist.User
+	ChainAddresses     []persist.ChainAddress
+	DebugToolsPassword string
 }
 
 func (d DebugAuthenticator) GetDescription() string {
 	return fmt.Sprintf("DebugAuthenticator(user: %+v, addresses: %v)", d.User, d.ChainAddresses)
 }
 
-func NewDebugAuthenticator(user *persist.User, chainAddresses []persist.ChainAddress) auth.Authenticator {
+func NewDebugAuthenticator(user *persist.User, chainAddresses []persist.ChainAddress, debugToolsPassword string) auth.Authenticator {
 	return DebugAuthenticator{
-		User:           user,
-		ChainAddresses: chainAddresses,
+		User:               user,
+		ChainAddresses:     chainAddresses,
+		DebugToolsPassword: debugToolsPassword,
 	}
 }
 
 type DebugSocialAuthenticator struct {
-	Provider persist.SocialProvider
-	ID       string
-	Metadata map[string]interface{}
+	Provider           persist.SocialProvider
+	ID                 string
+	Metadata           map[string]interface{}
+	DebugToolsPassword string
 }
 
-func NewDebugSocialAuthenticator(provider persist.SocialProvider, id string, metadata map[string]interface{}) socialauth.Authenticator {
+func NewDebugSocialAuthenticator(provider persist.SocialProvider, id string, metadata map[string]interface{}, debugToolsPassword string) socialauth.Authenticator {
 	return DebugSocialAuthenticator{
-		Provider: provider,
-		ID:       id,
-		Metadata: metadata,
+		Provider:           provider,
+		ID:                 id,
+		Metadata:           metadata,
+		DebugToolsPassword: debugToolsPassword,
 	}
 }

--- a/docker/backend/dev/Dockerfile
+++ b/docker/backend/dev/Dockerfile
@@ -11,7 +11,8 @@ COPY go.mod go.sum /app/
 RUN go mod download
 
 COPY . /app
-RUN go build -o ./bin/backend ./cmd/server/main.go
+# Enable debug_tools on dev
+RUN go build -tags debug_tools -o ./bin/backend ./cmd/server/main.go
 
 ARG VERSION
 ENV GAE_VERSION=$VERSION

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -7964,6 +7964,9 @@ input DebugAuth @restrictEnvironment(allowed: ["local"]) {
   # The chainAddresses that will be returned from the resulting authenticator.
   # Cannot be used in conjunction with the asUsername parameter.
   chainAddresses: [ChainAddressInput!]
+
+  # A password required to use debug tools. Typically empty in local environments.
+  debugToolsPassword: String
 }
 
 input GnosisSafeAuth {
@@ -7988,6 +7991,9 @@ input DebugSocialAuth {
   provider: SocialAccountType!
   id: String!
   username: String!
+
+  # A password required to use debug tools. Typically empty in local environments.
+  debugToolsPassword: String
 }
 
 input DeepRefreshInput {
@@ -46082,7 +46088,7 @@ func (ec *executionContext) unmarshalInputDebugAuth(ctx context.Context, obj int
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"asUsername", "userId", "chainAddresses"}
+	fieldsInOrder := [...]string{"asUsername", "userId", "chainAddresses", "debugToolsPassword"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -46177,6 +46183,34 @@ func (ec *executionContext) unmarshalInputDebugAuth(ctx context.Context, obj int
 				err := fmt.Errorf(`unexpected type %T from directive, should be []*github.com/mikeydub/go-gallery/service/persist.ChainAddress`, tmp)
 				return it, graphql.ErrorOnPath(ctx, err)
 			}
+		case "debugToolsPassword":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("debugToolsPassword"))
+			directive0 := func(ctx context.Context) (interface{}, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+			directive1 := func(ctx context.Context) (interface{}, error) {
+				allowed, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"local"})
+				if err != nil {
+					return nil, err
+				}
+				if ec.directives.RestrictEnvironment == nil {
+					return nil, errors.New("directive restrictEnvironment is not implemented")
+				}
+				return ec.directives.RestrictEnvironment(ctx, obj, directive0, allowed)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.DebugToolsPassword = data
+			} else if tmp == nil {
+				it.DebugToolsPassword = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 
@@ -46190,7 +46224,7 @@ func (ec *executionContext) unmarshalInputDebugSocialAuth(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"provider", "id", "username"}
+	fieldsInOrder := [...]string{"provider", "id", "username", "debugToolsPassword"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -46218,6 +46252,14 @@ func (ec *executionContext) unmarshalInputDebugSocialAuth(ctx context.Context, o
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("username"))
 			it.Username, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "debugToolsPassword":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("debugToolsPassword"))
+			it.DebugToolsPassword, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/graphql/generated_test.go
+++ b/graphql/generated_test.go
@@ -218,9 +218,10 @@ func (v *CreateUserInput) GetGalleryDescription() *string { return v.GalleryDesc
 func (v *CreateUserInput) GetGalleryPosition() *string { return v.GalleryPosition }
 
 type DebugAuth struct {
-	AsUsername     *string             `json:"asUsername"`
-	UserId         *persist.DBID       `json:"userId"`
-	ChainAddresses []ChainAddressInput `json:"chainAddresses"`
+	AsUsername         *string             `json:"asUsername"`
+	UserId             *persist.DBID       `json:"userId"`
+	ChainAddresses     []ChainAddressInput `json:"chainAddresses"`
+	DebugToolsPassword *string             `json:"debugToolsPassword"`
 }
 
 // GetAsUsername returns DebugAuth.AsUsername, and is useful for accessing the field via an interface.
@@ -232,10 +233,14 @@ func (v *DebugAuth) GetUserId() *persist.DBID { return v.UserId }
 // GetChainAddresses returns DebugAuth.ChainAddresses, and is useful for accessing the field via an interface.
 func (v *DebugAuth) GetChainAddresses() []ChainAddressInput { return v.ChainAddresses }
 
+// GetDebugToolsPassword returns DebugAuth.DebugToolsPassword, and is useful for accessing the field via an interface.
+func (v *DebugAuth) GetDebugToolsPassword() *string { return v.DebugToolsPassword }
+
 type DebugSocialAuth struct {
-	Provider SocialAccountType `json:"provider"`
-	Id       string            `json:"id"`
-	Username string            `json:"username"`
+	Provider           SocialAccountType `json:"provider"`
+	Id                 string            `json:"id"`
+	Username           string            `json:"username"`
+	DebugToolsPassword *string           `json:"debugToolsPassword"`
 }
 
 // GetProvider returns DebugSocialAuth.Provider, and is useful for accessing the field via an interface.
@@ -246,6 +251,9 @@ func (v *DebugSocialAuth) GetId() string { return v.Id }
 
 // GetUsername returns DebugSocialAuth.Username, and is useful for accessing the field via an interface.
 func (v *DebugSocialAuth) GetUsername() string { return v.Username }
+
+// GetDebugToolsPassword returns DebugSocialAuth.DebugToolsPassword, and is useful for accessing the field via an interface.
+func (v *DebugSocialAuth) GetDebugToolsPassword() *string { return v.DebugToolsPassword }
 
 type EoaAuth struct {
 	ChainPubKey ChainPubKeyInput `json:"chainPubKey"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -676,15 +676,17 @@ type CreateUserPayload struct {
 func (CreateUserPayload) IsCreateUserPayloadOrError() {}
 
 type DebugAuth struct {
-	AsUsername     *string                 `json:"asUsername"`
-	UserID         *persist.DBID           `json:"userId"`
-	ChainAddresses []*persist.ChainAddress `json:"chainAddresses"`
+	AsUsername         *string                 `json:"asUsername"`
+	UserID             *persist.DBID           `json:"userId"`
+	ChainAddresses     []*persist.ChainAddress `json:"chainAddresses"`
+	DebugToolsPassword *string                 `json:"debugToolsPassword"`
 }
 
 type DebugSocialAuth struct {
-	Provider persist.SocialProvider `json:"provider"`
-	ID       string                 `json:"id"`
-	Username string                 `json:"username"`
+	Provider           persist.SocialProvider `json:"provider"`
+	ID                 string                 `json:"id"`
+	Username           string                 `json:"username"`
+	DebugToolsPassword *string                `json:"debugToolsPassword"`
 }
 
 type DeepRefreshInput struct {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gammazero/workerpool"
 	"github.com/magiclabs/magic-admin-go/token"
-	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/service/emails"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -183,7 +182,7 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 	authApi := publicapi.For(ctx).Auth
 
 	if debugtools.Enabled {
-		if env.GetString("ENV") == "local" && m.Debug != nil {
+		if debugtools.IsDebugEnv() && m.Debug != nil {
 			return authApi.NewDebugAuthenticator(ctx, *m.Debug)
 		}
 	}
@@ -212,8 +211,9 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 func (r *Resolver) socialAuthMechanismToAuthenticator(ctx context.Context, m model.SocialAuthMechanism) (socialauth.Authenticator, error) {
 
 	if debugtools.Enabled {
-		if env.GetString("ENV") == "local" && m.Debug != nil {
-			return debugtools.NewDebugSocialAuthenticator(m.Debug.Provider, m.Debug.ID, map[string]interface{}{"username": m.Debug.Username}), nil
+		if debugtools.IsDebugEnv() && m.Debug != nil {
+			password := util.FromPointer(m.Debug.DebugToolsPassword)
+			return debugtools.NewDebugSocialAuthenticator(m.Debug.Provider, m.Debug.ID, map[string]interface{}{"username": m.Debug.Username}, password), nil
 		}
 	}
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1406,6 +1406,9 @@ input DebugAuth @restrictEnvironment(allowed: ["local"]) {
   # The chainAddresses that will be returned from the resulting authenticator.
   # Cannot be used in conjunction with the asUsername parameter.
   chainAddresses: [ChainAddressInput!]
+
+  # A password required to use debug tools. Typically empty in local environments.
+  debugToolsPassword: String
 }
 
 input GnosisSafeAuth {
@@ -1430,6 +1433,9 @@ input DebugSocialAuth {
   provider: SocialAccountType!
   id: String!
   username: String!
+
+  # A password required to use debug tools. Typically empty in local environments.
+  debugToolsPassword: String
 }
 
 input DeepRefreshInput {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1389,11 +1389,11 @@ input EoaAuth {
   signature: String! @scrub
 }
 
-# DebugAuth is a local-only authentication mechanism for testing and debugging.
+# DebugAuth is a debug-only authentication mechanism for testing and debugging.
 # It creates an authenticator that will return the supplied userId and chainAddresses as if they had been
 # successfully authenticated. For existing users, the asUsername parameter may be supplied as a convenience
 # method to look up and return their userId and chainAddresses.
-input DebugAuth @restrictEnvironment(allowed: ["local"]) {
+input DebugAuth @restrictEnvironment(allowed: ["local", "development", "sandbox"]) {
   # Convenience method to authenticate as an existing user.
   # Cannot be used in conjunction with the userId and chainAddresses parameters.
   asUsername: String
@@ -1429,7 +1429,7 @@ input TwitterAuth {
   code: String!
 }
 
-input DebugSocialAuth {
+input DebugSocialAuth @restrictEnvironment(allowed: ["local", "development", "sandbox"]) {
   provider: SocialAccountType!
   id: String!
   username: String!

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -59,6 +59,7 @@ INFURA_API_SECRET: ENC[AES256_GCM,data:UuHwPIj7dHbsTZpes/LnD1SCLOY6DUtd/TErdldIA
 INFURA_API_KEY: ENC[AES256_GCM,data:Q5U/rsXuLFtlIqEBsA3pF/KVMDltMd6ArkCtD8nyE3c=,iv:1l46FiXIedCbnl72kAAFnCshRpf/7IPiOD6S3s9UdFk=,tag:4SKOPAJiwt8m7L9+tEGGVw==,type:str]
 FALLBACK_IPFS_URL: ENC[AES256_GCM,data:7NRmSkpptPP1tE1xDlygfTw70tqc3a9+lpKrzV37doCkxdTu,iv:5KRKS5oeYQPyC5tfH+vudosWVS4n/oKKK/kN6S67iIc=,tag:n9IaoDE0wuux6XnVZTsFaQ==,type:str]
 GCLOUD_FEEDBOT_TASK_QUEUE: ENC[AES256_GCM,data:mkruCDQD7dIdNtJAqHG9VFUZRny/9NmY1FVdgoB6svcUxYYR7wOA92ksQskhKiftiwtLTNXKStJEr53eOw==,iv:K9IO77Q2hPCh8dgI18XyBSIJt/r9mVohEJ0MyRxkysY=,tag:NeqzpnnXuxf6gJkb+GmNGw==,type:str]
+DEBUG_TOOLS_PASSWORD: ENC[AES256_GCM,data:B/WT5ObvsY16IcsBQg3EusqVoN0=,iv:wjTyNAbvY/StbyqoyE3is+aEt/yotgDfKZBOrLezGQk=,tag:5OjyDOXyJXW0afTHuUOWCA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -68,8 +69,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-07T20:12:00Z"
-    mac: ENC[AES256_GCM,data:3cEZaB+oNxTh8eHI7sIR+kDKngm9euUINAUXJ5bawPqXFXyBmwmxhrJ8fZj11iNAOcLcDgpwri5SS0gTemag03Ww7y2LuXXtMgA/f3C9F80S8a0W5rs7naGpqMbsA2T9UJHBBN9QmGHVdzTZEejFCHxnWC1MMvam/osO2IMRHlo=,iv:7H8QfXoG5r7CqKZKcTruseBab9sB01pT9xvQHeYVSgw=,tag:iLWZwcLi48A1B5ZH6I1Z5g==,type:str]
+    lastmodified: "2023-04-29T18:30:11Z"
+    mac: ENC[AES256_GCM,data:oAIvZbs2+2IFQ2UumUozCUjetCsGCIU5sxKImzESHAuPKMokTiXbqRNsF9WVX/Tg0/WGseEfUHTBH9WzU4IjNxIc7rVWXT5bXyIrmKZROion9pmslTNop6TlvhoHz9Lqx48nZOjbHnHXMibHvFlRxdCTno5bJ4V2hTZpgfwbxlY=,iv:lBlE+TEvpMQKqZMNEwcd5/sCqFD1AOTARNQ6XbhIAB0=,tag:JbwYp+hLZCaqJW3hOAaXfQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-sandbox-env.yaml
+++ b/secrets/dev/backend-sandbox-env.yaml
@@ -55,6 +55,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:ZoS8S1xWGg6dK81vWOfPFyk6HVBLbCJaUD
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:jowGiyPbSQc4CFXLcQjQ5WtpAQY1XqL1qfF4mJe7ijU3iwv1TlM8OeqpcwoQg0/4+ZokKsKtvyxTOzl0gEKHCgT132gCCvaPdw==,iv:G4sfu4UzDfptDf6Wt6S6OTPWwoYHY91qUTa5jVDuMsw=,tag:Z72v5u09jg/TmQzzJjmZOA==,type:str]
 ALCHEMY_API_URL: ENC[AES256_GCM,data:EGo9yMQBGUZjq8wz/Pc/QxEFYSYnE/M1cj3wIr3MqIj76l7tHgdhPD/4UlMPNuLAxahvRpKSVj2nrr8VU8+cJ3CHw1I=,iv:KZkwUyaKlBBPnEU4qpK4lq3JXnlEVQdpy/mJE5PMv7E=,tag:s1eg9a6MaCMbIA300sJ/dA==,type:str]
 GCLOUD_FEEDBOT_TASK_QUEUE: ENC[AES256_GCM,data:3Wg6RGjw4cwgHofGz+81wwbhsqnVoQVSd3VmeInANZQfS5ndYN2C/7T0HuXX8g68syRbfngTZfG9xC3VPA==,iv:VeMsZyKP4tLS2eaCh9F2BfUAN/QmnIaGky1Wqfek3I4=,tag:yg3awa33oZzzpC61XylydQ==,type:str]
+DEBUG_TOOLS_PASSWORD: ENC[AES256_GCM,data:gdtKl+Try3HB8/QmDlm9KwDeVTc=,iv:B0FHdRIRLntCvVbcDVfFm8R0BObInr9da/ddCUVejkc=,tag:Fa1mrd/ZG4y3vS2h6N1k/Q==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -64,8 +65,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-05T00:26:24Z"
-    mac: ENC[AES256_GCM,data:H+HsI9SwzUDAv94vfTky+sEB5367SWkh57jJS8VcJjMgqveQU/UaQ6af91ewo80hoCt21FxVglVlHJOhQdMkPktZlZ9quvrMO/edTowlFB2LvUlj3azCPe4bG2eHVIWcAvODgyLy4YNO+bluyshOikTxkItiYQeMN8vPVzDbKQ4=,iv:OY5kxY6o7kE93YJfHshjocaUMl0cLHqxve8Qp8nzxcs=,tag:IiG9JQkTMGfRhuzrtirnnw==,type:str]
+    lastmodified: "2023-04-29T18:30:51Z"
+    mac: ENC[AES256_GCM,data:X7AZLpU5JMQKEkoPO4RbxA1UVEZQB6YLRcjectvTYxI6AilqXSI1xL9WoXXFNtUscFOhANIv+Wm/khCNvo6ZVBc4zW3WUWoVz9zX+0Z+j67V1hDFlW0vlqp6wN8RUevp2I9ZaI6UCGJ2BJf++TIm25SqbOWCcrgst6szqKNg43I=,iv:ypqUk5LkhNDdDKbfda16z1YKMSeuPHocA2fcx8YCozk=,tag:UPeQGgP8TfnY5STSdBNH4Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
Per @Robinnnnn's request, this PR enables debug tools on dev.

Some considerations:
- our dev environment doesn't contain sensitive information, but it's still public-facing and accessible by anyone on the internet. In the interest of not having strangers mess around with accounts while we're testing stuff on dev, I've added password protection to debug tools on dev.
- local environments technically use a password now, too, but the password is empty and can be omitted.
- prod is still several layers of isolation away from any of this: compile-time and runtime safeguards continue to ensure that debug logins do not work in production environments.
- @Robinnnnn The debug login popup seems pretty broken right now, so we may want to clean that up! We'll also need to add a field for "debug tools password" in addition to the login username. It's the optional `debugToolsPassword` on the `DebugAuth` type in the GraphQL schema
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Password protection for debug tools on dev environment
- Bug fix: Authentication mechanism modified to allow use of debug tools in development and sandbox environments
- Refactor: Constructors and functions modified to accept new `DebugToolsPassword` parameter
- Test: Modifications made to enable testing of new functionality

> "Debugging made secure,  
> With password protection sure.  
> Code refactored with care,  
> Testing done to be fair.  
> Celebrate this PR,  
> For it takes us far!"
<!-- end of auto-generated comment: release notes by openai -->