### PR TITLE
Add magic link env var to local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -465,13 +465,13 @@ format-graphql:
 	yarn prettier --write graphql/testdata/operations.graphql;
 
 start-local-graphql-gateway:
-	docker-compose -f docker/graphql-gateway/docker-compose.yml up -d graphql-gateway-local
+	docker-compose -f docker/graphql-gateway/docker-compose.yml up --build -d graphql-gateway-local
 
 start-dev-graphql-gateway:
-	docker-compose -f docker/graphql-gateway/docker-compose.yml up -d graphql-gateway-dev
+	docker-compose -f docker/graphql-gateway/docker-compose.yml up --build -d graphql-gateway-dev
 
 start-prod-graphql-gateway:
-	docker-compose -f docker/graphql-gateway/docker-compose.yml up -d graphql-gateway-prod
+	docker-compose -f docker/graphql-gateway/docker-compose.yml up --build -d graphql-gateway-prod
 
 # Listing targets as dependencies doesn't pull in target-specific secrets, so we need to
 # invoke $(MAKE) here to read appropriate secrets for each target.

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -38,6 +38,7 @@ GCLOUD_PUSH_NOTIFICATIONS_QUEUE: ENC[AES256_GCM,data:P9LGA9PBH4XWX/J/cHAzU9O0HeQ
 PUSH_NOTIFICATIONS_URL: ENC[AES256_GCM,data:CeXWXrykbn9wZSu9cyfD5XXm1dekTvjW1F6n0wAReq4F5a+5KD+nvwtvw0MvnJ1lQJFpxgg=,iv:3ltCzX36L2kLt7Ewwvjwye5h9j+MlcJR0IhYHQe1PFw=,tag:BOlNKFPJsGjsus6li01VeA==,type:str]
 PUSH_NOTIFICATIONS_SECRET: ENC[AES256_GCM,data:EwXgbG88OZLEe32c28nezn110dhm+eqlYNPHEi2j8yA=,iv:HT4fDlxTYgT3O+IDvMNmOo7nQSgaDs7DSZ8n1zTRTxU=,tag:uUqj5Q9tp6+QOSmRVa+oHA==,type:str]
 RPC_URL: ENC[AES256_GCM,data:Kh4kHqIp/Kpro1v9zw/olAbRnwVdACNjSsicwEivReU33HBUiC9wepy4ayUV1pTV5YPlJdewobsbdPhjLYR6DVe0qxZ0,iv:Soz9ZRjuR0JrqkK9n3rp0o8FXOCF9zmbM1u7VTbz7eM=,tag:tD+VYgBw+2goI8t+87j4cg==,type:str]
+MAGIC_LINK_SECRET_KEY: ENC[AES256_GCM,data:2s6VhHxi7Ru/9H/0vGisPYUdpryJMM/8,iv:lj1AICPUgi9XU+XIziRDWk8ldGn9ZvrTKu4oDdiN0Ko=,tag:M0xONYdGgpLiPNj7k/5ZjA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -47,8 +48,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-05-12T21:58:50Z"
-    mac: ENC[AES256_GCM,data:Icc2AzVMa4p99yMpRCr/rlLKcNmq/STCbrZ9kNH0EYlHf0BgKb7WEgINU+ObjSITbQDKVgYCLhcLjdvbN4PnHkT6E0SLkXNEONIx5yoeqhmrKHNYp4lfc2+QXFfU69bcbXrZhD/AX2cMTJG+wS7fZFEy7BWHcBBpXugODJQviIs=,iv:Y24ac5G3YuLBgc4Fn4v/YnUzBwBkUuvIwr8U9rGTh1k=,tag:yp+pj8/c06+zRRY+q7qRvw==,type:str]
+    lastmodified: "2023-05-22T17:41:14Z"
+    mac: ENC[AES256_GCM,data:jx8/lCP+1J8ajfEfx0xLcCwDtZpvTaM+duGgr5XF9xIs5FsEqR0dktBM2ogniSahsOIHLR7GiohEvsagPfGdbYMicv2DQsiF3zYN4+4oOnHVbsF3OzRm9ijEiMx1wjdBMnyl5EmiFI+iaMBD7k00JuKju/kgT0w5zZefw1yPJcU=,iv:937foEPjHOPWOCNLTtZfH48X2jpwr/KY61UJfTK2Kns=,tag:ytK3/BXfxGF/LzMVKBoK+A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
We didn't have the magic link secret key on local dev before, now we do!

I also updated the `make start-x-graphql-gateway` targets to build the container every time so you always have an up to date schema.