### PR TITLE
Rate limit push notifications

### DIFF
--- a/emails/handlers.go
+++ b/emails/handlers.go
@@ -2,6 +2,7 @@ package emails
 
 import (
 	"context"
+	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/redis"
 	"time"
 
@@ -20,7 +21,7 @@ func handlersInitServer(router *gin.Engine, loaders *dataloader.Loaders, queries
 	limiterCtx := context.Background()
 	limiterCache := redis.NewCache(redis.EmailRateLimitersCache)
 
-	verificationLimiter := middleware.NewKeyRateLimiter(limiterCtx, limiterCache, "verification", 1, time.Second*5)
+	verificationLimiter := limiters.NewKeyRateLimiter(limiterCtx, limiterCache, "verification", 1, time.Second*5)
 	sendGroup.POST("/verification", middleware.IPRateLimited(verificationLimiter), sendVerificationEmail(loaders, queries, s))
 
 	router.POST("/subscriptions", updateSubscriptions(queries))
@@ -28,7 +29,7 @@ func handlersInitServer(router *gin.Engine, loaders *dataloader.Loaders, queries
 	router.POST("/resubscribe", resubscribe(queries))
 
 	router.POST("/verify", verifyEmail(queries))
-	preverifyLimiter := middleware.NewKeyRateLimiter(limiterCtx, limiterCache, "preverify", 1, time.Millisecond*500)
+	preverifyLimiter := limiters.NewKeyRateLimiter(limiterCtx, limiterCache, "preverify", 1, time.Millisecond*500)
 	router.GET("/preverify", middleware.IPRateLimited(preverifyLimiter), preverifyEmail())
 	return router
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/mikeydub/go-gallery/service/auth/basicauth"
+	"github.com/mikeydub/go-gallery/service/limiters"
 	"net/http"
 
 	"github.com/getsentry/sentry-go"
@@ -143,7 +144,7 @@ func AddAuthToContext() gin.HandlerFunc {
 }
 
 // IPRateLimited is a middleware that rate limits requests by IP address
-func IPRateLimited(lim *KeyRateLimiter) gin.HandlerFunc {
+func IPRateLimited(lim *limiters.KeyRateLimiter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		canContinue, tryAgainAfter, err := lim.ForKey(c, c.ClientIP())
 		if err != nil {

--- a/service/limiters/rate.go
+++ b/service/limiters/rate.go
@@ -1,4 +1,4 @@
-package middleware
+package limiters
 
 import (
 	"context"
@@ -83,6 +83,11 @@ func (i *KeyRateLimiter) ForKey(ctx context.Context, key string) (bool, time.Dur
 	}
 
 	return true, 0, nil
+}
+
+// Name returns the name of this limiter
+func (i *KeyRateLimiter) Name() string {
+	return i.name
 }
 
 type logAdapter struct {

--- a/service/redis/redis.go
+++ b/service/redis/redis.go
@@ -42,17 +42,18 @@ const (
 // Every cache is uniquely defined by its database and key prefix. Display names are used for tracing.
 
 var (
-	NotificationLockCache        = CacheConfig{database: locks, keyPrefix: "notif", displayName: "notificationLock"}
-	EmailRateLimitersCache       = CacheConfig{database: rateLimiters, keyPrefix: "email", displayName: "emailRateLimiters"}
-	OneTimeLoginCache            = CacheConfig{database: misc, keyPrefix: "otl", displayName: "oneTimeLogin"}
-	CommunitiesCache             = CacheConfig{database: communities, keyPrefix: "", displayName: "communities"}
-	IndexerServerThrottleCache   = CacheConfig{database: indexerServerThrottle, keyPrefix: "", displayName: "indexerServerThrottle"}
-	RefreshNFTsThrottleCache     = CacheConfig{database: refreshNFTsThrottle, keyPrefix: "", displayName: "refreshNFTsThrottle"}
-	TokenProcessingThrottleCache = CacheConfig{database: tokenProcessingThrottle, keyPrefix: "", displayName: "tokenProcessingThrottle"}
-	EmailThrottleCache           = CacheConfig{database: emailThrottle, keyPrefix: "", displayName: "emailThrottle"}
-	GraphQLAPQCache              = CacheConfig{database: graphQLAPQ, keyPrefix: "", displayName: "graphQLAPQ"}
-	FeedCache                    = CacheConfig{database: feed, keyPrefix: "", displayName: "feed"}
-	SocialCache                  = CacheConfig{database: social, keyPrefix: "", displayName: "social"}
+	NotificationLockCache             = CacheConfig{database: locks, keyPrefix: "notif", displayName: "notificationLock"}
+	EmailRateLimitersCache            = CacheConfig{database: rateLimiters, keyPrefix: "email", displayName: "emailRateLimiters"}
+	PushNotificationRateLimitersCache = CacheConfig{database: rateLimiters, keyPrefix: "push", displayName: "pushNotificationLimiters"}
+	OneTimeLoginCache                 = CacheConfig{database: misc, keyPrefix: "otl", displayName: "oneTimeLogin"}
+	CommunitiesCache                  = CacheConfig{database: communities, keyPrefix: "", displayName: "communities"}
+	IndexerServerThrottleCache        = CacheConfig{database: indexerServerThrottle, keyPrefix: "", displayName: "indexerServerThrottle"}
+	RefreshNFTsThrottleCache          = CacheConfig{database: refreshNFTsThrottle, keyPrefix: "", displayName: "refreshNFTsThrottle"}
+	TokenProcessingThrottleCache      = CacheConfig{database: tokenProcessingThrottle, keyPrefix: "", displayName: "tokenProcessingThrottle"}
+	EmailThrottleCache                = CacheConfig{database: emailThrottle, keyPrefix: "", displayName: "emailThrottle"}
+	GraphQLAPQCache                   = CacheConfig{database: graphQLAPQ, keyPrefix: "", displayName: "graphQLAPQ"}
+	FeedCache                         = CacheConfig{database: feed, keyPrefix: "", displayName: "feed"}
+	SocialCache                       = CacheConfig{database: social, keyPrefix: "", displayName: "social"}
 )
 
 func newClient(db redisDB, traceName string) *redis.Client {


### PR DESCRIPTION
This PR uses our existing Redis-based rate limiters to limit the number of push notifications a user can receive. The current limits are:

1 admire per `sender:receiver:feedEvent` every 10 minutes
1 follow per `sender:receiver` every 10 minutes
5 comments per `sender:receiver:feedEvent` every minute

In practical terms, this means you'll get notifications every time someone admires one of your feed events, but you won't get a notification if they un-admire and re-admire the same event (unless 10 minutes has passed since the last time they admired it). Same with follows: you won't get spammed by someone unfollowing and reflowing you, though you could get notified once every 10 minutes.

Comments are more spammable: the limit is 5 per feed event every minute, and in practice, I find it difficult to even write comments quickly enough to surpass this limit. My goal here was to make it permissive, since we're not really trying to limit legitimate activity, but we may want to tweak this. Our notifications currently say "ezra commented on your activity" and don't give any additional information, which means they can start to feel redundant when you get 5 of them in a row and they all say the same thing.