### PR TITLE
Chore: Fix "composite literal uses unkeyed fields"

### DIFF
--- a/adminapi/admin.go
+++ b/adminapi/admin.go
@@ -31,8 +31,8 @@ func (api *AdminAPI) AddRolesToUser(ctx context.Context, username string, roles 
 	requireRetoolAuthorized(ctx)
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"username": {username, "required"},
-		"roles":    {roles, "required,unique,dive,role"},
+		"username": validate.WithTag(username, "required"),
+		"roles":    validate.WithTag(roles, "required,unique,dive,role"),
 	}); err != nil {
 		return nil, err
 	}
@@ -74,8 +74,8 @@ func (api *AdminAPI) RemoveRolesFromUser(ctx context.Context, username string, r
 	requireRetoolAuthorized(ctx)
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"username": {username, "required"},
-		"roles":    {roles, "required,unique,dive,role"},
+		"username": validate.WithTag(username, "required"),
+		"roles":    validate.WithTag(roles, "required,unique,dive,role"),
 	}); err != nil {
 		return nil, err
 	}
@@ -120,8 +120,8 @@ func (api *AdminAPI) AddWalletToUserUnchecked(ctx context.Context, username stri
 	requireRetoolAuthorized(ctx)
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"username":     {username, "required,username"},
-		"chainAddress": {chainAddress, "required"},
+		"username":     validate.WithTag(username, "required,username"),
+		"chainAddress": validate.WithTag(chainAddress, "required"),
 	}); err != nil {
 		return err
 	}
