### PR TITLE
Curated caching

### DIFF
--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -143,6 +143,17 @@ type FeedEntity struct {
 	ActorID        persist.DBID `json:"actor_id"`
 }
 
+type FeedEntityScore struct {
+	ID             persist.DBID     `json:"id"`
+	CreatedAt      time.Time        `json:"created_at"`
+	ActorID        persist.DBID     `json:"actor_id"`
+	Action         persist.Action   `json:"action"`
+	ContractIds    persist.DBIDList `json:"contract_ids"`
+	Interactions   int32            `json:"interactions"`
+	FeedEntityType int32            `json:"feed_entity_type"`
+	LastUpdated    time.Time        `json:"last_updated"`
+}
+
 type FeedEvent struct {
 	ID          persist.DBID          `json:"id"`
 	Version     int32                 `json:"version"`

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -154,6 +154,17 @@ type FeedEntityScore struct {
 	LastUpdated    time.Time        `json:"last_updated"`
 }
 
+type FeedEntityScoreView struct {
+	ID             persist.DBID     `json:"id"`
+	CreatedAt      time.Time        `json:"created_at"`
+	ActorID        persist.DBID     `json:"actor_id"`
+	Action         persist.Action   `json:"action"`
+	ContractIds    persist.DBIDList `json:"contract_ids"`
+	Interactions   int32            `json:"interactions"`
+	FeedEntityType int32            `json:"feed_entity_type"`
+	LastUpdated    time.Time        `json:"last_updated"`
+}
+
 type FeedEvent struct {
 	ID          persist.DBID          `json:"id"`
 	Version     int32                 `json:"version"`

--- a/db/gen/coredb/recommend.sql.go
+++ b/db/gen/coredb/recommend.sql.go
@@ -7,128 +7,9 @@ package coredb
 
 import (
 	"context"
-	"time"
 
 	"github.com/mikeydub/go-gallery/service/persist"
 )
-
-const feedEntityScoring = `-- name: FeedEntityScoring :many
-with ids as (
-    select id, feed_entity_type, created_at, actor_id
-    from feed_entities fe
-    where 
-      fe.created_at >= $1
-      and ($2::bool or fe.actor_id != $3::varchar)
-      and ($4::bool or feed_entity_type != $5)
-), selected_posts as (
-    select
-      ids.id,
-      ids.feed_entity_type,
-      ids.created_at,
-      p.actor_id,
-      p.contract_ids,
-      count(distinct c.id) + count(distinct a.id) interactions
-    from ids
-    join posts p on p.id = ids.id and feed_entity_type = $5
-    left join comments c on c.post_id = ids.id
-    left join admires a on a.post_id = ids.id
-    group by ids.id, ids.feed_entity_type, ids.created_at, p.actor_id, p.contract_ids
-), feed_event_contract_ids as (
-    select t.feed_event_id feed_event_id, array_agg(t.contract_id) contract_ids
-    from (
-      select f.id feed_event_id, c.id contract_id
-      from ids,
-        feed_events f,
-        -- The only event that we currently store with token ids is the 'GalleryUpdated' event
-        -- which includes the 'gallery_new_token_ids' field
-        lateral jsonb_each((data->>'gallery_new_token_ids')::jsonb) x(key, value),
-        jsonb_array_elements_text(x.value) tid(id),
-        tokens t,
-        contracts c
-      where
-        ids.id = f.id
-        and feed_entity_type = $6
-        and tid.id = t.id
-        and c.id = t.contract
-        and not t.deleted
-        and not c.deleted
-      group by 1, 2
-    ) t
-    group by 1
-), selected_events as (
-    select
-      ids.id,
-      ids.feed_entity_type,
-      ids.created_at,
-      ids.actor_id,
-      feed_event_contract_ids.contract_ids,
-      count(distinct c.id) + count(distinct a.id) interactions
-    from ids
-    join feed_events e on e.id = ids.id and feed_entity_type = $6
-    left join comments c on c.feed_event_id = ids.id
-    left join admires a on a.feed_event_id = ids.id
-    left join feed_event_contract_ids on feed_event_contract_ids.feed_event_id = ids.id
-    where not action = any($7::varchar[])
-    group by ids.id, ids.feed_entity_type, ids.created_at, ids.actor_id, feed_event_contract_ids.contract_ids
-)
-select id, feed_entity_type, created_at, actor_id, contract_ids, interactions from selected_posts
-union all
-select id, feed_entity_type, created_at, actor_id, contract_ids, interactions from selected_events
-`
-
-type FeedEntityScoringParams struct {
-	WindowEnd           time.Time `json:"window_end"`
-	IncludeViewer       bool      `json:"include_viewer"`
-	ViewerID            string    `json:"viewer_id"`
-	IncludePosts        bool      `json:"include_posts"`
-	PostEntityType      int32     `json:"post_entity_type"`
-	FeedEventEntityType int32     `json:"feed_event_entity_type"`
-	ExcludedFeedActions []string  `json:"excluded_feed_actions"`
-}
-
-type FeedEntityScoringRow struct {
-	ID             persist.DBID     `json:"id"`
-	FeedEntityType int32            `json:"feed_entity_type"`
-	CreatedAt      time.Time        `json:"created_at"`
-	ActorID        persist.DBID     `json:"actor_id"`
-	ContractIds    persist.DBIDList `json:"contract_ids"`
-	Interactions   int32            `json:"interactions"`
-}
-
-func (q *Queries) FeedEntityScoring(ctx context.Context, arg FeedEntityScoringParams) ([]FeedEntityScoringRow, error) {
-	rows, err := q.db.Query(ctx, feedEntityScoring,
-		arg.WindowEnd,
-		arg.IncludeViewer,
-		arg.ViewerID,
-		arg.IncludePosts,
-		arg.PostEntityType,
-		arg.FeedEventEntityType,
-		arg.ExcludedFeedActions,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []FeedEntityScoringRow
-	for rows.Next() {
-		var i FeedEntityScoringRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.FeedEntityType,
-			&i.CreatedAt,
-			&i.ActorID,
-			&i.ContractIds,
-			&i.Interactions,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
 
 const getContractLabels = `-- name: GetContractLabels :many
 select user_id, contract_id, displayed
@@ -154,6 +35,58 @@ func (q *Queries) GetContractLabels(ctx context.Context, excludedContracts []str
 	for rows.Next() {
 		var i GetContractLabelsRow
 		if err := rows.Scan(&i.UserID, &i.ContractID, &i.Displayed); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getFeedEntityScores = `-- name: GetFeedEntityScores :many
+select id, created_at, actor_id, action, contract_ids, interactions, feed_entity_type, last_updated
+from feed_entity_scores
+where 
+  ($1::bool or actor_id != $2)
+  and ($3::bool or feed_entity_type != $4)
+  and (action != any($5::varchar[]) or action is null)
+`
+
+type GetFeedEntityScoresParams struct {
+	IncludeViewer       bool         `json:"include_viewer"`
+	ViewerID            persist.DBID `json:"viewer_id"`
+	IncludePosts        bool         `json:"include_posts"`
+	PostEntityType      int32        `json:"post_entity_type"`
+	ExcludedFeedActions []string     `json:"excluded_feed_actions"`
+}
+
+func (q *Queries) GetFeedEntityScores(ctx context.Context, arg GetFeedEntityScoresParams) ([]FeedEntityScore, error) {
+	rows, err := q.db.Query(ctx, getFeedEntityScores,
+		arg.IncludeViewer,
+		arg.ViewerID,
+		arg.IncludePosts,
+		arg.PostEntityType,
+		arg.ExcludedFeedActions,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FeedEntityScore
+	for rows.Next() {
+		var i FeedEntityScore
+		if err := rows.Scan(
+			&i.ID,
+			&i.CreatedAt,
+			&i.ActorID,
+			&i.Action,
+			&i.ContractIds,
+			&i.Interactions,
+			&i.FeedEntityType,
+			&i.LastUpdated,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/db/migrations/core/000101_add_feed_entity_scores.up.sql
+++ b/db/migrations/core/000101_add_feed_entity_scores.up.sql
@@ -1,0 +1,58 @@
+create materialized view feed_entity_scores as (
+  with report_after as (
+    select now() - interval '7 day' ts
+  ),
+
+  selected_posts as (
+      select posts.id, posts.created_at, posts.actor_id, posts.contract_ids, count(distinct comments.id) + count(distinct admires.id) interactions
+      from posts
+      left join comments on comments.post_id = posts.id
+      left join admires on admires.post_id = posts.id
+      where posts.created_at >= (select ts from report_after)
+      group by posts.id, posts.created_at, posts.actor_id, posts.contract_ids
+  ),
+
+  selected_events as (
+      select feed_events.id, feed_events.created_at, feed_events.owner_id actor_id, feed_events.action, count(distinct comments.id) + count(distinct admires.id) interactions
+      from feed_events
+      left join comments on comments.post_id = feed_events.id
+      left join admires on admires.post_id = feed_events.id
+      where feed_events.created_at >= (select ts from report_after)
+      group by feed_events.id, feed_events.created_at, feed_events.owner_id, feed_events.action
+  ),
+
+  event_contracts as (
+      select feed_event_id, array_agg(contract_id) contract_ids
+      from (
+        select feed_events.id feed_event_id, contracts.id contract_id
+        from 
+          feed_events,
+          -- The only event that we currently store with token ids is the 'GalleryUpdated' event which includes the 'gallery_new_token_ids' field
+          lateral jsonb_each((data->>'gallery_new_token_ids')::jsonb) x(key, value),
+          jsonb_array_elements_text(x.value) tid(id),
+          tokens,
+          contracts
+        where
+          feed_events.created_at >= (select ts from report_after)
+          and tid.id = tokens.id
+          and contracts.id = tokens.contract
+          and not tokens.deleted
+          and not contracts.deleted
+        group by feed_events.id, contracts.id
+      ) t
+      group by feed_event_id
+  )
+
+  select id, created_at, actor_id, action, contract_ids, interactions, 0 feed_entity_type, now()::timestamptz as last_updated
+  from selected_events
+  left join event_contracts on selected_events.id = event_contracts.feed_event_id
+
+  union all
+
+  select id, created_at, actor_id, null, contract_ids, interactions, 1 feed_entity_type, now()::timestamptz as last_updated
+  from selected_posts
+);
+
+create index feed_entity_scores_actor_id on feed_entity_scores(actor_id);
+create index feed_entity_scores_action on feed_entity_scores(action);
+create index feed_entity_scores_entity_type on feed_entity_scores(feed_entity_type);

--- a/db/migrations/core/000101_add_feed_entity_scores.up.sql
+++ b/db/migrations/core/000101_add_feed_entity_scores.up.sql
@@ -15,8 +15,8 @@ create view feed_entity_score_view as (
   selected_events as (
       select feed_events.id, feed_events.created_at, feed_events.owner_id actor_id, feed_events.action, count(distinct comments.id) + count(distinct admires.id) interactions
       from feed_events
-      left join comments on comments.post_id = feed_events.id
-      left join admires on admires.post_id = feed_events.id
+      left join comments on comments.feed_event_id = feed_events.id
+      left join admires on admires.feed_event_id = feed_events.id
       where feed_events.created_at >= (select ts from report_after)
       group by feed_events.id, feed_events.created_at, feed_events.owner_id, feed_events.action
   ),
@@ -60,6 +60,7 @@ create materialized view feed_entity_scores as (
 );
 
 create unique index feed_entity_scores_id on feed_entity_scores(id);
+create index feed_entity_scores_created_at on feed_entity_scores(created_at);
 create index feed_entity_scores_actor_id on feed_entity_scores(actor_id);
 create index feed_entity_scores_entity_type_action on feed_entity_scores(feed_entity_type, action);
 

--- a/db/migrations/core/000101_add_feed_entity_scores.up.sql
+++ b/db/migrations/core/000101_add_feed_entity_scores.up.sql
@@ -1,4 +1,4 @@
-create view feed_entity_score_view as (
+create or replace view feed_entity_score_view as (
   with report_after as (
     select now() - interval '7 day' ts
   ),
@@ -9,16 +9,18 @@ create view feed_entity_score_view as (
       left join comments on comments.post_id = posts.id
       left join admires on admires.post_id = posts.id
       where posts.created_at >= (select ts from report_after)
+        and not posts.deleted
       group by posts.id, posts.created_at, posts.actor_id, posts.contract_ids
   ),
 
   selected_events as (
-      select feed_events.id, feed_events.created_at, feed_events.owner_id actor_id, feed_events.action, count(distinct comments.id) + count(distinct admires.id) interactions
+      select feed_events.id, feed_events.event_time created_at, feed_events.owner_id actor_id, feed_events.action, count(distinct comments.id) + count(distinct admires.id) interactions
       from feed_events
       left join comments on comments.feed_event_id = feed_events.id
       left join admires on admires.feed_event_id = feed_events.id
-      where feed_events.created_at >= (select ts from report_after)
-      group by feed_events.id, feed_events.created_at, feed_events.owner_id, feed_events.action
+      where feed_events.event_time >= (select ts from report_after)
+        and not feed_events.deleted
+      group by feed_events.id, feed_events.event_time, feed_events.owner_id, feed_events.action
   ),
 
   event_contracts as (
@@ -33,7 +35,8 @@ create view feed_entity_score_view as (
           tokens,
           contracts
         where
-          feed_events.created_at >= (select ts from report_after)
+          feed_events.event_time >= (select ts from report_after)
+          and not feed_events.deleted
           and tid.id = tokens.id
           and contracts.id = tokens.contract
           and not tokens.deleted
@@ -61,7 +64,5 @@ create materialized view feed_entity_scores as (
 
 create unique index feed_entity_scores_id on feed_entity_scores(id);
 create index feed_entity_scores_created_at on feed_entity_scores(created_at);
-create index feed_entity_scores_actor_id on feed_entity_scores(actor_id);
-create index feed_entity_scores_entity_type_action on feed_entity_scores(feed_entity_type, action);
 
 select cron.schedule('refresh-feed-entity-scores', '30 * * * *', 'refresh materialized view concurrently feed_entity_scores with data');

--- a/db/migrations/core/000101_add_feed_entity_scores.up.sql
+++ b/db/migrations/core/000101_add_feed_entity_scores.up.sql
@@ -49,7 +49,7 @@ create view feed_entity_score_view as (
 
   union all
 
-  select id, created_at, actor_id, 'how-are-you-today', contract_ids, interactions, 1 feed_entity_type, now()::timestamptz as last_updated
+  select id, created_at, actor_id, '', contract_ids, interactions, 1 feed_entity_type, now()::timestamptz as last_updated
   from selected_posts
 );
 
@@ -59,6 +59,8 @@ create materialized view feed_entity_scores as (
   select * from feed_entity_score_view where created_at >= now() - interval '7 day'
 );
 
+create unique index feed_entity_scores_id on feed_entity_scores(id);
 create index feed_entity_scores_actor_id on feed_entity_scores(actor_id);
-create index feed_entity_scores_action on feed_entity_scores(action);
-create index feed_entity_scores_entity_type on feed_entity_scores(feed_entity_type);
+create index feed_entity_scores_entity_type_action on feed_entity_scores(feed_entity_type, action);
+
+select cron.schedule('refresh-feed-entity-scores', '30 * * * *', 'refresh materialized view concurrently feed_entity_scores with data');

--- a/db/migrations/core/000101_add_feed_entity_scores.up.sql
+++ b/db/migrations/core/000101_add_feed_entity_scores.up.sql
@@ -1,4 +1,4 @@
-create materialized view feed_entity_scores as (
+create view feed_entity_score_view as (
   with report_after as (
     select now() - interval '7 day' ts
   ),
@@ -49,8 +49,14 @@ create materialized view feed_entity_scores as (
 
   union all
 
-  select id, created_at, actor_id, null, contract_ids, interactions, 1 feed_entity_type, now()::timestamptz as last_updated
+  select id, created_at, actor_id, 'how-are-you-today', contract_ids, interactions, 1 feed_entity_type, now()::timestamptz as last_updated
   from selected_posts
+);
+
+drop materialized view if exists feed_entity_scores;
+
+create materialized view feed_entity_scores as (
+  select * from feed_entity_score_view where created_at >= now() - interval '7 day'
 );
 
 create index feed_entity_scores_actor_id on feed_entity_scores(actor_id);

--- a/db/migrations/core/000102_add_posts_created_at_idx.up.sql
+++ b/db/migrations/core/000102_add_posts_created_at_idx.up.sql
@@ -1,0 +1,1 @@
+create index posts_created_at_idx on posts(created_at) where not deleted;

--- a/db/queries/core/recommend.sql
+++ b/db/queries/core/recommend.sql
@@ -59,65 +59,10 @@ where contract_id not in (
   select id from contracts where chain || ':' || address = any(@excluded_contracts::varchar[])
 ) and displayed;
 
--- name: FeedEntityScoring :many
-with ids as (
-    select *
-    from feed_entities fe
-    where 
-      fe.created_at >= @window_end
-      and (@include_viewer::bool or fe.actor_id != @viewer_id::varchar)
-      and (@include_posts::bool or feed_entity_type != @post_entity_type)
-), selected_posts as (
-    select
-      ids.id,
-      ids.feed_entity_type,
-      ids.created_at,
-      p.actor_id,
-      p.contract_ids,
-      count(distinct c.id) + count(distinct a.id) interactions
-    from ids
-    join posts p on p.id = ids.id and feed_entity_type = @post_entity_type
-    left join comments c on c.post_id = ids.id
-    left join admires a on a.post_id = ids.id
-    group by ids.id, ids.feed_entity_type, ids.created_at, p.actor_id, p.contract_ids
-), feed_event_contract_ids as (
-    select t.feed_event_id feed_event_id, array_agg(t.contract_id) contract_ids
-    from (
-      select f.id feed_event_id, c.id contract_id
-      from ids,
-        feed_events f,
-        -- The only event that we currently store with token ids is the 'GalleryUpdated' event
-        -- which includes the 'gallery_new_token_ids' field
-        lateral jsonb_each((data->>'gallery_new_token_ids')::jsonb) x(key, value),
-        jsonb_array_elements_text(x.value) tid(id),
-        tokens t,
-        contracts c
-      where
-        ids.id = f.id
-        and feed_entity_type = @feed_event_entity_type
-        and tid.id = t.id
-        and c.id = t.contract
-        and not t.deleted
-        and not c.deleted
-      group by 1, 2
-    ) t
-    group by 1
-), selected_events as (
-    select
-      ids.id,
-      ids.feed_entity_type,
-      ids.created_at,
-      ids.actor_id,
-      feed_event_contract_ids.contract_ids,
-      count(distinct c.id) + count(distinct a.id) interactions
-    from ids
-    join feed_events e on e.id = ids.id and feed_entity_type = @feed_event_entity_type
-    left join comments c on c.feed_event_id = ids.id
-    left join admires a on a.feed_event_id = ids.id
-    left join feed_event_contract_ids on feed_event_contract_ids.feed_event_id = ids.id
-    where not action = any(@excluded_feed_actions::varchar[])
-    group by ids.id, ids.feed_entity_type, ids.created_at, ids.actor_id, feed_event_contract_ids.contract_ids
-)
-select * from selected_posts
-union all
-select * from selected_events;
+-- name: GetFeedEntityScores :many
+select *
+from feed_entity_scores
+where 
+  (@include_viewer::bool or actor_id != @viewer_id)
+  and (@include_posts::bool or feed_entity_type != @post_entity_type)
+  and (action != any(@excluded_feed_actions::varchar[]) or action is null);

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -311,6 +311,7 @@ func (api FeedAPI) TrendingFeed(ctx context.Context, before *string, after *stri
 	if !hasCursors {
 		calcFunc := func(ctx context.Context) ([]persist.FeedEntityType, []persist.DBID, error) {
 			trendData, err := api.queries.GetFeedEntityScores(ctx, db.GetFeedEntityScoresParams{
+				WindowEnd:           time.Now().Add(-time.Duration(3 * 24 * time.Hour)),
 				PostEntityType:      int32(persist.PostTypeTag),
 				ExcludedFeedActions: []string{string(persist.ActionUserCreated), string(persist.ActionUserFollowedUsers)},
 				IncludeViewer:       true,
@@ -432,6 +433,7 @@ func (api FeedAPI) CuratedFeed(ctx context.Context, before, after *string, first
 
 	if !hasCursors {
 		trendData, err := api.queries.GetFeedEntityScores(ctx, db.GetFeedEntityScoresParams{
+			WindowEnd:           time.Now().Add(-time.Duration(7 * 24 * time.Hour)),
 			PostEntityType:      int32(persist.PostTypeTag),
 			ExcludedFeedActions: []string{string(persist.ActionUserCreated), string(persist.ActionUserFollowedUsers)},
 			IncludeViewer:       false,

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -310,9 +310,7 @@ func (api FeedAPI) TrendingFeed(ctx context.Context, before *string, after *stri
 
 	if !hasCursors {
 		calcFunc := func(ctx context.Context) ([]persist.FeedEntityType, []persist.DBID, error) {
-			trendData, err := api.queries.FeedEntityScoring(ctx, db.FeedEntityScoringParams{
-				WindowEnd:           time.Now().Add(-time.Duration(3 * 24 * time.Hour)),
-				FeedEventEntityType: int32(persist.FeedEventTypeTag),
+			trendData, err := api.queries.GetFeedEntityScores(ctx, db.GetFeedEntityScoresParams{
 				PostEntityType:      int32(persist.PostTypeTag),
 				ExcludedFeedActions: []string{string(persist.ActionUserCreated), string(persist.ActionUserFollowedUsers)},
 				IncludeViewer:       true,
@@ -321,7 +319,7 @@ func (api FeedAPI) TrendingFeed(ctx context.Context, before *string, after *stri
 			if err != nil {
 				return nil, nil, err
 			}
-			entityTypes, entityIDs = api.scoreFeedEntities(ctx, trendData, func(e db.FeedEntityScoringRow) float64 {
+			entityTypes, entityIDs = api.scoreFeedEntities(ctx, trendData, func(e db.FeedEntityScore) float64 {
 				return timeFactor(e.CreatedAt, now) * engagementFactor(int(e.Interactions))
 			})
 			return entityTypes, entityIDs, nil
@@ -433,13 +431,11 @@ func (api FeedAPI) CuratedFeed(ctx context.Context, before, after *string, first
 	now := time.Now()
 
 	if !hasCursors {
-		trendData, err := api.queries.FeedEntityScoring(ctx, db.FeedEntityScoringParams{
-			WindowEnd:           time.Now().Add(-time.Duration(7 * 24 * time.Hour)),
+		trendData, err := api.queries.GetFeedEntityScores(ctx, db.GetFeedEntityScoresParams{
 			PostEntityType:      int32(persist.PostTypeTag),
-			FeedEventEntityType: int32(persist.FeedEventTypeTag),
 			ExcludedFeedActions: []string{string(persist.ActionUserCreated), string(persist.ActionUserFollowedUsers)},
 			IncludeViewer:       false,
-			ViewerID:            userID.String(),
+			ViewerID:            userID,
 			IncludePosts:        includePosts,
 		})
 		if err != nil {
@@ -450,7 +446,7 @@ func (api FeedAPI) CuratedFeed(ctx context.Context, before, after *string, first
 			p := userpref.For(ctx)
 			p.Mu.RLock()
 			defer p.Mu.RUnlock()
-			return api.scoreFeedEntities(ctx, trendData, func(e db.FeedEntityScoringRow) float64 {
+			return api.scoreFeedEntities(ctx, trendData, func(e db.FeedEntityScore) float64 {
 				return scoreFeedEntity(p, userID, e, now, int(e.Interactions))
 			})
 		}()
@@ -660,7 +656,7 @@ func loadFeedEntities(ctx context.Context, d *dataloader.Loaders, typs []persist
 	return entities, nil
 }
 
-func (api FeedAPI) scoreFeedEntities(ctx context.Context, trendData []db.FeedEntityScoringRow, scoreF func(db.FeedEntityScoringRow) float64) ([]persist.FeedEntityType, []persist.DBID) {
+func (api FeedAPI) scoreFeedEntities(ctx context.Context, trendData []db.FeedEntityScore, scoreF func(db.FeedEntityScore) float64) ([]persist.FeedEntityType, []persist.DBID) {
 	h := &heap{}
 
 	var wg sync.WaitGroup
@@ -714,7 +710,7 @@ func (api FeedAPI) scoreFeedEntities(ctx context.Context, trendData []db.FeedEnt
 	return entityTypes, entityIDs
 }
 
-func scoreFeedEntity(p *userpref.Personalization, viewerID persist.DBID, e db.FeedEntityScoringRow, t time.Time, interactions int) float64 {
+func scoreFeedEntity(p *userpref.Personalization, viewerID persist.DBID, e db.FeedEntityScore, t time.Time, interactions int) float64 {
 	timeF := timeFactor(e.CreatedAt, t)
 	engagementF := engagementFactor(interactions)
 	personalizationF, err := p.RelevanceTo(viewerID, e)

--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -189,7 +189,7 @@ func NewPersonalization(ctx context.Context, q *db.Queries, c *storage.Client) *
 	return k
 }
 
-func (p *Personalization) RelevanceTo(userID persist.DBID, e db.FeedEntityScoringRow) (float64, error) {
+func (p *Personalization) RelevanceTo(userID persist.DBID, e db.FeedEntityScore) (float64, error) {
 	// We don't have personalization data for this user yet
 	_, vOK := p.pM.uL[userID]
 	if !vOK {

--- a/service/store/cloudstorage.go
+++ b/service/store/cloudstorage.go
@@ -32,7 +32,7 @@ func (s BucketStorer) Metadata(ctx context.Context, objName string) (*storage.Ob
 	return o.Attrs(ctx)
 }
 
-func (s BucketStorer) NewReader(ctx context.Context, objName string) (io.ReadCloser, error) {
+func (s BucketStorer) NewReader(ctx context.Context, objName string) (*storage.Reader, error) {
 	o := s.b.Object(objName)
 	return o.NewReader(ctx)
 }


### PR DESCRIPTION
This PR adds a materialized view, `feed_entity_scores`, containing the last week of feed entities plus data needed for the koala algo. It's refreshed half-hourly with the help of a regular view `feed_entity_score_view`. When a request is made for a user's feed, the query unions both views to get the cached feed entities plus the most recent entities that haven't been cached yet.