### PR TITLE
Send push notifications

### DIFF
--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -297,6 +297,7 @@ type PushNotificationTicket struct {
 	CheckAfter       time.Time
 	NumCheckAttempts int32
 	Deleted          bool
+	Status           string
 }
 
 type PushNotificationToken struct {

--- a/db/migrations/core/000082_add_push_ticket_status.up.sql
+++ b/db/migrations/core/000082_add_push_ticket_status.up.sql
@@ -1,0 +1,3 @@
+alter table push_notification_tickets add status text;
+update push_notification_tickets set status = 'unknown' where status is null;
+alter table push_notification_tickets alter column status set not null;

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1038,7 +1038,7 @@ select * from push_notification_tokens where user_id = @user_id and deleted = fa
 select t.* from unnest(@ids::text[]) ids join push_notification_tokens t on t.id = ids and t.deleted = false;
 
 -- name: CreatePushTickets :exec
-insert into push_notification_tickets (id, push_token_id, ticket_id, created_at, check_after, num_check_attempts, deleted) values
+insert into push_notification_tickets (id, push_token_id, ticket_id, created_at, check_after, num_check_attempts, status, deleted) values
   (
    unnest(@ids::text[]),
    unnest(@push_token_ids::text[]),
@@ -1046,14 +1046,15 @@ insert into push_notification_tickets (id, push_token_id, ticket_id, created_at,
    now(),
    now() + interval '15 minutes',
    0,
+   'pending',
    false
   );
 
 -- name: UpdatePushTickets :exec
 with updates as (
-    select unnest(@ids::text[]) as id, unnest(@check_after::timestamptz[]) as check_after, unnest(@num_check_attempts::int[]) as num_check_attempts, unnest(@deleted::bool[]) as deleted
+    select unnest(@ids::text[]) as id, unnest(@check_after::timestamptz[]) as check_after, unnest(@num_check_attempts::int[]) as num_check_attempts, unnest(@status::text[]) as status, unnest(@deleted::bool[]) as deleted
 )
-update push_notification_tickets t set check_after = updates.check_after, num_check_attempts = updates.num_check_attempts, deleted = updates.deleted from updates where t.id = updates.id and t.deleted = false;
+update push_notification_tickets t set check_after = updates.check_after, num_check_attempts = updates.num_check_attempts, status = updates.status, deleted = updates.deleted from updates where t.id = updates.id and t.deleted = false;
 
 -- name: GetCheckablePushTickets :many
 select * from push_notification_tickets where check_after <= now() and deleted = false limit sqlc.arg('limit');

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -706,7 +706,7 @@ type ComplexityRoot struct {
 		GenerateQRCodeLoginToken        func(childComplexity int) int
 		GetAuthNonce                    func(childComplexity int, chainAddress persist.ChainAddress) int
 		Login                           func(childComplexity int, authMechanism model.AuthMechanism) int
-		Logout                          func(childComplexity int) int
+		Logout                          func(childComplexity int, pushTokenToUnregister *string) int
 		MintPremiumCardToWallet         func(childComplexity int, input model.MintPremiumCardToWalletInput) int
 		MoveCollectionToGallery         func(childComplexity int, input *model.MoveCollectionToGalleryInput) int
 		PreverifyEmail                  func(childComplexity int, input model.PreverifyEmailInput) int
@@ -1406,7 +1406,7 @@ type MutationResolver interface {
 	UpdateEmailNotificationSettings(ctx context.Context, input model.UpdateEmailNotificationSettingsInput) (model.UpdateEmailNotificationSettingsPayloadOrError, error)
 	UnsubscribeFromEmailType(ctx context.Context, input model.UnsubscribeFromEmailTypeInput) (model.UnsubscribeFromEmailTypePayloadOrError, error)
 	Login(ctx context.Context, authMechanism model.AuthMechanism) (model.LoginPayloadOrError, error)
-	Logout(ctx context.Context) (*model.LogoutPayload, error)
+	Logout(ctx context.Context, pushTokenToUnregister *string) (*model.LogoutPayload, error)
 	ConnectSocialAccount(ctx context.Context, input model.SocialAuthMechanism, display bool) (model.ConnectSocialAccountPayloadOrError, error)
 	DisconnectSocialAccount(ctx context.Context, accountType persist.SocialProvider) (model.DisconnectSocialAccountPayloadOrError, error)
 	UpdateSocialAccountDisplayed(ctx context.Context, input model.UpdateSocialAccountDisplayedInput) (model.UpdateSocialAccountDisplayedPayloadOrError, error)
@@ -3953,7 +3953,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.Mutation.Logout(childComplexity), true
+		args, err := ec.field_Mutation_logout_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.Logout(childComplexity, args["pushTokenToUnregister"].(*string)), true
 
 	case "Mutation.mintPremiumCardToWallet":
 		if e.complexity.Mutation.MintPremiumCardToWallet == nil {
@@ -8753,7 +8758,7 @@ type Mutation {
     input: UnsubscribeFromEmailTypeInput!
   ): UnsubscribeFromEmailTypePayloadOrError
   login(authMechanism: AuthMechanism!): LoginPayloadOrError
-  logout: LogoutPayload
+  logout(pushTokenToUnregister: String): LogoutPayload
 
   connectSocialAccount(
     input: SocialAuthMechanism!
@@ -9631,6 +9636,21 @@ func (ec *executionContext) field_Mutation_login_args(ctx context.Context, rawAr
 		}
 	}
 	args["authMechanism"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_logout_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["pushTokenToUnregister"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pushTokenToUnregister"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["pushTokenToUnregister"] = arg0
 	return args, nil
 }
 
@@ -27766,7 +27786,7 @@ func (ec *executionContext) _Mutation_logout(ctx context.Context, field graphql.
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().Logout(rctx)
+		return ec.resolvers.Mutation().Logout(rctx, fc.Args["pushTokenToUnregister"].(*string))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -27793,6 +27813,17 @@ func (ec *executionContext) fieldContext_Mutation_logout(ctx context.Context, fi
 			}
 			return nil, fmt.Errorf("no field named %q was found under type LogoutPayload", field.Name)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_logout_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
 	}
 	return fc, nil
 }

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2113,7 +2113,7 @@ type Mutation {
     input: UnsubscribeFromEmailTypeInput!
   ): UnsubscribeFromEmailTypePayloadOrError
   login(authMechanism: AuthMechanism!): LoginPayloadOrError
-  logout: LogoutPayload
+  logout(pushTokenToUnregister: String): LogoutPayload
 
   connectSocialAccount(
     input: SocialAuthMechanism!

--- a/server/handler.go
+++ b/server/handler.go
@@ -124,7 +124,7 @@ func graphqlHandler(repos *postgres.Repositories, queries *db.Queries, ethClient
 		return publicapi.New(ctx, disableDataloaderCaching, repos, queries, ethClient, ipfsClient, arweaveClient, storageClient, mp, taskClient, throttler, secrets, apqCache, feedCache, socialCache, magicClient)
 	}
 
-	notificationsHandler := notifications.New(queries, pub, lock)
+	notificationsHandler := notifications.New(queries, pub, taskClient, lock)
 
 	h.AroundFields(graphql.MutationCachingHandler(newPublicAPI))
 


### PR DESCRIPTION
## What's new?
- Admires, comments, and follows now trigger push notifications (if the user has any devices registered to receive push notifications)
- The `push_notification_tickets` table now has a status column so we know whether a notification was ultimately delivered or not
- The `logout` mutation takes an optional `pushTokenToUnregister` parameter to allow logging out and disabling push notifications in a single mutation