### PR TITLE
Add ENS PFP to schema

### DIFF
--- a/graphql/model/models.go
+++ b/graphql/model/models.go
@@ -125,6 +125,10 @@ type HelperTokenData struct {
 	CollectionID *persist.DBID
 }
 
+type HelperEnsProfileImageData struct {
+	WalletID persist.DBID
+}
+
 type ErrInvalidIDFormat struct {
 	message string
 }

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -779,9 +779,12 @@ type EmailNotificationSettings struct {
 }
 
 type EnsProfileImage struct {
-	ChainAddress *persist.ChainAddress `json:"chainAddress"`
-	ProfileImage ProfileImage          `json:"profileImage"`
+	HelperEnsProfileImageData
+	Wallet       *Wallet            `json:"wallet"`
+	ProfileImage *HTTPSProfileImage `json:"profileImage"`
 }
+
+func (EnsProfileImage) IsProfileImage() {}
 
 type EoaAuth struct {
 	ChainPubKey *persist.ChainPubKey `json:"chainPubKey"`
@@ -1312,8 +1315,6 @@ type GroupNotificationUsersConnection struct {
 type HTTPSProfileImage struct {
 	PreviewURLs *PreviewURLSet `json:"previewURLs"`
 }
-
-func (HTTPSProfileImage) IsProfileImage() {}
 
 type HTMLMedia struct {
 	PreviewURLs      *PreviewURLSet   `json:"previewURLs"`

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -264,6 +264,11 @@ func (r *createCollectionPayloadResolver) FeedEvent(ctx context.Context, obj *mo
 	return resolveFeedEventByEventID(ctx, obj.FeedEvent.Dbid)
 }
 
+// Wallet is the resolver for the wallet field.
+func (r *ensProfileImageResolver) Wallet(ctx context.Context, obj *model.EnsProfileImage) (*model.Wallet, error) {
+	return resolveWalletByWalletID(ctx, obj.HelperEnsProfileImageData.WalletID)
+}
+
 // EventData is the resolver for the eventData field.
 func (r *feedEventResolver) EventData(ctx context.Context, obj *model.FeedEvent) (model.FeedEventData, error) {
 	return resolveFeedEventDataByEventID(ctx, obj.Dbid)
@@ -2082,10 +2087,8 @@ func (r *queryResolver) EnsProfileImageByUserID(ctx context.Context, userID pers
 	if err != nil {
 		return nil, err
 	}
-	return &model.EnsProfileImage{
-		ChainAddress: util.ToPointer(persist.NewChainAddress(a.Address, a.Chain)),
-		ProfileImage: &model.HTTPSProfileImage{PreviewURLs: previewURLs(ctx, a.URI, nil)},
-	}, nil
+	pfp := ensProfileImageToModel(ctx, a.WalletID, a.URI)
+	return &pfp, nil
 }
 
 // FeedEvent is the resolver for the feedEvent field.
@@ -2494,6 +2497,11 @@ func (r *Resolver) CreateCollectionPayload() generated.CreateCollectionPayloadRe
 	return &createCollectionPayloadResolver{r}
 }
 
+// EnsProfileImage returns generated.EnsProfileImageResolver implementation.
+func (r *Resolver) EnsProfileImage() generated.EnsProfileImageResolver {
+	return &ensProfileImageResolver{r}
+}
+
 // FeedEvent returns generated.FeedEventResolver implementation.
 func (r *Resolver) FeedEvent() generated.FeedEventResolver { return &feedEventResolver{r} }
 
@@ -2643,6 +2651,7 @@ type commentResolver struct{ *Resolver }
 type commentOnFeedEventPayloadResolver struct{ *Resolver }
 type communityResolver struct{ *Resolver }
 type createCollectionPayloadResolver struct{ *Resolver }
+type ensProfileImageResolver struct{ *Resolver }
 type feedEventResolver struct{ *Resolver }
 type followInfoResolver struct{ *Resolver }
 type followUserPayloadResolver struct{ *Resolver }

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1941,10 +1941,17 @@ func profileImageToModel(ctx context.Context, pfp db.ProfileImage) (model.Profil
 		if pfp.EnsAvatarUri.String == "" {
 			return nil, nil
 		}
-		urls := previewURLs(ctx, pfp.EnsAvatarUri.String, nil)
-		return &model.HTTPSProfileImage{PreviewURLs: urls}, nil
+		return ensProfileImageToModel(ctx, pfp.WalletID, pfp.EnsAvatarUri.String), nil
 	default:
 		return nil, publicapi.ErrProfileImageUnknownSource
+	}
+}
+
+func ensProfileImageToModel(ctx context.Context, walletID persist.DBID, url string) model.EnsProfileImage {
+	return model.EnsProfileImage{
+		ProfileImage:              &model.HTTPSProfileImage{PreviewURLs: previewURLs(ctx, url, nil)},
+		Wallet:                    nil, // handled by dedicated resolver
+		HelperEnsProfileImageData: model.HelperEnsProfileImageData{WalletID: walletID},
 	}
 }
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -75,12 +75,12 @@ type HTTPSProfileImage {
   previewURLs: PreviewURLSet
 }
 
-type EnsProfileImage {
-  chainAddress: ChainAddress!
-  profileImage: ProfileImage
+type EnsProfileImage @goEmbedHelper {
+  wallet: Wallet @goField(forceResolver: true)
+  profileImage: HTTPSProfileImage
 }
 
-union ProfileImage = TokenProfileImage | HTTPSProfileImage
+union ProfileImage = TokenProfileImage | EnsProfileImage
 
 type GalleryUser implements Node @goEmbedHelper {
   id: ID!

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -1463,9 +1463,8 @@ func (api UserAPI) GetProfileImageByUserID(ctx context.Context, userID persist.D
 }
 
 type EnsAvatar struct {
-	Address persist.Address
-	Chain   persist.Chain
-	URI     string
+	WalletID persist.DBID
+	URI      string
 }
 
 // GetEnsProfileImageByUserID returns the an ENS profile image for a user based on their set of wallets
@@ -1520,11 +1519,7 @@ func (api UserAPI) GetEnsProfileImageByUserID(ctx context.Context, userID persis
 			return a, err
 		}
 
-		return EnsAvatar{
-			Address: w.Address,
-			Chain:   w.Chain,
-			URI:     uri,
-		}, nil
+		return EnsAvatar{WalletID: w.ID, URI: uri}, nil
 	}
 
 	if len(errs) > 0 {


### PR DESCRIPTION
Small schema change to add `EnsProfileImage` to the `ProfileImage` type and adds `wallet` to `EnsProfileImage`
```graphql
type EnsProfileImage @goEmbedHelper {
  wallet: Wallet @goField(forceResolver: true)
  profileImage: HTTPSProfileImage
}

union ProfileImage = TokenProfileImage | EnsProfileImage
```