### PR TITLE
use opensea at further up errors as well

### DIFF
--- a/service/persist/token_processing_jobs.go
+++ b/service/persist/token_processing_jobs.go
@@ -112,6 +112,14 @@ type PipelineMetadata struct {
 	ImageStoreGCP                         PipelineStepStatus `json:"image_store_gcp,omitempty"`
 	ImageThumbnailGCP                     PipelineStepStatus `json:"image_thumbnail_gcp,omitempty"`
 	ImageLiveRenderGCP                    PipelineStepStatus `json:"image_live_render_gcp,omitempty"`
+	AlternateContentHeaderValueRetrieval  PipelineStepStatus `json:"alternate_content_header_value_retrieval,omitempty"`
+	AlternateReaderRetrieval              PipelineStepStatus `json:"alternate_reader_retrieval,omitempty"`
+	AlternateOpenseaFallback              PipelineStepStatus `json:"alternate_opensea_fallback,omitempty"`
+	AlternateDetermineMediaTypeWithReader PipelineStepStatus `json:"alternate_determine_media_type_with_reader,omitempty"`
+	AlternateAnimationGzip                PipelineStepStatus `json:"alternate_animation_gzip,omitempty"`
+	AlternateStoreGCP                     PipelineStepStatus `json:"alternate_store_gcp,omitempty"`
+	AlternateThumbnailGCP                 PipelineStepStatus `json:"alternate_thumbnail_gcp,omitempty"`
+	AlternateLiveRenderGCP                PipelineStepStatus `json:"alternate_live_render_gcp,omitempty"`
 	NothingCachedWithErrors               PipelineStepStatus `json:"nothing_cached_errors,omitempty"`
 	NothingCachedWithoutErrors            PipelineStepStatus `json:"nothing_cached_no_errors,omitempty"`
 	CreateMediaFromCachedObjects          PipelineStepStatus `json:"create_media_from_cached_objects,omitempty"`

--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -189,6 +189,8 @@ func CreateTaskForTokenProcessing(ctx context.Context, client *gcptasks.Client, 
 		return err
 	}
 
+	logger.For(ctx).Infof("creating task for v2 token processing, sending to %s\nmessage: %s", task.GetHttpRequest().GetUrl(), string(body))
+
 	err = submitHttpTask(ctx, client, queue, task, body)
 	if err != nil {
 		return err
@@ -215,6 +217,8 @@ func CreateTaskForTokenProcessing(ctx context.Context, client *gcptasks.Client, 
 	if err != nil {
 		return err
 	}
+
+	logger.For(ctx).Infof("creating task for v3 token processing, sending to %s\nmessage: %s", task.GetHttpRequest().GetUrl(), string(v3Body))
 
 	return submitHttpTask(ctx, client, queue, task, v3Body)
 }

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -1116,7 +1116,11 @@ func cacheObjectsFromOpensea(pCtx context.Context, tids persist.TokenIdentifiers
 			continue
 		}
 
-		return cacheObjectsFromURL(pCtx, tids, firstNonEmptyURL, oType, ipfsClient, arweaveClient, storageClient, bucket, subMeta, true)
+		objects, err := cacheObjectsFromURL(pCtx, tids, firstNonEmptyURL, oType, ipfsClient, arweaveClient, storageClient, bucket, subMeta, true)
+		if err != nil {
+			continue
+		}
+		return objects, nil
 	}
 	return nil, errNoDataFromOpensea{err: err, url: mediaURL}
 }

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -207,8 +207,25 @@ func cacheObjectsForMetadata(pCtx context.Context, metadata persist.TokenMetadat
 
 	// neither download worked, unexpectedly
 	if (animCh == nil || !isCacheResultValid(animResult)) && (imgCh == nil || !isCacheResultValid(imgResult)) {
-		traceCallback, _ := persist.TrackStepStatus(pCtx, &pMeta.NothingCachedWithErrors, "NothingCachedWithErrors")
+		traceCallback, pCtx := persist.TrackStepStatus(pCtx, &pMeta.NothingCachedWithErrors, "NothingCachedWithErrors")
 		defer traceCallback()
+
+		openseaObjects, err := cacheObjectsFromOpensea(pCtx, tids, "", objectTypeImage, ipfsClient, arweaveClient, storageClient, tokenBucket, &cachePipelineMetadata{
+			ContentHeaderValueRetrieval:  &pMeta.AlternateContentHeaderValueRetrieval,
+			ReaderRetrieval:              &pMeta.AlternateReaderRetrieval,
+			OpenseaFallback:              &pMeta.AlternateOpenseaFallback,
+			DetermineMediaTypeWithReader: &pMeta.AlternateDetermineMediaTypeWithReader,
+			AnimationGzip:                &pMeta.AlternateAnimationGzip,
+			StoreGCP:                     &pMeta.AlternateStoreGCP,
+			ThumbnailGCP:                 &pMeta.AlternateThumbnailGCP,
+			LiveRenderGCP:                &pMeta.AlternateLiveRenderGCP,
+		})
+		if err == nil && len(openseaObjects) > 0 {
+			// Fail nothing cached with errors because we were able to get media from opensea
+			persist.FailStep(&pMeta.NothingCachedWithErrors)
+			return append(objects, openseaObjects...), nil
+		}
+		logger.For(pCtx).Errorf("failed to cache media from opensea: %s", err)
 
 		if animCh != nil {
 			if _, ok := animResult.err.(errInvalidMedia); ok {
@@ -250,6 +267,21 @@ func cacheObjectsForMetadata(pCtx context.Context, metadata persist.TokenMetadat
 	if len(objects) == 0 {
 		traceCallback, _ := persist.TrackStepStatus(pCtx, &pMeta.NothingCachedWithoutErrors, "NothingCachedWithoutErrors")
 		defer traceCallback()
+		openseaObjects, err := cacheObjectsFromOpensea(pCtx, tids, "", objectTypeImage, ipfsClient, arweaveClient, storageClient, tokenBucket, &cachePipelineMetadata{
+			ContentHeaderValueRetrieval:  &pMeta.AlternateContentHeaderValueRetrieval,
+			ReaderRetrieval:              &pMeta.AlternateReaderRetrieval,
+			OpenseaFallback:              &pMeta.AlternateOpenseaFallback,
+			DetermineMediaTypeWithReader: &pMeta.AlternateDetermineMediaTypeWithReader,
+			AnimationGzip:                &pMeta.AlternateAnimationGzip,
+			StoreGCP:                     &pMeta.AlternateStoreGCP,
+			ThumbnailGCP:                 &pMeta.AlternateThumbnailGCP,
+			LiveRenderGCP:                &pMeta.AlternateLiveRenderGCP,
+		})
+		if err == nil && len(openseaObjects) > 0 {
+			// Fail nothing cached with errors because we were able to get media from opensea
+			persist.FailStep(&pMeta.NothingCachedWithoutErrors)
+			return append(objects, openseaObjects...), nil
+		}
 		return nil, errNoCachedObjects{tids: tids}
 	}
 
@@ -982,33 +1014,8 @@ func cacheObjectsFromURL(pCtx context.Context, tids persist.TokenIdentifiers, me
 		traceCallback, pCtx := persist.TrackStepStatus(pCtx, subMeta.OpenseaFallback, "OpenseaFallback")
 		logger.For(pCtx).Infof("failed to get data from uri '%s' for '%s' because of (err: %s <%T>), trying opensea", mediaURL, tids, err, err)
 		defer traceCallback()
-		// if token is ETH, backup to asking opensea
-		assets, err := opensea.FetchAssetsForTokenIdentifiers(pCtx, persist.EthereumAddress(tids.ContractAddress), opensea.TokenID(tids.TokenID.Base10String()))
-		if err != nil || len(assets) == 0 {
-			// no data from opensea, return error
-			return nil, errNoDataFromOpensea{err: err, url: mediaURL}
-		}
 
-		for _, asset := range assets {
-			// does this asset have any valid URLs?
-			firstNonEmptyURL, ok := util.FindFirst([]string{asset.AnimationURL, asset.ImageURL, asset.ImagePreviewURL, asset.ImageOriginalURL, asset.ImageThumbnailURL}, func(s string) bool {
-				return s != ""
-			})
-			if !ok {
-				continue
-			}
-
-			reader, err = rpc.GetDataFromURIAsReader(pCtx, persist.TokenURI(firstNonEmptyURL), ipfsClient, arweaveClient, util.MB, time.Second*30)
-			if err != nil {
-				continue
-			}
-
-			logger.For(pCtx).Infof("got reader for %s from opensea in %s (%s)", tids, time.Since(timeBeforeDataReader), firstNonEmptyURL)
-
-			return cacheObjectsFromURL(pCtx, tids, firstNonEmptyURL, oType, ipfsClient, arweaveClient, storageClient, bucket, subMeta, true)
-		}
-
-		return nil, errNoDataFromOpensea{err: err, url: mediaURL}
+		return cacheObjectsFromOpensea(pCtx, tids, mediaURL, oType, ipfsClient, arweaveClient, storageClient, bucket, subMeta)
 	}
 
 	if err != nil {
@@ -1092,6 +1099,26 @@ func cacheObjectsFromURL(pCtx context.Context, tids persist.TokenIdentifiers, me
 	}
 
 	return result, nil
+}
+
+func cacheObjectsFromOpensea(pCtx context.Context, tids persist.TokenIdentifiers, mediaURL string, oType objectType, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, bucket string, subMeta *cachePipelineMetadata) ([]cachedMediaObject, error) {
+	assets, err := opensea.FetchAssetsForTokenIdentifiers(pCtx, persist.EthereumAddress(tids.ContractAddress), opensea.TokenID(tids.TokenID.Base10String()))
+	if err != nil || len(assets) == 0 {
+		return nil, errNoDataFromOpensea{err: err, url: mediaURL}
+	}
+
+	for _, asset := range assets {
+
+		firstNonEmptyURL, ok := util.FindFirst([]string{asset.AnimationURL, asset.ImageURL, asset.ImagePreviewURL, asset.ImageOriginalURL, asset.ImageThumbnailURL}, func(s string) bool {
+			return s != ""
+		})
+		if !ok {
+			continue
+		}
+
+		return cacheObjectsFromURL(pCtx, tids, firstNonEmptyURL, oType, ipfsClient, arweaveClient, storageClient, bucket, subMeta, true)
+	}
+	return nil, errNoDataFromOpensea{err: err, url: mediaURL}
 }
 
 func thumbnailVideoToWriter(ctx context.Context, url string, writer io.Writer) error {

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -16,7 +16,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/sentry"
+	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/mikeydub/go-gallery/service/throttle"
 	"github.com/mikeydub/go-gallery/util"
@@ -56,6 +56,8 @@ func processMediaForUsersTokens(tp *tokenProcessor, tokenRepo *postgres.TokenGal
 		defer throttler.Unlock(reqCtx, input.UserID.String())
 
 		wp := pool.New().WithMaxGoroutines(50).WithErrors()
+
+		logger.For(reqCtx).Infof("Processing Media: %s - Started (%d tokens)", input.UserID, len(input.TokenIDs))
 
 		for _, tokenID := range input.TokenIDs {
 			t, err := tokenRepo.GetByID(reqCtx, tokenID)


### PR DESCRIPTION
Changes:

- **Added** opensea token processing fallback step to more top level failure points in the caching of objects