### PR TITLE
l2 providers gaina ccess to metadata

### DIFF
--- a/cmd/refresh/refresh.go
+++ b/cmd/refresh/refresh.go
@@ -21,7 +21,7 @@ func main() {
 
 	pgClient := postgres.MustCreateClient()
 
-	rows, err := pgClient.Query("select tokens.id from tokens where owner_user_id = (select id from users where username_idempotent = 'pixelsushirobot') and chain = 4 order by tokens.last_updated desc limit 10;")
+	rows, err := pgClient.Query("select tokens.id from tokens where chain = 4 order by tokens.last_updated desc limit 2500;")
 	if err != nil {
 		panic(err)
 	}

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -417,13 +417,16 @@ func (d *Provider) getTokenWithMetadata(ctx context.Context, ti multichain.Chain
 func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
 	if d.chain == persist.ChainETH {
 		// don't use alchemy for ETH
-		return nil, nil
+		return nil, fmt.Errorf("not implemented")
 	}
 
 	cached, err := d.fetchMetadataFromCache(ctx, ti)
 	if cached != nil && err == nil {
+		logger.For(ctx).Infof("got cached metadata for %s", ti)
 		return cached, nil
 	}
+
+	logger.For(ctx).Infof("no cached metadata for %s", ti)
 
 	tokens, _, err := d.getTokenWithMetadata(ctx, ti, true, 0)
 	if err != nil {

--- a/service/redis/redis.go
+++ b/service/redis/redis.go
@@ -27,17 +27,17 @@ type CacheConfig struct {
 }
 
 const (
-	locks                   redisDB = 0
-	rateLimiters            redisDB = 1
-	communities             redisDB = 2
-	misc                    redisDB = 3
-	indexerServerThrottle   redisDB = 6
-	refreshNFTsThrottle     redisDB = 7
-	tokenProcessingThrottle redisDB = 8
-	emailThrottle           redisDB = 9
-	graphQLAPQ              redisDB = 12
-	feed                    redisDB = 13
-	social                  redisDB = 14
+	locks                 redisDB = 0
+	rateLimiters          redisDB = 1
+	communities           redisDB = 2
+	misc                  redisDB = 3
+	indexerServerThrottle redisDB = 6
+	refreshNFTsThrottle   redisDB = 7
+	tokenProcessing       redisDB = 8
+	emailThrottle         redisDB = 9
+	graphQLAPQ            redisDB = 12
+	feed                  redisDB = 13
+	social                redisDB = 14
 )
 
 // Every cache is uniquely defined by its database and key prefix. Display names are used for tracing.
@@ -51,7 +51,8 @@ var (
 	CommunitiesCache                  = CacheConfig{database: communities, keyPrefix: "", displayName: "communities"}
 	IndexerServerThrottleCache        = CacheConfig{database: indexerServerThrottle, keyPrefix: "", displayName: "indexerServerThrottle"}
 	RefreshNFTsThrottleCache          = CacheConfig{database: refreshNFTsThrottle, keyPrefix: "", displayName: "refreshNFTsThrottle"}
-	TokenProcessingThrottleCache      = CacheConfig{database: tokenProcessingThrottle, keyPrefix: "", displayName: "tokenProcessingThrottle"}
+	TokenProcessingThrottleCache      = CacheConfig{database: tokenProcessing, keyPrefix: "throttle", displayName: "tokenProcessingThrottle"}
+	TokenProcessingMetadataCache      = CacheConfig{database: tokenProcessing, keyPrefix: "metadata", displayName: "tokenProcessingMetadata"}
 	EmailThrottleCache                = CacheConfig{database: emailThrottle, keyPrefix: "", displayName: "emailThrottle"}
 	GraphQLAPQCache                   = CacheConfig{database: graphQLAPQ, keyPrefix: "", displayName: "graphQLAPQ"}
 	FeedCache                         = CacheConfig{database: feed, keyPrefix: "", displayName: "feed"}


### PR DESCRIPTION
Changes:

- **Added** metadata fetcher to alchemy provider but only works for l2s. Added caching so that metadata can be shared from the initial sync call to the fetching of metadata by the token processing service