### PR TITLE
resolve spam separately

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,6 @@ require (
 	github.com/wealdtech/go-ens/v3 v3.5.5
 	go.mozilla.org/sops/v3 v3.7.3
 	golang.org/x/term v0.8.0
-	gonum.org/v1/gonum v0.13.0
 )
 
 require (
@@ -261,6 +260,7 @@ require (
 	golang.org/x/time v0.1.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	gonum.org/v1/gonum v0.13.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2567,6 +2567,22 @@ func (r *tokenResolver) Community(ctx context.Context, obj *model.Token) (*model
 	return resolveCommunityByTokenID(ctx, obj.Dbid)
 }
 
+// IsSpamByProvider is the resolver for the isSpamByProvider field.
+func (r *tokenResolver) IsSpamByProvider(ctx context.Context, obj *model.Token) (*bool, error) {
+	var c *model.Contract
+	var err error
+	if obj.Token.Contract != "" {
+		c, err = resolveContractByContractID(ctx, obj.Token.Contract)
+	} else {
+		c, err = resolveContractByTokenID(ctx, obj.Dbid)
+	}
+	if err != nil {
+		return nil, err
+	}
+	isSpam := (c.IsSpam != nil && *c.IsSpam) || (obj.IsSpamByProvider != nil && *obj.IsSpamByProvider)
+	return &isSpam, nil
+}
+
 // Wallets is the resolver for the wallets field.
 func (r *tokenHolderResolver) Wallets(ctx context.Context, obj *model.TokenHolder) ([]*model.Wallet, error) {
 	wallets := make([]*model.Wallet, 0, len(obj.WalletIds))

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -438,7 +438,7 @@ type Token implements Node @goEmbedHelper {
   externalUrl: String
   blockNumber: String # source is uint64
   isSpamByUser: Boolean
-  isSpamByProvider: Boolean
+  isSpamByProvider: Boolean @goField(forceResolver: true)
   # These are subject to change; unlike the other fields, they aren't present on the current persist.Token
   # struct and may ultimately end up elsewhere
   creatorAddress: ChainAddress


### PR DESCRIPTION
Changes:

- **Added** a separate resolver for resolving spam set by providers for tokens that utilizes the contract's spam field as well as the token's spam field