### PR TITLE
return objects cached anyway

### DIFF
--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -200,9 +200,9 @@ func cacheObjectsForMetadata(pCtx context.Context, metadata persist.TokenMetadat
 
 	// the media type is not cacheable but is valid
 	if notCacheableErr, ok := animResult.err.(errNotCacheable); ok {
-		return nil, notCacheableErr
+		return objects, notCacheableErr
 	} else if notCacheableErr, ok := imgResult.err.(errNotCacheable); ok {
-		return nil, notCacheableErr
+		return objects, notCacheableErr
 	}
 
 	// neither download worked, unexpectedly


### PR DESCRIPTION
Changes:

- **Added** objects to the return of any errors for html media types not being cacheable so that the thumbnails can still be used if there are any