### PR TITLE
seen provider

### DIFF
--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -225,7 +225,7 @@ func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      d.chain,
 		ChainID:    chainID,
-		ProviderID: 1,
+		ProviderID: "alchemy",
 	}
 }
 

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -214,7 +214,7 @@ func NewProvider(chain persist.Chain, httpClient *http.Client) *Provider {
 }
 
 // GetBlockchainInfo retrieves blockchain info for ETH
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	chainID := 0
 	switch d.chain {
 	case persist.ChainOptimism:
@@ -223,9 +223,10 @@ func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.Blockchain
 		chainID = 137
 	}
 	return multichain.BlockchainInfo{
-		Chain:   d.chain,
-		ChainID: chainID,
-	}, nil
+		Chain:      d.chain,
+		ChainID:    chainID,
+		ProviderID: 1,
+	}
 }
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Ethereum Blockchain

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -51,7 +51,7 @@ func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      persist.ChainETH,
 		ChainID:    0,
-		ProviderID: 3,
+		ProviderID: "eth",
 	}
 }
 

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -47,11 +47,12 @@ func NewProvider(indexerBaseURL string, httpClient *http.Client, ec *ethclient.C
 }
 
 // GetBlockchainInfo retrieves blockchain info for ETH
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
-		Chain:   persist.ChainETH,
-		ChainID: 0,
-	}, nil
+		Chain:      persist.ChainETH,
+		ChainID:    0,
+		ProviderID: 3,
+	}
 }
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID

--- a/service/multichain/fallback.go
+++ b/service/multichain/fallback.go
@@ -46,8 +46,8 @@ type SyncFailureSecondary interface {
 	TokenDescriptorsFetcher
 }
 
-func (f SyncWithContractEvalFallbackProvider) GetBlockchainInfo(ctx context.Context) (BlockchainInfo, error) {
-	return f.Primary.GetBlockchainInfo(ctx)
+func (f SyncWithContractEvalFallbackProvider) GetBlockchainInfo() BlockchainInfo {
+	return f.Primary.GetBlockchainInfo()
 }
 
 func (f SyncWithContractEvalFallbackProvider) GetTokensByWalletAddress(ctx context.Context, address persist.Address, limit int, offset int) ([]ChainAgnosticToken, []ChainAgnosticContract, error) {
@@ -126,8 +126,8 @@ func (f SyncWithContractEvalFallbackProvider) GetSubproviders() []any {
 	return []any{f.Primary, f.Fallback}
 }
 
-func (f SyncFailureFallbackProvider) GetBlockchainInfo(ctx context.Context) (BlockchainInfo, error) {
-	return f.Primary.GetBlockchainInfo(ctx)
+func (f SyncFailureFallbackProvider) GetBlockchainInfo() BlockchainInfo {
+	return f.Primary.GetBlockchainInfo()
 }
 
 func (f SyncFailureFallbackProvider) GetTokensByWalletAddress(ctx context.Context, address persist.Address, limit int, offset int) ([]ChainAgnosticToken, []ChainAgnosticContract, error) {

--- a/service/multichain/infura/infura.go
+++ b/service/multichain/infura/infura.go
@@ -129,11 +129,12 @@ func NewProvider(httpClient *http.Client) *Provider {
 }
 
 // GetBlockchainInfo retrieves blockchain info for ETH
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
-		Chain:   persist.ChainETH,
-		ChainID: 0,
-	}, nil
+		Chain:      persist.ChainETH,
+		ChainID:    0,
+		ProviderID: 2,
+	}
 }
 
 func (p *Provider) GetTokensByWalletAddress(ctx context.Context, address persist.Address, limit int, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {

--- a/service/multichain/infura/infura.go
+++ b/service/multichain/infura/infura.go
@@ -133,7 +133,7 @@ func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      persist.ChainETH,
 		ChainID:    0,
-		ProviderID: 2,
+		ProviderID: "infura",
 	}
 }
 

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -218,7 +218,7 @@ func (p *Provider) GetBlockchainInfo(context.Context) (multichain.BlockchainInfo
 	return multichain.BlockchainInfo{
 		Chain:      p.chain,
 		ChainID:    0,
-		ProviderID: 0,
+		ProviderID: "opensea",
 	}, nil
 }
 

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -216,8 +216,9 @@ func NewProvider(ethClient *ethclient.Client, httpClient *http.Client, chain per
 // GetBlockchainInfo returns Ethereum blockchain info
 func (p *Provider) GetBlockchainInfo(context.Context) (multichain.BlockchainInfo, error) {
 	return multichain.BlockchainInfo{
-		Chain:   p.chain,
-		ChainID: 0,
+		Chain:      p.chain,
+		ChainID:    0,
+		ProviderID: 0,
 	}, nil
 }
 

--- a/service/multichain/poap/poap.go
+++ b/service/multichain/poap/poap.go
@@ -149,7 +149,7 @@ func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      persist.ChainPOAP,
 		ChainID:    0,
-		ProviderID: 6,
+		ProviderID: "poap",
 	}
 }
 

