### PR TITLE
opensea fallback supports multiple chains

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -179,18 +179,22 @@ func tezosRequirements(
 // optimismProviderSet is a wire injector that creates the set of Optimism providers
 func optimismProviderSet(*http.Client) optimismProviderList {
 	wire.Build(
+		rpc.NewEthClient,
 		optimismProvidersConfig,
+		wire.Value(persist.ChainOptimism),
 		// Add providers for Optimism here
 		newOptimismProvider,
+		opensea.NewProvider,
 	)
 	return optimismProviderList{}
 }
 
 // optimismProvidersConfig is a wire injector that binds multichain interfaces to their concrete Optimism implementations
-func optimismProvidersConfig(optimismProvider *optimismProvider) optimismProviderList {
+func optimismProvidersConfig(optimismProvider *optimismProvider, openseaProvier *opensea.Provider) optimismProviderList {
 	wire.Build(
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(optimismProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(optimismProvider)),
+		wire.Bind(new(multichain.OpenSeaChildContractFetcher), util.ToPointer(openseaProvier)),
 		optimismRequirements,
 	)
 	return nil
@@ -200,25 +204,30 @@ func optimismProvidersConfig(optimismProvider *optimismProvider) optimismProvide
 func optimismRequirements(
 	tof multichain.TokensOwnerFetcher,
 	toc multichain.TokensContractFetcher,
+	opensea multichain.OpenSeaChildContractFetcher,
 ) optimismProviderList {
-	return optimismProviderList{tof, toc}
+	return optimismProviderList{tof, toc, opensea}
 }
 
 // arbitrumProviderSet is a wire injector that creates the set of Arbitrum providers
 func arbitrumProviderSet(*http.Client) arbitrumProviderList {
 	wire.Build(
+		rpc.NewEthClient,
 		arbitrumProvidersConfig,
+		wire.Value(persist.ChainArbitrum),
 		// Add providers for Optimism here
 		newArbitrumProvider,
+		opensea.NewProvider,
 	)
 	return arbitrumProviderList{}
 }
 
 // arbitrumProvidersConfig is a wire injector that binds multichain interfaces to their concrete Arbitrum implementations
-func arbitrumProvidersConfig(arbitrumProvider *arbitrumProvider) arbitrumProviderList {
+func arbitrumProvidersConfig(arbitrumProvider *arbitrumProvider, openseaProvider *opensea.Provider) arbitrumProviderList {
 	wire.Build(
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(arbitrumProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(arbitrumProvider)),
+		wire.Bind(new(multichain.OpenSeaChildContractFetcher), util.ToPointer(openseaProvider)),
 		arbitrumRequirements,
 	)
 	return nil
@@ -228,8 +237,9 @@ func arbitrumProvidersConfig(arbitrumProvider *arbitrumProvider) arbitrumProvide
 func arbitrumRequirements(
 	tof multichain.TokensOwnerFetcher,
 	toc multichain.TokensContractFetcher,
+	opensea multichain.OpenSeaChildContractFetcher,
 ) arbitrumProviderList {
-	return arbitrumProviderList{tof, toc}
+	return arbitrumProviderList{tof, toc, opensea}
 }
 
 // poapProviderSet is a wire injector that creates the set of POAP providers
@@ -295,18 +305,22 @@ func zoraRequirements(
 // polygonProviderSet is a wire injector that creates the set of polygon providers
 func polygonProviderSet(*http.Client) polygonProviderList {
 	wire.Build(
+		rpc.NewEthClient,
 		polygonProvidersConfig,
-		// Add providers for POAP here
+		wire.Value(persist.ChainPolygon),
+		// Add providers for Polygon here
 		newPolygonProvider,
+		opensea.NewProvider,
 	)
 	return polygonProviderList{}
 }
 
 // polygonProvidersConfig is a wire injector that binds multichain interfaces to their concrete Polygon implementations
-func polygonProvidersConfig(polygonProvider *polygonProvider) polygonProviderList {
+func polygonProvidersConfig(polygonProvider *polygonProvider, openseaProvider *opensea.Provider) polygonProviderList {
 	wire.Build(
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(polygonProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(polygonProvider)),
+		wire.Bind(new(multichain.OpenSeaChildContractFetcher), util.ToPointer(openseaProvider)),
 		polygonRequirements,
 	)
 	return nil
@@ -316,8 +330,9 @@ func polygonProvidersConfig(polygonProvider *polygonProvider) polygonProviderLis
 func polygonRequirements(
 	tof multichain.TokensOwnerFetcher,
 	toc multichain.TokensContractFetcher,
+	opensea multichain.OpenSeaChildContractFetcher,
 ) polygonProviderList {
-	return polygonProviderList{tof, toc}
+	return polygonProviderList{tof, toc, opensea}
 }
 
 // newMultichain is a wire provider that creates a multichain provider

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -760,9 +760,6 @@ func alchemyTokenToChainAgnosticToken(owner persist.EthereumAddress, token Token
 		OwnerAddress:    persist.Address(owner),
 		ContractAddress: persist.Address(token.Contract.Address),
 		ExternalURL:     token.Metadata.ExternalURL,
-		FallbackMedia: persist.FallbackMedia{
-			ImageURL: persist.NullString(token.Metadata.Image),
-		},
 	}
 
 	isSpam, err := strconv.ParseBool(token.SpamInfo.IsSpam)

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -326,30 +326,6 @@ type FallbackMedia struct {
 	Dimensions Dimensions `json:"dimensions"`
 }
 
-// NFTContract represents a smart contract's information for a given NFT
-type NFTContract struct {
-	ContractAddress      EthereumAddress `json:"address"`
-	ContractName         NullString      `json:"name"`
-	ContractImage        NullString      `json:"image_url"`
-	ContractDescription  NullString      `json:"description"`
-	ContractExternalLink NullString      `json:"external_link"`
-	ContractSchemaName   NullString      `json:"schema_name"`
-	ContractSymbol       NullString      `json:"symbol"`
-	ContractTotalSupply  NullString      `json:"total_supply"`
-}
-
-// OldOpenseaNFTContract represents how we used to store contracts
-type OldOpenseaNFTContract struct {
-	ContractAddress      EthereumAddress `json:"contract_address"`
-	ContractName         NullString      `json:"contract_name"`
-	ContractImage        NullString      `json:"contract_image_url"`
-	ContractDescription  NullString      `json:"contract_description"`
-	ContractExternalLink NullString      `json:"contract_external_link"`
-	ContractSchemaName   NullString      `json:"contract_schema_name"`
-	ContractSymbol       NullString      `json:"contract_symbol"`
-	ContractTotalSupply  NullString      `json:"contract_total_supply"`
-}
-
 // ContractCollectionNFT represents a contract within a collection nft
 type ContractCollectionNFT struct {
 	ContractName  NullString `json:"name"`
@@ -946,32 +922,6 @@ func (t *TokenType) Scan(src interface{}) error {
 		return nil
 	}
 	*t = TokenType(src.(string))
-	return nil
-}
-
-func (c *NFTContract) Scan(src interface{}) error {
-	if src == nil {
-		return nil
-	}
-	err := json.Unmarshal(src.([]uint8), &c)
-	if err != nil {
-		return err
-	}
-	if c.ContractAddress == "" {
-		old := OldOpenseaNFTContract{}
-		err := json.Unmarshal(src.([]uint8), &old)
-		if err != nil {
-			return err
-		}
-		c.ContractAddress = old.ContractAddress
-		c.ContractDescription = old.ContractDescription
-		c.ContractExternalLink = old.ContractExternalLink
-		c.ContractImage = old.ContractImage
-		c.ContractName = old.ContractName
-		c.ContractSchemaName = old.ContractSchemaName
-		c.ContractSymbol = old.ContractSymbol
-		c.ContractTotalSupply = old.ContractTotalSupply
-	}
 	return nil
 }
 


### PR DESCRIPTION
Changes:

- **Added** `opensea.Provider` to Polygon, Optimism, and Arbitrum chains
- **Added** chain parameters to the opensea provider
- **Removed** unused persist code that was sort of being used uselessly by the opensea provider
- **Removed** alchemy fallback media because it is not correct fallback format and would override what is correctly being returned by opensea. Given that ETH doesn't use it, neither should the other chains