### PR TITLE
xml with content type

### DIFF
--- a/service/media/media.go
+++ b/service/media/media.go
@@ -1062,7 +1062,7 @@ func PredictMediaType(pCtx context.Context, url string) (persist.MediaType, *str
 	case persist.URITypeBase64JSON, persist.URITypeJSON:
 		return persist.MediaTypeJSON, util.ToPointer("application/json"), &lenURI, nil
 	case persist.URITypeBase64SVG, persist.URITypeSVG:
-		return persist.MediaTypeSVG, util.ToPointer("image/svg"), &lenURI, nil
+		return persist.MediaTypeSVG, util.ToPointer("image/svg+xml"), &lenURI, nil
 	case persist.URITypeBase64BMP:
 		return persist.MediaTypeBase64BMP, util.ToPointer("image/bmp"), &lenURI, nil
 	case persist.URITypeBase64PNG:


### PR DESCRIPTION
Changes:

- **Added** quick fix for svgs needing `image/svg+xml` to render inline as opposed to `image/svg` which requires a content dispostion header to render (which we never provide)