### PR TITLE
Trending feed optimization by encoding entity type in cursor

### DIFF
--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -417,12 +417,6 @@ ORDER BY
     CASE WHEN NOT sqlc.arg('paging_forward')::bool THEN (created_at, id) END DESC
 LIMIT sqlc.arg('limit');
 
--- name: PaginateTrendingFeed :many
-select *
-from feed_entities join unnest(@feed_entity_ids::text[]) with ordinality t(id, pos) using(id)
-order by case when @paging_forward::bool then t.pos end desc,
-    case when not @paging_forward::bool then t.pos end asc;
-
 -- name: PaginatePostsByContractID :batchmany
 SELECT posts.*
 FROM posts

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -643,9 +643,7 @@ func (p *feedPaginator) paginate(before, after *string, first, last *int) ([]any
 		}
 
 		if before != nil {
-			now := time.Now()
 			curBeforePos, typs, ids, err := p.decodeCursor(*before)
-			fmt.Printf("took %s to decode cursor\n", time.Since(now))
 			if err != nil {
 				return nil, err
 			}

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -290,27 +290,28 @@ func (api FeedAPI) PaginateTrendingFeed(ctx context.Context, before *string, aft
 	}
 
 	var (
-		err         error
-		trendingIDs []persist.DBID
-		paginator   = positionPaginator{}
-		lookup      = make(map[persist.DBID]int)
+		err           error
+		entityTypes   []persist.FeedEntityType
+		entityIDs     []persist.DBID
+		paginator     = feedPaginator{}
+		entityIDToPos = make(map[persist.DBID]int)
 	)
 
 	// If a cursor is provided, we can skip querying the cache
 	if before != nil {
-		if _, trendingIDs, err = paginator.decodeCursor(*before); err != nil {
+		if _, entityTypes, entityIDs, err = paginator.decodeCursor(*before); err != nil {
 			return nil, PageInfo{}, err
 		}
 	} else if after != nil {
-		if _, trendingIDs, err = paginator.decodeCursor(*after); err != nil {
+		if _, entityTypes, entityIDs, err = paginator.decodeCursor(*after); err != nil {
 			return nil, PageInfo{}, err
 		}
 	} else {
 		calcFunc := func(ctx context.Context) ([]persist.DBID, error) {
 			trendData, err := api.queries.GetLatestFeedEntities(ctx, db.GetLatestFeedEntitiesParams{
 				WindowEnd:           time.Now().Add(-time.Duration(72 * time.Hour)),
-				FeedEventEntityType: persist.FeedEventTypeTag,
-				PostEntityType:      persist.PostTypeTag,
+				FeedEventEntityType: int32(persist.FeedEventTypeTag),
+				PostEntityType:      int32(persist.PostTypeTag),
 				ExcludedFeedActions: []string{string(persist.ActionUserCreated), string(persist.ActionUserFollowedUsers)},
 			})
 			if err != nil {
@@ -322,7 +323,11 @@ func (api FeedAPI) PaginateTrendingFeed(ctx context.Context, before *string, aft
 
 			for _, event := range trendData {
 				score := timeFactor(now, event.CreatedAt) * float64(event.Interactions)
-				node := heapNode{id: event.ID, score: score}
+				node := feedNode{
+					id:    event.ID,
+					score: score,
+					typ:   persist.FeedEntityType(event.FeedEntityType),
+				}
 
 				// Add first 100 numbers in the heap
 				if len(h) < 100 {
@@ -331,85 +336,46 @@ func (api FeedAPI) PaginateTrendingFeed(ctx context.Context, before *string, aft
 				}
 
 				// If the score is greater than the smallest score in the heap, replace it
-				if score > h[0].(heapNode).score {
+				if score > h[0].(feedNode).score {
 					heappkg.Pop(&h)
 					heappkg.Push(&h, node)
 				}
 			}
 
-			trendingIDs := make([]persist.DBID, len(h))
+			entityTypes = make([]persist.FeedEntityType, len(h))
+			entityIDs = make([]persist.DBID, len(h))
 
 			i := 0
 			for len(h) > 0 {
-				node := heappkg.Pop(&h).(heapNode)
-				trendingIDs[i] = node.id
+				node := heappkg.Pop(&h).(feedNode)
+				entityTypes[i] = node.typ
+				entityIDs[i] = node.id
 				i++
 			}
 
-			return trendingIDs, nil
+			return entityIDs, nil
 		}
 
 		l := newDBIDCache(api.cache, "trending:feedEvents", time.Minute*10, calcFunc)
 
-		trendingIDs, err = l.Load(ctx)
+		entityIDs, err = l.Load(ctx)
 		if err != nil {
 			return nil, PageInfo{}, err
 		}
 	}
 
-	asStr := make([]string, len(trendingIDs))
-	for i, id := range trendingIDs {
+	for i, id := range entityIDs {
 		// Postgres uses 1-based indexing
-		lookup[id] = i + 1
-		asStr[i] = id.String()
+		entityIDToPos[id] = i + 1
 	}
 
-	min := func(a, b int32) int32 {
-		if a < b {
-			return a
-		}
-		return b
+	queryFunc := func(params feedPagingParams) ([]any, error) {
+		return loadFeedEntities(ctx, api.loaders, params.EntityTypes, params.EntityIDs)
 	}
 
-	max := func(a, b int32) int32 {
-		if a > b {
-			return a
-		}
-		return b
-	}
-
-	queryFunc := func(params positionPagingParams) ([]any, error) {
-		// Restrict cursors to actual size of the slice
-		curBeforePos := max(params.CursorBeforePos, 0)
-		curAfterPos := min(params.CursorAfterPos-1, int32(len(asStr)))
-		var idsToQuery []string
-
-		if params.PagingForward {
-			// If paging forward, we extend from the after cursor up to the limit or to the before cursor, whatever is larger
-			limitPos := max(curAfterPos-params.Limit, curBeforePos)
-			idsToQuery = asStr[limitPos:curAfterPos]
-		} else {
-			// If paging backwards, we extend from the before cursor up to the limit or to the after cursor, whatever is smaller
-			limitPos := min(curBeforePos+params.Limit, curAfterPos)
-			idsToQuery = asStr[curBeforePos:limitPos]
-		}
-
-		keys, err := api.queries.PaginateTrendingFeed(ctx, db.PaginateTrendingFeedParams{
-			FeedEntityIds: idsToQuery,
-			PagingForward: params.PagingForward,
-		})
-
-		events, err := feedEntityToTypedType(ctx, api.loaders, keys)
-		if err != nil {
-			return nil, err
-		}
-
-		return events, err
-	}
-
-	cursorFunc := func(node any) (int, []persist.DBID, error) {
+	cursorFunc := func(node any) (int, []persist.FeedEntityType, []persist.DBID, error) {
 		_, id, err := feedCursor(node)
-		return lookup[id], trendingIDs, err
+		return entityIDToPos[id], entityTypes, entityIDs, err
 	}
 
 	paginator.QueryFunc = queryFunc
@@ -462,18 +428,31 @@ func feedCursor(i interface{}) (time.Time, persist.DBID, error) {
 	return time.Time{}, "", fmt.Errorf("interface{} is not a feed entity: %T", i)
 }
 
-func feedEntityToTypedType(ctx context.Context, d *dataloader.Loaders, ids []db.FeedEntity) ([]any, error) {
+func feedEntityToTypedType(ctx context.Context, d *dataloader.Loaders, entities []db.FeedEntity) ([]any, error) {
+	idTypes := make([]persist.FeedEntityType, len(entities))
+	entityIDs := make([]persist.DBID, len(entities))
+	for i := 0; i < len(entities); i++ {
+		idTypes[i] = persist.FeedEntityType(entities[i].FeedEntityType)
+		entityIDs[i] = entities[i].ID
+	}
+	return loadFeedEntities(ctx, d, idTypes, entityIDs)
+}
+
+func loadFeedEntities(ctx context.Context, d *dataloader.Loaders, typs []persist.FeedEntityType, ids []persist.DBID) ([]any, error) {
+	if len(typs) != len(ids) {
+		panic("length of typs and ids must be equal")
+	}
 	entities := make([]any, len(ids))
 	feedEventIDs := make([]persist.DBID, 0, len(ids))
 	postIDs := make([]persist.DBID, 0, len(ids))
-	for _, id := range ids {
-		switch id.FeedEntityType {
+	for i := 0; i < len(typs); i++ {
+		switch persist.FeedEntityType(typs[i]) {
 		case persist.FeedEventTypeTag:
-			feedEventIDs = append(feedEventIDs, id.ID)
+			feedEventIDs = append(feedEventIDs, ids[i])
 		case persist.PostTypeTag:
-			postIDs = append(postIDs, id.ID)
+			postIDs = append(postIDs, ids[i])
 		default:
-			return nil, fmt.Errorf("unknown feed entity type %d", id.FeedEntityType)
+			return nil, fmt.Errorf("unknown feed entity type %d", typs[i])
 		}
 	}
 
@@ -512,7 +491,7 @@ func feedEntityToTypedType(ctx context.Context, d *dataloader.Loaders, ids []db.
 			}
 
 			for j, id := range ids {
-				if it, ok := idsToFeedEvents[id.ID]; ok {
+				if it, ok := idsToFeedEvents[id]; ok {
 					entities[j] = it
 				}
 			}
@@ -523,7 +502,7 @@ func feedEntityToTypedType(ctx context.Context, d *dataloader.Loaders, ids []db.
 			}
 
 			for j, id := range ids {
-				if it, ok := idsToFeedPosts[id.ID]; ok {
+				if it, ok := idsToFeedPosts[id]; ok {
 					entities[j] = it
 				}
 			}
@@ -541,8 +520,13 @@ func timeFactor(t0, t1 time.Time) float64 {
 	return 1 * math.Pow(math.E, (-lambda*age))
 }
 
-type heapNode struct {
+type priorityNode interface {
+	Score() float64
+}
+
+type feedNode struct {
 	id    persist.DBID
+	typ   persist.FeedEntityType
 	score float64
 }
 
@@ -554,7 +538,7 @@ func (h *heap) Push(s any)   { *h = append(*h, s) }
 
 func (h heap) Less(i, j int) bool {
 	// We want Pop to give us the highest, not lowest, score so we use greater than here.
-	return h[i].(heapNode).score > h[j].(heapNode).score
+	return h[i].(priorityNode).Score() > h[j].(priorityNode).Score()
 }
 
 func (h *heap) Pop() any {
@@ -564,4 +548,152 @@ func (h *heap) Pop() any {
 	old[n-1] = nil
 	*h = old[:n-1]
 	return item
+}
+
+type feedPagingParams struct {
+	EntityTypes []persist.FeedEntityType
+	EntityIDs   []persist.DBID
+}
+
+type feedPaginator struct {
+	QueryFunc  func(params feedPagingParams) ([]any, error)
+	CursorFunc func(node any) (pos int, feedEntityType []persist.FeedEntityType, ids []persist.DBID, err error)
+	CountFunc  func() (count int, err error)
+}
+
+func (p *feedPaginator) encodeCursor(pos int, typ []persist.FeedEntityType, ids []persist.DBID) (string, error) {
+	if len(typ) != len(ids) {
+		panic("type and ids must be the same length")
+	}
+	encoder := newCursorEncoder()
+	encoder.appendInt64(int64(pos))
+	encoder.appendInt64(int64(len(ids)))
+	for i := range typ {
+		encoder.appendInt64(int64(typ[i]))
+		encoder.appendDBID(ids[i])
+	}
+	return encoder.AsBase64(), nil
+}
+
+func (p *feedPaginator) decodeCursor(cursor string) (pos int, typs []persist.FeedEntityType, ids []persist.DBID, err error) {
+	decoder, err := newCursorDecoder(cursor)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	curPos, err := decoder.readInt64()
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	totalItems, err := decoder.readInt64()
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	typs = make([]persist.FeedEntityType, totalItems)
+	ids = make([]persist.DBID, totalItems)
+
+	for i := 0; i < int(totalItems); i++ {
+		typ, err := decoder.readInt64()
+		if err != nil {
+			return 0, nil, nil, err
+		}
+
+		id, err := decoder.readDBID()
+		if err != nil {
+			return 0, nil, nil, err
+		}
+
+		typs[i] = persist.FeedEntityType(typ)
+		ids[i] = id
+	}
+
+	return int(curPos), typs, ids, nil
+}
+
+func (p *feedPaginator) paginate(before, after *string, first, last *int) ([]any, PageInfo, error) {
+	min := func(a, b int) int {
+		if a < b {
+			return a
+		}
+		return b
+	}
+
+	max := func(a, b int) int {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	queryFunc := func(limit int32, pagingForward bool) ([]any, error) {
+		var err error
+		var typs []persist.FeedEntityType
+		var ids []persist.DBID
+		var curBeforePos int
+		var curAfterPos int
+
+		args := positionPaginatorArgs{}
+		args.CurBeforePos = defaultCursorBeforePosition
+		args.CurAfterPos = defaultCursorAfterPosition
+
+		if before != nil {
+			curBeforePos, typs, ids, err = p.decodeCursor(*before)
+			if err != nil {
+				return nil, err
+			}
+			args.CurBeforePos = curBeforePos
+		}
+
+		if after != nil {
+			curAfterPos, typs, ids, err = p.decodeCursor(*after)
+			if err != nil {
+				return nil, err
+			}
+			args.CurAfterPos = curAfterPos
+		}
+
+		// Restrict cursors to actual size of the slize
+		curBeforePos = max(curBeforePos, 0)
+		curAfterPos = min(curAfterPos-1, len(ids))
+
+		var subsetTypes []persist.FeedEntityType
+		var subsetIDs []persist.DBID
+
+		if pagingForward {
+			// If paging forward, we extend from the after cursor up to the limit or to the before cursor, whatever is larger
+			limitPos := max(curAfterPos-int(limit), curBeforePos)
+			subsetTypes = typs[limitPos:curAfterPos]
+			subsetIDs = ids[limitPos:curAfterPos]
+		} else {
+			// If paging backwards, we extend from the before cursor up to the limit or to the after cursor, whatever is smaller
+			limitPos := min(curBeforePos+int(limit), curAfterPos)
+			subsetTypes = typs[curBeforePos:limitPos]
+			subsetIDs = ids[curBeforePos:limitPos]
+		}
+
+		// ==== TODO Fix order of ids based on paging direction TODO =====
+
+		return p.QueryFunc(feedPagingParams{
+			EntityTypes: subsetTypes,
+			EntityIDs:   subsetIDs,
+		})
+	}
+
+	cursorFunc := func(node any) (string, error) {
+		pos, typs, ids, err := p.CursorFunc(node)
+		if err != nil {
+			return "", err
+		}
+		return p.encodeCursor(pos, typs, ids)
+	}
+
+	paginator := keysetPaginator{
+		QueryFunc:  queryFunc,
+		CursorFunc: cursorFunc,
+		CountFunc:  p.CountFunc,
+	}
+
+	return paginator.paginate(before, after, first, last)
 }

--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -768,11 +768,11 @@ func (p *positionPaginator) paginate(before *string, after *string, first *int, 
 	}
 
 	cursorFunc := func(node any) (string, error) {
-		pos, nodeID, err := p.CursorFunc(node)
+		pos, nodeIDs, err := p.CursorFunc(node)
 		if err != nil {
 			return "", err
 		}
-		return p.encodeCursor(pos, nodeID)
+		return p.encodeCursor(pos, nodeIDs)
 	}
 
 	paginator := keysetPaginator{

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-#ENC[AES256_GCM,data:AgrxsSYBtC4JpdSbi6wsEuJOH0qQsQ==,iv:NEMnxCgHUDkxL7zqdtvSu71uiywC6nFcA1KPJkvpfio=,tag:U7lNkFS2IiitXyyStQjieQ==,type:comment]
-#ENC[AES256_GCM,data:QEDjM2fOjetmNHsX7ipVE1STpr7YOAc8NHZKupgDCw==,iv:bP0BkYo5B2/RCPV0vfYJWJkFSiFdMb4VK6TDbmtj0aU=,tag:LeiKpoMNKp0hjua1jprIEA==,type:comment]
-#ENC[AES256_GCM,data:wK5u9NOfCPgxGbtMfdlanhdLnbKjBdoKJm/EK6DPMrkWHeJStCEkqgfsdiBb4SXLoeEUSg==,iv:jdCBAGsA6soiZXNcRvrUXnIeKBXXv1bzobHGenj8wjA=,tag:4M4ZUL/upbEKDQRWygC/Qw==,type:comment]
+POSTGRES_PORT: ENC[AES256_GCM,data:1efIiw==,iv:2K9a5ZYDgCxV4dF36R5PJ85BcCrLqHPP8DX+576yQ/c=,tag:53nc30YWEb/l49aDPaLCgg==,type:str]
+POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:18Zy616OGPJdbmdDK5okGPpVK9QMZjBWs0BF+2ZHywk=,iv:4VG8V8IaahLSrdNcZSG17krqYWIjuuWkKwk62n04D9I=,tag:Q1Wg4OV0U0NOEWq/PyfRyw==,type:str]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:NhqX2lTdozj5/ETkvf2wBZXivOBrmmO3byHMq7ybn1o=,iv:EgHZov5iB9XNFMKwYNc8g8t7od9oU/n2W7reAcHPPUI=,tag:/0MrSud8j35Th+6VQ7hejQ==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -41,10 +41,6 @@ RPC_URL: ENC[AES256_GCM,data:Kh4kHqIp/Kpro1v9zw/olAbRnwVdACNjSsicwEivReU33HBUiC9
 ZORA_API_KEY: ENC[AES256_GCM,data:AJd6PziP1BFsocQj2ltpKFlCb94gAg==,iv:rNtJUsab+6mLVKh9rdAD/EtAgtSYQtuRc6oIcUo0IFo=,tag:C6btexQq3JkeIg5IxtHDhQ==,type:str]
 GOLDSKY_API_KEY: ENC[AES256_GCM,data:VS+WZDi3x35hkyJiHAgo5iCdRLESsaZIIw==,iv:ZOmu0gqncXQjAPNkPl5xEYWCfRsxFORgttm9wOtmMlM=,tag:oJci3PXhd/W64fBQGjFm0Q==,type:str]
 MAGIC_LINK_SECRET_KEY: ENC[AES256_GCM,data:2s6VhHxi7Ru/9H/0vGisPYUdpryJMM/8,iv:lj1AICPUgi9XU+XIziRDWk8ldGn9ZvrTKu4oDdiN0Ko=,tag:M0xONYdGgpLiPNj7k/5ZjA==,type:str]
-#ENC[AES256_GCM,data:FIW03IiDtZ9cZ0BjnD3HreUIbtCUSE4=,iv:8b660zTWwiZ2HxOSdOAVgKmTQM8/ywA7UDVcqGz/dhM=,tag:hcxyRjlMtVALp32rz00ezQ==,type:comment]
-POSTGRES_PORT: ENC[AES256_GCM,data:FhGeZA==,iv:k5QeH3XqoIiP77ALqlk28VH1MdAb+3IJw1xzmhdkgmU=,tag:J7Q9QINcUIXqjctQ4jAxFQ==,type:int]
-POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:xVjaaC7uUFb3fxjdJo9OEqecDj4bFwKodP25M2g43rU=,iv:iPkO7VNUFk1tr6iIoKj+S7p0EZc9Z2Adhp+dW0gOz0E=,tag:X+n+QDKiNRur69Hh8/eobw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -54,8 +50,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-20T05:54:57Z"
-    mac: ENC[AES256_GCM,data:25EN7b/UJkZpv+SwHEJaxOAB3yaTqlqATzvydz9mct+XZHCrIij8SP2MwOh4yj0bDQx3tg+hfbIvdhZo+KV08YYDjwbKRwzjIwbbH+v08SDu3DKiZzJzz1jPrTWt3XLcX/xjTOYNPJroqzpweJUihc5P+zU00qVdwhGyHCBG+8Y=,iv:jMiVqxK1K1/Ik2bu7F9ejwtdAAZzp462imxcVgDTZWU=,tag:PhzN3QBv7p+B7DeDk21fyQ==,type:str]
+    lastmodified: "2023-07-05T17:50:07Z"
+    mac: ENC[AES256_GCM,data:NFjPqu9iYEUjbPlpUhXIrTDqjpKxFdmo/AJYFke+HaYE0OCLxGNXZVbbLMkUxUrS1wJ73TwlACKXsPQIMu/iQI9NPZLDa/EDo0MAayEtc/8iWwiPsGQopsfxGeLWa0j+pUG8fxzcOGyzcS90wovc/PwIOWz4gcWlWB7kMPOtNVU=,iv:dBL5ZlusV+iLYXwtKQTzst3TxxHBdeXMU5mMX7hu2j0=,tag:PXCIJVTVNcEldDmdtOHJ1g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:1efIiw==,iv:2K9a5ZYDgCxV4dF36R5PJ85BcCrLqHPP8DX+576yQ/c=,tag:53nc30YWEb/l49aDPaLCgg==,type:str]
-POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:18Zy616OGPJdbmdDK5okGPpVK9QMZjBWs0BF+2ZHywk=,iv:4VG8V8IaahLSrdNcZSG17krqYWIjuuWkKwk62n04D9I=,tag:Q1Wg4OV0U0NOEWq/PyfRyw==,type:str]
+#ENC[AES256_GCM,data:AgrxsSYBtC4JpdSbi6wsEuJOH0qQsQ==,iv:NEMnxCgHUDkxL7zqdtvSu71uiywC6nFcA1KPJkvpfio=,tag:U7lNkFS2IiitXyyStQjieQ==,type:comment]
+#ENC[AES256_GCM,data:QEDjM2fOjetmNHsX7ipVE1STpr7YOAc8NHZKupgDCw==,iv:bP0BkYo5B2/RCPV0vfYJWJkFSiFdMb4VK6TDbmtj0aU=,tag:LeiKpoMNKp0hjua1jprIEA==,type:comment]
+#ENC[AES256_GCM,data:wK5u9NOfCPgxGbtMfdlanhdLnbKjBdoKJm/EK6DPMrkWHeJStCEkqgfsdiBb4SXLoeEUSg==,iv:jdCBAGsA6soiZXNcRvrUXnIeKBXXv1bzobHGenj8wjA=,tag:4M4ZUL/upbEKDQRWygC/Qw==,type:comment]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:NhqX2lTdozj5/ETkvf2wBZXivOBrmmO3byHMq7ybn1o=,iv:EgHZov5iB9XNFMKwYNc8g8t7od9oU/n2W7reAcHPPUI=,tag:/0MrSud8j35Th+6VQ7hejQ==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -41,6 +41,10 @@ RPC_URL: ENC[AES256_GCM,data:Kh4kHqIp/Kpro1v9zw/olAbRnwVdACNjSsicwEivReU33HBUiC9
 ZORA_API_KEY: ENC[AES256_GCM,data:AJd6PziP1BFsocQj2ltpKFlCb94gAg==,iv:rNtJUsab+6mLVKh9rdAD/EtAgtSYQtuRc6oIcUo0IFo=,tag:C6btexQq3JkeIg5IxtHDhQ==,type:str]
 GOLDSKY_API_KEY: ENC[AES256_GCM,data:VS+WZDi3x35hkyJiHAgo5iCdRLESsaZIIw==,iv:ZOmu0gqncXQjAPNkPl5xEYWCfRsxFORgttm9wOtmMlM=,tag:oJci3PXhd/W64fBQGjFm0Q==,type:str]
 MAGIC_LINK_SECRET_KEY: ENC[AES256_GCM,data:2s6VhHxi7Ru/9H/0vGisPYUdpryJMM/8,iv:lj1AICPUgi9XU+XIziRDWk8ldGn9ZvrTKu4oDdiN0Ko=,tag:M0xONYdGgpLiPNj7k/5ZjA==,type:str]
+#ENC[AES256_GCM,data:FIW03IiDtZ9cZ0BjnD3HreUIbtCUSE4=,iv:8b660zTWwiZ2HxOSdOAVgKmTQM8/ywA7UDVcqGz/dhM=,tag:hcxyRjlMtVALp32rz00ezQ==,type:comment]
+POSTGRES_PORT: ENC[AES256_GCM,data:FhGeZA==,iv:k5QeH3XqoIiP77ALqlk28VH1MdAb+3IJw1xzmhdkgmU=,tag:J7Q9QINcUIXqjctQ4jAxFQ==,type:int]
+POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:xVjaaC7uUFb3fxjdJo9OEqecDj4bFwKodP25M2g43rU=,iv:iPkO7VNUFk1tr6iIoKj+S7p0EZc9Z2Adhp+dW0gOz0E=,tag:X+n+QDKiNRur69Hh8/eobw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -50,8 +54,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-05T17:50:07Z"
-    mac: ENC[AES256_GCM,data:NFjPqu9iYEUjbPlpUhXIrTDqjpKxFdmo/AJYFke+HaYE0OCLxGNXZVbbLMkUxUrS1wJ73TwlACKXsPQIMu/iQI9NPZLDa/EDo0MAayEtc/8iWwiPsGQopsfxGeLWa0j+pUG8fxzcOGyzcS90wovc/PwIOWz4gcWlWB7kMPOtNVU=,iv:dBL5ZlusV+iLYXwtKQTzst3TxxHBdeXMU5mMX7hu2j0=,tag:PXCIJVTVNcEldDmdtOHJ1g==,type:str]
+    lastmodified: "2023-07-20T05:54:57Z"
+    mac: ENC[AES256_GCM,data:25EN7b/UJkZpv+SwHEJaxOAB3yaTqlqATzvydz9mct+XZHCrIij8SP2MwOh4yj0bDQx3tg+hfbIvdhZo+KV08YYDjwbKRwzjIwbbH+v08SDu3DKiZzJzz1jPrTWt3XLcX/xjTOYNPJroqzpweJUihc5P+zU00qVdwhGyHCBG+8Y=,iv:jMiVqxK1K1/Ik2bu7F9ejwtdAAZzp462imxcVgDTZWU=,tag:PhzN3QBv7p+B7DeDk21fyQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/persist/feed.go
+++ b/service/persist/feed.go
@@ -1,7 +1,9 @@
 package persist
 
+type FeedEntityType int
+
 const (
-	FeedEventTypeTag = iota
+	FeedEventTypeTag FeedEntityType = iota
 	PostTypeTag
 )
 

--- a/service/redis/redis.go
+++ b/service/redis/redis.go
@@ -2,17 +2,16 @@ package redis
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/bsm/redislock"
+	"github.com/go-redis/redis/v8"
 
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/tracing"
-
-	"github.com/go-redis/redis/v8"
+	"github.com/mikeydub/go-gallery/util"
 )
 
 type ErrKeyNotFound struct {
@@ -281,8 +280,7 @@ func (l LazyCache) Load(ctx context.Context) ([]byte, error) {
 	if err == nil {
 		return b, nil
 	}
-	var errMiss ErrKeyNotFound
-	if !errors.As(err, &errMiss) {
+	if !util.ErrorAs[ErrKeyNotFound](err) {
 		return nil, err
 	}
 	b, err = l.CalcFunc(ctx)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -47,8 +47,6 @@ sql:
         output_models_file_name: 'models_gen.go'
         emit_json_tags: true
         overrides:
-          - db_type: 'feed_entity'
-            go_type: 'github.com/mikeydub/go-gallery/service/persist.FeedEntity'
           # Overrides are prioritized from top to bottom, so if we need to override one of the * entries (like *.id),
           # the override should come _before_ the * entry
           # Users (and pii.user_view)


### PR DESCRIPTION
**Changes**
This PR makes a change to the feed cursor to also encode the type of the feed entity alongside the DBID. This means we can skip the query that finds what type the entity is, which should save a few hundred milliseconds. 

The cursor is now encoded as:
```
<current position of cursor><length of ids><dbid type><dbid><dbid type><dbid>....
```

Going to test on dev a bit more to make sure it actually is faster, before deploying on prod.
