### PR TITLE
Add tablefunc ext

### DIFF
--- a/db/migrations/core/000083_add_tablefunc_ext.up.sql
+++ b/db/migrations/core/000083_add_tablefunc_ext.up.sql
@@ -1,0 +1,2 @@
+/* {% require_sudo %} */
+create extension if not exists tablefunc;


### PR DESCRIPTION
Adding the [tablefunc](https://www.postgresql.org/docs/current/tablefunc.html) extension to our db to use some funcs helpful in the dashboard and perhaps other things