### PR TITLE
Redis refactor

### DIFF
--- a/emails/emails.go
+++ b/emails/emails.go
@@ -76,9 +76,7 @@ func coreInitServer() *gin.Engine {
 
 	go autoSendNotificationEmails(queries, sendgridClient, pub)
 
-	redisClient := redis.NewClient(redis.EmailRateLimiterDB)
-
-	return handlersInitServer(router, loaders, queries, sendgridClient, redisClient)
+	return handlersInitServer(router, loaders, queries, sendgridClient)
 }
 
 func setDefaults() {
@@ -126,7 +124,7 @@ func setDefaults() {
 }
 
 func newThrottler() *throttle.Locker {
-	return throttle.NewThrottleLocker(redis.NewCache(redis.EmailThrottleDB), time.Minute*5)
+	return throttle.NewThrottleLocker(redis.NewCache(redis.EmailThrottleCache), time.Minute*5)
 }
 
 func initSentry() {

--- a/emails/handlers.go
+++ b/emails/handlers.go
@@ -1,30 +1,34 @@
 package emails
 
 import (
+	"context"
+	"github.com/mikeydub/go-gallery/service/redis"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/go-redis/redis/v8"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
 	"github.com/mikeydub/go-gallery/middleware"
 	"github.com/sendgrid/sendgrid-go"
 )
 
-func handlersInitServer(router *gin.Engine, loaders *dataloader.Loaders, queries *coredb.Queries, s *sendgrid.Client, r *redis.Client) *gin.Engine {
+func handlersInitServer(router *gin.Engine, loaders *dataloader.Loaders, queries *coredb.Queries, s *sendgrid.Client) *gin.Engine {
 	sendGroup := router.Group("/send")
 
 	sendGroup.POST("/notifications", middleware.AdminRequired(), adminSendNotificationEmail(queries, s))
 
-	verificationLimiter := middleware.RateLimited(middleware.NewKeyRateLimiter(1, time.Second*5, r))
-	sendGroup.POST("/verification", verificationLimiter, sendVerificationEmail(loaders, queries, s))
+	limiterCtx := context.Background()
+	limiterCache := redis.NewCache(redis.EmailRateLimitersCache)
+
+	verificationLimiter := middleware.NewKeyRateLimiter(limiterCtx, limiterCache, "verification", 1, time.Second*5)
+	sendGroup.POST("/verification", middleware.IPRateLimited(verificationLimiter), sendVerificationEmail(loaders, queries, s))
 
 	router.POST("/subscriptions", updateSubscriptions(queries))
 	router.POST("/unsubscribe", unsubscribe(queries))
 	router.POST("/resubscribe", resubscribe(queries))
 
 	router.POST("/verify", verifyEmail(queries))
-	preVerifyLimiter := middleware.RateLimited(middleware.NewKeyRateLimiter(1, time.Millisecond*500, r))
-	router.GET("/preverify", preVerifyLimiter, preverifyEmail())
+	preverifyLimiter := middleware.NewKeyRateLimiter(limiterCtx, limiterCache, "preverify", 1, time.Millisecond*500)
+	router.GET("/preverify", middleware.IPRateLimited(preverifyLimiter), preverifyEmail())
 	return router
 }

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -163,7 +163,7 @@ func newRepos(storageClient *storage.Client) (persist.TokenRepository, persist.C
 }
 
 func newThrottler() *throttle.Locker {
-	return throttle.NewThrottleLocker(redis.NewCache(redis.IndexerServerThrottleDB), time.Minute*5)
+	return throttle.NewThrottleLocker(redis.NewCache(redis.IndexerServerThrottleCache), time.Minute*5)
 }
 
 func initSentry() {

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -142,8 +142,8 @@ func AddAuthToContext() gin.HandlerFunc {
 	}
 }
 
-// RateLimited is a middleware that rate limits requests by IP address
-func RateLimited(lim *KeyRateLimiter) gin.HandlerFunc {
+// IPRateLimited is a middleware that rate limits requests by IP address
+func IPRateLimited(lim *KeyRateLimiter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		canContinue, tryAgainAfter, err := lim.ForKey(c, c.ClientIP())
 		if err != nil {

--- a/middleware/rate.go
+++ b/middleware/rate.go
@@ -3,56 +3,136 @@ package middleware
 import (
 	"context"
 	"fmt"
-	"log"
+	"github.com/bsm/redislock"
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/redis"
+	"github.com/sirupsen/logrus"
 	"time"
 
 	"github.com/benny-conn/limiters"
-	"github.com/go-redis/redis/v8"
-	gredis "github.com/mikeydub/go-gallery/service/redis"
 )
 
-// KeyRateLimiter .
 type KeyRateLimiter struct {
-	rateDuration time.Duration
-	rateAmount   int64
+	cache        *redis.Cache
+	name         string
+	capacity     int64
+	refillRate   time.Duration
+	timeToRefill time.Duration
 	reg          *limiters.Registry
-	red          *redis.Client
 	clock        *limiters.SystemClock
-	logger       *limiters.StdLogger
-	lock         *gredis.GlobalLock
+	logger       limiters.Logger
+	lock         *distributedLock
 }
 
-// NewKeyRateLimiter creates a new rate limiter that will limit to `rateAmount` requests `every` duration
-// uses redis in the backend
-func NewKeyRateLimiter(rateAmount int64, every time.Duration, red *redis.Client) *KeyRateLimiter {
+// NewKeyRateLimiter creates a new rate limiter that will limit to `amount` operations `every` duration.
+// The name will be used to uniquely identify this limiter in the specified redis cache. Consequently,
+// two different limiters in the same cache should NOT have the same name. It is safe to share a single
+// KeyRateLimiter object among multiple consumers to share a limit.
+func NewKeyRateLimiter(ctx context.Context, cache *redis.Cache, name string, amount int64, every time.Duration) *KeyRateLimiter {
+	registry := limiters.NewRegistry()
+	clock := limiters.NewSystemClock()
 
-	i := &KeyRateLimiter{
-		rateDuration: every,
-		rateAmount:   rateAmount,
-		reg:          limiters.NewRegistry(),
-		clock:        limiters.NewSystemClock(),
-		logger:       limiters.NewStdLogger(),
-		red:          red,
-		lock:         gredis.NewGlobalLock(gredis.NewLockClient(red.Options().DB), every*time.Duration(rateAmount)),
+	// Refill rate is per token, so we have to divide to get the correct rate
+	refillRate := time.Duration(float64(every) / float64(amount))
+
+	// Assuming no tokens are taken, this is how long it will take to completely refill the bucket.
+	// This is useful for TTLs, because if this much time has passed and no tokens have been taken,
+	// the bucket is full and we no longer need to track its state
+	timeToRefill := every
+
+	limiter := &KeyRateLimiter{
+		cache:        cache,
+		name:         name,
+		capacity:     amount,
+		refillRate:   refillRate,
+		timeToRefill: timeToRefill,
+		reg:          registry,
+		clock:        clock,
+		logger:       newLogAdapter(ctx),
+		lock:         newDistributedLock(cache, name),
 	}
 
-	return i
+	go func() {
+		// Garbage collect the old limiters to prevent memory leaks
+		for {
+			// Check for expired limiters every second
+			<-time.After(time.Second)
+			registry.DeleteExpired(clock.Now())
+		}
+	}()
+
+	return limiter
 }
 
-// ForKey will check if the IP address has exceeded the rate limit
+// ForKey will check if the given key has exceeded the rate limit for this named limiter
 func (i *KeyRateLimiter) ForKey(ctx context.Context, key string) (bool, time.Duration, error) {
 	bucket := i.reg.GetOrCreate(key, func() interface{} {
-		return limiters.NewTokenBucket(i.rateAmount, i.rateDuration, i.lock, limiters.NewTokenBucketRedis(i.red, fmt.Sprintf("limiter:%s", key), i.rateDuration, false), i.clock, i.logger)
-	}, i.rateDuration, i.clock.Now())
+		bucketPrefix := i.cache.Prefix() + ":" + i.name + ":" + key
+		tokenBucket := limiters.NewTokenBucketRedis(i.cache.Client(), bucketPrefix, i.timeToRefill, false)
+		return limiters.NewTokenBucket(i.capacity, i.refillRate, i.lock, tokenBucket, i.clock, i.logger)
+	}, i.timeToRefill, i.clock.Now())
 
 	w, err := bucket.(*limiters.TokenBucket).Limit(ctx)
 	if err == limiters.ErrLimitExhausted {
 		return false, w, nil
 	} else if err != nil {
 		// The limiter failed. This error should be logged and examined.
-		log.Println(err)
-		return false, 0, fmt.Errorf("rate limiting err: %s", err)
+		rateErr := fmt.Errorf("rate limiting err: %s", err)
+		logger.For(ctx).Warn(rateErr)
+		return false, 0, rateErr
 	}
 
 	return true, 0, nil
+}
+
+type logAdapter struct {
+	entry *logrus.Entry
+}
+
+func newLogAdapter(ctx context.Context) logAdapter {
+	return logAdapter{
+		entry: logger.For(ctx),
+	}
+}
+
+func (l logAdapter) Log(v ...interface{}) {
+	l.entry.Info(v...)
+}
+
+type distributedLock struct {
+	client  *redislock.Client
+	lock    *redislock.Lock
+	key     string
+	ttl     time.Duration
+	options *redislock.Options
+}
+
+func newDistributedLock(cache *redis.Cache, limiterName string) *distributedLock {
+	options := &redislock.Options{
+		RetryStrategy: redislock.LimitRetry(redislock.LinearBackoff(time.Millisecond*500), 10),
+	}
+
+	// Unlocking should be handled by the limiter, but if it's not, we'll release the lock
+	// after one second.
+	ttl := time.Second
+
+	return &distributedLock{
+		client:  redis.NewLockClient(cache),
+		key:     limiterName + ":lock",
+		ttl:     ttl,
+		options: options,
+	}
+}
+
+func (l *distributedLock) Lock(ctx context.Context) error {
+	lock, err := l.client.Obtain(ctx, l.key, l.ttl, l.options)
+	if err != nil {
+		return err
+	}
+	l.lock = lock
+	return nil
+}
+
+func (l *distributedLock) Unlock(ctx context.Context) error {
+	return l.lock.Release(ctx)
 }

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -3,6 +3,7 @@ package publicapi
 import (
 	"context"
 	"fmt"
+	"github.com/mikeydub/go-gallery/service/redis"
 	"github.com/mikeydub/go-gallery/util"
 	"time"
 
@@ -29,6 +30,7 @@ type AuthAPI struct {
 	ethClient          *ethclient.Client
 	multiChainProvider *multichain.Provider
 	magicLinkClient    *magicclient.API
+	oneTimeLoginCache  *redis.Cache
 }
 
 func (api AuthAPI) NewNonceAuthenticator(chainAddress persist.ChainPubKey, nonce string, signature string, walletType persist.WalletType) auth.Authenticator {
@@ -110,8 +112,9 @@ func (api AuthAPI) NewMagicLinkAuthenticator(token token.Token) auth.Authenticat
 
 func (api AuthAPI) NewOneTimeLoginTokenAuthenticator(loginToken string) auth.Authenticator {
 	authenticator := auth.OneTimeLoginTokenAuthenticator{
-		UserRepo:   api.repos.UserRepository,
-		LoginToken: loginToken,
+		ConsumedTokenCache: api.oneTimeLoginCache,
+		UserRepo:           api.repos.UserRepository,
+		LoginToken:         loginToken,
 	}
 	return authenticator
 }

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -74,7 +74,7 @@ func New(ctx context.Context, disableDataloaderCaching bool, repos *postgres.Rep
 		validator: validator,
 		APQ:       apq,
 
-		Auth:          &AuthAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient, multiChainProvider: multichainProvider, magicLinkClient: magicClient},
+		Auth:          &AuthAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient, multiChainProvider: multichainProvider, magicLinkClient: magicClient, oneTimeLoginCache: redis.NewCache(redis.OneTimeLoginCache)},
 		Collection:    &CollectionAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient},
 		Gallery:       &GalleryAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient},
 		User:          &UserAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient, ipfsClient: ipfsClient, arweaveClient: arweaveClient, storageClient: storageClient, multichainProvider: multichainProvider},

--- a/server/server.go
+++ b/server/server.go
@@ -128,15 +128,10 @@ func CoreInit(c *Clients, provider *multichain.Provider, recommender *recommend.
 		validate.RegisterCustomValidators(v)
 	}
 
-	err := redis.ClearCache(redis.GalleriesDB)
-	if err != nil {
-		panic(err)
-	}
-
-	lock := redis.NewLockClient(redis.NotificationLockDB)
-	graphqlAPQCache := redis.NewCache(redis.GraphQLAPQ)
-	feedCache := redis.NewCache(redis.FeedDB)
-	socialCache := redis.NewCache(redis.SocialDB)
+	lock := redis.NewLockClient(redis.NewCache(redis.NotificationLockCache))
+	graphqlAPQCache := redis.NewCache(redis.GraphQLAPQCache)
+	feedCache := redis.NewCache(redis.FeedCache)
+	socialCache := redis.NewCache(redis.SocialCache)
 
 	recommender.Run(context.Background(), time.NewTicker(time.Hour))
 
@@ -300,7 +295,7 @@ func NewMultichainProvider(c *Clients) *multichain.Provider {
 		},
 	}
 	poapProvider := poap.NewProvider(c.HTTPClient, env.GetString("POAP_API_KEY"), env.GetString("POAP_AUTH_TOKEN"))
-	cache := redis.NewCache(redis.CommunitiesDB)
+	cache := redis.NewCache(redis.CommunitiesCache)
 	return multichain.NewProvider(context.Background(), c.Repos, c.Queries, cache, c.TaskClient,
 		overrides,
 		failureEthProvider,
@@ -314,5 +309,5 @@ func NewMultichainProvider(c *Clients) *multichain.Provider {
 }
 
 func newThrottler() *throttle.Locker {
-	return throttle.NewThrottleLocker(redis.NewCache(redis.RefreshNFTsThrottleDB), time.Minute*5)
+	return throttle.NewThrottleLocker(redis.NewCache(redis.RefreshNFTsThrottleCache), time.Minute*5)
 }

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/mikeydub/go-gallery/service/redis"
 	"math/rand"
 	"net/http"
 	"time"
@@ -267,8 +268,9 @@ func NewMagicLinkClient() *magicclient.API {
 }
 
 type OneTimeLoginTokenAuthenticator struct {
-	UserRepo   *postgres.UserRepository
-	LoginToken string
+	ConsumedTokenCache *redis.Cache
+	UserRepo           *postgres.UserRepository
+	LoginToken         string
 }
 
 func (a OneTimeLoginTokenAuthenticator) GetDescription() string {
@@ -276,9 +278,20 @@ func (a OneTimeLoginTokenAuthenticator) GetDescription() string {
 }
 
 func (a OneTimeLoginTokenAuthenticator) Authenticate(ctx context.Context) (*AuthResult, error) {
-	userID, _, err := ParseOneTimeLoginToken(ctx, a.LoginToken)
+	userID, expiresAt, err := ParseOneTimeLoginToken(ctx, a.LoginToken)
 	if err != nil {
 		return nil, err
+	}
+
+	// Use redis to stop this token from being used again (and add an extra minute to the TTL account for clock differences)
+	ttl := time.Until(expiresAt) + time.Minute
+	success, err := a.ConsumedTokenCache.SetNX(ctx, a.LoginToken, []byte{1}, ttl)
+	if err != nil {
+		return nil, err
+	}
+
+	if !success {
+		return nil, errors.New("token already used")
 	}
 
 	user, err := a.UserRepo.GetByID(ctx, userID)

--- a/service/redis/redis.go
+++ b/service/redis/redis.go
@@ -100,6 +100,19 @@ func (c *Cache) Set(pCtx context.Context, key string, value []byte, expiration t
 	return c.client.Set(pCtx, c.getPrefixedKey(key), value, expiration).Err()
 }
 
+// SetNX sets a value in the redis cache if it doesn't already exist. Returns true if the key did not
+// already exist and was set, false if the key did exist and therefore was not set.
+func (c *Cache) SetNX(pCtx context.Context, key string, value []byte, expiration time.Duration) (bool, error) {
+	cmd := c.client.SetNX(pCtx, c.getPrefixedKey(key), value, expiration)
+
+	err := cmd.Err()
+	if err != nil {
+		return false, err
+	}
+
+	return cmd.Val(), nil
+}
+
 // Get gets a value from the redis cache
 func (c *Cache) Get(pCtx context.Context, key string) ([]byte, error) {
 	bs, err := c.client.Get(pCtx, c.getPrefixedKey(key)).Bytes()

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -102,7 +102,7 @@ func setDefaults() {
 }
 
 func newThrottler() *throttle.Locker {
-	return throttle.NewThrottleLocker(redis.NewCache(redis.TokenProcessingThrottleDB), time.Minute*30)
+	return throttle.NewThrottleLocker(redis.NewCache(redis.TokenProcessingThrottleCache), time.Minute*30)
 }
 
 func initSentry() {


### PR DESCRIPTION
## What's new?
- Our redis `Cache` abstraction now allows namespacing within a redis database via key prefix
- We always use `Caches` instead of `Clients` to make sure that namespacing is consistent and enforced
- Existing uses of `redis.Client` have been updated to use the `Cache` type instead
  - These include distributed locks via `redislock` and rate limiters
- Fixed a bug where the email service `/verification` and `/preverify` handlers were sharing the same rate limiters
- Refactored rate limiters to make it easier to understand how they work
- OneTimeLogin (e.g. QR code login) now uses redis to consume a token so it can't be used to log in twice

Also of note: I moved our notification locks into a different redis DB and gave them a prefix. We don't necessarily _have_ to do this right now, but it felt like a good time to make a `locks` DB. That being said, there could be some weirdness here, since existing notification locks could have been started in the old DB and will be queried in the new DB after this is deployed. I'm assuming we don't hold locks very long and the risk is negligible, but I'd love input from @benny-conn or @jarrel-b!