### PR TITLE
don't use empty address display names

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -1299,7 +1300,11 @@ func (p *Provider) createUsersForTokens(ctx context.Context, tokens []chainToken
 							displayCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 							defer cancel()
 							display := resolver.GetDisplayNameByAddress(displayCtx, t.OwnerAddress)
-							if display != "" {
+
+							// if display is an empty address, this will return empty
+							displayCopy := strings.TrimLeft(display, "0x")
+							displayCopy = strings.TrimRight(displayCopy, "0")
+							if displayCopy != "" {
 								username = display
 								return true
 							}

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -257,7 +257,7 @@ func (p *Provider) GetTokensByContractAddressAndOwner(ctx context.Context, owner
 		defer close(assetsChan)
 		streamAssetsForContractAddressAndOwner(ctx, persist.EthereumAddress(owner), persist.EthereumAddress(address), assetsChan)
 	}()
-	tokens, contracts, err := assetsToTokens(ctx, "", assetsChan, p.ethClient, p.chain)
+	tokens, contracts, err := assetsToTokens(ctx, owner, assetsChan, p.ethClient, p.chain)
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}


### PR DESCRIPTION
Changes:

- **Added** a check for empty address display names when creating universal users, these will collide with each other causing some users not to get added and tokens to then be left without an owner.