### PR TITLE
just wallet overrides

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -51,7 +51,7 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 	wire.Build(
 		setEnv,
 		wire.Value(&http.Client{Timeout: 0}), // HTTP client shared between providers
-		defaultChainOverrides,
+		defaultWalletOverrides,
 		task.NewClient,
 		newCommunitiesCache,
 		postgres.NewRepositories,
@@ -318,14 +318,15 @@ func newMultichainSet(
 	return chainToProviders
 }
 
-// defaultChainOverrides is a wire provider for chain overrides
-func defaultChainOverrides() multichain.ChainOverrideMap {
-	var ethChain = persist.ChainETH
-	return multichain.ChainOverrideMap{
-		persist.ChainPOAP:     &ethChain,
-		persist.ChainOptimism: &ethChain,
-		persist.ChainPolygon:  &ethChain,
-		persist.ChainArbitrum: &ethChain,
+// defaultWalletOverrides is a wire provider for wallet overrides
+func defaultWalletOverrides() multichain.WalletOverrideMap {
+	var evmChains = []persist.Chain{persist.ChainETH, persist.ChainOptimism, persist.ChainPolygon, persist.ChainArbitrum, persist.ChainPOAP}
+	return multichain.WalletOverrideMap{
+		persist.ChainPOAP:     evmChains,
+		persist.ChainOptimism: evmChains,
+		persist.ChainPolygon:  evmChains,
+		persist.ChainArbitrum: evmChains,
+		persist.ChainETH:      evmChains,
 	}
 }
 

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -50,15 +50,15 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 	serverPolygonProviderList := polygonProviderSet(httpClient)
 	serverArbitrumProviderList := arbitrumProviderSet(httpClient)
 	v := newMultichainSet(serverEthProviderList, serverOptimismProviderList, serverTezosProviderList, serverPoapProviderList, serverPolygonProviderList, serverArbitrumProviderList)
-	v2 := defaultChainOverrides()
+	v2 := defaultWalletOverrides()
 	sendTokens := newSendTokensFunc(ctx, client)
 	provider := &multichain.Provider{
-		Repos:                 repositories,
-		Queries:               queries,
-		Cache:                 cache,
-		Chains:                v,
-		ChainAddressOverrides: v2,
-		SendTokens:            sendTokens,
+		Repos:           repositories,
+		Queries:         queries,
+		Cache:           cache,
+		Chains:          v,
+		WalletOverrides: v2,
+		SendTokens:      sendTokens,
 	}
 	return provider, func() {
 		cleanup2()
@@ -317,10 +317,10 @@ func newMultichainSet(
 	return chainToProviders
 }
 
-// defaultChainOverrides is a wire provider for chain overrides
-func defaultChainOverrides() multichain.ChainOverrideMap {
-	var ethChain = persist.ChainETH
-	return multichain.ChainOverrideMap{persist.ChainPOAP: &ethChain, persist.ChainOptimism: &ethChain, persist.ChainPolygon: &ethChain, persist.ChainArbitrum: &ethChain}
+// defaultWalletOverrides is a wire provider for wallet overrides
+func defaultWalletOverrides() multichain.WalletOverrideMap {
+	var evmChains = []persist.Chain{persist.ChainETH, persist.ChainOptimism, persist.ChainPolygon, persist.ChainArbitrum, persist.ChainPOAP}
+	return multichain.WalletOverrideMap{persist.ChainPOAP: evmChains, persist.ChainOptimism: evmChains, persist.ChainPolygon: evmChains, persist.ChainArbitrum: evmChains, persist.ChainETH: evmChains}
 }
 
 func newIndexerProvider(e envInit, httpClient *http.Client, ethClient *ethclient.Client, taskClient *cloudtasks.Client) *eth.Provider {


### PR DESCRIPTION
Changes:

- **Added** `WalletOverrides` which is a mapping of chain to many other chains that will be used to allow wallets to be reused across chains they are shared (EVM chains all share same wallet address)
- **Removed** current `ChainOverrides`, it was being used in two places, one in place of the where the new wallet overrides is and another in a place that did not functionally do anything. When syncing contracts it would check whether the contract addresses had overrides, looked like this:

```
    // let's say Arbitrum and ETH are chains here
    for _, chain := range chains {
                 // if chain was Arbitrum this would return ETH
                 // no override for ETH though
		override := p.ChainAddressOverrides[chain]
		for _, contract := range contracts {
		     // because the override is ETH for arbitrum, the ETH contracts would be added to chainsToAddresses under the arbitrum chain, even though contracts are not shared across EVM chains
		     // eth contracts would then get processed unnecessarily by arbitrum providers, potentially returning bad data if the contract does exist on that EVM.
			if contract.Chain == chain || (override != nil && *override == contract.Chain) {
			if contract.Chain == chain {
				chainsToAddresses[chain] = append(chainsToAddresses[chain], contract.Address)
			}
		}
	}
```