### PR TITLE
Fix token name

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -304,9 +304,9 @@ func NewMultichainProvider(c *Clients) *multichain.Provider {
 	cache := redis.NewCache(redis.CommunitiesCache)
 	return multichain.NewProvider(context.Background(), c.Repos, c.Queries, cache, c.TaskClient,
 		overrides,
-		failureEthProvider,
 		ethProvider,
 		openseaProvider,
+		failureEthProvider,
 		tezosProvider,
 		poapProvider,
 		alchemyOptimismProvider,

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -923,10 +923,10 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 		token, contract, err := tokenFetcher.GetTokenDescriptorsByTokenIdentifiers(ctx, id)
 		if err == nil {
 			// token
-			if token.Name != "" && finalContractDescriptors.Name == "" {
+			if token.Name != "" && finalTokenDescriptors.Name == "" {
 				finalTokenDescriptors.Name = token.Name
 			}
-			if token.Description != "" && finalContractDescriptors.Description == "" {
+			if token.Description != "" && finalTokenDescriptors.Description == "" {
 				finalTokenDescriptors.Description = token.Description
 			}
 


### PR DESCRIPTION
**Changes**
* Fixes checks for filling out token descriptors
* The order of providers passed to multichain matter: the fallback eth provider was first meaning that its results are prioritized. The fallback provider was returning an inaccurate token name, and wasn't being replaced with later providers data

In the future, we can make the priority of providers more explicit