### PR TITLE
new context just for persist

### DIFF
--- a/cmd/reprocess/main.go
+++ b/cmd/reprocess/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	tp := tokenprocessing.NewTokenProcessor(clients.Queries, clients.EthClient, server.NewMultichainProvider(clients), clients.IPFSClient, clients.ArweaveClient, clients.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), clients.Repos.TokenRepository, metric.NewLogMetricReporter())
 
-	var rows []coredb.GetMissingThumbnailTokensByIDRangeRow
+	var rows []coredb.GetAllTokensWithContractsByIDsRow
 	var err error
 
 	if env.GetString("CLOUD_RUN_JOB") != "" {
@@ -63,7 +63,7 @@ func main() {
 			panic(err)
 		}
 
-		rows, err = clients.Queries.GetMissingThumbnailTokensByIDRange(ctx, coredb.GetMissingThumbnailTokensByIDRangeParams{
+		rows, err = clients.Queries.GetAllTokensWithContractsByIDs(ctx, coredb.GetAllTokensWithContractsByIDsParams{
 			StartID: r.TokenStartID,
 			EndID:   r.TokenEndID,
 		})
@@ -83,7 +83,7 @@ func main() {
 			logrus.Errorf("error getting job range: %v", err)
 			panic(err)
 		}
-		rows, err = clients.Queries.GetMissingThumbnailTokensByIDRange(ctx, coredb.GetMissingThumbnailTokensByIDRangeParams{
+		rows, err = clients.Queries.GetAllTokensWithContractsByIDs(ctx, coredb.GetAllTokensWithContractsByIDsParams{
 			StartID: r.TokenStartID,
 			EndID:   r.TokenEndID,
 		})

--- a/cmd/reprocess/orchestrator/main.go
+++ b/cmd/reprocess/orchestrator/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	var totalTokenCount int
 
-	err := pg.QueryRow(ctx, fmt.Sprintf(`select count(*) from tokens %s;`, tokenprocessing.MissingThumbnailQuery)).Scan(&totalTokenCount)
+	err := pg.QueryRow(ctx, fmt.Sprintf(`select count(*) from tokens %s;`, tokenprocessing.FullReprocessQuery)).Scan(&totalTokenCount)
 	if err != nil {
 		logrus.Errorf("error getting total token count: %v", err)
 		panic(err)
@@ -50,7 +50,7 @@ func main() {
 
 	limit := int(math.Ceil(float64(totalTokenCount) / float64(totalJobs)))
 
-	rows, err := pg.Query(ctx, fmt.Sprintf(`select tokens.id from tokens %s order by tokens.id;`, tokenprocessing.MissingThumbnailQuery))
+	rows, err := pg.Query(ctx, fmt.Sprintf(`select tokens.id from tokens %s order by tokens.id;`, tokenprocessing.FullReprocessQuery))
 	if err != nil {
 		logrus.Errorf("error getting token ids: %v", err)
 		panic(err)

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -326,7 +326,7 @@ func (tpj *tokenProcessingJob) upsertDB(ctx context.Context, tmetadata coredb.To
 	}
 
 	// new context just for insert so that if the rest of the job failed because of a context cancellation, we still insert
-	insertContext, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	insertContext, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	job, err := tpj.tp.queries.InsertJob(insertContext, coredb.InsertJobParams{

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -132,8 +132,12 @@ func (tpj *tokenProcessingJob) run(ctx context.Context) runResult {
 	persistErr := tpj.persistResults(persistCtx, media)
 
 	var err error
-	if persistErr != nil || mediaErr != nil {
+	if persistErr != nil && mediaErr != nil {
 		err = util.MultiErr{persistErr, mediaErr}
+	} else if persistErr != nil {
+		err = persistErr
+	} else if mediaErr != nil {
+		err = mediaErr
 	}
 	return runResult{
 		Chain:     media.Chain,


### PR DESCRIPTION
Changes:

- **Changed** persist token processing step to use its own context just in case the rest of the job failed with a timeout