### PR TITLE
Turn off V2 tokenprocessing

### DIFF
--- a/.github/workflows/deployer.yml
+++ b/.github/workflows/deployer.yml
@@ -28,29 +28,7 @@ jobs:
           gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
         run: make deploy-prod-backend
-  # deploy-dev-tokenprocessing:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: "Install build deps"
-  #       uses: ./.github/actions/build-deps
-  #       with:
-  #         sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
-  #         gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
-  #     - name: "Deploy"
-  #       run: make deploy-dev-tokenprocessing
-  # deploy-prod-tokenprocessing:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: "Install build deps"
-  #       uses: ./.github/actions/build-deps
-  #       with:
-  #         sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
-  #         gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
-  #     - name: "Deploy"
-  #       run: make deploy-prod-tokenprocessing
-  deploy-dev-tokenprocessingV3:
+  deploy-dev-tokenprocessing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -60,8 +38,8 @@ jobs:
           sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           gcp-credentials-json: ${{ secrets.GCP_DEV_CREDENTIALS }}
       - name: "Deploy"
-        run: make deploy-dev-tokenprocessingV3
-  deploy-prod-tokenprocessingV3:
+        run: make deploy-dev-tokenprocessing
+  deploy-prod-tokenprocessing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +49,7 @@ jobs:
           sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
           gcp-credentials-json: ${{ secrets.GCP_PROD_CREDENTIALS }}
       - name: "Deploy"
-        run: make deploy-prod-tokenprocessingV3
+        run: make deploy-prod-tokenprocessing
   deploy-prod-indexer-api:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ $(DEPLOY)-$(DEV)-indexer-server     : SERVICE_FILE := indexer-server-env.yaml
 $(DEPLOY)-$(DEV)-admin              : SERVICE_FILE := app-dev-admin.yaml
 $(DEPLOY)-$(DEV)-feed               : SERVICE_FILE := feed-env.yaml
 $(DEPLOY)-$(DEV)-tokenprocessing    : SERVICE_FILE := tokenprocessing-env.yaml
-$(DEPLOY)-$(DEV)-tokenprocessingV3  : SERVICE_FILE := tokenprocessing-env.yaml
 $(DEPLOY)-$(DEV)-pushnotifications  : SERVICE_FILE := pushnotifications-env.yaml
 $(DEPLOY)-$(DEV)-emails             : SERVICE_FILE := emails-server-env.yaml
 $(DEPLOY)-$(DEV)-feedbot            : SERVICE_FILE := feedbot-env.yaml
@@ -85,7 +84,6 @@ $(DEPLOY)-$(PROD)-admin             : SERVICE_FILE := app-prod-admin.yaml
 $(DEPLOY)-$(PROD)-feed              : SERVICE_FILE := feed-env.yaml
 $(DEPLOY)-$(PROD)-feedbot           : SERVICE_FILE := feedbot-env.yaml
 $(DEPLOY)-$(PROD)-tokenprocessing   : SERVICE_FILE := tokenprocessing-env.yaml
-$(DEPLOY)-$(PROD)-tokenprocessingV3 : SERVICE_FILE := tokenprocessing-env.yaml
 $(DEPLOY)-$(PROD)-pushnotifications : SERVICE_FILE := pushnotifications-env.yaml
 $(DEPLOY)-$(PROD)-dummymetadata     : SERVICE_FILE := dummymetadata-env.yaml
 $(DEPLOY)-$(PROD)-emails            : SERVICE_FILE := emails-server-env.yaml
@@ -98,7 +96,6 @@ $(DEPLOY)-%-backend               : SENTRY_PROJECT := gallery-backend
 $(DEPLOY)-%-indexer               : SENTRY_PROJECT := indexer
 $(DEPLOY)-%-indexer-server        : SENTRY_PROJECT := indexer-api
 $(DEPLOY)-%-tokenprocessing       : SENTRY_PROJECT := tokenprocessing
-$(DEPLOY)-%-tokenprocessingV3     : SENTRY_PROJECT := tokenprocessing
 $(DEPLOY)-%-pushnotifications     : SENTRY_PROJECT := pushnotifications
 $(DEPLOY)-%-dummymetadata         : SENTRY_PROJECT := dummymetadata
 $(DEPLOY)-%-feed                  : SENTRY_PROJECT := feed
@@ -106,24 +103,15 @@ $(DEPLOY)-%-feedbot               : SENTRY_PROJECT := feedbot
 $(DEPLOY)-%-emails                : SENTRY_PROJECT := emails
 
 # Docker builds
-$(DEPLOY)-%-tokenprocessing            : REPO           := tokenprocessing
+$(DEPLOY)-%-tokenprocessing            : REPO           := tokenprocessing-v3
 $(DEPLOY)-%-tokenprocessing            : DOCKER_FILE    := $(DOCKER_DIR)/tokenprocessing/Dockerfile
 $(DEPLOY)-%-tokenprocessing            : PORT           := 6500
 $(DEPLOY)-%-tokenprocessing            : TIMEOUT        := $(TOKENPROCESSING_TIMEOUT)
 $(DEPLOY)-%-tokenprocessing            : CPU            := $(TOKENPROCESSING_CPU)
 $(DEPLOY)-%-tokenprocessing            : MEMORY         := $(TOKENPROCESSING_MEMORY)
 $(DEPLOY)-%-tokenprocessing            : CONCURRENCY    := $(TOKENPROCESSING_CONCURRENCY)
