### PR TITLE
Remove user marked spam from bulk insert

### DIFF
--- a/db/gen/coredb/token_gallery.sql.go
+++ b/db/gen/coredb/token_gallery.sql.go
@@ -35,7 +35,6 @@ insert into tokens
   , owned_by_wallets
   , chain
   , contract
-  , is_user_marked_spam
   , is_provider_marked_spam
   , last_synced
   , token_uri
@@ -63,7 +62,6 @@ insert into tokens
     , owned_by_wallets[owned_by_wallets_start_idx::int:owned_by_wallets_end_idx::int]
     , chain
     , contract
-    , is_user_marked_spam
     , is_provider_marked_spam
     , now()
     , token_uri
@@ -96,12 +94,11 @@ insert into tokens
       , $17::varchar[] as owned_by_wallets
       , unnest($18::int[]) as owned_by_wallets_start_idx
       , unnest($19::int[]) as owned_by_wallets_end_idx
-      , unnest($20::bool[]) as is_user_marked_spam
-      , unnest($21::bool[]) as is_provider_marked_spam
-      , unnest($22::varchar[]) as token_uri
-      , unnest($23::varchar[]) as token_id
-      , unnest($24::varchar[]) as contract
-      , unnest($25::int[]) as chain
+      , unnest($20::bool[]) as is_provider_marked_spam
+      , unnest($21::varchar[]) as token_uri
+      , unnest($22::varchar[]) as token_id
+      , unnest($23::varchar[]) as contract
+      , unnest($24::int[]) as chain
   ) bulk_upsert
 )
 on conflict (token_id, contract, chain, owner_user_id) where deleted = false
@@ -119,7 +116,6 @@ do update set
   , block_number = excluded.block_number
   , version = excluded.version
   , last_updated = excluded.last_updated
-  , is_user_marked_spam = tokens.is_user_marked_spam
   , is_provider_marked_spam = excluded.is_provider_marked_spam
   , last_synced = greatest(excluded.last_synced,tokens.last_synced)
 returning id, deleted, version, created_at, last_updated, name, description, collectors_note, media, token_uri, token_type, token_id, quantity, ownership_history, token_metadata, external_url, block_number, owner_user_id, owned_by_wallets, chain, contract, is_user_marked_spam, is_provider_marked_spam, last_synced, fallback_media, token_media_id
@@ -145,7 +141,6 @@ type UpsertTokensParams struct {
 	OwnedByWallets           []string
 	OwnedByWalletsStartIdx   []int32
 	OwnedByWalletsEndIdx     []int32
-	IsUserMarkedSpam         []bool
 	IsProviderMarkedSpam     []bool
 	TokenUri                 []string
 	TokenID                  []string
@@ -174,7 +169,6 @@ func (q *Queries) UpsertTokens(ctx context.Context, arg UpsertTokensParams) ([]T
 		arg.OwnedByWallets,
 		arg.OwnedByWalletsStartIdx,
 		arg.OwnedByWalletsEndIdx,
-		arg.IsUserMarkedSpam,
 		arg.IsProviderMarkedSpam,
 		arg.TokenUri,
 		arg.TokenID,

--- a/db/queries/core/token_gallery.sql
+++ b/db/queries/core/token_gallery.sql
@@ -22,7 +22,6 @@ insert into tokens
   , owned_by_wallets
   , chain
   , contract
-  , is_user_marked_spam
   , is_provider_marked_spam
   , last_synced
   , token_uri
@@ -50,7 +49,6 @@ insert into tokens
     , owned_by_wallets[owned_by_wallets_start_idx::int:owned_by_wallets_end_idx::int]
     , chain
     , contract
-    , is_user_marked_spam
     , is_provider_marked_spam
     , now()
     , token_uri
@@ -83,7 +81,6 @@ insert into tokens
       , @owned_by_wallets::varchar[] as owned_by_wallets
       , unnest(@owned_by_wallets_start_idx::int[]) as owned_by_wallets_start_idx
       , unnest(@owned_by_wallets_end_idx::int[]) as owned_by_wallets_end_idx
-      , unnest(@is_user_marked_spam::bool[]) as is_user_marked_spam
       , unnest(@is_provider_marked_spam::bool[]) as is_provider_marked_spam
       , unnest(@token_uri::varchar[]) as token_uri
       , unnest(@token_id::varchar[]) as token_id
@@ -106,7 +103,6 @@ do update set
   , block_number = excluded.block_number
   , version = excluded.version
   , last_updated = excluded.last_updated
-  , is_user_marked_spam = tokens.is_user_marked_spam
   , is_provider_marked_spam = excluded.is_provider_marked_spam
   , last_synced = greatest(excluded.last_synced,tokens.last_synced)
 returning *;

--- a/service/persist/postgres/token_gallery.go
+++ b/service/persist/postgres/token_gallery.go
@@ -357,7 +357,6 @@ func (t *TokenGalleryRepository) bulkUpsert(pCtx context.Context, pTokens []pers
 		InsertHelpers.AppendWalletList(&params.OwnedByWallets, t.OwnedByWallets, &params.OwnedByWalletsStartIdx, &params.OwnedByWalletsEndIdx)
 		params.Chain = append(params.Chain, int32(t.Chain))
 		params.Contract = append(params.Contract, t.Contract.String())
-		appendBool(&params.IsUserMarkedSpam, t.IsUserMarkedSpam, &errors)
 		appendBool(&params.IsProviderMarkedSpam, t.IsProviderMarkedSpam, &errors)
 		params.TokenUri = append(params.TokenUri, "")
 


### PR DESCRIPTION
This PR removes upserting `is_user_marked_spam` for the token bulk upsert step. Ideally the caller could still update `is_user_marked_spam`, but handling null types would require a change to the sqlc config to set `emit_pointers_for_null_types: true` which requires a larger refactor. For now I'm just removing the param so that the field is always initially set to null.