### PR TITLE
Add missing condition to CountOwnersByContractId where clause

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -160,6 +160,7 @@ func (q *Queries) ClearNotificationsForUser(ctx context.Context, ownerID persist
 const countOwnersByContractId = `-- name: CountOwnersByContractId :one
 SELECT count(DISTINCT users.id) FROM users, tokens, contracts
     WHERE (contracts.id = $1 or contracts.parent_id = $1)
+    AND tokens.contract = contracts.id
     AND tokens.owner_user_id = users.id
     AND (NOT $2::bool OR users.universal = false)
     AND tokens.deleted = false AND users.deleted = false AND contracts.deleted = false

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -249,6 +249,7 @@ select users.* from (
 -- name: CountOwnersByContractId :one
 SELECT count(DISTINCT users.id) FROM users, tokens, contracts
     WHERE (contracts.id = @id or contracts.parent_id = @id)
+    AND tokens.contract = contracts.id
     AND tokens.owner_user_id = users.id
     AND (NOT @gallery_users_only::bool OR users.universal = false)
     AND tokens.deleted = false AND users.deleted = false AND contracts.deleted = false;


### PR DESCRIPTION
We were missing a condition in the `CountOwnersByContractId` query, causing community load times to be significantly longer than necessary (and returning an inaccurate count, too!).

Adding the appropriate constraint takes query time from ~5 seconds to ~50ms.