### PR TITLE
Add retool postgres role

### DIFF
--- a/db/migrations/core/000081_add_retool_role.up.sql
+++ b/db/migrations/core/000081_add_retool_role.up.sql
@@ -1,5 +1,5 @@
 /* {% require_sudo %} */
 drop role if exists gallery_retool;
 create role gallery_retool noinherit login;
-grant access_rw to gallery_retool;
-alter role gallery_retool set role to access_rw;
+grant access_ro to gallery_retool;
+alter role gallery_retool set role to access_ro;

--- a/db/migrations/core/000081_add_retool_role.up.sql
+++ b/db/migrations/core/000081_add_retool_role.up.sql
@@ -1,5 +1,5 @@
 /* {% require_sudo %} */
-drop role if exists gallery_tools_retool;
-create role gallery_tools_retool noinherit login;
-grant access_rw to gallery_tools_retool;
-alter role gallery_tools_retool set role to access_rw;
+drop role if exists gallery_retool;
+create role gallery_retool noinherit login;
+grant access_rw to gallery_retool;
+alter role gallery_retool set role to access_rw;

--- a/db/migrations/core/000081_add_retool_role.up.sql
+++ b/db/migrations/core/000081_add_retool_role.up.sql
@@ -1,0 +1,5 @@
+/* {% require_sudo %} */
+drop role if exists gallery_tools_retool;
+create role gallery_tools_retool noinherit login;
+grant access_rw to gallery_tools_retool;
+alter role gallery_tools_retool set role to access_rw;


### PR DESCRIPTION
Adding retool postgres user
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Adds a new PostgreSQL role for the `gallery_retool` user with read-write access to the database.

> "A new role is born,
> With read-write access adorned.
> Database now secure,
> Thanks to this PR."
<!-- end of auto-generated comment: release notes by openai -->