### PR TITLE
Benny/community fallback fetcher

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -118,7 +118,7 @@ func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.
 		wire.Bind(new(multichain.NameResolver), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.Verifier), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(fallbackProvider)),
-		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(openseaProvider)),
+		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(fallbackProvider)),
 		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.ContractRefresher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(indexerProvider)),

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -84,7 +84,7 @@ func ethProviderSet(serverEnvInit envInit, client *cloudtasks.Client, httpClient
 
 // ethProvidersConfig is a wire injector that binds multichain interfaces to their concrete Ethereum implementations
 func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.Provider, fallbackProvider multichain.SyncFailureFallbackProvider) ethProviderList {
-	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, openseaProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider, openseaProvider)
+	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider, openseaProvider)
 	return serverEthProviderList
 }
 

--- a/service/multichain/fallback.go
+++ b/service/multichain/fallback.go
@@ -165,6 +165,7 @@ func (f SyncFailureFallbackProvider) GetTokensByContractAddress(ctx context.Cont
 		if tcf, ok := f.Fallback.(TokensContractFetcher); ok {
 			return tcf.GetTokensByContractAddress(ctx, contract, limit, offset)
 		}
+		return nil, ChainAgnosticContract{}, err
 	}
 	return ts, c, nil
 }
@@ -175,6 +176,7 @@ func (f SyncFailureFallbackProvider) GetTokensByContractAddressAndOwner(ctx cont
 		if tcf, ok := f.Fallback.(TokensContractFetcher); ok {
 			return tcf.GetTokensByContractAddressAndOwner(ctx, owner, contract, limit, offset)
 		}
+		return nil, ChainAgnosticContract{}, err
 	}
 	return ts, c, nil
 }

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -1099,6 +1099,7 @@ outer:
 	for {
 		select {
 		case err := <-errChan:
+			logger.For(ctx).Errorf("error fetching tokens for contract %s-%d: %s", ci.ContractAddress, ci.Chain, err)
 			if err.priority == 0 {
 				return err
 			}


### PR DESCRIPTION
Changes:

- **Added** community refresh capabilities to the fallback multichain provider so that opensea does not have to handle the responsibility of refreshing communities. Opensea cannot refresh communities correctly because opensea does not return token holder information when querying for tokens in a contract

This stops the bleeding for now for the issue where refreshing a community with universal user's will delete all of the tokens in that community because the tokens "have no owner" (as returned by just opensea). 