### PR TITLE
Add storage error

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -806,7 +806,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contr
 		wp.Go(func(ctx context.Context) error {
 			metadata, err := metadataFetcher.GetTokenMetadataByTokenIdentifiers(ctx, ChainAgnosticIdentifiers{ContractAddress: contractAddress, TokenID: tokenID})
 			if err != nil {
-				if err != context.Canceled && !strings.Contains(err.Error(), context.Canceled.Error()) {
+				if !errors.Is(err, context.Canceled) {
 					logger.For(ctx).Warnf("error fetching token metadata from provider %d (%T): %s", i, metadataFetcher, err)
 				}
 				switch caught := err.(type) {
@@ -824,7 +824,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contr
 	go func() {
 		defer close(metadatas)
 		err := wp.Wait()
-		if err != nil && (err != context.Canceled || strings.Contains(err.Error(), context.Canceled.Error())) {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			logger.For(ctx).Warnf("error fetching token metadata after wait: %s", err)
 		}
 	}()

--- a/util/response.go
+++ b/util/response.go
@@ -39,6 +39,10 @@ func (h ErrHTTP) Error() string {
 	return fmt.Sprintf("HTTP Error Status - %d | URL - %s | Error: %s", h.Status, h.URL, h.Err)
 }
 
+func (h ErrHTTP) Unwrap() error {
+	return h.Err
+}
+
 // ErrResponse sends a json response for an error during endpoint execution
 func ErrResponse(c *gin.Context, code int, err error) {
 	c.Error(err)


### PR DESCRIPTION
**Changes**
* Add new error for when storing objects to GCP fails
* Lowers the log levels for a few more log lines from error to warn
* Adds Unwrap method to custom errors that have reference to the original error
* Less logging when getting failed readers