### PR TITLE
use chains in lock

### DIFF
--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -34,9 +34,10 @@ type FeedbotMessage struct {
 }
 
 type TokenProcessingUserMessage struct {
-	UserID   persist.DBID   `json:"user_id" binding:"required"`
-	TokenIDs []persist.DBID `json:"token_ids" binding:"required"`
-	IsV3     bool           `json:"is_v3" binding:"-"` // V3Migration: Remove when migration is complete
+	UserID   persist.DBID    `json:"user_id" binding:"required"`
+	TokenIDs []persist.DBID  `json:"token_ids" binding:"required"`
+	Chains   []persist.Chain `json:"chains" binding:"required"`
+	IsV3     bool            `json:"is_v3" binding:"-"` // V3Migration: Remove when migration is complete
 }
 
 type TokenProcessingContractTokensMessage struct {

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -104,7 +104,7 @@ func (tpj *tokenProcessingJob) run(ctx context.Context) runResult {
 	span, ctx := tracing.StartSpan(ctx, "pipeline.run", fmt.Sprintf("run %s", tpj.id))
 	defer tracing.FinishSpan(span)
 
-	logger.For(ctx).Info("starting token processing pipeline for token %s", tpj.key)
+	logger.For(ctx).Infof("starting token processing pipeline for token %s (tokenDBID: %s)", tpj.key, tpj.token.ID)
 
 	var media coredb.TokenMedia
 	var mediaErr error

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"time"
 
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
@@ -42,8 +43,15 @@ func processMediaForUsersTokens(tp *tokenProcessor, tokenRepo *postgres.TokenGal
 
 		reqCtx := logger.NewContextWithFields(c.Request.Context(), logrus.Fields{"userID": input.UserID})
 
-		// V3Migration: Remove when migration is complete
+		sort.Slice(input.Chains, func(i, j int) bool {
+			return input.Chains[i] < input.Chains[j]
+		})
+
 		lockID := input.UserID.String()
+		for _, chain := range input.Chains {
+			lockID += fmt.Sprintf(":%d", chain)
+		}
+		// V3Migration: Remove when migration is complete
 		if input.IsV3 {
 			lockID += ":v3"
 		}


### PR DESCRIPTION
Changes:

- **Added** chains to throttle lock on token processor

This was previously not causing any obvious issues in v2 because tokens would just end up not getting reprocessed, it is a lot more obvious in v3 when a new token would not receive a token media ID.

What would happen is a user would sync tokens of one chain, then do another right after, and because we throttled on user ID, all of the second chain's tokens would get throttled and not get processed by the token processor.