### PR TITLE
Don't overwrite existing contract owner addresses by default

### DIFF
--- a/db/queries/core/contract_gallery.sql
+++ b/db/queries/core/contract_gallery.sql
@@ -15,7 +15,13 @@ on conflict (chain, address) where parent_id is null
 do update set symbol = excluded.symbol
   , version = excluded.version
   , name = excluded.name
-  , owner_address = excluded.owner_address
+  , owner_address =
+      case
+          when nullif(contracts.owner_address, '') is null or (@can_overwrite_owner_address::bool and nullif (excluded.owner_address, '') is not null)
+            then excluded.owner_address
+          else
+            contracts.owner_address
+      end
   , description = excluded.description
   , deleted = excluded.deleted
   , last_updated = now()

--- a/service/persist/contract_gallery.go
+++ b/service/persist/contract_gallery.go
@@ -39,7 +39,7 @@ type ContractGalleryRepository interface {
 	GetByID(ctx context.Context, id DBID) (ContractGallery, error)
 	GetByAddress(context.Context, Address, Chain) (ContractGallery, error)
 	UpsertByAddress(context.Context, Address, Chain, ContractGallery) error
-	BulkUpsert(context.Context, []ContractGallery) ([]ContractGallery, error)
+	BulkUpsert(context.Context, []ContractGallery, bool) ([]ContractGallery, error)
 	GetOwnersByAddress(context.Context, Address, Chain, int, int) ([]TokenHolder, error)
 }
 


### PR DESCRIPTION
This PR changes our contract upsert methods to preserve existing `owner_address` fields by default, with an optional `canOverwriteOwnerAddress` parameter that allows the upsert to modify a non-empty `owner_address`.

**Old behavior**: every contract upsert would overwrite `owner_address` with a new value

**New behavior**: every contract upsert will overwrite `owner_address` if the existing value is null or empty. Otherwise, the existing value will only be overwritten if the new value is not null/empty _and_ the `canOverwriteOwnerAddress` flag is specified.

The practical implications of this change: syncing/refreshing tokens will update contracts, but won't change an existing contract's owner address unless the existing contract has an empty owner address. Syncing creator tokens, however, will always update a contract's owner.