### PR TITLE
Add gcp project to prod

### DIFF
--- a/secrets/dev/local/app-dev-tokenprocessing.yaml
+++ b/secrets/dev/local/app-dev-tokenprocessing.yaml
@@ -26,6 +26,7 @@ ZORA_API_KEY: ENC[AES256_GCM,data:ZJ0C6xYozS22fRDH21I0PFeo1CS2cQ==,iv:9N/RqpD7QG
 GOLDSKY_API_KEY: ENC[AES256_GCM,data:Ha8fqm4Tk1IBtEUlkMpOAM8a7/JvpIqWIg==,iv:lFx54ZxXLPFLA9O+o/B0R7Aj3hjgglYNGlcGRHBo+X4=,tag:JtzHy5kk0FtjPgyhn/zhbw==,type:str]
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:vFNsWWiiix2Bk3ylzeLo/w/9aLmmNyJn/2DD/Guc1aFcRaEF,iv:FS8BSUSsGLQHcUa6xywzC6PmlX9LN8h+s4uHrzt2fOE=,tag:IpzySgL1owhL1C3HG9J5ZA==,type:str]
 RPC_URL: ENC[AES256_GCM,data:gVCI5ASCPQYpE5i2FdmR5oYBONQPVz80Y6MvmLudIPtDllro1Q9pARKJ9RkTBxVGAzWybzcvxV7haTBtdrCNJyBkpSEs,iv:aFwlmQ2BVrYvYZHFbVCetQMBmKcTEAEXzeMkNTyaHbc=,tag:pgpjUseyo5HWrw91UdxSHQ==,type:str]
+GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:MuAtBTPxizTS7hvu9YlHCSe6,iv:HpfRqwVVb2VMRtpwnGrt7GWRlhwfbecyMLmbvmptGSY=,tag:fhqmK+qB4MzoUasBspfNFg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -35,8 +36,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-31T20:23:41Z"
-    mac: ENC[AES256_GCM,data:Wq4uwbqAkxCC/INAqwEbrRKycwmM/fqLL0cwctyvl7niuvNNSO3V6Kuqi+BPBYcC4R0HTTX6wEFb2q3YzQfskggovSSibN5tKf3hplx1qJRTuDNdo1nNWSuf6rMrIi+s9h7bDn45bmtZQhYLpsC1Mtjv3lMCzWGIiTQi5Ly6baA=,iv:ZZ/fvF0go1F+mr6o+o2/qBeA/Z4l3GsNV1I/UWw0xxE=,tag:yQb37b9uwLxu6tgfZlmUbA==,type:str]
+    lastmodified: "2023-07-31T22:54:16Z"
+    mac: ENC[AES256_GCM,data:DBZTCtdbqjBtBw0gJGosHIalrdb5v2x8PwzRTlqIUJptA0LK3Dpa77YhijSr/gkwpX06DjpwjWsJKemFqA7BKxLoAzXNIp0Ku5GfQ2aDd8BvwaPesjwR+FHqge4ObpyDiwG8d/MGj7lNJnR6KtVKHdN/X0S5JOq+YEIlcm7Glgk=,iv:e/vfAlRYT3uH7KdQsdtbUZ6d0YeYSmVgQciJNi4ZM24=,tag:zIWnUwZFN99dPi7y1DM/lQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/tokenprocessing-env.yaml
+++ b/secrets/dev/tokenprocessing-env.yaml
@@ -38,6 +38,7 @@ PUBSUB_TOPIC_UPDATED_NOTIFICATIONS: ENC[AES256_GCM,data:2duVjOy9ET3zD0J/R1JGgpdS
 PUBSUB_SUB_NEW_NOTIFICATIONS: ENC[AES256_GCM,data:ZUsVy5Wr/pdi0bRga5qJWI0B2IqTy6sq8w==,iv:9s/3UM8Xv3N02R7mMD263vrgXTvPb03cuDqcrbnI4yo=,tag:junOsppZ1+AVj1+w5xSy4A==,type:str]
 PUBSUB_SUB_UPDATED_NOTIFICATIONS: ENC[AES256_GCM,data:Rb4P9kpMfm0pirSG7fESVRpv9AtEnQoP3lAxdEw=,iv:H+G1EBs2LgrxP3RbOfb/QusNqt+HKa0/HVh2/rQajtA=,tag:hFZc3pXGJzEH11YLmtuC0w==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:zjSDUFqohCcjA6Wtv34p0sddTH0sUkjsdwrImn5Tyew=,iv:Cv5BiLV9CuObxrDx9D93l0NLeCYSW4ZMx/TXeH8TNEk=,tag:zcwae01wcAsGC5kvYS8Ttw==,type:str]
+GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:gmaScAKafegb30IgB0vE/L54,iv:70810oyubxDDjkG2ptfZStUZExNet7Aw5I05P03f6hE=,tag:ea37A6ZRjuTRpAIfYswdpw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -47,8 +48,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-31T21:55:02Z"
-    mac: ENC[AES256_GCM,data:xebhO7daP9sLMcu6vIvav7OM6YzNecc5db65KkDCBovIrJ190KuAjrUwr2XhKaXcHhK5Z3j/MTR0VEnwE/yIFD/7eG1wJcVQx5F4yLpw/8VhxCrmOhQeniLgrkOjOFBkcWpDHLP23YeywnVrivCvhKqXb9ldMNGDiz+GTsPqJ30=,iv:1sOVWDrTuPQ4zPoyigiBtx0DaqYbZ2YLx+U2oQhWM+k=,tag:aRQRFRkXOU5ZcKfTxG0aAw==,type:str]
+    lastmodified: "2023-07-31T22:54:07Z"
+    mac: ENC[AES256_GCM,data:i14bewkvfuZyMsFPXpIan9MOz7FXVeYzzROMgTQkXwHNis9/6b0yNp3uuHv0uGLKa5kVaNRPdNBhAy8t8B2HngM8lO4JUvKILGcSR9oURryFrKBjdV29svU6X/WcsOGYaSb6HpupgK4OCny91Ng9AABP5dp/pF0hCt0KEtZWjdU=,iv:LRICaz4S9F8U1pgtuY9FAIQK8H2jqMLBxVLSwjKiCJU=,tag:4XVGso3BmMpMLInApS8wnQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/local/app-prod-tokenprocessing.yaml
+++ b/secrets/prod/local/app-prod-tokenprocessing.yaml
@@ -29,6 +29,7 @@ PUBSUB_SUB_NEW_NOTIFICATIONS: ENC[AES256_GCM,data:GFv1PmV2UmwNWK/Br462DsLl56Pn,i
 PUBSUB_SUB_UPDATED_NOTIFICATIONS: ENC[AES256_GCM,data:wqc0w9M3Fgxx5BiC8rym7f/MhV+GgyZnhg==,iv:agv+TGDrL6GTWdwZhKTY6jICSyd3w9EGJP/v4mll8r4=,tag:+4+x7BehBGQfXcMz1wk4Iw==,type:str]
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:Z7BUlYQzuWtD098rxmTTgCaFFXBmxIxxk+GIY5TSCdUKXr7V,iv:cG9nlXnKDMFzCfPZRTp6QvM9P6qUUAGytSUUFJTEpw8=,tag:Xu/jdWWXeuLMerv9MYb3Gw==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:6owfra+B3BMgN+CleRGE9zUMbL0GNXmwd1tbLxFLHZQ=,iv:Ub+oe/xVaY39Nvo42FL9+9s5WEjy/Uy1KKpFPuk3P2w=,tag:p3fGTq8o/ooKKXlN0WnFvQ==,type:str]
+GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:q1u8a7ZGOsvMLlbRCW+IQ8AOGw==,iv:+Q6wvn2eof1nb3SVhZItxcgNo4tg/7Te4aYFlDjw9vs=,tag:Y121oFKFYsMMQjxF09bp1g==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -38,8 +39,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-31T20:27:48Z"
-    mac: ENC[AES256_GCM,data:UUGeS0ZUqRT0TbiazHa4YO5gAQ3hsm4XUaYCSq9whj6bmhg7Cxc4+wyd+5NVKKDxqc/tagOvROXwV1/4ssN2Kz5eibBGA+u2pVyvHpMJMML72h1UMGDRKstLCCqzKzAU+WBNpsu1UZu6fjTzII3pSJ4tQ/OpQDhUesu7R9QETGw=,iv:aB/oQHmQ4b5OnW7Y19igF2A3c5QXew7cV/K7KnIrWw8=,tag:xJLktWmRrbOGA446J2EZVg==,type:str]
+    lastmodified: "2023-07-31T22:53:35Z"
+    mac: ENC[AES256_GCM,data:TEDL4sTsG6ve3kw7r+IY26HN+sXcjUlNWkn499X0wvL7XzNt7MJ2IboKl502/0PecdgMRiM6uaoeEAm0JbdA4QU5X5K99cf7RImB2HDEiHif9Hc5IS/i2kDmoHh14+5wLFlbvk95kq1aYpXvqJiQldAaDVnDVondVNcX9kafVns=,iv:LK08tX+Gh7fnw43iN5UNqxNMAPrBn3qWyb1diJljk4E=,tag:pPIfDVfXnsY9UcjCnAS+vw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/tokenprocessing-env.yaml
+++ b/secrets/prod/tokenprocessing-env.yaml
@@ -38,6 +38,7 @@ PUBSUB_SUB_NEW_NOTIFICATIONS: ENC[AES256_GCM,data:ucqa1eDipA+BbeU/34B/mstcl3Fk,i
 PUBSUB_SUB_UPDATED_NOTIFICATIONS: ENC[AES256_GCM,data:mtJyFT2HO2Kx5WyIXx9hoO2JAtaZ7piFwg==,iv:ipQf/sIqe5IB4fdfsTT40ab6uYUWl1nlNhLidWzxDEU=,tag:6mUH132JMVgXDXIR5plTgA==,type:str]
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:1YwSdXkA3N72wQ0HA+9KDBBuePALHZ32EZUwncFHg9k1Iuye,iv:9E3R6Bb0P8h7XnSDT1DzPLIMZ5RXQLtjKKin+LbyvT0=,tag:1zvf4BrDnjqxmUvAINz4lQ==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:y/ElGPDzk7pAJY7OVGtF6MIpdhimVpimsTyt857NPgA=,iv:5FEJrMDr9xzXDvG/eMiWX2ZR2JB8ShhT6ZK2oEuLPSE=,tag:ZaPgMttzWlJXEvSN1YZl1g==,type:str]
+GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:+0Mkd7ofOeQ7CpvhEYxu6Yodrw==,iv:As8yVmie+ATevE3jCQa99sMct6loq90cZD9foCgPFrs=,tag:MxpxIJ+j0gGc4d/Jv/4fHA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -47,8 +48,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-31T20:27:46Z"
-    mac: ENC[AES256_GCM,data:FB+yqGZqXDFqgx7kwe3FfQjrs2BObT1XvH9NLNPhPlyLBx06wS6cVSNSP+TrK1IMGmlfp7sGE9SbMPG07Qu7Ew/yjRxa4K9GkOS6hS+LzdGrJ8R59p1Dx2MswPZmzcu211Wtp2y6VUbCeMSHu2vpCK7I9+DYybnsTmakmgQJpq4=,iv:L7njFAo94OOVDeXWnHT92h1Pxuu0RZMYBTlrGbRy7Q0=,tag:karS7vWIqTjUjlRbi9eECQ==,type:str]
+    lastmodified: "2023-07-31T22:53:16Z"
+    mac: ENC[AES256_GCM,data:LPc4eUbexG35UjSxeC/LsHADQY87me6q6CHWW00aQWxl3gnkWRsX642mNNBv8mgoGf0bxcXbav/oXcEK/QITv2u/bRi5PuuUPIyBuSvA0FzZFCaOvqcFKj8rfp9Dx9JqzLDPlYKvgGE8Lv2lr/cga1+2Cp0HdMA52N88kUwkeq0=,iv:y8nz065n7Vcg6i3aHnFod3RMERyuHZVlXI6ysByzPzc=,tag:3eijApCM8vd4Vb56U1XDVQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/pubsub/gcp/pubsub.go
+++ b/service/pubsub/gcp/pubsub.go
@@ -47,6 +47,10 @@ func NewClient(ctx context.Context) *pubsub.Client {
 		}
 	}
 
+	if projectID == "" {
+		panic("GOOGLE_CLOUD_PROJECT env var not set")
+	}
+
 	pub, err := pubsub.NewClient(ctx, projectID, options...)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Adds the google cloud project to prod secrets and panics if project id isn't set in client init.