### PR TITLE
Save matrices to cloud storage

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -71,7 +71,7 @@ func testGraphQL(t *testing.T) {
 		{title: "update gallery and ensure name still gets set when not sent in update", run: testUpdateGalleryWithNoNameChange},
 		{title: "update gallery with a new collection", run: testUpdateGalleryWithNewCollection},
 		{title: "should get trending users", run: testTrendingUsers, fixtures: []fixture{usePostgres, useRedis}},
-		{title: "should get trending feed events", run: testTrendingFeedEvents, fixtures: []fixture{usePostgres, useRedis}},
+		{title: "should get trending feed events", run: testTrendingFeedEvents},
 		{title: "should delete a post", run: testDeletePost},
 		{title: "should get community with posts", run: testGetCommunity},
 		{title: "should delete collection in gallery update", run: testUpdateGalleryDeleteCollection},
@@ -759,7 +759,7 @@ func testTrendingFeedEvents(t *testing.T) {
 		userF.FeedEventIDs[1],
 	}
 
-	actual := trendingFeedEvents(t, ctx, c, 10, true)
+	actual := trendingFeedEvents(t, ctx, c, 4, true)
 
 	assert.Equal(t, expected, actual)
 }

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -70,6 +70,7 @@ GOLDSKY_API_KEY: ENC[AES256_GCM,data:jNVenOaWTgv5xX9pPlrgGa8z+q+Nx1W/wQ==,iv:ULP
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:UjwOY7/p8Y5WIhYRbRjJjKIEyv38SnWDAMKhXiHPbrONos1F,iv:V0N8uW3vV+y9WaTnzFhXNoKPxUb9+CsrFnOMIGf/dsY=,tag:5v2S/gHFNB2xAz4+jE4bHQ==,type:str]
 NEYNAR_API_KEY: ENC[AES256_GCM,data:yyzvvw/JqCle1jYgFLB21V7ZdzUpI/1PiBhTp0yG4gYmheih,iv:qtYeCABbh0CYraNudrsT8wOHcEb6JeWz+Y8BizCLKjE=,tag:Bex/DmBciij/0bWoiO4vmA==,type:str]
 DEBUG_TOOLS_PASSWORD: ENC[AES256_GCM,data:B/WT5ObvsY16IcsBQg3EusqVoN0=,iv:wjTyNAbvY/StbyqoyE3is+aEt/yotgDfKZBOrLezGQk=,tag:5OjyDOXyJXW0afTHuUOWCA==,type:str]
