### PR TITLE
Always resolve connected social info despite preference setting

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -490,7 +490,6 @@ func testUpdateUserExperiences(t *testing.T) {
 func testConnectSocialAccount(t *testing.T) {
 	userF := newUserFixture(t)
 	c := authedHandlerClient(t, userF.ID)
-	dc := defaultHandlerClient(t)
 
 	connectResp, err := connectSocialAccount(context.Background(), c, SocialAuthMechanism{
 		Debug: &DebugSocialAuth{
@@ -521,10 +520,13 @@ func testConnectSocialAccount(t *testing.T) {
 	assert.Equal(t, updateDisplayedPayload.Viewer.SocialAccounts.Twitter.Username, "test")
 	assert.False(t, updateDisplayedPayload.Viewer.SocialAccounts.Twitter.Display)
 
-	userResp, err := userByIdQuery(context.Background(), dc, userF.ID)
-	require.NoError(t, err)
-	userPayload := (*userResp.UserById).(*userByIdQueryUserByIdGalleryUser)
-	assert.Nil(t, userPayload.SocialAccounts.Twitter)
+	// For now, we're always returning the user's social accounts despite preference setting.
+	// If there's community significant pushback about this then we can reinstate the feature.
+	// dc := defaultHandlerClient(t)
+	// userResp, err := userByIdQuery(context.Background(), dc, userF.ID)
+	// require.NoError(t, err)
+	// userPayload := (*userResp.UserById).(*userByIdQueryUserByIdGalleryUser)
+	// assert.Nil(t, userPayload.SocialAccounts.Twitter)
 
 	disconnectResp, err := disconnectSocialAccount(context.Background(), c, SocialAccountTypeTwitter)
 	require.NoError(t, err)

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/jackc/pgx/v4"
 	"time"
+
+	"github.com/jackc/pgx/v4"
 
 	"github.com/jackc/pgtype"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -993,12 +994,6 @@ func (api UserAPI) GetDisplayedSocials(ctx context.Context, userID persist.DBID)
 	socials, err := api.queries.GetSocialsByUserID(ctx, userID)
 	if err != nil {
 		return nil, err
-	}
-
-	for prov, social := range socials {
-		if !social.Display {
-			delete(socials, prov)
-		}
 	}
 
 	result := &model.SocialAccounts{}


### PR DESCRIPTION
Always return connected social accounts as we'll no longer allow users to toggle this off