-$(DEPLOY)-$(DEV)-tokenprocessing       : SERVICE        := tokenprocessing-dev
-$(DEPLOY)-$(PROD)-tokenprocessing      : SERVICE        := tokenprocessing-v2
-$(DEPLOY)-%-tokenprocessingV3          : REPO           := tokenprocessing-v3
-$(DEPLOY)-%-tokenprocessingV3          : DOCKER_FILE    := $(DOCKER_DIR)/tokenprocessing/Dockerfile
-$(DEPLOY)-%-tokenprocessingV3          : PORT           := 6500
-$(DEPLOY)-%-tokenprocessingV3          : TIMEOUT        := $(TOKENPROCESSING_TIMEOUT)
-$(DEPLOY)-%-tokenprocessingV3          : CPU            := $(TOKENPROCESSING_CPU)
-$(DEPLOY)-%-tokenprocessingV3          : MEMORY         := $(TOKENPROCESSING_MEMORY)
-$(DEPLOY)-%-tokenprocessingV3          : CONCURRENCY    := $(TOKENPROCESSING_CONCURRENCY)
-$(DEPLOY)-$(DEV)-tokenprocessingV3     : SERVICE        := tokenprocessing-v3
-$(DEPLOY)-$(PROD)-tokenprocessingV3    : SERVICE        := tokenprocessing-v3
+$(DEPLOY)-$(DEV)-tokenprocessing       : SERVICE        := tokenprocessing-v3
+$(DEPLOY)-$(PROD)-tokenprocessing      : SERVICE        := tokenprocessing-v3
 $(DEPLOY)-%-pushnotifications          : REPO           := pushnotifications
 $(DEPLOY)-%-pushnotifications          : DOCKER_FILE    := $(DOCKER_DIR)/pushnotifications/Dockerfile
 $(DEPLOY)-%-pushnotifications          : PORT           := 6600
@@ -232,7 +220,7 @@ $(PROMOTE)-%-indexer                   : SERVICE := indexer
 $(PROMOTE)-%-indexer-server            : SERVICE := indexer-api
 $(PROMOTE)-%-emails                    : SERVICE := emails
 $(PROMOTE)-%-tokenprocessing           : SERVICE := tokenprocessing
-$(PROMOTE)-%-tokenprocessingV3         : SERVICE := tokenprocessing-v3
+$(PROMOTE)-%-tokenprocessing           : SERVICE := tokenprocessing-v3
 $(PROMOTE)-%-pushnotifications         : SERVICE := pushnotifications
 $(PROMOTE)-%-dummymetadata             : SERVICE := dummymetadata
 $(PROMOTE)-%-feed                      : SERVICE := feed
@@ -352,7 +340,6 @@ _$(RELEASE)-%:
 $(DEPLOY)-$(DEV)-backend            : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-backend _$(RELEASE)-backend
 $(DEPLOY)-$(DEV)-indexer-server     : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-indexer-server _$(RELEASE)-indexer-server
 $(DEPLOY)-$(DEV)-tokenprocessing    : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-tokenprocessing _$(RELEASE)-tokenprocessing
-$(DEPLOY)-$(DEV)-tokenprocessingV3  : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-tokenprocessingV3 _$(RELEASE)-tokenprocessingV3
 $(DEPLOY)-$(DEV)-pushnotifications  : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-pushnotifications _$(RELEASE)-pushnotifications
 $(DEPLOY)-$(DEV)-emails             : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-emails _$(RELEASE)-emails
 $(DEPLOY)-$(DEV)-admin              : _set-project-$(ENV) _$(DEPLOY)-admin
@@ -371,7 +358,6 @@ $(DEPLOY)-$(PROD)-backend            : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-
 $(DEPLOY)-$(PROD)-indexer            : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-indexer _$(RELEASE)-indexer
 $(DEPLOY)-$(PROD)-indexer-server     : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-indexer-server _$(RELEASE)-indexer-server
 $(DEPLOY)-$(PROD)-tokenprocessing    : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-tokenprocessing _$(RELEASE)-tokenprocessing
-$(DEPLOY)-$(PROD)-tokenprocessingV3  : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-tokenprocessingV3 _$(RELEASE)-tokenprocessingV3
 $(DEPLOY)-$(PROD)-pushnotifications  : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-pushnotifications _$(RELEASE)-pushnotifications
 $(DEPLOY)-$(PROD)-dummymetadata      : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-dummymetadata _$(RELEASE)-dummymetadata
 $(DEPLOY)-$(PROD)-emails             : _set-project-$(ENV) _$(DOCKER)-$(DEPLOY)-emails _$(RELEASE)-emails
@@ -392,7 +378,6 @@ $(PROMOTE)-$(PROD)-backend            : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE
 $(PROMOTE)-$(PROD)-indexer            : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE)-indexer
 $(PROMOTE)-$(PROD)-indexer-server     : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE)-indexer-server
 $(PROMOTE)-$(PROD)-tokenprocessing    : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE)-tokenprocessing
