### PR TITLE
Add metrics to token pipeline

### DIFF
--- a/service/metric/metric.go
+++ b/service/metric/metric.go
@@ -18,7 +18,7 @@ type MetricReporter struct {
 
 var LogOptions = LogOptionBulder{}
 
-func NewGCPLogMetricReporter() MetricReporter {
+func NewLogMetricReporter() MetricReporter {
 	return MetricReporter{Record: LogMetricReporter{}.Record}
 }
 

--- a/service/metric/metric.go
+++ b/service/metric/metric.go
@@ -1,0 +1,65 @@
+package metric
+
+import (
+	"context"
+	"fmt"
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/sirupsen/logrus"
+)
+
+type Measure struct {
+	Name  string
+	Value float64
+}
+
+type MetricReporter struct {
+	Record func(ctx context.Context, m Measure, opts ...any)
+}
+
+var LogOptions = LogOptionBulder{}
+
+func NewGCPLogMetricReporter() MetricReporter {
+	return MetricReporter{Record: LogMetricReporter{}.Record}
+}
+
+type LogMetricReporter struct{}
+
+type LogArgs struct {
+	Tags   map[string]string
+	LogMsg string
+}
+
+type LogOptionBulder struct{}
+
+func (LogOptionBulder) WithLogMessage(msg string) func(*LogArgs) {
+	return func(a *LogArgs) {
+		a.LogMsg = msg
+	}
+}
+
+func (LogOptionBulder) WithTags(tags map[string]string) func(*LogArgs) {
+	return func(a *LogArgs) {
+		a.Tags = tags
+	}
+}
+
+func (l LogMetricReporter) Record(ctx context.Context, metric Measure, opts ...any) {
+	args := LogArgs{}
+	for _, opt := range opts {
+		opt.(func(*LogArgs))(&args)
+	}
+
+	metricPayload := logrus.Fields{"metric": logrus.Fields{
+		"metricName":  metric.Name,
+		"metricValue": metric.Value,
+		"metricTags":  args.Tags,
+	}}
+
+	logLine := fmt.Sprintf("reporting metric %s(val=%0.2f)", metric.Name, metric.Value)
+
+	if args.LogMsg != "" {
+		logLine += ": " + args.LogMsg
+	}
+
+	logger.For(ctx).WithFields(metricPayload).Infof(logLine)
+}

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -400,16 +400,16 @@ func recordPipelineEndState(ctx context.Context, mr metric.MetricReporter, r *ru
 		mr.Record(ctx, pipelineTimedOutMetric(), opts...)
 	}
 
+	recordPipelineDuration(ctx, mr, d, baseOpts)
+
 	if r != nil && r.Err != nil {
 		opts := append(baseOpts, metric.LogOptions.WithLogMessage("pipeline completed with error: "+r.Err.Error()))
 		mr.Record(ctx, pipelineErroredMetric(), opts...)
-		recordPipelineDuration(ctx, mr, d, baseOpts)
 		return
 	}
 
 	opts := append(baseOpts, metric.LogOptions.WithLogMessage("pipeline completed successfully"))
 	mr.Record(ctx, pipelineCompletedMetric(), opts...)
-	recordPipelineDuration(ctx, mr, d, baseOpts)
 }
 
 func recordPipelineDuration(ctx context.Context, mr metric.MetricReporter, d time.Duration, opts []any) {

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -58,7 +58,7 @@ func CoreInitServer(c *server.Clients, mc *multichain.Provider) *gin.Engine {
 
 	t := newThrottler()
 
-	tp := NewTokenProcessor(c.Queries, c.EthClient, mc, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), c.Repos.TokenRepository, metric.NewGCPLogMetricReporter())
+	tp := NewTokenProcessor(c.Queries, c.EthClient, mc, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), c.Repos.TokenRepository, metric.NewLogMetricReporter())
 
 	return handlersInitServer(router, tp, mc, c.Repos, t)
 }

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -57,7 +57,7 @@ func CoreInitServer(c *server.Clients, mc *multichain.Provider) *gin.Engine {
 
 	t := newThrottler()
 
-	tp := NewTokenProcessor(c.Queries, c.EthClient, mc, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), c.Repos.TokenRepository)
+	tp := NewTokenProcessor(c.Queries, c.EthClient, mc, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), c.Repos.TokenRepository, newGCPLogMetricReporter())
 
 	return handlersInitServer(router, tp, mc, c.Repos, t)
 }

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mikeydub/go-gallery/server"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/metric"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/redis"
@@ -57,7 +58,7 @@ func CoreInitServer(c *server.Clients, mc *multichain.Provider) *gin.Engine {
 
 	t := newThrottler()
 
-	tp := NewTokenProcessor(c.Queries, c.EthClient, mc, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), c.Repos.TokenRepository, newGCPLogMetricReporter())
+	tp := NewTokenProcessor(c.Queries, c.EthClient, mc, c.IPFSClient, c.ArweaveClient, c.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), c.Repos.TokenRepository, metric.NewGCPLogMetricReporter())
 
 	return handlersInitServer(router, tp, mc, c.Repos, t)
 }


### PR DESCRIPTION
#### Changes
* Adds `metric` package. The metrics reporter used should be easy to switch out if/when we want to record metrics in some other way like custom metrics
* Adds log-based metrics to the pipeline, to start it will track:
    * `pipeline_completed`: pipeline completed
    * `pipeline_duration`: how long it took to run the pipeline
    * `pipeline_failed`: error in executing the pipeline
    * `pipeline_timedout`: pipeline either timed out or was canceled
* Metrics are tagged by media type and chain so that we can plot different time series

     