### PR TITLE
Fix finding primary media

### DIFF
--- a/service/media/media.go
+++ b/service/media/media.go
@@ -285,12 +285,13 @@ func createRawMedia(pCtx context.Context, tids persist.TokenIdentifiers, mediaTy
 
 func createMediaFromCachedObjects(ctx context.Context, tokenBucket string, objects []cachedMediaObject) persist.Media {
 	var primaryObject cachedMediaObject
+outer:
 	for _, obj := range objects {
 		switch obj.objectType {
 		case ObjectTypeAnimation:
 			// if we receive an animation, that takes top priority and will be the primary object
 			primaryObject = obj
-			break
+			break outer
 		case ObjectTypeImage, ObjectTypeSVG:
 			// if we don't have an animation, an image like object will be the primary object
 			primaryObject = obj


### PR DESCRIPTION
Small bug where if we find an animation object, we break out of the `switch` statement but not the outer `for` loop causing the primary object to get overridden with images and svgs