+GCLOUD_USER_PREF_BUCKET: ENC[AES256_GCM,data:xRr1aKffotk+aaqjCQ==,iv:SWp8vm2Tb5Gvvh2Q7bYKB0ZKuOxmZSWLY2C/+t49tCU=,tag:z9uNGdl1mEIARSFSPzq9DA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -79,8 +80,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-27T22:00:47Z"
-    mac: ENC[AES256_GCM,data:ySf+tpXUF83+NWUd81ZFpsQXB/r5OctQuUubv8EwzVWfN0tey1b0GVs4rn3hChIZvPbzYwKRpEDjhMK60oyxS+eOqX19jpK5NhytikqtzJBRB1t9CTthnAGwyqjDA6W/2iPdBx7RlrSKljbz7gIXkN4Zkwnyv1Uh/assIAkC8Fs=,iv:Vd/o2KOCv9iWKdynDh5n4qhchMJtqy3wlC8MQas00fo=,tag:uJBUrn5Li748YfO39pDTHQ==,type:str]
+    lastmodified: "2023-08-03T19:03:42Z"
+    mac: ENC[AES256_GCM,data:5oZwONcDJ9LjOtTVtT/vO3jIjzpWmPYbRhLhdOyn6vijHithxVf1lqnbJCl1HlvvPtFZNvJfzTOgZBrkMa96wGDRVGPSeUfVXxHzkvpUUJaiFkn8RcXlPvy9ptOCiz4UIVE7M7AeADfEYm2bbaos3b23vvsvjgFJZgH69U4rU4Y=,iv:+unbckTxxoIrlkejvmtR7LeguvnsUULmn6Hqvvp0B+A=,tag:8/ZV4dMX+ZKf8GhG9UNjLw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-sandbox-env.yaml
+++ b/secrets/dev/backend-sandbox-env.yaml
@@ -67,6 +67,7 @@ PUSH_NOTIFICATIONS_SECRET: ENC[AES256_GCM,data:NubQwGCFrg5CKTZ0wUZ1aWuNxJUWsbz+K
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:o6AVhfDwM2959Z0mYoMHBovihQn1YkgDbJoyAVg8iCOIHf3l,iv:vsCWTvLzJhuDJDyyqzjfjMimdHassfyxBwDHTqcnlwo=,tag:zvcJCQPHMfY1CmGM0k+ZOw==,type:str]
 NEYNAR_API_KEY: ENC[AES256_GCM,data:xboLUvLZaffKjzro+6ZQihRCRH4FsFuC+IMfwgmWZG2IdA89,iv:kbyx3aHgxF43xGEJK6d7gNKwBgcooA7RuWicMKm/on8=,tag:9wpVdds2ETL1Dw3TsXfLJA==,type:str]
 DEBUG_TOOLS_PASSWORD: ENC[AES256_GCM,data:gdtKl+Try3HB8/QmDlm9KwDeVTc=,iv:B0FHdRIRLntCvVbcDVfFm8R0BObInr9da/ddCUVejkc=,tag:Fa1mrd/ZG4y3vS2h6N1k/Q==,type:str]
+GCLOUD_USER_PREF_BUCKET: ENC[AES256_GCM,data:3FoRipkg+znAmUFFyA==,iv:9WMQvCFgfrkjfGUEqaVRk7ysRBnnYUBwi4VRz5HVtaM=,tag:6wNvEfVOr63vCD9OOWRAGw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -76,8 +77,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-27T22:00:56Z"
-    mac: ENC[AES256_GCM,data:+eipwnioV3dEMc12xIbrKpJ0Agi0cxAPwMf0yR/Xiivsum9b5kxQExWWbnQ3S/48jSuUX4LrTT+ZI0TYFcBc3olAlE9sMiXNzhJOVTP28N8LJJC5kdNSo9bS452FDhssNdeLDAzQGNykfA2HtYkGrbURseeybqYg9tKeQrHD2T8=,iv:nEMYZCCxU3AabDlDq1qxEZOtELRBDl2CbXLvRnDMd50=,tag:TSL6rZowrXxvILo5dKMulQ==,type:str]
+    lastmodified: "2023-08-03T19:04:27Z"
+    mac: ENC[AES256_GCM,data:1snoccwMixOEMg7m9Vq6aMSEcXmarXzwtXY06ELh5nByhMZNxE7NqPmiz+G0UxyVMc7DBLU7n5JNJf7E1bsQss2UpEBiUHL74nqIzv+hAr7BNyNRLnLq6TpMZ3LLIYoFQ460dEGLSA2wSRNu7O4J3sMIroL7z5q4Ap9MJoX0x8c=,iv:f0c4c7pPhlcH6NnMv3FXn8dOzBWfa8yuYuMm81fOV2c=,tag:YJ64JJfndQ09sF4k3yuk0A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -43,6 +43,7 @@ GOLDSKY_API_KEY: ENC[AES256_GCM,data:VS+WZDi3x35hkyJiHAgo5iCdRLESsaZIIw==,iv:ZOm
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:1m/LBDJuyabeuoPkEAJCyMGW2tK5q1LgmdSDg1YxqD8RMLCW,iv:f0fnTn9WAEJ+FkUVaIQjKJPsx9pgEAiTQZyGabqaJyM=,tag:ZfX3cKYAb8swQSVIt5vxTg==,type:str]
 NEYNAR_API_KEY: ENC[AES256_GCM,data:BSWD+zx8ijQKO51m+y5WocCDH3lRGCkfxneQco7U/X9VJ/dM,iv:C9Pnb4MTbBkrBE2+V8rPWSYxI8LpvaC5pM5Z2g6WNYQ=,tag:VpCydAeSPk3B1UOZJnjL6A==,type:str]
 MAGIC_LINK_SECRET_KEY: ENC[AES256_GCM,data:2s6VhHxi7Ru/9H/0vGisPYUdpryJMM/8,iv:lj1AICPUgi9XU+XIziRDWk8ldGn9ZvrTKu4oDdiN0Ko=,tag:M0xONYdGgpLiPNj7k/5ZjA==,type:str]
+GCLOUD_USER_PREF_BUCKET: ENC[AES256_GCM,data:AIY3S7RuiaphDQ2Tqg==,iv:JIEYz3k7M2Mk6+uDEjtLTTF0WoBc2rQp3Umwowq+r5E=,tag:ZxU6jnLTxafgtFvxXQ7gAg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -52,8 +53,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-27T22:00:27Z"
-    mac: ENC[AES256_GCM,data:QI05t97/F64gnwpwVdEyh+I29TTMbcACp/ri6BPU1/fGX/9RdH7q6rByxLGQtl4kHyhCitAtpp9uc28sGajC7LQTOSD5wdamrEm8jKmbg5jbf8rR4jokpfbDeHIL7zPUFQfrOzKZcNoY+vFJnOarRD22liWTRmjddFU+apeTf6U=,iv:hbz5VOtB76W0zFGGvkuTPeCY/2kBjkGaMWfflkMT3Nw=,tag:w+AfDXkoV7bcgWXIUiUsXw==,type:str]
+    lastmodified: "2023-08-03T19:03:57Z"
+    mac: ENC[AES256_GCM,data:FPdSE25QWPKvkVH3ibJUf1ry059rSdWrC76YNzwNp8H/NEPX+Ujfd2/nGti2c0AhiW8EFTmANCAFtwoe4ymp1O/L0jF/LpztgS67kEKpu1AuiilN1DfHgR0oey+eXgq6kSXl1czxLhWdnWMBnGOxuqP3G4cUUH1yMrk/1IT2qtE=,iv:qSPG4KIpo7ppg70364wfztYrsASUV8FPnpBJSGOTSng=,tag:l5YZ1o4WfH/w1A1VYA3SKQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-backend.yaml
+++ b/secrets/local/local/app-local-backend.yaml
@@ -39,6 +39,7 @@ GOLDSKY_API_KEY: ENC[AES256_GCM,data:kBVp9DCmmf/UqYsK0nMIlGE98mZOkBN2IQ==,iv:tkc
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:bHtaHTzIf8BSGxTkpJpbFX2LAr521dq7bfNZ9y/DxfXAiveY,iv:tMfy5eAjMJACJVVKiwc/Y43/GX7w9q23v+Ga8kCj+iQ=,tag:lGGWb+Uk1SNVetz0GVDitA==,type:str]
 NEYNAR_API_KEY: ENC[AES256_GCM,data:432Y4ChTsMLtMITx/QDH3bsv0IV2ptDA7/Qr5Q0caZAU12ym,iv:atbehCZ89lS0JurWx5am6dpteXbXQNSMIjggLF67z94=,tag:WyXJtqQ3UTFJWay4PeTmqg==,type:str]
 RPC_URL: ENC[AES256_GCM,data:Qt54Eru5hohZXpV2pUCx/0+dg7CpVK7bHYEGye/fej+WV2HxjGo0MYUVE9xo0ATD2YIjFsTx/KhOdwbYY7XdcUMKVA==,iv:R7soMYboVNQNxmaAeDNsB+UPcGuSZgUY1qyeMAhO7Qw=,tag:wWWOlXXYmL3LMKJAARQMNw==,type:str]
+GCLOUD_USER_PREF_BUCKET: ENC[AES256_GCM,data:+abxLn4GAtNR/PRAjg==,iv:pywnL1YJzPfgEyHVvCJeJc83WaScMhL81QNCJasTzac=,tag:+91RyaN4clWzmXURuXqxMA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -48,8 +49,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-08-01T20:09:39Z"
-    mac: ENC[AES256_GCM,data:Ks/7B+whNkgu3nAY/VYUzUGRsRE/GHKSQPLC8wveqLoa2LxKOJHBmqaNo67G/MXkHVvpSOrAJcBd3NbJ5WjTdDNJBi99SLaWUQc1uXjRWCV4rKOdcMu0gNlUgqBljtdx6U3+UukQ2KD9TaSktJuZhoaZZrEQqnM5P41WLUux/ak=,iv:NHaPFuUlN+c3B6Q3lq18Q1ApTBhbbtaUO3bclAzGnM8=,tag:UT+HFJN0+NURi/sLstV36w==,type:str]
+    lastmodified: "2023-08-03T19:03:11Z"
+    mac: ENC[AES256_GCM,data:LAL0kq4WgDA+l4htAGPJ68rfzMp1LlfOcdHL3JW5J1f614U/p60Tajza8oD/wGDAjZnYAGuV4wIX6sZzPX8jb0qrkqDxY+fceVtTLH2C+9+IjpgO4Zi4Vrbqxcd5Zrz44E4k6HmMZZoWb6gTHG1N5ajHJfb2zGhvtEsiaPyC1qY=,iv:JuzYaoWWfIwOlZ+LlN25icTr7jXap24jgoNNf5mraN8=,tag:O5BYyLbRGI/gLotbPmDHcQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -70,6 +70,7 @@ ZORA_API_KEY: ENC[AES256_GCM,data:u3EHTQsp51m5sOzKWL4IBj1pm5hKGg==,iv:KWctctx/Tu
 RESERVOIR_API_KEY: ENC[AES256_GCM,data:9urMPp4zRyjjplYUxos85F5WpnwJX7qybS0Dy4cY/VS6Tzze,iv:22iSUMTnaxVwmmq0z5gljEp7vODhrNUEAYw1V011aYo=,tag:ev5uV+nXHvCzmyqZP6PkkA==,type:str]
 NEYNAR_API_KEY: ENC[AES256_GCM,data:ht+xpZ4OPywebb69iJtRPFPiGcKuhAMTLl4Dc6tdcU9oLtqi,iv:BE1W7cK9rWx9Zj6teypo9fN+k6/iZXXJLdDcmlmwFTg=,tag:CIMDGkICsnotCzrGgjD3Mw==,type:str]
 GOLDSKY_API_KEY: ENC[AES256_GCM,data:Cof9gRBnQ3OXV8Fo+aJhv7J34tgd/KyNQA==,iv:5CBTBhIPx8eFmaJp2nohqJYQ4f4oZYSuzJq95CbhTA0=,tag:xAqX7eqcRezlpQk4cLviog==,type:str]
+GCLOUD_USER_PREF_BUCKET: ENC[AES256_GCM,data:d30SUr/1z/8u0XPCgb8=,iv:xKanYFb0ySLhZu0vrTcBycAqMuQb+RsSw5x/lwhYmTM=,tag:0rXKTpz2DUQkB1cacv906Q==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -79,8 +80,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-07-27T22:01:04Z"
-    mac: ENC[AES256_GCM,data:HzOLXCwp/sFRM+3tCEKzkOVp30M2vpHb7dPoC5/dEYWtLTZM9gvoDwrLp7X8jidNTmaSqz3Ie5DTiBvEJBZvTW4XzyyaxDkc/BiTBNLhXRPZvxQuCd7UzjPVztrSdtN994jdmV+Uw1ATRCmpoV3v2qwryojbzp7fJWKs66u9yjE=,iv:OHeExwWZjMj8vZETR3BqalJe1CoZEqx7G2cwdBwGcuk=,tag:gW8LLkEE/RAcn6YV8nNsBg==,type:str]
+    lastmodified: "2023-08-03T19:04:47Z"
+    mac: ENC[AES256_GCM,data:uq4ZeA6a1y3O0r3NGQT04kS2hbBKdavn6mpDkiakh1au05NDZqnWp+AfBNuKO4/AmbDk3Ka+UutdmOd3yAdD0ZN9g4hGIgTiaW99wknw9kr9/3v+nkOySYOjdPMLz5CI/58LKl+WCvLOV5nxYKqjWX5+N0rjWdYlthDOQRJKet0=,iv:qLwTInyrfeB0VBOUaUHkdiEf51UXhC3rCxy+ln1mtT0=,tag:lLUe2b8PEvClykAH/ICiaw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/server/server.go
+++ b/server/server.go
@@ -175,6 +175,7 @@ func SetDefaults() {
 	viper.SetDefault("IPFS_PROJECT_ID", "")
 	viper.SetDefault("IPFS_PROJECT_SECRET", "")
 	viper.SetDefault("GCLOUD_TOKEN_CONTENT_BUCKET", "dev-token-content")
+	viper.SetDefault("GCLOUD_USER_PREF_BUCKET", "dev-user-pref")
 	viper.SetDefault("REDIS_URL", "localhost:6379")
 	viper.SetDefault("PREMIUM_CONTRACT_ADDRESS", "0xe01569ca9b39e55bc7c0dfa09f05fa15cb4c7698=[0,1,2,3,4,5,6,7,8]")
 	viper.SetDefault("RPC_URL", "https://eth-goerli.g.alchemy.com/v2/_2u--i79yarLYdOT4Bgydqa0dBceVRLD")

--- a/server/server.go
+++ b/server/server.go
@@ -59,7 +59,7 @@ func Init() {
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
 	recommender := recommend.NewRecommender(c.Queries)
-	p := userpref.NewPersonalization(ctx, c.Queries)
+	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
 	router := CoreInit(ctx, c, provider, recommender, p)
 	http.Handle("/", router)
 }

--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -303,7 +303,7 @@ func (p *Personalization) updateCache(ctx context.Context) {
 	m := readMatrices(ctx, p.q)
 	b, err := m.MarshalBinary()
 	check(err)
-	_, err = p.b.WriteGzip(ctx, gcpObjectName, b, store.ObjAttrsOptions.WithContentType("application/octect-stream"))
+	_, err = p.b.WriteGzip(ctx, gcpObjectName, b, store.ObjAttrsOptions.WithContentType("application/octet-stream"))
 	check(err)
 	p.updateMatrices(&m)
 }

--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -291,7 +291,7 @@ func (p *Personalization) update(ctx context.Context) {
 }
 
 func (p *Personalization) readCache(ctx context.Context) {
-	r, err := p.b.Reader(ctx, gcpObjectName)
+	r, err := p.b.NewReader(ctx, gcpObjectName)
 	check(err)
 	defer r.Close()
 	var m personalizationMatrices

--- a/service/redis/redis.go
+++ b/service/redis/redis.go
@@ -112,13 +112,13 @@ func NewCache(config CacheConfig) *Cache {
 
 // Set sets a value in the redis cache
 func (c *Cache) Set(pCtx context.Context, key string, value []byte, expiration time.Duration) error {
-	return c.client.Set(pCtx, c.GetPrefixedKey(key), value, expiration).Err()
+	return c.client.Set(pCtx, c.getPrefixedKey(key), value, expiration).Err()
 }
 
 // SetNX sets a value in the redis cache if it doesn't already exist. Returns true if the key did not
 // already exist and was set, false if the key did exist and therefore was not set.
 func (c *Cache) SetNX(pCtx context.Context, key string, value []byte, expiration time.Duration) (bool, error) {
-	cmd := c.client.SetNX(pCtx, c.GetPrefixedKey(key), value, expiration)
+	cmd := c.client.SetNX(pCtx, c.getPrefixedKey(key), value, expiration)
 
 	err := cmd.Err()
 	if err != nil {
@@ -134,7 +134,7 @@ func (c *Cache) SetTime(ctx context.Context, key string, value time.Time, expira
 	unixTimestamp := value.Unix()
 
 	if !onlyIfLater {
-		return c.client.Set(ctx, c.GetPrefixedKey(key), unixTimestamp, expiration).Err()
+		return c.client.Set(ctx, c.getPrefixedKey(key), unixTimestamp, expiration).Err()
 	}
 
 	unixExpiration := time.Now().Add(expiration).Unix()
@@ -149,7 +149,7 @@ func (c *Cache) SetTime(ctx context.Context, key string, value time.Time, expira
 }
 
 func (c *Cache) GetTime(ctx context.Context, key string) (time.Time, error) {
-	result, err := c.client.Get(ctx, c.GetPrefixedKey(key)).Result()
+	result, err := c.client.Get(ctx, c.getPrefixedKey(key)).Result()
 	if err != nil {
 		if err == redis.Nil {
 			return time.Time{}, ErrKeyNotFound{Key: key}
@@ -167,7 +167,7 @@ func (c *Cache) GetTime(ctx context.Context, key string) (time.Time, error) {
 
 // Get gets a value from the redis cache
 func (c *Cache) Get(pCtx context.Context, key string) ([]byte, error) {
-	bs, err := c.client.Get(pCtx, c.GetPrefixedKey(key)).Bytes()
+	bs, err := c.client.Get(pCtx, c.getPrefixedKey(key)).Bytes()
 	if err != nil {
 		if err == redis.Nil {
 			return nil, ErrKeyNotFound{Key: key}
@@ -177,37 +177,8 @@ func (c *Cache) Get(pCtx context.Context, key string) ([]byte, error) {
 	return bs, nil
 }
 
-// GetFieldRef returns the contents of a key stored as a reference in a hash field
-func (c *Cache) GetFromField(ctx context.Context, key, field string) (any, error) {
-	r, err := readReferenceScript.Run(ctx, c.scripter, []string{key}, field).Result()
-	if err == redis.Nil {
-		return r, ErrKeyNotFound{Key: fmt.Sprintf("%s.%s", key, field)}
-	}
-	return r, err
-}
-
-// Watch watches a set of keys for changes, and executes fn. It closes the transaction
-// when fn exists. Watch returns a redis.TxFailedErr if the transaction failed.
-func (c *Cache) Watch(ctx context.Context, fn func(*redis.Tx) error, keys ...string) error {
-	return c.client.Watch(ctx, fn, c.getPrefixedKeys(keys)...)
-}
-
-// HSet sets a value of a hash field
-func (c *Cache) HSet(ctx context.Context, key string, values ...any) error {
-	return c.client.HSet(ctx, c.GetPrefixedKey(key), values).Err()
-}
-
-// HGet sets dest to the value of a hash field
-func (c *Cache) HGetScan(ctx context.Context, key, field string, dest any) error {
-	err := c.client.HGet(ctx, c.GetPrefixedKey(key), field).Scan(dest)
-	if err == redis.Nil {
-		return ErrKeyNotFound{Key: fmt.Sprintf("%s.%s", key, field)}
-	}
-	return err
-}
-
 func (c *Cache) Delete(pCtx context.Context, key string) error {
-	return c.client.Del(pCtx, c.GetPrefixedKey(key)).Err()
+	return c.client.Del(pCtx, c.getPrefixedKey(key)).Err()
 }
 
 // Close closes the underlying redis client
@@ -215,7 +186,7 @@ func (c *Cache) Close() error {
 	return c.client.Close()
 }
 
-func (c *Cache) GetPrefixedKey(key string) string {
+func (c *Cache) getPrefixedKey(key string) string {
 	if c.keyPrefix == "" {
 		return key
 	}
@@ -272,7 +243,7 @@ type redislockCacheClient struct {
 }
 
 func (r *redislockCacheClient) SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.BoolCmd {
-	return r.cache.client.SetNX(ctx, r.cache.GetPrefixedKey(key), value, expiration)
+	return r.cache.client.SetNX(ctx, r.cache.getPrefixedKey(key), value, expiration)
 }
 
 // Scripts
@@ -290,17 +261,6 @@ if currentTimestamp == false or tonumber(currentTimestamp) < tonumber(newTimesta
 end
 
 return 0
-`)
-
-var readReferenceScript = redis.NewScript(`
-local key = KEYS[1]
-local field = ARGV[1]
-local fieldRef = redis.call('HGET', key, field)
-if fieldRef then
-	local value = redis.call('GET', fieldRef)
-	return value
-end
-return nil
 `)
 
 // LazyCache implements a lazy loading cache that stores data only when it is requested

--- a/service/store/cloudstorage.go
+++ b/service/store/cloudstorage.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+
+	"cloud.google.com/go/storage"
+)
+
+var ObjAttrsOptions objectAttrsOptions
+
+type BucketStorer struct {
+	b *storage.BucketHandle
+}
+
+func NewBucketStorer(c *storage.Client, bucketName string) BucketStorer {
+	return BucketStorer{c.Bucket(string(bucketName))}
+}
+
+func (s BucketStorer) Metadata(ctx context.Context, objName string) (*storage.ObjectAttrs, error) {
+	o := s.b.Object(objName)
+	return o.Attrs(ctx)
+}
+
+func (s BucketStorer) Reader(ctx context.Context, objName string) (io.ReadCloser, error) {
+	o := s.b.Object(objName)
+	return o.NewReader(ctx)
+}
+
+func (s BucketStorer) Write(ctx context.Context, objName string, b []byte, opts ...func(*storage.ObjectAttrs)) (int, error) {
+	w := s.NewWriter(ctx, objName)
+	defer w.Close()
+	return w.Write(b)
+}
+
+func (s BucketStorer) WriteGzip(ctx context.Context, objName string, b []byte, opts ...func(*storage.ObjectAttrs)) (int, error) {
+	w := s.NewWriter(ctx, objName, opts...)
+
+	w.ObjectAttrs.ContentEncoding = "gzip"
+
+	gz := gzip.NewWriter(w)
+	buf := bytes.NewReader(b)
+
+	n, err := io.Copy(gz, buf)
+	if err != nil {
+		return int(n), err
+	}
+
+	err = gz.Close()
+	if err != nil {
+		return int(n), err
+	}
+
+	err = w.Close()
+	return int(n), err
+}
+
+func (s BucketStorer) NewWriter(ctx context.Context, objName string, opts ...func(*storage.ObjectAttrs)) *storage.Writer {
+	o := s.b.Object(objName)
+	w := o.NewWriter(ctx)
+	for _, opt := range opts {
+		opt(&w.ObjectAttrs)
+	}
+	return w
+}
+
+type objectAttrsOptions struct{}
+
+// WithContentType sets the Content-Type header of the object
+func (objectAttrsOptions) WithContentType(typ string) func(*storage.ObjectAttrs) {
+	return func(a *storage.ObjectAttrs) {
+		a.ContentType = typ
+	}
+}
+
+// WithCustomMetadata sets custom metadata on the object
+func (objectAttrsOptions) WithCustomMetadata(m map[string]string) func(*storage.ObjectAttrs) {
+	return func(a *storage.ObjectAttrs) {
+		a.Metadata = m
+	}
+}
+
+// WithContentEncoding sets the Content-Encoding header of the object
+func (objectAttrsOptions) WithContentEncoding(enc string) func(*storage.ObjectAttrs) {
+	return func(a *storage.ObjectAttrs) {
+		a.ContentEncoding = enc
+	}
+}


### PR DESCRIPTION
This PR changes the algorithm's database from Redis to Cloud Storage instead. I also added a new package, `store`, and a wrapper around the cloud storage client, `BucketStorer`, to make reading and writing to Cloud Storage easier. At some point, I'll refactor tokenprocessing to use the package since they share much of the same logic.

I also tried to address the flaky test, it should run more reliably 🤞 