@@ -162,8 +162,8 @@ func (api *AdminAPI) SetContractOverrideCreator(ctx context.Context, contractID 
 
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID":    {contractID, "required"},
-		"creatorUserID": {creatorUserID, "required"},
+		"contractID":    validate.WithTag(contractID, "required"),
+		"creatorUserID": validate.WithTag(creatorUserID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (api *AdminAPI) RemoveContractOverrideCreator(ctx context.Context, contract
 
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": {contractID, "required"},
+		"contractID": validate.WithTag(contractID, "required"),
 	}); err != nil {
 		return err
 	}

--- a/cmd/contract_owners/main.go
+++ b/cmd/contract_owners/main.go
@@ -135,7 +135,7 @@ func main() {
 			ctx = sentryutil.NewSentryHubContext(ctx)
 
 			defer func() {
-				logger.For(ctx).Infof("finished processing %s", i)
+				logger.For(ctx).Infof("finished processing %d", i)
 			}()
 			results, err := indexer.GetContractMetadatas(ctx, group, httpClient, ethClient)
 			if err != nil {

--- a/graphql/dataloader/dataloaders.go
+++ b/graphql/dataloader/dataloaders.go
@@ -1247,7 +1247,7 @@ func loadProfileImageByID(q *db.Queries) func(context.Context, []db.GetProfileIm
 
 		b.QueryRow(func(i int, media db.ProfileImage, err error) {
 			if err == pgx.ErrNoRows {
-				err = persist.ErrProfileImageNotFound{err, params[i].ID}
+				err = persist.ErrProfileImageNotFound{Err: err, ProfileImageID: params[i].ID}
 			}
 			results[i], errors[i] = media, err
 		})

--- a/publicapi/collection.go
+++ b/publicapi/collection.go
@@ -36,7 +36,7 @@ type CollectionAPI struct {
 func (api CollectionAPI) GetCollectionById(ctx context.Context, collectionID persist.DBID) (*db.Collection, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID": {collectionID, "required"},
+		"collectionID": validate.WithTag(collectionID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (api CollectionAPI) GetCollectionsByIds(ctx context.Context, collectionIDs 
 	collectionThunk := func(collectionID persist.DBID) func() (db.Collection, error) {
 		// Validate
 		if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-			"collectionID": {collectionID, "required"},
+			"collectionID": validate.WithTag(collectionID, "required"),
 		}); err != nil {
 			return func() (db.Collection, error) { return db.Collection{}, err }
 		}
@@ -90,7 +90,7 @@ func (api CollectionAPI) GetCollectionsByIds(ctx context.Context, collectionIDs 
 func (api CollectionAPI) GetCollectionsByGalleryId(ctx context.Context, galleryID persist.DBID) ([]db.Collection, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (api CollectionAPI) GetCollectionsByGalleryId(ctx context.Context, galleryI
 func (api CollectionAPI) GetTopCollectionsForCommunity(ctx context.Context, chainAddress persist.ChainAddress, before, after *string, first, last *int) (c []db.Collection, pageInfo PageInfo, err error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"chainAddress": {chainAddress, "required"},
+		"chainAddress": validate.WithTag(chainAddress, "required"),
 	}); err != nil {
 		return nil, pageInfo, err
 	}
@@ -180,18 +180,18 @@ func (api CollectionAPI) GetTopCollectionsForCommunity(ctx context.Context, chai
 
 func (api CollectionAPI) CreateCollection(ctx context.Context, galleryID persist.DBID, name string, collectorsNote string, tokens []persist.DBID, layout persist.TokenLayout, tokenSettings map[persist.DBID]persist.CollectionTokenSettings, caption *string) (*db.Collection, *db.FeedEvent, error) {
 	fieldsToValidate := validate.ValidationMap{
-		"galleryID":      {galleryID, "required"},
-		"name":           {name, "collection_name"},
-		"collectorsNote": {collectorsNote, "collection_note"},
-		"tokens":         {tokens, fmt.Sprintf("required,unique,min=1,max=%d", maxTokensPerCollection)},
-		"sections":       {layout.Sections, fmt.Sprintf("unique,sorted_asc,lte=%d,min=1,max=%d,len=%d,dive,gte=0,lte=%d", len(tokens), maxSectionsPerCollection, len(layout.SectionLayout), len(tokens)-1)},
+		"galleryID":      validate.WithTag(galleryID, "required"),
+		"name":           validate.WithTag(name, "collection_name"),
+		"collectorsNote": validate.WithTag(collectorsNote, "collection_note"),
+		"tokens":         validate.WithTag(tokens, fmt.Sprintf("required,unique,min=1,max=%d", maxTokensPerCollection)),
+		"sections":       validate.WithTag(layout.Sections, fmt.Sprintf("unique,sorted_asc,lte=%d,min=1,max=%d,len=%d,dive,gte=0,lte=%d", len(tokens), maxSectionsPerCollection, len(layout.SectionLayout), len(tokens)-1)),
 	}
 
 	// Trim and optimistically sanitize the input while we're at it.
 	var trimmedCaption string
 	if caption != nil {
 		trimmedCaption = strings.TrimSpace(*caption)
-		fieldsToValidate["caption"] = validate.ValWithTags{trimmedCaption, fmt.Sprintf("required,caption")}
+		fieldsToValidate["caption"] = validate.WithTag(trimmedCaption, fmt.Sprintf("required,caption"))
 		cleaned := validate.SanitizationPolicy.Sanitize(trimmedCaption)
 		caption = &cleaned
 	}
@@ -273,7 +273,7 @@ func (api CollectionAPI) CreateCollection(ctx context.Context, galleryID persist
 func (api CollectionAPI) DeleteCollection(ctx context.Context, collectionID persist.DBID) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID": {collectionID, "required"},
+		"collectionID": validate.WithTag(collectionID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -294,9 +294,9 @@ func (api CollectionAPI) DeleteCollection(ctx context.Context, collectionID pers
 func (api CollectionAPI) UpdateCollectionInfo(ctx context.Context, collectionID persist.DBID, name string, collectorsNote string) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID":   {collectionID, "required"},
-		"name":           {name, "collection_name"},
-		"collectorsNote": {collectorsNote, "collection_note"},
+		"collectionID":   validate.WithTag(collectionID, "required"),
+		"name":           validate.WithTag(name, "collection_name"),
+		"collectorsNote": validate.WithTag(collectorsNote, "collection_note"),
 	}); err != nil {
 		return err
 	}
@@ -341,16 +341,16 @@ func (api CollectionAPI) UpdateCollectionInfo(ctx context.Context, collectionID 
 
 func (api CollectionAPI) UpdateCollectionTokens(ctx context.Context, collectionID persist.DBID, tokens []persist.DBID, layout persist.TokenLayout, tokenSettings map[persist.DBID]persist.CollectionTokenSettings, caption *string) (*db.FeedEvent, error) {
 	fieldsToValidate := validate.ValidationMap{
-		"collectionID": {collectionID, "required"},
-		"tokens":       {tokens, fmt.Sprintf("required,unique,min=1,max=%d", maxTokensPerCollection)},
-		"sections":     {layout.Sections, fmt.Sprintf("unique,sorted_asc,lte=%d,min=1,max=%d,len=%d,dive,gte=0,lte=%d", len(tokens), maxSectionsPerCollection, len(layout.SectionLayout), len(tokens)-1)},
+		"collectionID": validate.WithTag(collectionID, "required"),
+		"tokens":       validate.WithTag(tokens, fmt.Sprintf("required,unique,min=1,max=%d", maxTokensPerCollection)),
+		"sections":     validate.WithTag(layout.Sections, fmt.Sprintf("unique,sorted_asc,lte=%d,min=1,max=%d,len=%d,dive,gte=0,lte=%d", len(tokens), maxSectionsPerCollection, len(layout.SectionLayout), len(tokens)-1)),
 	}
 
 	// Trim and optimistically sanitize the input while we're at it.
 	var trimmedCaption string
 	if caption != nil {
 		trimmedCaption = strings.TrimSpace(*caption)
-		fieldsToValidate["caption"] = validate.ValWithTags{trimmedCaption, fmt.Sprintf("required,caption")}
+		fieldsToValidate["caption"] = validate.WithTag(trimmedCaption, fmt.Sprintf("required,caption"))
 		cleaned := validate.SanitizationPolicy.Sanitize(trimmedCaption)
 		caption = &cleaned
 	}
@@ -415,7 +415,7 @@ func (api CollectionAPI) UpdateCollectionTokens(ctx context.Context, collectionI
 func (api CollectionAPI) UpdateCollectionHidden(ctx context.Context, collectionID persist.DBID, hidden bool) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID": {collectionID, "required"},
+		"collectionID": validate.WithTag(collectionID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -439,8 +439,8 @@ func (api CollectionAPI) UpdateCollectionHidden(ctx context.Context, collectionI
 func (api CollectionAPI) UpdateCollectionGallery(ctx context.Context, collectionID, galleryID persist.DBID) (persist.DBID, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID": {collectionID, "required"},
-		"galleryID":    {galleryID, "required"},
+		"collectionID": validate.WithTag(collectionID, "required"),
+		"galleryID":    validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return "", err
 	}

--- a/publicapi/contract.go
+++ b/publicapi/contract.go
@@ -33,7 +33,7 @@ type ContractAPI struct {
 func (api ContractAPI) GetContractByID(ctx context.Context, contractID persist.DBID) (*db.Contract, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": {contractID, "required"},
+		"contractID": validate.WithTag(contractID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func (api ContractAPI) GetContractByID(ctx context.Context, contractID persist.D
 func (api ContractAPI) GetContractByAddress(ctx context.Context, contractAddress persist.ChainAddress) (*db.Contract, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractAddress": {contractAddress, "required"},
+		"contractAddress": validate.WithTag(contractAddress, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (api ContractAPI) GetContractByAddress(ctx context.Context, contractAddress
 func (api ContractAPI) GetChildContractsByParentID(ctx context.Context, contractID persist.DBID, before, after *string, first, last *int) ([]db.Contract, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": {contractID, "required"},
+		"contractID": validate.WithTag(contractID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -125,7 +125,7 @@ func (api ContractAPI) GetChildContractsByParentID(ctx context.Context, contract
 func (api ContractAPI) GetContractCreatorByContractID(ctx context.Context, contractID persist.DBID) (db.ContractCreator, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": {contractID, "required"},
+		"contractID": validate.WithTag(contractID, "required"),
 	}); err != nil {
 		return db.ContractCreator{}, err
 	}
@@ -136,7 +136,7 @@ func (api ContractAPI) GetContractCreatorByContractID(ctx context.Context, contr
 func (api ContractAPI) GetContractsDisplayedByUserID(ctx context.Context, userID persist.DBID) ([]db.Contract, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (api ContractAPI) GetContractsDisplayedByUserID(ctx context.Context, userID
 func (api ContractAPI) RefreshContract(ctx context.Context, contractID persist.DBID) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": {contractID, "required"},
+		"contractID": validate.WithTag(contractID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (api ContractAPI) RefreshContract(ctx context.Context, contractID persist.D
 func (api ContractAPI) RefreshOwnersAsync(ctx context.Context, contractID persist.DBID, forceRefresh bool) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": {contractID, "required"},
+		"contractID": validate.WithTag(contractID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -190,7 +190,7 @@ func (api ContractAPI) RefreshOwnersAsync(ctx context.Context, contractID persis
 func (api ContractAPI) GetCommunityOwnersByContractAddress(ctx context.Context, contractAddress persist.ChainAddress, before, after *string, first, last *int, onlyGalleryUsers bool) ([]db.User, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractAddress": {contractAddress, "required"},
+		"contractAddress": validate.WithTag(contractAddress, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -32,8 +32,8 @@ type FeedAPI struct {
 func (api FeedAPI) BlockUser(ctx context.Context, userId persist.DBID, action persist.Action) error {
 	// Validate
 	err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userId": {userId, "required"},
-		"action": {action, "required"},
+		"userId": validate.WithTag(userId, "required"),
+		"action": validate.WithTag(action, "required"),
 	})
 
 	if err != nil {
@@ -51,7 +51,7 @@ func (api FeedAPI) BlockUser(ctx context.Context, userId persist.DBID, action pe
 func (api FeedAPI) UnBlockUser(ctx context.Context, userId persist.DBID) error {
 	// Validate
 	err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userId": {userId, "required"},
+		"userId": validate.WithTag(userId, "required"),
 	})
 
 	if err != nil {
@@ -65,7 +65,7 @@ func (api FeedAPI) UnBlockUser(ctx context.Context, userId persist.DBID) error {
 func (api FeedAPI) GetFeedEventById(ctx context.Context, feedEventID persist.DBID) (*db.FeedEvent, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"feedEventID": {feedEventID, "required"},
+		"feedEventID": validate.WithTag(feedEventID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (api FeedAPI) GetFeedEventById(ctx context.Context, feedEventID persist.DBI
 func (api FeedAPI) GetRawEventById(ctx context.Context, eventID persist.DBID) (*db.Event, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"eventID": {eventID, "required"},
+		"eventID": validate.WithTag(eventID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (api FeedAPI) PaginatePersonalFeed(ctx context.Context, before *string, aft
 
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -153,7 +153,7 @@ func (api FeedAPI) PaginateUserFeed(ctx context.Context, userID persist.DBID, be
 	first *int, last *int) ([]db.FeedEvent, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}

--- a/publicapi/gallery.go
+++ b/publicapi/gallery.go
@@ -38,9 +38,9 @@ type GalleryAPI struct {
 func (api GalleryAPI) CreateGallery(ctx context.Context, name, description *string, position string) (db.Gallery, error) {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"name":        {name, "max=200"},
-		"description": {description, "max=1200"},
-		"position":    {position, "required"},
+		"name":        validate.WithTag(name, "max=200"),
+		"description": validate.WithTag(description, "max=1200"),
+		"position":    validate.WithTag(position, "required"),
 	}); err != nil {
 		return db.Gallery{}, err
 	}
@@ -67,11 +67,11 @@ func (api GalleryAPI) CreateGallery(ctx context.Context, name, description *stri
 func (api GalleryAPI) UpdateGallery(ctx context.Context, update model.UpdateGalleryInput) (db.Gallery, error) {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID":           {update.GalleryID, "required"},
-		"name":                {update.Name, "omitempty,max=200"},
-		"description":         {update.Description, "omitempty,max=1200"},
-		"deleted_collections": {update.DeletedCollections, "omitempty,unique"},
-		"created_collections": {update.CreatedCollections, "omitempty,created_collections"},
+		"galleryID":           validate.WithTag(update.GalleryID, "required"),
+		"name":                validate.WithTag(update.Name, "omitempty,max=200"),
+		"description":         validate.WithTag(update.Description, "omitempty,max=1200"),
+		"deleted_collections": validate.WithTag(update.DeletedCollections, "omitempty,unique"),
+		"created_collections": validate.WithTag(update.CreatedCollections, "omitempty,created_collections"),
 	}); err != nil {
 		return db.Gallery{}, err
 	}
@@ -237,8 +237,8 @@ func (api GalleryAPI) UpdateGallery(ctx context.Context, update model.UpdateGall
 func (api GalleryAPI) PublishGallery(ctx context.Context, update model.PublishGalleryInput) error {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {update.GalleryID, "required"},
-		"editID":    {update.EditID, "required"},
+		"galleryID": validate.WithTag(update.GalleryID, "required"),
+		"editID":    validate.WithTag(update.EditID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func updateCollectionsInfoAndTokens(ctx context.Context, q *db.Queries, actor, g
 func (api GalleryAPI) DeleteGallery(ctx context.Context, galleryID persist.DBID) error {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func (api GalleryAPI) DeleteGallery(ctx context.Context, galleryID persist.DBID)
 func (api GalleryAPI) GetGalleryById(ctx context.Context, galleryID persist.DBID) (*db.Gallery, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -407,7 +407,7 @@ func (api GalleryAPI) GetGalleryById(ctx context.Context, galleryID persist.DBID
 func (api GalleryAPI) GetViewerGalleryById(ctx context.Context, galleryID persist.DBID) (*db.Gallery, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func (api GalleryAPI) GetViewerGalleryById(ctx context.Context, galleryID persis
 func (api GalleryAPI) GetGalleryByCollectionId(ctx context.Context, collectionID persist.DBID) (*db.Gallery, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID": {collectionID, "required"},
+		"collectionID": validate.WithTag(collectionID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -449,7 +449,7 @@ func (api GalleryAPI) GetGalleryByCollectionId(ctx context.Context, collectionID
 func (api GalleryAPI) GetGalleriesByUserId(ctx context.Context, userID persist.DBID) ([]db.Gallery, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -465,7 +465,7 @@ func (api GalleryAPI) GetGalleriesByUserId(ctx context.Context, userID persist.D
 func (api GalleryAPI) GetTokenPreviewsByGalleryID(ctx context.Context, galleryID persist.DBID) ([]db.TokenMedia, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -487,8 +487,8 @@ func (api GalleryAPI) GetTokenPreviewsByGalleryID(ctx context.Context, galleryID
 func (api GalleryAPI) UpdateGalleryCollections(ctx context.Context, galleryID persist.DBID, collections []persist.DBID) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID":   {galleryID, "required"},
-		"collections": {collections, fmt.Sprintf("required,unique,max=%d", maxCollectionsPerGallery)},
+		"galleryID":   validate.WithTag(galleryID, "required"),
+		"collections": validate.WithTag(collections, fmt.Sprintf("required,unique,max=%d", maxCollectionsPerGallery)),
 	}); err != nil {
 		return err
 	}
@@ -511,9 +511,9 @@ func (api GalleryAPI) UpdateGalleryCollections(ctx context.Context, galleryID pe
 func (api GalleryAPI) UpdateGalleryInfo(ctx context.Context, galleryID persist.DBID, name, description *string) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID":   {galleryID, "required"},
-		"name":        {name, "max=200"},
-		"description": {description, "max=1200"},
+		"galleryID":   validate.WithTag(galleryID, "required"),
+		"name":        validate.WithTag(name, "max=200"),
+		"description": validate.WithTag(description, "max=1200"),
 	}); err != nil {
 		return err
 	}
@@ -546,7 +546,7 @@ func (api GalleryAPI) UpdateGalleryInfo(ctx context.Context, galleryID persist.D
 func (api GalleryAPI) UpdateGalleryHidden(ctx context.Context, galleryID persist.DBID, hidden bool) (coredb.Gallery, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return db.Gallery{}, err
 	}
@@ -565,7 +565,7 @@ func (api GalleryAPI) UpdateGalleryHidden(ctx context.Context, galleryID persist
 func (api GalleryAPI) UpdateGalleryPositions(ctx context.Context, positions []*model.GalleryPositionInput) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"positions": {positions, "required,min=1"},
+		"positions": validate.WithTag(positions, "required,min=1"),
 	}); err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (api GalleryAPI) UpdateGalleryPositions(ctx context.Context, positions []*m
 func (api GalleryAPI) ViewGallery(ctx context.Context, galleryID persist.DBID) (db.Gallery, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return db.Gallery{}, err
 	}

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -40,7 +40,7 @@ func (api InteractionAPI) PaginateInteractionsByFeedEventID(ctx context.Context,
 	first *int, last *int) ([]interface{}, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"feedEventID": {feedEventID, "required"},
+		"feedEventID": validate.WithTag(feedEventID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -184,7 +184,7 @@ func (api InteractionAPI) PaginateAdmiresByFeedEventID(ctx context.Context, feed
 	first *int, last *int) ([]db.Admire, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"feedEventID": {feedEventID, "required"},
+		"feedEventID": validate.WithTag(feedEventID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -248,7 +248,7 @@ func (api InteractionAPI) PaginateCommentsByFeedEventID(ctx context.Context, fee
 	first *int, last *int) ([]db.Comment, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"feedEventID": {feedEventID, "required"},
+		"feedEventID": validate.WithTag(feedEventID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -311,8 +311,8 @@ func (api InteractionAPI) PaginateCommentsByFeedEventID(ctx context.Context, fee
 func (api InteractionAPI) GetAdmireByActorIDAndFeedEventID(ctx context.Context, actorID persist.DBID, feedEventID persist.DBID) (*db.Admire, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"actorID":     {actorID, "required"},
-		"feedEventID": {feedEventID, "required"},
+		"actorID":     validate.WithTag(actorID, "required"),
+		"feedEventID": validate.WithTag(feedEventID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -332,7 +332,7 @@ func (api InteractionAPI) GetAdmireByActorIDAndFeedEventID(ctx context.Context, 
 func (api InteractionAPI) GetAdmireByID(ctx context.Context, admireID persist.DBID) (*db.Admire, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"admireID": {admireID, "required"},
+		"admireID": validate.WithTag(admireID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -348,7 +348,7 @@ func (api InteractionAPI) GetAdmireByID(ctx context.Context, admireID persist.DB
 func (api InteractionAPI) AdmireFeedEvent(ctx context.Context, feedEventID persist.DBID) (persist.DBID, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"feedEventID": {feedEventID, "required"},
+		"feedEventID": validate.WithTag(feedEventID, "required"),
 	}); err != nil {
 		return "", err
 	}
@@ -388,7 +388,7 @@ func (api InteractionAPI) AdmireFeedEvent(ctx context.Context, feedEventID persi
 func (api InteractionAPI) RemoveAdmire(ctx context.Context, admireID persist.DBID) (persist.DBID, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"admireID": {admireID, "required"},
+		"admireID": validate.WithTag(admireID, "required"),
 	}); err != nil {
 		return "", err
 	}
@@ -408,8 +408,8 @@ func (api InteractionAPI) RemoveAdmire(ctx context.Context, admireID persist.DBI
 func (api InteractionAPI) HasUserAdmiredFeedEvent(ctx context.Context, userID persist.DBID, feedEventID persist.DBID) (*bool, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID":      {userID, "required"},
-		"feedEventID": {feedEventID, "required"},
+		"userID":      validate.WithTag(userID, "required"),
+		"feedEventID": validate.WithTag(feedEventID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -432,7 +432,7 @@ func (api InteractionAPI) HasUserAdmiredFeedEvent(ctx context.Context, userID pe
 func (api InteractionAPI) GetCommentByID(ctx context.Context, commentID persist.DBID) (*db.Comment, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"commentID": {commentID, "required"},
+		"commentID": validate.WithTag(commentID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -452,8 +452,8 @@ func (api InteractionAPI) CommentOnFeedEvent(ctx context.Context, feedEventID pe
 
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"feedEventID": {feedEventID, "required"},
-		"comment":     {comment, "required"},
+		"feedEventID": validate.WithTag(feedEventID, "required"),
+		"comment":     validate.WithTag(comment, "required"),
 	}); err != nil {
 		return "", err
 	}
@@ -489,7 +489,7 @@ func (api InteractionAPI) CommentOnFeedEvent(ctx context.Context, feedEventID pe
 func (api InteractionAPI) RemoveComment(ctx context.Context, commentID persist.DBID) (persist.DBID, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"commentID": {commentID, "required"},
+		"commentID": validate.WithTag(commentID, "required"),
 	}); err != nil {
 		return "", err
 	}

--- a/publicapi/merch.go
+++ b/publicapi/merch.go
@@ -64,7 +64,7 @@ type MerchAPI struct {
 func (api MerchAPI) GetMerchTokens(ctx context.Context, address persist.Address) ([]*model.MerchToken, error) {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"address": {address, "required"},
+		"address": validate.WithTag(address, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -150,7 +150,7 @@ func (api MerchAPI) GetMerchTokens(ctx context.Context, address persist.Address)
 func (api MerchAPI) GetMerchTokenByTokenID(ctx context.Context, tokenID persist.TokenID) (*model.MerchToken, error) {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenID": {tokenID, "required"},
+		"tokenID": validate.WithTag(tokenID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -234,9 +234,9 @@ func (api MerchAPI) GetMerchTokenByTokenID(ctx context.Context, tokenID persist.
 func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.TokenID, address persist.ChainAddress, sig string, walletType persist.WalletType) ([]*model.MerchToken, error) {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenIDs": {tokenIDs, "required,unique"},
-		"address":  {address, "required"},
-		"sig":      {sig, "required"},
+		"tokenIDs": validate.WithTag(tokenIDs, "required,unique"),
+		"address":  validate.WithTag(address, "required"),
+		"sig":      validate.WithTag(sig, "required"),
 	}); err != nil {
 		return nil, err
 	}

--- a/publicapi/notifications.go
+++ b/publicapi/notifications.go
@@ -26,7 +26,7 @@ func (api NotificationsAPI) GetViewerNotifications(ctx context.Context, before, 
 
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, 0, err
 	}

--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -45,8 +45,8 @@ type PageInfo struct {
 
 func validatePaginationParams(validator *validator.Validate, first *int, last *int) error {
 	if err := validate.ValidateFields(validator, validate.ValidationMap{
-		"first": {first, "omitempty,gte=0"},
-		"last":  {last, "omitempty,gte=0"},
+		"first": validate.WithTag(first, "omitempty,gte=0"),
+		"last":  validate.WithTag(last, "omitempty,gte=0"),
 	}); err != nil {
 		return err
 	}

--- a/publicapi/search.go
+++ b/publicapi/search.go
@@ -23,10 +23,10 @@ type SearchAPI struct {
 func (api SearchAPI) SearchUsers(ctx context.Context, query string, limit int, usernameWeight float32, bioWeight float32) ([]db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"query":          {query, fmt.Sprintf("required,min=1,max=%d", maxSearchQueryLength)},
-		"limit":          {limit, fmt.Sprintf("min=1,max=%d", maxSearchResults)},
-		"usernameWeight": {usernameWeight, "gte=0.0,lte=1.0"},
-		"bioWeight":      {bioWeight, "gte=0.0,lte=1.0"},
+		"query":          validate.WithTag(query, fmt.Sprintf("required,min=1,max=%d", maxSearchQueryLength)),
+		"limit":          validate.WithTag(limit, fmt.Sprintf("min=1,max=%d", maxSearchResults)),
+		"usernameWeight": validate.WithTag(usernameWeight, "gte=0.0,lte=1.0"),
+		"bioWeight":      validate.WithTag(bioWeight, "gte=0.0,lte=1.0"),
 	}); err != nil {
 		return nil, err
 	}
@@ -47,10 +47,10 @@ func (api SearchAPI) SearchUsers(ctx context.Context, query string, limit int, u
 func (api SearchAPI) SearchGalleries(ctx context.Context, query string, limit int, nameWeight float32, descriptionWeight float32) ([]db.Gallery, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"query":             {query, fmt.Sprintf("required,min=1,max=%d", maxSearchQueryLength)},
-		"limit":             {limit, fmt.Sprintf("min=1,max=%d", maxSearchResults)},
-		"nameWeight":        {nameWeight, "gte=0.0,lte=1.0"},
-		"descriptionWeight": {descriptionWeight, "gte=0.0,lte=1.0"},
+		"query":             validate.WithTag(query, fmt.Sprintf("required,min=1,max=%d", maxSearchQueryLength)),
+		"limit":             validate.WithTag(limit, fmt.Sprintf("min=1,max=%d", maxSearchResults)),
+		"nameWeight":        validate.WithTag(nameWeight, "gte=0.0,lte=1.0"),
+		"descriptionWeight": validate.WithTag(descriptionWeight, "gte=0.0,lte=1.0"),
 	}); err != nil {
 		return nil, err
 	}
@@ -71,11 +71,11 @@ func (api SearchAPI) SearchGalleries(ctx context.Context, query string, limit in
 func (api SearchAPI) SearchContracts(ctx context.Context, query string, limit int, nameWeight float32, descriptionWeight float32, poapAddressWeight float32) ([]db.Contract, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"query":             {query, fmt.Sprintf("required,min=1,max=%d", maxSearchQueryLength)},
-		"limit":             {limit, fmt.Sprintf("min=1,max=%d", maxSearchResults)},
-		"nameWeight":        {nameWeight, "gte=0.0,lte=1.0"},
-		"descriptionWeight": {descriptionWeight, "gte=0.0,lte=1.0"},
-		"poapAddressWeight": {poapAddressWeight, "gte=0.0,lte=1.0"},
+		"query":             validate.WithTag(query, fmt.Sprintf("required,min=1,max=%d", maxSearchQueryLength)),
+		"limit":             validate.WithTag(limit, fmt.Sprintf("min=1,max=%d", maxSearchResults)),
+		"nameWeight":        validate.WithTag(nameWeight, "gte=0.0,lte=1.0"),
+		"descriptionWeight": validate.WithTag(descriptionWeight, "gte=0.0,lte=1.0"),
+		"poapAddressWeight": validate.WithTag(poapAddressWeight, "gte=0.0,lte=1.0"),
 	}); err != nil {
 		return nil, err
 	}

--- a/publicapi/socials.go
+++ b/publicapi/socials.go
@@ -39,7 +39,7 @@ func (s SocialAPI) NewTwitterAuthenticator(userID persist.DBID, authCode string)
 func (api SocialAPI) GetConnectionsPaginate(ctx context.Context, socialProvider persist.SocialProvider, before, after *string, first, last *int, onlyUnfollowing *bool) ([]model.SocialConnection, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"socialProvider": {socialProvider, "required"},
+		"socialProvider": validate.WithTag(socialProvider, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -179,7 +179,7 @@ func (api SocialAPI) GetConnectionsPaginate(ctx context.Context, socialProvider 
 func (api SocialAPI) GetConnections(ctx context.Context, socialProvider persist.SocialProvider, onlyUnfollowing *bool) ([]model.SocialConnection, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"socialProvider": {socialProvider, "required"},
+		"socialProvider": validate.WithTag(socialProvider, "required"),
 	}); err != nil {
 		return nil, err
 	}

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -44,7 +44,7 @@ func (e ErrTokenRefreshFailed) Error() string {
 func (api TokenAPI) GetTokenById(ctx context.Context, tokenID persist.DBID) (*db.Token, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenID": {tokenID, "required"},
+		"tokenID": validate.WithTag(tokenID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (api TokenAPI) GetTokenById(ctx context.Context, tokenID persist.DBID) (*db
 func (api TokenAPI) GetTokensByCollectionId(ctx context.Context, collectionID persist.DBID, limit *int) ([]db.Token, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID": {collectionID, "required"},
+		"collectionID": validate.WithTag(collectionID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (api TokenAPI) GetTokensByCollectionId(ctx context.Context, collectionID pe
 func (api TokenAPI) GetTokensByContractIdPaginate(ctx context.Context, contractID persist.DBID, before, after *string, first, last *int, onlyGalleryUsers bool) ([]db.Token, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": {contractID, "required"},
+		"contractID": validate.WithTag(contractID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -178,7 +178,7 @@ func (api TokenAPI) GetTokensByIDs(ctx context.Context, tokenIDs []persist.DBID)
 func (api TokenAPI) GetNewTokensByFeedEventID(ctx context.Context, eventID persist.DBID) ([]db.Token, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"eventID": {eventID, "required"},
+		"eventID": validate.WithTag(eventID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func (api TokenAPI) GetNewTokensByFeedEventID(ctx context.Context, eventID persi
 func (api TokenAPI) GetTokensByWalletID(ctx context.Context, walletID persist.DBID) ([]db.Token, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"walletID": {walletID, "required"},
+		"walletID": validate.WithTag(walletID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (api TokenAPI) GetTokensByWalletID(ctx context.Context, walletID persist.DB
 func (api TokenAPI) GetTokensByUserID(ctx context.Context, userID persist.DBID, ownershipFilter []persist.TokenOwnershipType) ([]db.Token, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -242,8 +242,8 @@ func (api TokenAPI) GetTokensByUserID(ctx context.Context, userID persist.DBID, 
 func (api TokenAPI) GetTokensByUserIDAndChain(ctx context.Context, userID persist.DBID, chain persist.Chain) ([]db.Token, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
-		"chain":  {chain, "chain"},
+		"userID": validate.WithTag(userID, "required"),
+		"chain":  validate.WithTag(chain, "chain"),
 	}); err != nil {
 		return nil, err
 	}
@@ -346,7 +346,7 @@ func (api TokenAPI) SyncCreatedTokens(ctx context.Context, includeChains []persi
 
 func (api TokenAPI) RefreshToken(ctx context.Context, tokenDBID persist.DBID) error {
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenID": {tokenDBID, "required"},
+		"tokenID": validate.WithTag(tokenDBID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -370,7 +370,7 @@ func (api TokenAPI) RefreshToken(ctx context.Context, tokenDBID persist.DBID) er
 
 func (api TokenAPI) RefreshTokensInCollection(ctx context.Context, ci persist.ContractIdentifiers) error {
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractIdentifiers": {ci, "required"},
+		"contractIdentifiers": validate.WithTag(ci, "required"),
 	}); err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (api TokenAPI) RefreshTokensInCollection(ctx context.Context, ci persist.Co
 
 func (api TokenAPI) RefreshCollection(ctx context.Context, collectionDBID persist.DBID) error {
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"collectionID": {collectionDBID, "required"},
+		"collectionID": validate.WithTag(collectionDBID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -428,8 +428,8 @@ func (api TokenAPI) RefreshCollection(ctx context.Context, collectionDBID persis
 func (api TokenAPI) UpdateTokenInfo(ctx context.Context, tokenID persist.DBID, collectionID persist.DBID, collectorsNote string) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenID":        {tokenID, "required"},
-		"collectorsNote": {collectorsNote, "token_note"},
+		"tokenID":        validate.WithTag(tokenID, "required"),
+		"collectorsNote": validate.WithTag(collectorsNote, "token_note"),
 	}); err != nil {
 		return err
 	}
@@ -477,7 +477,7 @@ func (api TokenAPI) UpdateTokenInfo(ctx context.Context, tokenID persist.DBID, c
 func (api TokenAPI) SetSpamPreference(ctx context.Context, tokens []persist.DBID, isSpam bool) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokens": {tokens, "required,unique"},
+		"tokens": validate.WithTag(tokens, "required,unique"),
 	}); err != nil {
 		return err
 	}
@@ -498,7 +498,7 @@ func (api TokenAPI) SetSpamPreference(ctx context.Context, tokens []persist.DBID
 func (api TokenAPI) MediaByTokenID(ctx context.Context, tokenID persist.DBID) (db.TokenMedia, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenID": {tokenID, "required"},
+		"tokenID": validate.WithTag(tokenID, "required"),
 	}); err != nil {
 		return db.TokenMedia{}, err
 	}
@@ -509,7 +509,7 @@ func (api TokenAPI) MediaByTokenID(ctx context.Context, tokenID persist.DBID) (d
 func (api TokenAPI) GetTokenOwnershipByTokenID(ctx context.Context, tokenID persist.DBID) (db.TokenOwnership, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenID": {tokenID, "required"},
+		"tokenID": validate.WithTag(tokenID, "required"),
 	}); err != nil {
 		return db.TokenOwnership{}, err
 	}

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -71,7 +71,7 @@ func (api UserAPI) IsUserLoggedIn(ctx context.Context) bool {
 func (api UserAPI) GetUserById(ctx context.Context, userID persist.DBID) (*db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (api UserAPI) GetUserById(ctx context.Context, userID persist.DBID) (*db.Us
 func (api UserAPI) GetUserByVerifiedEmailAddress(ctx context.Context, emailAddress persist.Email) (*db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"emailAddress": {emailAddress, "required"},
+		"emailAddress": validate.WithTag(emailAddress, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (api UserAPI) GetUserWithPII(ctx context.Context) (*db.PiiUserView, error) 
 func (api UserAPI) GetUsersByIDs(ctx context.Context, userIDs []persist.DBID, before, after *string, first, last *int) ([]db.User, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userIDs": {userIDs, "required"},
+		"userIDs": validate.WithTag(userIDs, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -191,7 +191,7 @@ func (api UserAPI) GetUsersByIDs(ctx context.Context, userIDs []persist.DBID, be
 func (api UserAPI) GetUserByUsername(ctx context.Context, username string) (*db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"username": {username, "required"},
+		"username": validate.WithTag(username, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func (api UserAPI) GetUserByUsername(ctx context.Context, username string) (*db.
 func (api UserAPI) GetUserByAddress(ctx context.Context, chainAddress persist.ChainAddress) (*db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"chainAddress": {chainAddress, "required"},
+		"chainAddress": validate.WithTag(chainAddress, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (api UserAPI) GetUserByAddress(ctx context.Context, chainAddress persist.Ch
 func (api UserAPI) GetUsersWithTrait(ctx context.Context, trait string) ([]db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"trait": {trait, "required"},
+		"trait": validate.WithTag(trait, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func (api *UserAPI) UserIsAdmin(ctx context.Context) bool {
 func (api UserAPI) PaginateUsersWithRole(ctx context.Context, role persist.Role, before *string, after *string, first *int, last *int) ([]db.User, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"role": {role, "required,role"},
+		"role": validate.WithTag(role, "required,role"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -313,8 +313,8 @@ func (api UserAPI) PaginateUsersWithRole(ctx context.Context, role persist.Role,
 func (api UserAPI) AddWalletToUser(ctx context.Context, chainAddress persist.ChainAddress, authenticator auth.Authenticator) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"chainAddress":  {chainAddress, "required"},
-		"authenticator": {authenticator, "required"},
+		"chainAddress":  validate.WithTag(chainAddress, "required"),
+		"authenticator": validate.WithTag(authenticator, "required"),
 	}); err != nil {
 		return err
 	}
@@ -335,7 +335,7 @@ func (api UserAPI) AddWalletToUser(ctx context.Context, chainAddress persist.Cha
 func (api UserAPI) RemoveWalletsFromUser(ctx context.Context, walletIDs []persist.DBID) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"walletIDs": {walletIDs, "required,unique,dive,required"},
+		"walletIDs": validate.WithTag(walletIDs, "required,unique,dive,required"),
 	}); err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func (api UserAPI) RemoveWalletsFromUser(ctx context.Context, walletIDs []persis
 func (api UserAPI) AddSocialAccountToUser(ctx context.Context, authenticator socialauth.Authenticator, display bool) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"authenticator": {authenticator, "required"},
+		"authenticator": validate.WithTag(authenticator, "required"),
 	}); err != nil {
 		return err
 	}
@@ -387,8 +387,8 @@ func (api UserAPI) AddSocialAccountToUser(ctx context.Context, authenticator soc
 func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authenticator, username string, email *persist.Email, bio, galleryName, galleryDesc, galleryPos string) (userID persist.DBID, galleryID persist.DBID, err error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"username": {username, "required,username"},
-		"bio":      {bio, "bio"},
+		"username": validate.WithTag(username, "required,username"),
+		"bio":      validate.WithTag(bio, "bio"),
 	}); err != nil {
 		return "", "", err
 	}
@@ -459,8 +459,8 @@ func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authentica
 func (api UserAPI) UpdateUserInfo(ctx context.Context, username string, bio string) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"username": {username, "required,username"},
-		"bio":      {bio, "bio"},
+		"username": validate.WithTag(username, "required,username"),
+		"bio":      validate.WithTag(bio, "bio"),
 	}); err != nil {
 		return err
 	}
@@ -484,7 +484,7 @@ func (api UserAPI) UpdateUserInfo(ctx context.Context, username string, bio stri
 func (api UserAPI) UpdateUserPrimaryWallet(ctx context.Context, primaryWalletID persist.DBID) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"primaryWalletID": {primaryWalletID, "required"},
+		"primaryWalletID": validate.WithTag(primaryWalletID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func (api UserAPI) UpdateUserPrimaryWallet(ctx context.Context, primaryWalletID 
 func (api UserAPI) UpdateFeaturedGallery(ctx context.Context, galleryID persist.DBID) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"galleryID": {galleryID, "required"},
+		"galleryID": validate.WithTag(galleryID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -527,7 +527,7 @@ func (api UserAPI) UpdateFeaturedGallery(ctx context.Context, galleryID persist.
 func (api UserAPI) UpdateUserEmail(ctx context.Context, email persist.Email) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"email": {email, "required"},
+		"email": validate.WithTag(email, "required"),
 	}); err != nil {
 		return err
 	}
@@ -555,7 +555,7 @@ func (api UserAPI) UpdateUserEmail(ctx context.Context, email persist.Email) err
 func (api UserAPI) UpdateUserEmailNotificationSettings(ctx context.Context, settings persist.EmailUnsubscriptions) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"settings": {settings, "required"},
+		"settings": validate.WithTag(settings, "required"),
 	}); err != nil {
 		return err
 	}
@@ -589,7 +589,7 @@ func (api UserAPI) ResendEmailVerification(ctx context.Context) error {
 func (api UserAPI) UpdateUserNotificationSettings(ctx context.Context, notificationSettings persist.UserNotificationSettings) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"notification_settings": {notificationSettings, "required"},
+		"notification_settings": validate.WithTag(notificationSettings, "required"),
 	}); err != nil {
 		return err
 	}
@@ -610,7 +610,7 @@ func (api UserAPI) GetMembershipTiers(ctx context.Context, forceRefresh bool) ([
 func (api UserAPI) GetMembershipByMembershipId(ctx context.Context, membershipID persist.DBID) (*db.Membership, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"membershipID": {membershipID, "required"},
+		"membershipID": validate.WithTag(membershipID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -626,7 +626,7 @@ func (api UserAPI) GetMembershipByMembershipId(ctx context.Context, membershipID
 func (api UserAPI) GetFollowersByUserId(ctx context.Context, userID persist.DBID) ([]db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -646,7 +646,7 @@ func (api UserAPI) GetFollowersByUserId(ctx context.Context, userID persist.DBID
 func (api UserAPI) GetFollowingByUserId(ctx context.Context, userID persist.DBID) ([]db.User, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -671,7 +671,7 @@ func (api UserAPI) SharedFollowers(ctx context.Context, userID persist.DBID, bef
 	}
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -748,7 +748,7 @@ func (api UserAPI) SharedCommunities(ctx context.Context, userID persist.DBID, b
 	}
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -821,7 +821,7 @@ func (api UserAPI) SharedCommunities(ctx context.Context, userID persist.DBID, b
 
 func (api UserAPI) CreatedCommunities(ctx context.Context, userID persist.DBID, includeChains []persist.Chain, before, after *string, first, last *int) ([]db.Contract, PageInfo, error) {
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, PageInfo{}, err
 	}
@@ -891,7 +891,7 @@ func (api UserAPI) FollowUser(ctx context.Context, userID persist.DBID) error {
 	}
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, fmt.Sprintf("required,ne=%s", curUserID)},
+		"userID": validate.WithTag(userID, fmt.Sprintf("required,ne=%s", curUserID)),
 	}); err != nil {
 		return err
 	}
@@ -919,7 +919,7 @@ func (api UserAPI) FollowAllSocialConnections(ctx context.Context, socialType pe
 	}
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"socialType": {socialType, "required"},
+		"socialType": validate.WithTag(socialType, "required"),
 	}); err != nil {
 		return err
 	}
@@ -954,7 +954,7 @@ func (api UserAPI) FollowAllSocialConnections(ctx context.Context, socialType pe
 func (api UserAPI) UnfollowUser(ctx context.Context, userID persist.DBID) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return err
 	}
@@ -988,7 +988,7 @@ func dispatchFollowEventToFeed(ctx context.Context, api UserAPI, curUserID persi
 func (api UserAPI) GetUserExperiences(ctx context.Context, userID persist.DBID) ([]*model.UserExperience, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -1016,7 +1016,7 @@ func (api UserAPI) GetUserExperiences(ctx context.Context, userID persist.DBID) 
 func (api UserAPI) GetSocials(ctx context.Context, userID persist.DBID) (*model.SocialAccounts, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -1061,7 +1061,7 @@ func (api UserAPI) GetSocials(ctx context.Context, userID persist.DBID) (*model.
 func (api UserAPI) GetDisplayedSocials(ctx context.Context, userID persist.DBID) (*model.SocialAccounts, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -1106,7 +1106,7 @@ func (api UserAPI) GetDisplayedSocials(ctx context.Context, userID persist.DBID)
 func (api UserAPI) UpdateUserSocialDisplayed(ctx context.Context, socialType persist.SocialProvider, displayed bool) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"socialType": {socialType, "required"},
+		"socialType": validate.WithTag(socialType, "required"),
 	}); err != nil {
 		return err
 	}
@@ -1139,7 +1139,7 @@ func (api UserAPI) UpdateUserSocialDisplayed(ctx context.Context, socialType per
 func (api UserAPI) UpdateUserExperience(ctx context.Context, experienceType model.UserExperienceType, value bool) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"experienceType": {experienceType, "required"},
+		"experienceType": validate.WithTag(experienceType, "required"),
 	}); err != nil {
 		return err
 	}
@@ -1254,7 +1254,7 @@ func (api UserAPI) RecommendUsers(ctx context.Context, before, after *string, fi
 func (api UserAPI) CreatePushTokenForUser(ctx context.Context, pushToken string) (db.PushNotificationToken, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"pushToken": {pushToken, "required,min=1,max=255"},
+		"pushToken": validate.WithTag(pushToken, "required,min=1,max=255"),
 	}); err != nil {
 		return db.PushNotificationToken{}, err
 	}
@@ -1302,7 +1302,7 @@ func (api UserAPI) CreatePushTokenForUser(ctx context.Context, pushToken string)
 func (api UserAPI) DeletePushTokenByPushToken(ctx context.Context, pushToken string) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"pushToken": {pushToken, "required,min=1,max=255"},
+		"pushToken": validate.WithTag(pushToken, "required,min=1,max=255"),
 	}); err != nil {
 		return err
 	}
@@ -1373,8 +1373,8 @@ func (api UserAPI) SetProfileImage(ctx context.Context, tokenID *persist.DBID, w
 	if walletAddress != nil {
 		// Validate
 		if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-			"chain":   {walletAddress.Chain(), fmt.Sprintf("eq=%d", persist.ChainETH)},
-			"address": {walletAddress.Address(), "required"},
+			"chain":   validate.WithTag(walletAddress.Chain(), fmt.Sprintf("eq=%d", persist.ChainETH)),
+			"address": validate.WithTag(walletAddress.Address(), "required"),
 		}); err != nil {
 			return err
 		}
@@ -1469,7 +1469,9 @@ type EnsAvatar struct {
 // GetEnsProfileImageByUserID returns the an ENS profile image for a user based on their set of wallets
 func (api UserAPI) GetEnsProfileImageByUserID(ctx context.Context, userID persist.DBID) (a EnsAvatar, err error) {
 	// Validate
-	if err := validate.ValidateFields(api.validator, validate.ValidationMap{"userID": {userID, "required"}}); err != nil {
+	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
+		"userID": validate.WithTag(userID, "required"),
+	}); err != nil {
 		return a, err
 	}
 

--- a/publicapi/wallet.go
+++ b/publicapi/wallet.go
@@ -27,7 +27,7 @@ type WalletAPI struct {
 func (api WalletAPI) GetWalletByID(ctx context.Context, walletID persist.DBID) (*db.Wallet, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"walletID": {walletID, "required"},
+		"walletID": validate.WithTag(walletID, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (api WalletAPI) GetWalletByID(ctx context.Context, walletID persist.DBID) (
 func (api WalletAPI) GetWalletByChainAddress(ctx context.Context, chainAddress persist.ChainAddress) (*db.Wallet, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"chainAddress": {chainAddress, "required"},
+		"chainAddress": validate.WithTag(chainAddress, "required"),
 	}); err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (api WalletAPI) GetWalletByChainAddress(ctx context.Context, chainAddress p
 func (api WalletAPI) GetWalletsByUserID(ctx context.Context, userID persist.DBID) ([]db.Wallet, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"userID": {userID, "required"},
+		"userID": validate.WithTag(userID, "required"),
 	}); err != nil {
 		return nil, err
 	}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -87,6 +87,10 @@ type ValWithTags struct {
 	Tag   string
 }
 
+func WithTag(v any, t string) ValWithTags {
+	return ValWithTags{Value: v, Tag: t}
+}
+
 type ValidationMap map[string]ValWithTags
 
 // ValidateFields validates input fields based on a set of predefined validation tags


### PR DESCRIPTION
My editor allows me to jump to the next error in a file, but it would jump to these lines because of the warning: "composite literal uses unkeyed fields". I could've updated my config, but I thought I'd just update it in the codebase.

This also lets us run `go vet ./...` with no more errors!