--- a/service/multichain/poap/poap.go
+++ b/service/multichain/poap/poap.go
@@ -145,11 +145,12 @@ func NewProvider(httpClient *http.Client, apiKey string, authToken string) *Prov
 }
 
 // GetBlockchainInfo retrieves blockchain info for ETH
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
-		Chain:   persist.ChainPOAP,
-		ChainID: 0,
-	}, nil
+		Chain:      persist.ChainPOAP,
+		ChainID:    0,
+		ProviderID: 6,
+	}
 }
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Poap Blockchain

--- a/service/multichain/reservoir/reservoir.go
+++ b/service/multichain/reservoir/reservoir.go
@@ -177,7 +177,7 @@ func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      d.chain,
 		ChainID:    chainID,
-		ProviderID: 8,
+		ProviderID: "reservoir",
 	}
 }
 

--- a/service/multichain/reservoir/reservoir.go
+++ b/service/multichain/reservoir/reservoir.go
@@ -160,7 +160,7 @@ func NewProvider(chain persist.Chain, httpClient *http.Client) *Provider {
 }
 
 // GetBlockchainInfo retrieves blockchain info for ETH
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	chainID := 0
 	switch d.chain {
 	case persist.ChainOptimism:
@@ -175,9 +175,10 @@ func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.Blockchain
 		chainID = 84531
 	}
 	return multichain.BlockchainInfo{
-		Chain:   d.chain,
-		ChainID: chainID,
-	}, nil
+		Chain:      d.chain,
+		ChainID:    chainID,
+		ProviderID: 8,
+	}
 }
 
 func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -104,7 +104,7 @@ func (p *TezosObjktProvider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      persist.ChainTezos,
 		ChainID:    0,
-		ProviderID: 4,
+		ProviderID: "objkt",
 	}
 }
 

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -100,11 +100,12 @@ func NewObjktProvider(ipfsGatewayURL string) *TezosObjktProvider {
 	}
 }
 
-func (p *TezosObjktProvider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (p *TezosObjktProvider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
-		Chain:   persist.ChainTezos,
-		ChainID: 0,
-	}, nil
+		Chain:      persist.ChainTezos,
+		ChainID:    0,
+		ProviderID: 4,
+	}
 }
 
 func (p *TezosObjktProvider) RefreshToken(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, owner persist.Address) error {

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -135,7 +135,7 @@ func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      persist.ChainTezos,
 		ChainID:    0,
-		ProviderID: 5,
+		ProviderID: "tezos",
 	}
 }
 

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -131,11 +131,12 @@ func NewProvider(tezosAPIUrl string, httpClient *http.Client) *Provider {
 }
 
 // GetBlockchainInfo retrieves blockchain info for Tezos
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
-		Chain:   persist.ChainTezos,
-		ChainID: 0,
-	}, nil
+		Chain:      persist.ChainTezos,
+		ChainID:    0,
+		ProviderID: 5,
+	}
 }
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Tezos Blockchain

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -137,7 +137,7 @@ func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 	return multichain.BlockchainInfo{
 		Chain:      persist.ChainZora,
 		ChainID:    7777777,
-		ProviderID: 7,
+		ProviderID: "zora",
 	}
 }
 

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -132,12 +132,13 @@ func NewProvider(httpClient *http.Client) *Provider {
 }
 
 // GetBlockchainInfo retrieves blockchain info for ETH
-func (d *Provider) GetBlockchainInfo(ctx context.Context) (multichain.BlockchainInfo, error) {
+func (d *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 
 	return multichain.BlockchainInfo{
-		Chain:   persist.ChainZora,
-		ChainID: 7777777,
-	}, nil
+		Chain:      persist.ChainZora,
+		ChainID:    7777777,
+		ProviderID: 7,
+	}
 }
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the zora Blockchain


### PR DESCRIPTION
Changes:

- **Added** `ProviderID` to `BlockchainInfo` so that each provider can get a unique hard coded ID we can dedupe on.
- **Changed** `providersMatchingInterface` to perform the two checks listed below

1. Check if we have already seen a provider with the given provider ID
2. If a provider is a `ProviderSupplier` and matches the interface we are checking, add that provider's sub provider IDs to the duplicate checking map so that we don't add the individual sub providers later