### PR TITLE
Fix metadata pipeline bug

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -620,8 +620,9 @@ func (p *Provider) processTokenMedia(ctx context.Context, tokenID persist.TokenI
 	}
 
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
-		return util.GetErrFromResp(resp)
+		return util.BodyAsError(resp)
 	}
 
 	return nil

--- a/service/persist/postgres/contract_gallery.go
+++ b/service/persist/postgres/contract_gallery.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -64,6 +65,9 @@ func (c *ContractGalleryRepository) GetByID(ctx context.Context, id persist.DBID
 	contract := persist.ContractGallery{}
 	err := c.getByIDStmt.QueryRowContext(ctx, id).Scan(&contract.ID, &contract.Version, &contract.CreationTime, &contract.LastUpdated, &contract.Address, &contract.Symbol, &contract.Name, &contract.OwnerAddress, &contract.Chain, &contract.IsProviderMarkedSpam)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return persist.ContractGallery{}, persist.ErrContractNotFoundByID{ID: id}
+		}
 		return persist.ContractGallery{}, err
 	}
 

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -64,9 +64,7 @@ type errNoCachedObjects struct {
 }
 
 type errNoMediaURLs struct {
-	metadata persist.TokenMetadata
-	tokenURI persist.TokenURI
-	tids     persist.TokenIdentifiers
+	tids persist.TokenIdentifiers
 }
 
 type errStoreObjectFailed struct {
@@ -96,7 +94,7 @@ func (e errInvalidMedia) Unwrap() error {
 }
 
 func (e errNoMediaURLs) Error() string {
-	return fmt.Sprintf("no media URLs found in metadata: %s (metadata: %+v, tokenURI: %s)", e.tids, e.metadata, e.tokenURI)
+	return fmt.Sprintf("no media URLs found in metadata for %s", e.tids)
 }
 
 func (e errNoCachedObjects) Error() string {
@@ -539,6 +537,7 @@ func findImageAndAnimationURLs(ctx context.Context, tokenID persist.TokenID, con
 	}
 
 	image, anim := keywordsForToken(tokenID, contractAddress, chain)
+
 	for _, keyword := range anim {
 		if it, ok := util.GetValueFromMapUnsafe(metadata, keyword, util.DefaultSearchDepth).(string); ok && it != "" {
 			logger.For(ctx).Debugf("found initial animation url from '%s': %s", keyword, it)
@@ -557,7 +556,7 @@ func findImageAndAnimationURLs(ctx context.Context, tokenID persist.TokenID, con
 
 	if imgURL == "" && vURL == "" {
 		persist.FailStep(&pMeta.MediaURLsRetrieval)
-		return "", "", errNoMediaURLs{metadata: metadata, tokenURI: tokenURI, tids: persist.NewTokenIdentifiers(contractAddress, tokenID, chain)}
+		return "", "", errNoMediaURLs{tids: persist.NewTokenIdentifiers(contractAddress, tokenID, chain)}
 	}
 
 	if predict {

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -749,3 +749,12 @@ func (lr *LoggingReader) WriteTo(w io.Writer) (n int64, err error) {
 	}
 	return 0, fmt.Errorf("No WriterTo provided")
 }
+
+// ErrorAs returns true if the given error is of type T
+func ErrorAs[T error](e error) bool {
+	var t T
+	if errors.As(e, &t) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
#### Changes
* Fixes pipeline bug where the fetched metadata is not used in downloading the media
* Cleans up some error handling
* Returns `404` instead of `500` from tokenprocessing if a token or contract is missing
* Adds `util.ErrorAs` helper function