### PR TITLE
Handle tokenprocessing index error

### DIFF
--- a/service/media/media.go
+++ b/service/media/media.go
@@ -206,11 +206,18 @@ func MediaFromContentType(contentType string) persist.MediaType {
 	if whereCharset != -1 {
 		contentType = contentType[:whereCharset]
 	}
-	spl := strings.Split(contentType, "/")
 
-	switch spl[0] {
+	splt := strings.Split(contentType, "/")
+
+	typ, subType := splt[0], ""
+
+	if len(splt) == 2 {
+		subType = splt[1]
+	}
+
+	switch typ {
 	case "image":
-		switch spl[1] {
+		switch subType {
 		case "svg", "svg+xml":
 			return persist.MediaTypeSVG
 		case "gif":
@@ -223,14 +230,14 @@ func MediaFromContentType(contentType string) persist.MediaType {
 	case "audio":
 		return persist.MediaTypeAudio
 	case "text":
-		switch spl[1] {
+		switch subType {
 		case "html":
 			return persist.MediaTypeHTML
 		default:
 			return persist.MediaTypeText
 		}
 	case "application":
-		switch spl[1] {
+		switch subType {
 		case "pdf":
 			return persist.MediaTypePDF
 		}


### PR DESCRIPTION
Fixes the error: https://console.cloud.google.com/errors/detail/CJqn4_GK1YrjTQ;service=tokenprocessing-v3;version=tokenprocessing-v3-b0ab09d6b7;time=P1D?project=gallery-prod-325303

It's unlikely, but occasionally does occur where the mimeType isn't of the format `type/subtype`, this change checks the length before indexing.