### PR TITLE
check prefix for data before indexing comma

### DIFF
--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -12,9 +12,9 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/event"
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
+	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/logger"
-	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -522,7 +522,7 @@ func (api TokenAPI) GetTokenOwnershipByTokenID(ctx context.Context, tokenID pers
 func (api TokenAPI) ViewToken(ctx context.Context, tokenID persist.DBID, collectionID persist.DBID) (db.Event, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"tokenID": 		validate.WithTag(tokenID, "required"),
+		"tokenID":      validate.WithTag(tokenID, "required"),
 		"collectionID": validate.WithTag(collectionID, "required"),
 	}); err != nil {
 		return db.Event{}, err
@@ -546,14 +546,14 @@ func (api TokenAPI) ViewToken(ctx context.Context, tokenID persist.DBID, collect
 			return db.Event{}, err
 		}
 		eventPtr, err := api.repos.EventRepository.Add(ctx, db.Event{
-		ActorID:        persist.DBIDToNullStr(userID),
-		Action:         persist.ActionViewedToken,
-		ResourceTypeID: persist.ResourceTypeToken,
-		TokenID:        tokenID,
-		CollectionID:   collectionID,
-		GalleryID:      currCol.GalleryID,
-		SubjectID:      tokenID,
-		Data: persist.EventData{
+			ActorID:        persist.DBIDToNullStr(userID),
+			Action:         persist.ActionViewedToken,
+			ResourceTypeID: persist.ResourceTypeToken,
+			TokenID:        tokenID,
+			CollectionID:   collectionID,
+			GalleryID:      currCol.GalleryID,
+			SubjectID:      tokenID,
+			Data: persist.EventData{
 				TokenContractID: token.Contract,
 			},
 		})

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -540,13 +540,15 @@ func GetDataFromURIAsReader(ctx context.Context, turi persist.TokenURI, mediaTyp
 				logger.For(ctx).Errorf("error unescaping uri: %s", err)
 				asString = turi.String()
 			}
-			idx := strings.IndexByte(asString, ',')
-			if idx == -1 {
-				buf := bytes.NewBuffer(util.RemoveBOM([]byte(asString)))
-				readerChan <- util.NewFileHeaderReader(buf, bufSize)
-				return
+			if strings.HasPrefix(asString, "data:") {
+				idx := strings.IndexByte(asString, ',')
+				if idx != -1 {
+					buf := bytes.NewBuffer(util.RemoveBOM([]byte(asString[idx+1:])))
+					readerChan <- util.NewFileHeaderReader(buf, bufSize)
+					return
+				}
 			}
-			buf := bytes.NewBuffer(util.RemoveBOM([]byte(asString[idx+1:])))
+			buf := bytes.NewBuffer(util.RemoveBOM([]byte(asString)))
 			readerChan <- util.NewFileHeaderReader(buf, bufSize)
 		default:
 			buf := bytes.NewBuffer([]byte(turi))


### PR DESCRIPTION
Changes:

- **Added** a check for `data:` before looking for where the data starts for an SVG so that we don't accidentally start parsing an SVG at some further index because it "looks" like the start of the data (follows a comma)