### PR TITLE
Add setEnv param to multichain init

### DIFF
--- a/cmd/reprocess/main.go
+++ b/cmd/reprocess/main.go
@@ -37,7 +37,7 @@ func main() {
 	clients := server.ClientInit(ctx)
 	defer clients.Close()
 
-	provider, cleanup := server.NewMultichainProvider(ctx)
+	provider, cleanup := server.NewMultichainProvider(ctx, server.SetDefaults)
 	defer cleanup()
 	tp := tokenprocessing.NewTokenProcessor(clients.Queries, clients.EthClient, provider, clients.IPFSClient, clients.ArweaveClient, clients.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), clients.Repos.TokenRepository, metric.NewLogMetricReporter())
 
@@ -166,7 +166,8 @@ func main() {
 			defer func() {
 				logger.For(ctx).Infof("finished processing %s", token.ID)
 			}()
-			return tp.ProcessTokenPipeline(ctx, token, contract, persist.ProcessingCauseRefresh)
+			_, err = tp.ProcessTokenPipeline(ctx, token, contract, persist.ProcessingCauseRefresh)
+			return err
 		})
 	}
 	go func() {

--- a/graphql/fixture_test.go
+++ b/graphql/fixture_test.go
@@ -142,7 +142,7 @@ func useTokenProcessing(t *testing.T) {
 	t.Helper()
 	ctx := context.Background()
 	c := server.ClientInit(ctx)
-	p, cleanup := server.NewMultichainProvider(ctx)
+	p, cleanup := server.NewMultichainProvider(ctx, server.SetDefaults)
 	server := httptest.NewServer(tokenprocessing.CoreInitServer(c, p))
 	t.Setenv("TOKEN_PROCESSING_URL", server.URL)
 	t.Cleanup(func() {

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -166,7 +166,7 @@ func testSuggestedUsersForViewer(t *testing.T) {
 	userC := newUserFixture(t)
 	ctx := context.Background()
 	clients := server.ClientInit(ctx)
-	provider, cleanup := server.NewMultichainProvider(ctx)
+	provider, cleanup := server.NewMultichainProvider(ctx, server.SetDefaults)
 	recommender := newStubRecommender(t, []persist.DBID{
 		userA.ID,
 		userB.ID,
@@ -1359,7 +1359,7 @@ func defaultTokenSettings(tokens []persist.DBID) []CollectionTokenSettingsInput 
 func defaultHandler(t *testing.T) http.Handler {
 	ctx := context.Background()
 	c := server.ClientInit(ctx)
-	p, cleanup := server.NewMultichainProvider(ctx)
+	p, cleanup := server.NewMultichainProvider(ctx, server.SetDefaults)
 	r := newStubRecommender(t, []persist.DBID{})
 	handler := server.CoreInit(c, p, r)
 	t.Cleanup(func() {

--- a/server/inject.go
+++ b/server/inject.go
@@ -45,7 +45,7 @@ type optimismProvider struct{ *alchemy.Provider }
 type polygonProvider struct{ *alchemy.Provider }
 
 // NewMultichainProvider is a wire injector that sets up a multichain provider instance
-func NewMultichainProvider(ctx context.Context) (*multichain.Provider, func()) {
+func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Provider, func()) {
 	wire.Build(
 		setEnv,
 		wire.Value(&http.Client{Timeout: 0}), // HTTP client shared between providers
@@ -74,8 +74,8 @@ var dbConnSet = wire.NewSet(
 	newQueries,
 )
 
-func setEnv() envInit {
-	SetDefaults()
+func setEnv(f func()) envInit {
+	f()
 	return envInit{}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -57,7 +57,7 @@ func Init() {
 
 	ctx := context.Background()
 	c := ClientInit(ctx)
-	provider, _ := NewMultichainProvider(ctx)
+	provider, _ := NewMultichainProvider(ctx, SetDefaults)
 	recommender := recommend.NewRecommender(c.Queries)
 	router := CoreInit(c, provider, recommender)
 	http.Handle("/", router)

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -34,8 +34,8 @@ import (
 // Injectors from inject.go:
 
 // NewMultichainProvider is a wire injector that sets up a multichain provider instance
-func NewMultichainProvider(ctx context.Context) (*multichain.Provider, func()) {
-	serverEnvInit := setEnv()
+func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Provider, func()) {
+	serverEnvInit := setEnv(envFunc)
 	db, cleanup := newPqClient(serverEnvInit)
 	pool, cleanup2 := newPgxClient(serverEnvInit)
 	repositories := postgres.NewRepositories(db, pool)
@@ -192,8 +192,8 @@ var dbConnSet = wire.NewSet(
 	newQueries,
 )
 
-func setEnv() envInit {
-	SetDefaults()
+func setEnv(f func()) envInit {
+	f()
 	return envInit{}
 }
 

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -34,7 +34,7 @@ func InitServer() {
 	setDefaults()
 	ctx := context.Background()
 	c := server.ClientInit(ctx)
-	provider, _ := server.NewMultichainProvider(ctx)
+	provider, _ := server.NewMultichainProvider(ctx, setDefaults)
 	router := CoreInitServer(c, provider)
 	logger.For(nil).Info("Starting tokenprocessing server...")
 	http.Handle("/", router)


### PR DESCRIPTION
tokenprocessing was failing to start because it was using the backend's `SetDefault` func which requires `IMGIX_SECRET` to be set which tokenprocessing doesn't use. Fixed by adding an arg to the multichain func to provide which environment setting function to use.