### PR TITLE
Add sentry pipeline tracing

### DIFF
--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -1,15 +1,23 @@
 package tokenprocessing
 
 import (
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
+	"github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/throttle"
 )
 
 func handlersInitServer(router *gin.Engine, tp *tokenProcessor, mc *multichain.Provider, repos *postgres.Repositories, throttler *throttle.Locker) *gin.Engine {
 	mediaGroup := router.Group("/media")
-	mediaGroup.POST("/process", processMediaForUsersTokens(tp, repos.TokenRepository, repos.ContractRepository, throttler))
+	mediaGroup.POST("/process", func(c *gin.Context) {
+		if hub := sentryutil.SentryHubFromContext(c); hub != nil {
+			hub.Scope().AddEventProcessor(sentryutil.SpanFilterEventProcessor(c, 1000, 1*time.Millisecond, 8, true))
+		}
+		processMediaForUsersTokens(tp, repos.TokenRepository, repos.ContractRepository, throttler)
+	})
 	mediaGroup.POST("/process/token", processMediaForToken(tp, repos.TokenRepository, repos.ContractRepository, repos.UserRepository, repos.WalletRepository, throttler))
 	ownersGroup := router.Group("/owners")
 	ownersGroup.POST("/process/contract", processOwnersForContractTokens(mc, repos.ContractRepository, throttler))

--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -16,7 +16,7 @@ func handlersInitServer(router *gin.Engine, tp *tokenProcessor, mc *multichain.P
 		if hub := sentryutil.SentryHubFromContext(c); hub != nil {
 			hub.Scope().AddEventProcessor(sentryutil.SpanFilterEventProcessor(c, 1000, 1*time.Millisecond, 8, true))
 		}
-		processMediaForUsersTokens(tp, repos.TokenRepository, repos.ContractRepository, throttler)
+		processMediaForUsersTokens(tp, repos.TokenRepository, repos.ContractRepository, throttler)(c)
 	})
 	mediaGroup.POST("/process/token", processMediaForToken(tp, repos.TokenRepository, repos.ContractRepository, repos.UserRepository, repos.WalletRepository, throttler))
 	ownersGroup := router.Group("/owners")

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -202,7 +202,8 @@ func cacheObjectsForMetadata(pCtx context.Context, metadata persist.TokenMetadat
 
 	// neither download worked, unexpectedly
 	if (animCh == nil || (animResult.err != nil && len(animResult.cachedObjects) == 0)) && (imgCh == nil || (imgResult.err != nil && len(imgResult.cachedObjects) == 0)) {
-		persist.TrackStepStatus(pCtx, &pMeta.NothingCachedWithErrors, "NothingCachedWithErrors")
+		traceCallback, _ := persist.TrackStepStatus(pCtx, &pMeta.NothingCachedWithErrors, "NothingCachedWithErrors")
+		defer traceCallback()
 
 		if animCh != nil {
 			if _, ok := animResult.err.(errInvalidMedia); ok {
@@ -242,7 +243,8 @@ func cacheObjectsForMetadata(pCtx context.Context, metadata persist.TokenMetadat
 
 	// this should never be true, something is wrong if this is true
 	if len(objects) == 0 {
-		persist.TrackStepStatus(pCtx, &pMeta.NothingCachedWithoutErrors, "NothingCachedWithoutErrors")
+		traceCallback, _ := persist.TrackStepStatus(pCtx, &pMeta.NothingCachedWithoutErrors, "NothingCachedWithoutErrors")
+		defer traceCallback()
 		return nil, errNoCachedObjects{tids: tids}
 	}
 


### PR DESCRIPTION
This PR adds performance tracing to the pipeline: [example trace](https://usegallery.sentry.io/performance/tokenprocessing:a5bfc7adf1a74c4cb73fe95f99fb5a8a/?environment=local&project=6771759&query=http.method%3APOST&referrer=performance-transaction-summary&showTransactions=recent&statsPeriod=24h&transaction=POST+%2Fmedia%2Fprocess%2Ftoken&unselectedSeries=p100%28%29)
