### PR TITLE
More random pipeline improvements

### DIFF
--- a/cmd/reprocess/main.go
+++ b/cmd/reprocess/main.go
@@ -166,7 +166,8 @@ func main() {
 			defer func() {
 				logger.For(ctx).Infof("finished processing %s", token.ID)
 			}()
-			return tp.ProcessTokenPipeline(ctx, token, contract, persist.ProcessingCauseRefresh)
+			_, err = tp.ProcessTokenPipeline(ctx, token, contract, persist.ProcessingCauseRefresh)
+			return err
 		})
 	}
 	go func() {

--- a/service/metric/metric.go
+++ b/service/metric/metric.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,6 +28,7 @@ type LogMetricReporter struct{}
 type LogArgs struct {
 	Tags   map[string]string
 	LogMsg string
+	Level  *logrus.Level
 }
 
 type LogOptionBulder struct{}
@@ -40,6 +42,12 @@ func (LogOptionBulder) WithLogMessage(msg string) func(*LogArgs) {
 func (LogOptionBulder) WithTags(tags map[string]string) func(*LogArgs) {
 	return func(a *LogArgs) {
 		a.Tags = tags
+	}
+}
+
+func (LogOptionBulder) WithLevel(l logrus.Level) func(*LogArgs) {
+	return func(a *LogArgs) {
+		a.Level = &l
 	}
 }
 
@@ -61,5 +69,9 @@ func (l LogMetricReporter) Record(ctx context.Context, metric Measure, opts ...a
 		logLine += ": " + args.LogMsg
 	}
 
-	logger.For(ctx).WithFields(metricPayload).Infof(logLine)
+	if args.Level == nil {
+		args.Level = util.ToPointer(logrus.InfoLevel)
+	}
+
+	logger.For(ctx).WithFields(metricPayload).Log(*args.Level, logLine)
 }

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -472,8 +472,7 @@ func (p *Provider) processTokenMedia(ctx context.Context, tokenID persist.TokenI
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", "http://localhost:6500"), bytes.NewBuffer(asJSON))
-	// XXX req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
 	if err != nil {
 		return err
 	}

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -472,7 +472,8 @@ func (p *Provider) processTokenMedia(ctx context.Context, tokenID persist.TokenI
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", "http://localhost:6500"), bytes.NewBuffer(asJSON))
+	// XXX req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL")), bytes.NewBuffer(asJSON))
 	if err != nil {
 		return err
 	}

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -171,7 +171,7 @@ func cacheOpenSeaObjects(ctx context.Context, job *tokenProcessingJob) ([]cached
 		ThumbnailGCP:                 &job.pipelineMetadata.AlternateThumbnailGCP,
 		LiveRenderGCP:                &job.pipelineMetadata.AlternateLiveRenderGCP,
 	}
-	return cacheObjectsFromOpensea(ctx, tids, "", objectTypeImage, job.tp.ipfsClient, job.tp.arweaveClient, job.tp.stg, job.tp.tokenBucket, runMetadata)
+	return cacheObjectsFromOpensea(ctx, tids, objectTypeImage, job.tp.ipfsClient, job.tp.arweaveClient, job.tp.stg, job.tp.tokenBucket, runMetadata)
 }
 
 func isCacheResultValid(err error, numObjects int) bool {
@@ -924,7 +924,7 @@ func cacheObjectsFromURL(pCtx context.Context, tids persist.TokenIdentifiers, me
 		logger.For(pCtx).Infof("failed to get data from uri '%s' for '%s' because of (err: %s <%T>), trying opensea", mediaURL, tids, err, err)
 		defer traceCallback()
 
-		return cacheObjectsFromOpensea(pCtx, tids, mediaURL, oType, ipfsClient, arweaveClient, storageClient, bucket, subMeta)
+		return cacheObjectsFromOpensea(pCtx, tids, oType, ipfsClient, arweaveClient, storageClient, bucket, subMeta)
 	}
 
 	if err != nil {
@@ -1010,7 +1010,7 @@ func cacheObjectsFromURL(pCtx context.Context, tids persist.TokenIdentifiers, me
 	return result, nil
 }
 
-func cacheObjectsFromOpensea(pCtx context.Context, tids persist.TokenIdentifiers, mediaURL string, oType objectType, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, bucket string, subMeta *cachePipelineMetadata) ([]cachedMediaObject, error) {
+func cacheObjectsFromOpensea(pCtx context.Context, tids persist.TokenIdentifiers, oType objectType, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, bucket string, subMeta *cachePipelineMetadata) ([]cachedMediaObject, error) {
 	assets, err := opensea.FetchAssetsForTokenIdentifiers(pCtx, persist.EthereumAddress(tids.ContractAddress), opensea.TokenID(tids.TokenID.Base10String()))
 	if err != nil || len(assets) == 0 {
 		return nil, errNoDataFromOpensea{err: err}
@@ -1113,7 +1113,7 @@ func getMediaDimensions(ctx context.Context, url string) (persist.Dimensions, er
 }
 
 func getMediaDimensionsBackup(ctx context.Context, url string) (persist.Dimensions, error) {
-	outBuf := new(bytes.Buffer)
+	outBuf := bytes.NewBuffer(nil)
 	curlCmd := exec.CommandContext(ctx, "curl", "-s", url)
 	identifyCmd := exec.CommandContext(ctx, "identify", "-format", "%wx%h", "-")
 	identifyCmd.Stderr = os.Stderr

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -432,6 +432,7 @@ func recordPipelineEndState(ctx context.Context, mr metric.MetricReporter, token
 
 	if err != nil {
 		mr.Record(ctx, pipelineErroredMetric(), append(baseOpts,
+			metric.LogOptions.WithLevel(logrus.ErrorLevel),
 			metric.LogOptions.WithLogMessage("pipeline completed with error: "+err.Error()),
 		)...)
 		return


### PR DESCRIPTION
**Changes**
* Adds better error message for when failing to get dimensions
* Pipeline now logs an error when reporting an error metric
* Removes `mediaURL` arg for caching from OpenSea since its not used 