-$(PROMOTE)-$(PROD)-tokenprocessingV3  : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE)-tokenprocessingV3
 $(PROMOTE)-$(PROD)-pushnotifications  : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE)-pushnotifications
 $(PROMOTE)-$(PROD)-dummymetadata      : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE)-dummymetadata
 $(PROMOTE)-$(PROD)-emails             : _set-project-$(ENV) _$(DOCKER)-$(PROMOTE)-emails

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -991,7 +991,7 @@ func (r *mutationResolver) Logout(ctx context.Context, pushTokenToUnregister *st
 	if pushTokenToUnregister != nil {
 		err := publicapi.For(ctx).User.DeletePushTokenByPushToken(ctx, *pushTokenToUnregister)
 		if err != nil {
-			logger.For(ctx).Info("failed to delete push token %s on logout: %s\n", *pushTokenToUnregister, err)
+			logger.For(ctx).Infof("failed to delete push token %s on logout: %s\n", *pushTokenToUnregister, err)
 			return nil, err
 		}
 	}

--- a/graphql/stub_test.go
+++ b/graphql/stub_test.go
@@ -34,7 +34,7 @@ func (p stubProvider) GetTokensByWalletAddress(ctx context.Context, address pers
 	return p.Tokens, p.Contracts, nil
 }
 
-func (p stubProvider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error) {
+func (p stubProvider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
 	return p.FetchMetadata()
 }
 

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -3,7 +3,6 @@ package publicapi
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -351,19 +350,7 @@ func (api TokenAPI) RefreshToken(ctx context.Context, tokenDBID persist.DBID) er
 		return fmt.Errorf("failed to load contract for token: %w", err)
 	}
 
-	addresses := []persist.Address{}
-	for _, walletID := range token.OwnedByWallets {
-		wa, err := api.loaders.WalletByWalletID.Load(walletID)
-		if err != nil {
-			if strings.Contains(err.Error(), "no rows in result set") {
-				continue
-			}
-			return fmt.Errorf("failed to load wallet %s: %w", walletID, err)
-		}
-		addresses = append(addresses, wa.Address)
-	}
-
-	err = api.multichainProvider.RefreshToken(ctx, persist.NewTokenIdentifiers(contract.Address, token.TokenID, contract.Chain), addresses)
+	err = api.multichainProvider.RefreshToken(ctx, persist.NewTokenIdentifiers(contract.Address, token.TokenID, contract.Chain))
 	if err != nil {
 		return ErrTokenRefreshFailed{Message: err.Error()}
 	}
@@ -410,17 +397,7 @@ func (api TokenAPI) RefreshCollection(ctx context.Context, collectionDBID persis
 				return
 			}
 
-			addresses := []persist.Address{}
-			for _, walletID := range token.OwnedByWallets {
-				wa, err := api.loaders.WalletByWalletID.Load(walletID)
-				if err != nil {
-					errChan <- err
-					return
-				}
-				addresses = append(addresses, wa.Address)
-			}
-
-			err = api.multichainProvider.RefreshToken(ctx, persist.NewTokenIdentifiers(contract.Address, token.TokenID, contract.Chain), addresses)
+			err = api.multichainProvider.RefreshToken(ctx, persist.NewTokenIdentifiers(contract.Address, token.TokenID, contract.Chain))
 			if err != nil {
 				errChan <- ErrTokenRefreshFailed{Message: err.Error()}
 				return

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -9,8 +9,7 @@ ONE_TIME_LOGIN_JWT_SECRET: ENC[AES256_GCM,data:lRIFaqqw3Z8ceWNy4yS2gsGSimVjBiHCA
 PREMIUM_CONTRACT_ADDRESS: ENC[AES256_GCM,data:IZTLviyFrvpJCSMCE1IxeTKMvdy1K3gI1APcjelBoO+OCjm7ItfcyL7Qup/31JaTufEpI08yyWArop6IsIg=,iv:mhCrfgQoa9P8wpNTmg+1eXveyWjCictTmvwJwaR+7Go=,tag:ClRLDUs4SRnR/JcJnztjQg==,type:str]
 CONTRACT_ADDRESSES: ENC[AES256_GCM,data:8pFih2gIn0H7zR1D3cbcspKrQ5Npbnw1wD0iIUebAD6/mZmWfxYr4HTAh359V47WuIBZKQi9Z1ns2FSjZ5s=,iv:NXlsYRl4s0AIpIl1GshnmTje509AsS1ehvK6utMHqNA=,tag:anOMBpAK/XtVCjdgK4Bm/g==,type:str]
 RPC_URL: ENC[AES256_GCM,data:7noHpqwuruF7QdQtBXd+dd8Lj+Bk/kDr7o65bxJqn68RfwgzRknWDlO9kAM2LI7JWHLVg65Doxi8MZA/vGWjCf39MwA6,iv:Zy0//W8S/gkMwG8NYb6NFv+WGOw8GhIYubiX2Ilsnjk=,tag:WI2QPGNK2INY8pBjBYOgMA==,type:str]
-TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:CmcPtVPR4EArcOcagOPeTf/4mPphg5gQdrmW9FseP7NGILjs3vIfBbxdDhhq/fVJM5cp,iv:ZcfzwuK7iCHPOWXtzBoxdHtmKvkyVKV3vA5bfOUrrkk=,tag:BHgx6uYwJBT/u3QHOjbYqg==,type:str]
-NEW_TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:Zb+eTxqPslXsTgNMY1wtBG3X3WnXb72WNHg6Xt1RWhewxQwVbJBy8fkcp7OhFG7oq08=,iv:QD4MVCWNc8npX5Y83tbjLPxgXEHCngwkoAqIGWYDox0=,tag:ztAR4jFr+J5c74vyZhz/0A==,type:str]
+TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:cCCcXc+rFJV9UoHhJILNoS4kiZD+WwT6IcfiG1lJ8Q0ODY0YMY1TO3KxBOfaoPxFTHA=,iv:LxjolPP0gVSQTzVMQ+4nzniE+DspsvOl12DhptCLdmY=,tag:zKkuO7Dhkrrn3dMja0MAUg==,type:str]
 REQUIRE_NFTS: ENC[AES256_GCM,data:x3oGXQ==,iv:+94Es4GFiCmOSv/IcGWACnmSOjiUKZwDeq/SOSyA7uU=,tag:Y8OMxYLQ6VP1qri72TIa+Q==,type:str]
 GCLOUD_TOKEN_CONTENT_BUCKET: ENC[AES256_GCM,data:Az8twibqDBzhVJvWqQ==,iv:yuaR5luahbGORq06JIJQJSYEU89drvkhnikVRQQv5Mo=,tag:BFqbzh5u0OTG+T0cLsuYTw==,type:str]
 ADMIN_PASS: ENC[AES256_GCM,data:wBKLFLoHTrjiuTfqEa2ocJJGPSg=,iv:Rk77ARwfhiFKa2r//dyTK7meAOe5lCOriKGeAsxNoiU=,tag:c2MrnI3ZDzuHcYrcHFmu+g==,type:str]
@@ -76,8 +75,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-05-16T19:05:45Z"
-    mac: ENC[AES256_GCM,data:VH0QqS6Fdd+xzE8uoYRi3LImiWxxDjtZj9I7cC6OSHI5S/TNWQHRrNK4jeJc2U8G9LPd0TAHo5KTsm0T/K3ymnmm+kOyUZkVyIOIZ1uUSDZlUTMsR0jSK2qmPZ6J15hDc7V+Jys6LRL+SdA3YGLaEcU39LGSceVAWUAzNJUZF4U=,iv:HQyJPGjQ3C9e4Fpv8ceIj0MW+9ay2wQpK76CFRAL4Oo=,tag:vSTik4mkrHR4Ppb4AvQk2g==,type:str]
+    lastmodified: "2023-05-24T21:09:31Z"
+    mac: ENC[AES256_GCM,data:1b+anQcqXFSKQRB4zgV0YuDKO0xVXNsCfqHWaW1XsyzuBnM5tHwBAWDNKwhiEGz3LLCZXYokS/TZuQYhefxS6r9zRkQpYutbY7YOD5VEvhLm6tgiZRMdehT8wcHPyGjF9YUiUCyg0TsjFvGXFanL1wRoUgui/WWMAktBu+7OmRk=,iv:0st0Gm/tPx/hfDqhzjAZvLAxlDoFXfU0rIn+N321D4o=,tag:LeuXwSoOuYJIxreq0p/BAA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -8,10 +8,8 @@ POSTGRES_PASSWORD: ENC[AES256_GCM,data:18Zy616OGPJdbmdDK5okGPpVK9QMZjBWs0BF+2ZHy
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:SJWpF28oF+eqNuEGWOpSqkRvucwI9CzrvDTcSMlBY5I=,iv:CHYFkvPzr01hGa9NnXBBaZmRYxSxQOO4Ez6vy9pDrrs=,tag:TovBOu9orzTs4NDJsiy8KA==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
-TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:e9v4L0N8UjLTVwuDHaXFf1oXkkky,iv:wJDENBnGrtO0ld41kBgFCVfFXmEARwqCTFEhdvuqf+c=,tag:al8SyGARL69yLdQuBUBybQ==,type:str]
-#ENC[AES256_GCM,data:/ZJ4mKK5lmCQ1r1HZuu22mPkU0xJSE3G1I4Rn2Gj2kEhD5RvRd2zBnwXeBbVNvYgvhcScfuzKluaMfzGHWOOrt3+IthCRAjwCpA=,iv:OPlOMU2NPfAKQAUlj+ku/vkzwi3bbNjTKgWP9fEtGAg=,tag:VnoBBptR9JF89lv/i77eWw==,type:comment]
-NEW_TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:mEr57Y8ZpThfS8gWF0kYUsoCxnja,iv:XeR5hKu5vayxm1q7/hkwy2UPBW6aTtOF3S8xSI15zo4=,tag:PJ1PvdbP5i4BA8E0kjCIUQ==,type:str]
-#ENC[AES256_GCM,data:DJzTh4jbxMcUxGIp4lChEM+MdXtvnXqh32qfCRuVAi8n7zY2TeZ5W357fvkRcP8xCLgA+Lj3W7xZ9BvOqoZJDJnbpTMBWFzxGNaOnDM=,iv:YnA/eVCIywvGSzsCp/YpoiqHDmQHeJstals/Ih5iz20=,tag:v98+f6uxSyjNr3ekZF+5WA==,type:comment]
+#ENC[AES256_GCM,data:ET55602KN8cbNlfDyb+1ztAZgeYhIaseUlcAZrTJtnZiNdzZeXmtQYgX+4E=,iv:W/I1CgeL2QFwMYnYmQ9tjsM/seHRE3vS2m7tOuqY5Jc=,tag:1uUVz7pAudnm5INE0H1J1g==,type:comment]
+TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:3gBp4IfqM6+uhzfPOu3H1uiwMQNll5JLnS5Zn4/FUS/BuklJ6dVa0UM2VkIiEfC2f+c=,iv:IR/gKlxCGoeAyplR+FMzYP9Y8dIjbnPicAaS8SWbmHA=,tag:gPMvuixs8YqTMGY3sr51Ag==,type:str]
 INDEXER_HOST: ENC[AES256_GCM,data:AMSoNna+FClTDLT2p+9jVnH2qH9M,iv:vywl4L+b3B1WSIIYPwKzRMSRn67boCM531P5dLKw1Ls=,tag:y4erUfhOns07F4RqDLafGQ==,type:str]
 #ENC[AES256_GCM,data:kxDk5XyPsjJvjeJCrLoxZ8W52B7Wk4NgVQ9aJfOM3MBvOkumXBstjLTrZZCd/zbg3PwVRLeF/ZYISA==,iv:Ik9VWuJvIgVobthlV1mKTfCBqwqCVDi4UOIJ/4cDNz0=,tag:Xe49oB+2mypS+DbEGh9ErQ==,type:comment]
 TOKEN_PROCESSING_QUEUE: ENC[AES256_GCM,data:L7EdI/IY0tirUA4L1oUy/IB3WUx9LcYfyoi2+yAQuOwBvdAZJnXgwgqRXQ9KdmOMJJFaXVPcbLXk68bwACkbYMAq6A==,iv:lTE4K7RYhqoj8pMK6QWnk/ZH0agOmU5xFo7F29OZxDU=,tag:mE4hi42g2mmnyjxhJzUvJQ==,type:str]
@@ -49,8 +47,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-05-22T23:13:42Z"
-    mac: ENC[AES256_GCM,data:Cra3vemye6KXdEPAR2TmWnpcHf+ADlwieyJgmu/dSWpiYFsZLLT+dLCsTPPjtmkzDD0CvBuRNnr9E/FvqrHZySDZoVotxpk7p684BWQ48wigf6eyo5zG52E32q0Ck7k6NP3gYubOPY8q45mOymbgxCNBwLnkQrtMPn8ODgwnK00=,iv:PPKgX5SvkFlruSLHwbSHoVSlWqRPZG4NSUayJh+8qXA=,tag:5R7bGCZWw7T+8jTFhbhSQQ==,type:str]
+    lastmodified: "2023-05-24T21:11:25Z"
+    mac: ENC[AES256_GCM,data:iDh7rvdEX5DZrtgmIfngxZjo25fCZ5xFkApn2vQ9s2++gmXkToUR4quXlhkpalpynPsHB0tG7/vtMpGw34psjNjnccko7bqzvyEJR1o0twzbwczG714mEnd83JjEOKYMfcBszqHJFDQDbhDhK8l2wE/gDbupJSr98FDXxhWzmQw=,iv:co0ggCJyGueObNuVC3CBV2lG/+kfW/7b5XXPgVrTGgI=,tag:8hILyT8yCTMrokl0IrsESA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -20,8 +20,7 @@ POSTGRES_PORT: ENC[AES256_GCM,data:PISiaw==,iv:hVfpQLwM59hGULdJL7yMHlLlxE5+DOcGr
 POSTGRES_DB: ENC[AES256_GCM,data:i9gb4i/0Osw=,iv:a5qEC3WK4H71qnpr8dYdjnIMbZZ6wvBWiu29bD2hOPM=,tag:xKFB7dFVD83sucRIQToMyw==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:dz5FOk4nIGimMVXpMFf4,iv:S7hc/g/kaOW6RhxNrwZOljjl+mbk7jK/rr9mbMsRvLc=,tag:JWuPfAjPgLjz9UIEz6272w==,type:str]
 POSTGRES_PASSWORD: ENC[AES256_GCM,data:LakdjRumxbCVCgl++ka825gnQfyGz0H9a+r2b627OLM=,iv:iGVdal/DDoGDW54JKG6Dyq48DVVGxGo7a7lHrlCwQFQ=,tag:Wsj3PsSMjx3+qK0DgMvLWQ==,type:str]
-TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:w5vpV5SKkWbGEPgju/rFI41VA0BmfzP41/358QRjbBhJMIAUZYvEYBU+Tg511JjBdzI=,iv:EEU3qc+9mpHpKhtHkNVsrQ6K8lAYMoi6O4+ctHYbzdo=,tag:z5SOt7W+ePcMaleFwsv36g==,type:str]
-NEW_TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:DRXRO64OaaIGEpFTb3ZnVccSEmqcX4Ohaq/Y4gzJmpow71IcWaVVlgKv44K43tVm/UI=,iv:Pv2QrRWF7zapRusKk1ft9S2Mds0flASyKrt3SyW8q+E=,tag:cCOzQLmS+YWhm78ujvUgiw==,type:str]
+TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:ZZKo4+YzQ0LHDVLgvR0F9XUCRk8db8msRKEmS94/YxmEk1cG1c5QASjKs/Vw9SQ0U0k=,iv:9QuzcRM/Xmn40rPYlGITYHVBzbrqMbGLP9ot0LoBv94=,tag:dzHKI7I4L1bgzE2x0ZIBRA==,type:str]
 SNAPSHOT_BUCKET: ENC[AES256_GCM,data:yCTxODsLMxQUsprfsM+JMDnESQuahd6ioF8As9daIQ==,iv:S4wYnyKt3dmuadSIxwjGf43+1Sc56MvGEmNQDIJuLHI=,tag:8gSH9hMqHjsP/f0jc/fsLQ==,type:str]
 INDEXER_HOST: ENC[AES256_GCM,data:VKRvcNklnL9IF+FM1iYmZi2ANBpmSoTeepGeFzHvcfs6oJOms7Fh/s4lrg==,iv:+goyc8SNZ5Jz6qN4JXtrWZ4QDlHYgJ2vWwwoEeYo0C0=,tag:SJs89vI3ieX//cHznnuJng==,type:str]
 SENTRY_DSN: ENC[AES256_GCM,data:2pRvfV+xzN44+Yy7tQQTlW6k/r/iXr9e7MLh3zadoHThut+8DwrsKRehV5aqWYPnpfhpW4wPUiMTQqY4dHR5McLn1Mn3jls7FMI=,iv:eo+OOjVeXszf6b2jwfVTji3UCLSRJVTtQyBR8Agm/6w=,tag:Q5KNKppoVlomEC3xCkL6Jg==,type:str]
@@ -76,8 +75,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-05-16T19:05:37Z"
-    mac: ENC[AES256_GCM,data:75a4QEOajdOK6Mfyf2t6nKUMbL4Ry7iSoKb+4qIjVzTEl3LAWKN6ok6+2kBV87MDvI4CWyQLDrna5M9Ep4W+Jf1JlmG1egZtgmVVExWwkft/Hqsj1NnCpesK4OglYNCIJ7X2pHlL5CwpnpgA6V1y2O5Njk4rXCGUJ0K2lfx17E0=,iv:x4GiJYSIjEvnZfxPU5XmGp5V3IzYgrbQ0NQTuqnH71g=,tag:fGjj9pXDfdDDaDLHVewQLQ==,type:str]
+    lastmodified: "2023-05-24T21:09:44Z"
+    mac: ENC[AES256_GCM,data:g6Ee4cun9DY3n4LyfixtJBUib46z2pemgWgTqAg3uZ9wKY1pmFeIO+GENawhhNveN+LPd2RCNxc5s+UxpSbSIh+uwP27xSBuK7nkN5DchPJwnGU2CpCt1UPLeXi7q0FBiZ+rZ2HY5YkHK4dSM3DmTwrMIL1SKIQuqWamrUovQg0=,iv:OZGG56D3w7JxJf3GA5Usz3UAb55RzYR7ckHGr4rHPY4=,tag:2OFYXlfrUeVJzctUAlfZmA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/server/server.go
+++ b/server/server.go
@@ -196,7 +196,6 @@ func SetDefaults() {
 	viper.SetDefault("GCLOUD_FEED_BUFFER_SECS", 20)
 	viper.SetDefault("FEED_SECRET", "feed-secret")
 	viper.SetDefault("TOKEN_PROCESSING_URL", "http://localhost:6500")
-	viper.SetDefault("NEW_TOKEN_PROCESSING_URL", "http://localhost:6500")
 	viper.SetDefault("TEZOS_API_URL", "https://api.tzkt.io")
 	viper.SetDefault("POAP_API_KEY", "")
 	viper.SetDefault("POAP_AUTH_TOKEN", "")

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -335,7 +335,7 @@ func getNFTsPaginate[T tokensPaginated](ctx context.Context, baseURL string, def
 }
 
 // // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID
-// func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error) {
+// func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
 // 	tokens, _, err := d.getTokenWithMetadata(ctx, ti, false, 0)
 // 	if err != nil {
 // 		return persist.TokenMetadata{}, err

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -55,11 +55,8 @@ func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.Blockchain
 }
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID
-func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error) {
+func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
 	url := fmt.Sprintf("%s/nfts/get/metadata?contract_address=%s&token_id=%s", d.indexerBaseURL, ti.ContractAddress, ti.TokenID)
-	if ownerAddress != "" {
-		url = fmt.Sprintf("%s&address=%s", url, ownerAddress)
-	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +81,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti mu
 }
 
 func (d *Provider) GetTokenDescriptorsByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (multichain.ChainAgnosticTokenDescriptors, multichain.ChainAgnosticContractDescriptors, error) {
-	metadata, err := d.GetTokenMetadataByTokenIdentifiers(ctx, ti, "")
+	metadata, err := d.GetTokenMetadataByTokenIdentifiers(ctx, ti)
 	if err != nil {
 		return multichain.ChainAgnosticTokenDescriptors{}, multichain.ChainAgnosticContractDescriptors{}, err
 	}

--- a/service/multichain/fallback.go
+++ b/service/multichain/fallback.go
@@ -109,6 +109,10 @@ func (f *SyncWithContractEvalFallbackProvider) callFallback(ctx context.Context,
 	return primary
 }
 
+func (f SyncWithContractEvalFallbackProvider) GetTokenDescriptorsByTokenIdentifiers(ctx context.Context, id ChainAgnosticIdentifiers) (ChainAgnosticTokenDescriptors, ChainAgnosticContractDescriptors, error) {
+	return f.Primary.GetTokenDescriptorsByTokenIdentifiers(ctx, id)
+}
+
 func (f SyncWithContractEvalFallbackProvider) GetSubproviders() []any {
 	return []any{f.Primary, f.Fallback}
 }

--- a/service/multichain/infura/infura.go
+++ b/service/multichain/infura/infura.go
@@ -351,7 +351,7 @@ type TokenMetadata struct {
 }
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID
-func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error) {
+func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
 	meta, err := p.getMetadata(ctx, ti, true)
 	if err != nil {
 		return p.getMetadata(ctx, ti, false)

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -248,7 +248,6 @@ func (p *Provider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, ti m
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID
 func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
-	fmt.Println("CALLING OS!!!!")
 	tokens, _, err := p.GetTokensByTokenIdentifiers(ctx, ti, 1, 0)
 	if err != nil {
 		return nil, err
@@ -257,8 +256,6 @@ func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti mu
 	if len(tokens) == 0 {
 		return nil, fmt.Errorf("no tokens found for %s", ti)
 	}
-
-	fmt.Println("DONE CALLING OS!!!!")
 
 	return tokens[0].TokenMetadata, nil
 }

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -247,12 +247,20 @@ func (p *Provider) GetTokensByTokenIdentifiersAndOwner(ctx context.Context, ti m
 }
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID
-func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (persist.TokenMetadata, error) {
-	token, _, err := p.GetTokensByTokenIdentifiersAndOwner(ctx, ti, ownerAddress)
+func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
+	fmt.Println("CALLING OS!!!!")
+	tokens, _, err := p.GetTokensByTokenIdentifiers(ctx, ti, 1, 0)
 	if err != nil {
 		return nil, err
 	}
-	return token.TokenMetadata, nil
+
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no tokens found for %s", ti)
+	}
+
+	fmt.Println("DONE CALLING OS!!!!")
+
+	return tokens[0].TokenMetadata, nil
 }
 
 // GetContractByAddress returns a contract for a contract address

--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -37,13 +37,11 @@ type TokenProcessingUserMessage struct {
 	UserID   persist.DBID    `json:"user_id" binding:"required"`
 	TokenIDs []persist.DBID  `json:"token_ids" binding:"required"`
 	Chains   []persist.Chain `json:"chains" binding:"required"`
-	IsV3     bool            `json:"is_v3" binding:"-"` // V3Migration: Remove when migration is complete
 }
 
 type TokenProcessingContractTokensMessage struct {
 	ContractID   persist.DBID `json:"contract_id" binding:"required"`
 	ForceRefresh bool         `json:"force_refresh"`
-	IsV3         bool         `json:"is_v3" binding:"-"` // V3Migration: Remove when migration is complete
 }
 
 type ValidateNFTsMessage struct {
@@ -170,7 +168,6 @@ func CreateTaskForTokenProcessing(ctx context.Context, client *gcptasks.Client, 
 
 	queue := env.GetString("TOKEN_PROCESSING_QUEUE")
 
-	// V3Migration: Remove when migration is complete
 	task := &taskspb.Task{
 		DispatchDeadline: durationpb.New(time.Minute * 30),
 		MessageType: &taskspb.Task_HttpRequest{
@@ -190,38 +187,7 @@ func CreateTaskForTokenProcessing(ctx context.Context, client *gcptasks.Client, 
 		return err
 	}
 
-	logger.For(ctx).Infof("creating task for v2 token processing, sending to %s\nmessage: %s", task.GetHttpRequest().GetUrl(), string(body))
-
-	err = submitHttpTask(ctx, client, queue, task, body)
-	if err != nil {
-		return err
-	}
-	// V3Migration: End remove
-
-	task = &taskspb.Task{
-		DispatchDeadline: durationpb.New(time.Minute * 30),
-		MessageType: &taskspb.Task_HttpRequest{
-			HttpRequest: &taskspb.HttpRequest{
-				HttpMethod: taskspb.HttpMethod_POST,
-				Url:        fmt.Sprintf("%s/media/process", env.GetString("NEW_TOKEN_PROCESSING_URL")),
-				Headers: map[string]string{
-					"Content-type": "application/json",
-					"sentry-trace": span.TraceID.String(),
-				},
-			},
-		},
-	}
-
-	v3Message := message
-	v3Message.IsV3 = true
-	v3Body, err := json.Marshal(v3Message)
-	if err != nil {
-		return err
-	}
-
-	logger.For(ctx).Infof("creating task for v3 token processing, sending to %s\nmessage: %s", task.GetHttpRequest().GetUrl(), string(v3Body))
-
-	return submitHttpTask(ctx, client, queue, task, v3Body)
+	return submitHttpTask(ctx, client, queue, task, body)
 }
 
 func CreateTaskForContractOwnerProcessing(ctx context.Context, message TokenProcessingContractTokensMessage, client *gcptasks.Client) error {
@@ -234,7 +200,6 @@ func CreateTaskForContractOwnerProcessing(ctx context.Context, message TokenProc
 
 	queue := env.GetString("TOKEN_PROCESSING_QUEUE")
 
-	// V3Migration: Remove when migration is complete
 	task := &taskspb.Task{
 		MessageType: &taskspb.Task_HttpRequest{
 			HttpRequest: &taskspb.HttpRequest{
@@ -253,33 +218,7 @@ func CreateTaskForContractOwnerProcessing(ctx context.Context, message TokenProc
 		return err
 	}
 
-	err = submitHttpTask(ctx, client, queue, task, body)
-	if err != nil {
-		return err
-	}
-	// V3Migration: End remove
-
-	task = &taskspb.Task{
-		MessageType: &taskspb.Task_HttpRequest{
-			HttpRequest: &taskspb.HttpRequest{
-				HttpMethod: taskspb.HttpMethod_POST,
-				Url:        fmt.Sprintf("%s/owners/process/contract", env.GetString("NEW_TOKEN_PROCESSING_URL")),
-				Headers: map[string]string{
-					"Content-type": "application/json",
-					"sentry-trace": span.TraceID.String(),
-				},
-			},
-		},
-	}
-
-	v3Message := message
-	v3Message.IsV3 = true
-	v3Body, err := json.Marshal(v3Message)
-	if err != nil {
-		return err
-	}
-
-	return submitHttpTask(ctx, client, queue, task, v3Body)
+	return submitHttpTask(ctx, client, queue, task, body)
 }
 
 // NewClient returns a new task client with tracing enabled.

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -49,28 +49,26 @@ func NewTokenProcessor(queries *coredb.Queries, ethClient *ethclient.Client, mc 
 type tokenProcessingJob struct {
 	tp *tokenProcessor
 
-	id           persist.DBID
-	key          string
-	token        persist.TokenGallery
-	contract     persist.ContractGallery
-	ownerAddress persist.Address
+	id       persist.DBID
+	key      string
+	token    persist.TokenGallery
+	contract persist.ContractGallery
 
 	cause            persist.ProcessingCause
 	pipelineMetadata *persist.PipelineMetadata
 }
 
-func (tp *tokenProcessor) ProcessTokenPipeline(c context.Context, t persist.TokenGallery, contract persist.ContractGallery, ownerAddress persist.Address, cause persist.ProcessingCause) error {
+func (tp *tokenProcessor) ProcessTokenPipeline(c context.Context, t persist.TokenGallery, contract persist.ContractGallery, cause persist.ProcessingCause) error {
 
 	runID := persist.GenerateID()
 
 	job := &tokenProcessingJob{
 		id: runID,
 
-		tp:           tp,
-		key:          persist.NewTokenIdentifiers(contract.Address, t.TokenID, t.Chain).String(),
-		token:        t,
-		contract:     contract,
-		ownerAddress: ownerAddress,
+		tp:       tp,
+		key:      persist.NewTokenIdentifiers(contract.Address, t.TokenID, t.Chain).String(),
+		token:    t,
+		contract: contract,
 
 		cause:            cause,
 		pipelineMetadata: new(persist.PipelineMetadata),
@@ -246,7 +244,7 @@ func (tpj *tokenProcessingJob) retrieveMetadata(ctx context.Context) persist.Tok
 				Level:      multichain.FieldRequirementLevelAllOptional,
 			},
 		}
-		mcMetadata, err := tpj.tp.mc.GetTokenMetadataByTokenIdentifiers(ctx, tpj.contract.Address, tpj.token.TokenID, tpj.ownerAddress, tpj.token.Chain, fieldRequests)
+		mcMetadata, err := tpj.tp.mc.GetTokenMetadataByTokenIdentifiers(ctx, tpj.contract.Address, tpj.token.TokenID, tpj.token.Chain, fieldRequests)
 		if err != nil {
 			logger.For(ctx).Errorf("error getting metadata from chain: %s", err)
 			persist.FailStep(&tpj.pipelineMetadata.MetadataRetrieval)

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -28,7 +28,6 @@ type ProcessMediaForTokenInput struct {
 	TokenID         persist.TokenID `json:"token_id" binding:"required"`
 	ContractAddress persist.Address `json:"contract_address" binding:"required"`
 	Chain           persist.Chain   `json:"chain"`
-	OwnerAddress    persist.Address `json:"owner_address"`
 }
 
 func processMediaForUsersTokens(tp *tokenProcessor, tokenRepo *postgres.TokenGalleryRepository, contractRepo *postgres.ContractGalleryRepository, throttler *throttle.Locker) gin.HandlerFunc {
@@ -68,7 +67,7 @@ func processMediaForUsersTokens(tp *tokenProcessor, tokenRepo *postgres.TokenGal
 				defer throttler.Unlock(reqCtx, lockID)
 
 				ctx := sentryutil.NewSentryHubContext(reqCtx)
-				err := tp.ProcessTokenPipeline(reqCtx, t, contract, "", persist.ProcessingCauseSync)
+				err := tp.ProcessTokenPipeline(reqCtx, t, contract, persist.ProcessingCauseSync)
 				if err != nil {
 
 					logger.For(ctx).Errorf("Error processing token: %s", err)
@@ -105,36 +104,16 @@ func processMediaForToken(tp *tokenProcessor, tokenRepo *postgres.TokenGalleryRe
 		defer throttler.Unlock(reqCtx, lockID)
 
 		var token persist.TokenGallery
-		if input.OwnerAddress != "" {
-			wallet, err := walletRepo.GetByChainAddress(reqCtx, persist.NewChainAddress(input.OwnerAddress, input.Chain))
-			if err != nil {
-				util.ErrResponse(c, http.StatusInternalServerError, err)
-				return
-			}
-
-			user, err := userRepo.GetByWalletID(reqCtx, wallet.ID)
-			if err != nil {
-				util.ErrResponse(c, http.StatusInternalServerError, err)
-				return
-			}
-			reqCtx = logger.NewContextWithFields(reqCtx, logrus.Fields{"userID": user.ID})
-			token, err = tokenRepo.GetByFullIdentifiers(reqCtx, input.TokenID, input.ContractAddress, input.Chain, user.ID)
-			if err != nil {
-				util.ErrResponse(c, http.StatusInternalServerError, err)
-				return
-			}
-		} else {
-			tokens, err := tokenRepo.GetByTokenIdentifiers(reqCtx, input.TokenID, input.ContractAddress, input.Chain, 1, 0)
-			if err != nil {
-				util.ErrResponse(c, http.StatusInternalServerError, err)
-				return
-			}
-			if len(tokens) == 0 {
-				util.ErrResponse(c, http.StatusNotFound, fmt.Errorf("token not found by identifiers"))
-				return
-			}
-			token = tokens[0]
+		tokens, err := tokenRepo.GetByTokenIdentifiers(reqCtx, input.TokenID, input.ContractAddress, input.Chain, 1, 0)
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
 		}
+		if len(tokens) == 0 {
+			util.ErrResponse(c, http.StatusNotFound, fmt.Errorf("token not found by identifiers"))
+			return
+		}
+		token = tokens[0]
 
 		contract, err := contractRepo.GetByID(reqCtx, token.Contract)
 		if err != nil {
@@ -142,7 +121,7 @@ func processMediaForToken(tp *tokenProcessor, tokenRepo *postgres.TokenGalleryRe
 			return
 		}
 
-		err = tp.ProcessTokenPipeline(reqCtx, token, contract, input.OwnerAddress, persist.ProcessingCauseRefresh)
+		err = tp.ProcessTokenPipeline(reqCtx, token, contract, persist.ProcessingCauseRefresh)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return


### PR DESCRIPTION
**Changes**
* Removes sending messages to v2 tokenprocessing
* Moves v3 deployment from `make deploy-prod-tokenprocessingV3` to just `make deploy-prod-tokenprocessing`
* Removes owner as a dependency for refreshing tokens
* Improves multichain validation so the error is more human readable