### PR TITLE
Upgrade ffmpeg to 4.3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,12 @@ DEPLOY_FLAGS         = $(BASE_DEPLOY_FLAGS) --cpu-throttling
 DEPLOY_REGION        = us-east1
 SENTRY_RELEASE       = sentry-cli releases -o $(SENTRY_ORG) -p $(SENTRY_PROJECT)
 IMAGE_TAG            = $(DOCKER_REGISTRY)/$(GCP_PROJECT)/$(REPO)/$(CURRENT_BRANCH):$(CURRENT_COMMIT_HASH)
-DOCKER_BUILD         = docker build --file $(DOCKER_FILE) --platform linux/amd64 -t $(IMAGE_TAG) --build-arg VERSION=$(DEPLOY_VERSION) $(DOCKER_CONTEXT)
+DOCKER_BUILD         = docker build --file $(DOCKER_FILE) --platform linux/amd64 -t $(IMAGE_TAG) --build-arg VERSION=$(DEPLOY_VERSION) --build-arg FFMPEG_VERSION=$(FFMPEG_VERSION) $(DOCKER_CONTEXT)
 DOCKER_PUSH          = docker push $(IMAGE_TAG)
 DOCKER_DIR           := ./docker
 DOCKER_CONTEXT       := .
 DOCKER_REGISTRY      := us-east1-docker.pkg.dev
+FFMPEG_VERSION       = 7:4.3.6-0+deb11u1
 
 # Environments
 DEV     := dev

--- a/docker/backend/dev/Dockerfile
+++ b/docker/backend/dev/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM golang:1.19-bullseye
 
+ARG VERSION
+ARG FFMPEG_VERSION
+
 RUN apt-get update
-RUN apt-get install -y ffmpeg=7:4.3.5-0+deb11u1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y ffmpeg=$FFMPEG_VERSION && rm -rf /var/lib/apt/lists/*
 
 # Install deps
 WORKDIR /app
@@ -14,7 +17,6 @@ COPY . /app
 # Enable debug_tools on dev
 RUN go build -tags debug_tools -o ./bin/backend ./cmd/server/main.go
 
-ARG VERSION
 ENV GAE_VERSION=$VERSION
 
 EXPOSE 4000

--- a/docker/backend/prod/Dockerfile
+++ b/docker/backend/prod/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM golang:1.19-bullseye
 
+ARG VERSION
+ARG FFMPEG_VERSION
+
 RUN apt-get update
-RUN apt-get install -y ffmpeg=7:4.3.5-0+deb11u1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y ffmpeg=$FFMPEG_VERSION && rm -rf /var/lib/apt/lists/*
 
 # Install deps
 WORKDIR /app
@@ -13,7 +16,6 @@ RUN go mod download
 COPY . /app
 RUN go build -o ./bin/backend ./cmd/server/main.go
 
-ARG VERSION
 ENV GAE_VERSION=$VERSION
 
 EXPOSE 4000

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM golang:1.19-bullseye
 
+ARG VERSION
+ARG FFMPEG_VERSION
+
 RUN apt-get update
-RUN apt-get install -y ffmpeg=7:4.3.5-0+deb11u1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y ffmpeg=$FFMPEG_VERSION && rm -rf /var/lib/apt/lists/*
 
 # Install deps
 WORKDIR /app
@@ -17,7 +20,6 @@ RUN update-ca-certificates
 COPY . /app
 RUN go build -o ./bin/indexer ./cmd/indexer/main.go
 
-ARG VERSION
 ENV VERSION=$VERSION
 
 EXPOSE 4000

--- a/docker/indexer_api/Dockerfile
+++ b/docker/indexer_api/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM golang:1.19-bullseye
 
+ARG VERSION
+ARG FFMPEG_VERSION
+
 RUN apt-get update
-RUN apt-get install -y ffmpeg=7:4.3.5-0+deb11u1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y ffmpeg=$FFMPEG_VERSION && rm -rf /var/lib/apt/lists/*
 
 # Install deps
 WORKDIR /app
@@ -17,7 +20,6 @@ RUN update-ca-certificates
 COPY . /app
 RUN go build -o ./bin/indexer ./cmd/indexer/main.go
 
-ARG VERSION
 ENV VERSION=$VERSION
 
 EXPOSE 6000

--- a/docker/tokenprocessing/Dockerfile
+++ b/docker/tokenprocessing/Dockerfile
@@ -2,8 +2,11 @@
 
 FROM golang:1.19-bullseye
 
+ARG VERSION
+ARG FFMPEG_VERSION
+
 RUN apt-get update
-RUN apt-get install -y ffmpeg=7:4.3.5-0+deb11u1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y ffmpeg=$FFMPEG_VERSION && rm -rf /var/lib/apt/lists/*
 
 # Install deps
 WORKDIR /app
@@ -17,7 +20,6 @@ RUN update-ca-certificates
 COPY . /app
 RUN go build -o ./bin/tokenprocessing ./cmd/tokenprocessing/main.go
 
-ARG VERSION
 ENV VERSION=$VERSION
 
 EXPOSE 6500


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Chore: Upgraded the version of ffmpeg to 4.3.6 by using an argument for the version number instead of hardcoding it in various Dockerfiles.

> "Upgrading ffmpeg,  
> Dockerizing with ease.  
> Code quality improved,  
> Celebrate with some 🧁!"
<!-- end of auto-generated comment: release notes by openai -->