### PR TITLE
Push notification error handling

### DIFF
--- a/pushnotifications/expo/expo.go
+++ b/pushnotifications/expo/expo.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/getsentry/sentry-go"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/util"
@@ -55,25 +56,30 @@ type GetReceiptsRequest struct {
 
 type GetReceiptsResponse struct {
 	Data   map[string]PushReceipt `json:"data"`
-	Errors []map[string]string    `json:"errors"`
+	Errors []RequestError         `json:"errors"`
 }
 
 type SendMessagesResponse struct {
-	Data   []PushTicket        `json:"data"`
-	Errors []map[string]string `json:"errors"`
+	Data   []PushTicket   `json:"data"`
+	Errors []RequestError `json:"errors"`
 }
 
 type PushReceipt struct {
-	Status  string            `json:"status"`
-	Message string            `json:"message"`
-	Details map[string]string `json:"details"`
+	Status  string         `json:"status"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details"`
 }
 
 type PushTicket struct {
-	TicketID string            `json:"id"`
-	Status   string            `json:"status"`
-	Message  string            `json:"message"`
-	Details  map[string]string `json:"details"`
+	TicketID string         `json:"id"`
+	Status   string         `json:"status"`
+	Message  string         `json:"message"`
+	Details  map[string]any `json:"details"`
+}
+
+type RequestError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 type PushError struct {
@@ -90,12 +96,17 @@ func newPushError(code string) *PushError {
 
 // GetError gets the error for the ticket, if any. Returns nil if no error.
 // See: https://docs.expo.dev/push-notifications/sending-notifications/#push-ticket-errors
-func (t PushTicket) GetError() error {
+func (t PushTicket) GetError(ctx context.Context) error {
 	if t.Status != StatusError {
 		return nil
 	}
 
-	code := t.Details["error"]
+	code, ok := t.Details["error"].(string)
+	if !ok {
+		err := fmt.Errorf("invalid push error type: expected a string, got: %v", t.Details["error"])
+		logger.For(ctx).Error(err)
+		return err
+	}
 
 	err := findErrorByCode(code, []*PushError{
 		ErrDeviceNotRegistered,
@@ -110,12 +121,17 @@ func (t PushTicket) GetError() error {
 
 // GetError gets the error for the receipt, if any. Returns nil if no error.
 // See: https://docs.expo.dev/push-notifications/sending-notifications#push-receipt-errors
-func (t PushReceipt) GetError() error {
+func (t PushReceipt) GetError(ctx context.Context) error {
 	if t.Status != StatusError {
 		return nil
 	}
 
-	code := t.Details["error"]
+	code, ok := t.Details["error"].(string)
+	if !ok {
+		err := fmt.Errorf("invalid push error type: expected a string, got: %v", t.Details["error"])
+		logger.For(ctx).Error(err)
+		return err
+	}
 
 	err := findErrorByCode(code, []*PushError{
 		ErrDeviceNotRegistered,
@@ -150,14 +166,14 @@ func findErrorByCode(errorString string, errs []*PushError) error {
 	return nil
 }
 
-func getResponseError(errs []map[string]string) error {
+func getResponseError(errs []RequestError) error {
 	if len(errs) == 0 {
 		return nil
 	}
 
 	// Find a known error type if we can
 	for _, e := range errs {
-		code := e["code"]
+		code := e.Code
 
 		err := findErrorByCode(code, []*PushError{
 			ErrTooManyRequests,
@@ -172,7 +188,7 @@ func getResponseError(errs []map[string]string) error {
 	}
 
 	// Otherwise just return the first error
-	return errors.New("unknown error: " + errs[0]["code"])
+	return errors.New("unknown error: " + errs[0].Code)
 }
 
 // PushMessage is an Expo-formatted push message.

--- a/pushnotifications/expo/expo.go
+++ b/pushnotifications/expo/expo.go
@@ -113,6 +113,11 @@ func (t PushTicket) GetError(ctx context.Context) error {
 	})
 
 	if err != nil {
+		if message, ok := t.Details["message"]; ok {
+			if messageStr, ok := message.(string); ok {
+				logger.For(ctx).Infof("found details for push ticket error %s: %s", code, messageStr)
+			}
+		}
 		return err
 	}
 
@@ -142,6 +147,11 @@ func (t PushReceipt) GetError(ctx context.Context) error {
 	})
 
 	if err != nil {
+		if message, ok := t.Details["message"]; ok {
+			if messageStr, ok := message.(string); ok {
+				logger.For(ctx).Infof("found details for push receipt error %s: %s", code, messageStr)
+			}
+		}
 		return err
 	}
 
@@ -188,7 +198,7 @@ func getResponseError(errs []RequestError) error {
 	}
 
 	// Otherwise just return the first error
-	return errors.New("unknown error: " + errs[0].Code)
+	return errors.New("unknown error: " + errs[0].Code + ": " + errs[0].Message)
 }
 
 // PushMessage is an Expo-formatted push message.

--- a/pushnotifications/expo/handler.go
+++ b/pushnotifications/expo/handler.go
@@ -126,7 +126,7 @@ func (b *messageBatch) startTimer(l *PushNotificationHandler) {
 }
 
 func (b *messageBatch) end(h *PushNotificationHandler) {
-	h.sendMessageBatch(b.messages)
+	b.errors = h.sendMessageBatch(b.messages)
 	close(b.done)
 }
 
@@ -191,7 +191,7 @@ func (h *PushNotificationHandler) sendMessageBatch(messages []PushMessage) []err
 
 		// Get this message's position in the original slice of messages and use that for error indexing
 		errIndex := dbidToMessageIndex[message.pushTokenID]
-		e := response.GetError()
+		e := response.GetError(ctx)
 		errs[errIndex] = e
 
 		if e == ErrDeviceNotRegistered {
@@ -301,7 +301,7 @@ func processTicketReceipts(ctx context.Context, tickets []db.PushNotificationTic
 			continue
 		}
 
-		err := receipt.GetError()
+		err := receipt.GetError(ctx)
 		if err == nil {
 			// If we got a receipt and there wasn't an error, the message was delivered, and we don't need to check again.
 			params.Status[i] = "delivered"


### PR DESCRIPTION
An unmarshaling error has stopped us from seeing some push notification errors. This PR fixes that issue (changes a struct field from `map[string]string` to `map[string]any` and adds some additional logging. It also fixes an issue where errors weren't being propagated through push notification batches.

I don't think this will fix the reliability issues we've been seeing with push notifications, but hopefully it'll let us see actual errors explaining what's wrong.