### PR TITLE
More tokens.media removal / fixes

### DIFF
--- a/db/gen/coredb/gallery.sql.go
+++ b/db/gen/coredb/gallery.sql.go
@@ -184,7 +184,7 @@ const galleryRepoGetPreviewsForUserID = `-- name: GalleryRepoGetPreviewsForUserI
 select (tm.media ->> 'thumbnail_url')::text from galleries g,
     unnest(g.collections) with ordinality as collection_ids(id, ord) inner join collections c on c.id = collection_ids.id and c.deleted = false,
     unnest(c.nfts) with ordinality as token_ids(id, ord) inner join tokens t on t.id = token_ids.id and t.displayable and t.deleted = false
-    inner join token_medias tm on tm.token_id = t.id and tm.media ->> 'thumbnail_url' != ''
+    inner join token_medias tm on t.token_media_id = tm.id and tm.media ->> 'thumbnail_url' != ''
     where g.owner_user_id = $1 and g.deleted = false
     order by collection_ids.ord, token_ids.ord limit $2
 `

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -2857,7 +2857,16 @@ func (q *Queries) GetPostsByIds(ctx context.Context, ids []string) ([]Post, erro
 }
 
 const getPreviewURLsByContractIdAndUserId = `-- name: GetPreviewURLsByContractIdAndUserId :many
-select (media->>'thumbnail_url')::varchar as thumbnail_url from tokens where contract = $1 and displayable and deleted = false and owner_user_id = $2 and length(media->>'thumbnail_url'::varchar) > 0 order by id limit 3
+select (tm.media->>'thumbnail_url')::varchar as thumbnail_url
+    from tokens t
+        inner join token_medias tm on t.token_media_id = tm.id
+    where t.contract = $1
+      and t.owner_user_id = $2
+      and t.displayable
+      and t.deleted = false
+      and tm.media ->> 'thumbnail_url' != ''
+      and tm.deleted = false
+    order by t.id limit 3
 `
 
 type GetPreviewURLsByContractIdAndUserIdParams struct {

--- a/db/queries/core/gallery.sql
+++ b/db/queries/core/gallery.sql
@@ -29,7 +29,7 @@ select * from galleries g where g.owner_user_id = $1 and g.deleted = false order
 select (tm.media ->> 'thumbnail_url')::text from galleries g,
     unnest(g.collections) with ordinality as collection_ids(id, ord) inner join collections c on c.id = collection_ids.id and c.deleted = false,
     unnest(c.nfts) with ordinality as token_ids(id, ord) inner join tokens t on t.id = token_ids.id and t.displayable and t.deleted = false
-    inner join token_medias tm on tm.token_id = t.id and tm.media ->> 'thumbnail_url' != ''
+    inner join token_medias tm on t.token_media_id = tm.id and tm.media ->> 'thumbnail_url' != ''
     where g.owner_user_id = $1 and g.deleted = false
     order by collection_ids.ord, token_ids.ord limit $2;
 

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -267,7 +267,16 @@ select u.* from tokens t
     where t.id = $1 and t.displayable and t.deleted = false and u.deleted = false;
 
 -- name: GetPreviewURLsByContractIdAndUserId :many
-select (media->>'thumbnail_url')::varchar as thumbnail_url from tokens where contract = $1 and displayable and deleted = false and owner_user_id = $2 and length(media->>'thumbnail_url'::varchar) > 0 order by id limit 3;
+select (tm.media->>'thumbnail_url')::varchar as thumbnail_url
+    from tokens t
+        inner join token_medias tm on t.token_media_id = tm.id
+    where t.contract = $1
+      and t.owner_user_id = $2
+      and t.displayable
+      and t.deleted = false
+      and tm.media ->> 'thumbnail_url' != ''
+      and tm.deleted = false
+    order by t.id limit 3;
 
 -- name: GetTokensByUserIdBatch :batchmany
 select t.* from tokens t


### PR DESCRIPTION
I found another query that was referencing `tokens.media`. When I was updating it to use `token_medias`, I noticed that `GalleryRepoGetPreviewsForUserID` was joining on the wrong thing, so I fixed that too.