### PR TITLE
Curated fixes

### DIFF
--- a/db/queries/core/recommend.sql
+++ b/db/queries/core/recommend.sql
@@ -61,18 +61,18 @@ where contract_id not in (
 
 -- name: GetFeedEntityScores :many
 with refreshed as (
-  select greatest((select last_updated from feed_entity_scores limit 1), now() - interval '3 day') last_updated
+  select greatest((select last_updated from feed_entity_scores limit 1), @window_end::timestamptz) last_updated
 )
 select *
 from feed_entity_scores f1
-where (@include_viewer::bool or f1.actor_id != @viewer_id)
-  and f1.created_at > @window_end::timestamptz
+where f1.created_at > @window_end::timestamptz
+  and (@include_viewer::bool or f1.actor_id != @viewer_id)
   and (@include_posts::bool or f1.feed_entity_type != @post_entity_type)
-  and (f1.action != any(@excluded_feed_actions::varchar[]))
+  and not (f1.action = any(@excluded_feed_actions::varchar[]))
 union
 select *
 from feed_entity_score_view f2
 where created_at > (select last_updated from refreshed limit 1)
   and (@include_viewer::bool or f2.actor_id != @viewer_id)
   and (@include_posts::bool or f2.feed_entity_type != @post_entity_type)
-  and (f2.action != any(@excluded_feed_actions::varchar[]));
+  and not (f2.action = any(@excluded_feed_actions::varchar[]));

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -720,7 +720,7 @@ func scoreFeedEntity(p *userpref.Personalization, viewerID persist.DBID, e db.Fe
 		// Use a default value of 0.1 so that it isn't completely penalized because of missing data.
 		personalizationF = 0.1
 	}
-	return timeF * engagementF * personalizationF
+	return timeF * (1 + engagementF) * (1 + personalizationF)
 }
 
 func timeFactor(t0, t1 time.Time) float64 {
@@ -730,7 +730,7 @@ func timeFactor(t0, t1 time.Time) float64 {
 }
 
 func engagementFactor(interactions int) float64 {
-	return math.Log1p(float64(interactions))
+	return float64(interactions)
 }
 
 type priorityNode interface {

--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -328,7 +328,7 @@ func calcRelevanceScore(ratingM, displayM *sparse.CSR, vIdx, cIdx int) float64 {
 			t = s
 		}
 	})
-	return t / 0.05
+	return t
 }
 
 // calcSimilarityScore computes the similarity of vIdx and qIdx based on their interactions with other users


### PR DESCRIPTION
Fixes:
* Correctly excludes specific actions from curated query
* Removes saturation penalty of interactions
* Removes indexing of relevance score
* Adds `+1` to engagement and personalization factors so zero-valued scores don't completely penalize the total score