### PR TITLE
replies and mentions

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -1921,7 +1921,7 @@ func (b *GetNewTokensByFeedEventIdBatchBatchResults) Close() error {
 }
 
 const getNotificationByIDBatch = `-- name: GetNotificationByIDBatch :batchone
-SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id FROM notifications WHERE id = $1 AND deleted = false
+SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id FROM notifications WHERE id = $1 AND deleted = false
 `
 
 type GetNotificationByIDBatchBatchResults struct {
@@ -1970,6 +1970,7 @@ func (b *GetNotificationByIDBatchBatchResults) QueryRow(f func(int, Notification
 			&i.Amount,
 			&i.PostID,
 			&i.TokenID,
+			&i.ContractID,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -3337,7 +3338,7 @@ func (b *GetUserByUsernameBatchBatchResults) Close() error {
 }
 
 const getUserNotificationsBatch = `-- name: GetUserNotificationsBatch :batchmany
-SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id FROM notifications WHERE owner_id = $1 AND deleted = false
+SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id FROM notifications WHERE owner_id = $1 AND deleted = false
     AND (created_at, id) < ($2, $3)
     AND (created_at, id) > ($4, $5)
     ORDER BY CASE WHEN $6::bool THEN (created_at, id) END ASC,
@@ -3414,6 +3415,7 @@ func (b *GetUserNotificationsBatchBatchResults) Query(f func(int, []Notification
 					&i.Amount,
 					&i.PostID,
 					&i.TokenID,
+					&i.ContractID,
 				); err != nil {
 					return err
 				}

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -125,6 +125,7 @@ type Event struct {
 	Caption        sql.NullString       `json:"caption"`
 	GroupID        sql.NullString       `json:"group_id"`
 	PostID         persist.DBID         `json:"post_id"`
+	ContractID     persist.DBID         `json:"contract_id"`
 }
 
 type ExternalSocialConnection struct {
@@ -311,6 +312,7 @@ type Notification struct {
 	Amount      int32                    `json:"amount"`
 	PostID      persist.DBID             `json:"post_id"`
 	TokenID     persist.DBID             `json:"token_id"`
+	ContractID  persist.DBID             `json:"contract_id"`
 }
 
 type OwnedContract struct {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -119,7 +119,7 @@ func (q *Queries) BlockUserFromFeed(ctx context.Context, arg BlockUserFromFeedPa
 }
 
 const clearNotificationsForUser = `-- name: ClearNotificationsForUser :many
-UPDATE notifications SET seen = true WHERE owner_id = $1 AND seen = false RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id
+UPDATE notifications SET seen = true WHERE owner_id = $1 AND seen = false RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
 `
 
 func (q *Queries) ClearNotificationsForUser(ctx context.Context, ownerID persist.DBID) ([]Notification, error) {
@@ -148,6 +148,7 @@ func (q *Queries) ClearNotificationsForUser(ctx context.Context, ownerID persist
 			&i.Amount,
 			&i.PostID,
 			&i.TokenID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}
@@ -317,7 +318,7 @@ func (q *Queries) CountUserUnseenNotifications(ctx context.Context, ownerID pers
 }
 
 const createAdmireEvent = `-- name: CreateAdmireEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $9, $10, $5, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id
+INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $9, $10, $5, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
 `
 
 type CreateAdmireEventParams struct {
@@ -369,12 +370,13 @@ func (q *Queries) CreateAdmireEvent(ctx context.Context, arg CreateAdmireEventPa
 		&i.Caption,
 		&i.GroupID,
 		&i.PostID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const createAdmireNotification = `-- name: CreateAdmireNotification :one
-INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id, post_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id
+INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id, post_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
 `
 
 type CreateAdmireNotificationParams struct {
@@ -415,6 +417,7 @@ func (q *Queries) CreateAdmireNotification(ctx context.Context, arg CreateAdmire
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
@@ -453,7 +456,7 @@ func (q *Queries) CreateCollection(ctx context.Context, arg CreateCollectionPara
 }
 
 const createCollectionEvent = `-- name: CreateCollectionEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, collection_id, subject_id, data, caption, group_id, gallery_id) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id
+INSERT INTO events (id, actor_id, action, resource_type_id, collection_id, subject_id, data, caption, group_id, gallery_id) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
 `
 
 type CreateCollectionEventParams struct {
@@ -503,12 +506,13 @@ func (q *Queries) CreateCollectionEvent(ctx context.Context, arg CreateCollectio
 		&i.Caption,
 		&i.GroupID,
 		&i.PostID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const createCommentEvent = `-- name: CreateCommentEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $9, $10, $5, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id
+INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $9, $10, $5, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
 `
 
 type CreateCommentEventParams struct {
@@ -560,12 +564,13 @@ func (q *Queries) CreateCommentEvent(ctx context.Context, arg CreateCommentEvent
 		&i.Caption,
 		&i.GroupID,
 		&i.PostID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const createCommentNotification = `-- name: CreateCommentNotification :one
-INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id, post_id, comment_id) VALUES ($1, $2, $3, $4, $5, $7, $8, $6) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id
+INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id, post_id, comment_id) VALUES ($1, $2, $3, $4, $5, $7, $8, $6) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
 `
 
 type CreateCommentNotificationParams struct {
@@ -608,6 +613,118 @@ func (q *Queries) CreateCommentNotification(ctx context.Context, arg CreateComme
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
+	)
+	return i, err
+}
+
+const createContractEvent = `-- name: CreateContractEvent :one
+INSERT INTO events (id, actor_id, action, resource_type_id, contract_id, subject_id, post_id, comment_id, feed_event_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $5, $9, $10, $11, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
+`
+
+type CreateContractEventParams struct {
+	ID             persist.DBID         `json:"id"`
+	ActorID        sql.NullString       `json:"actor_id"`
+	Action         persist.Action       `json:"action"`
+	ResourceTypeID persist.ResourceType `json:"resource_type_id"`
+	ContractID     persist.DBID         `json:"contract_id"`
+	Data           persist.EventData    `json:"data"`
+	GroupID        sql.NullString       `json:"group_id"`
+	Caption        sql.NullString       `json:"caption"`
+	Post           sql.NullString       `json:"post"`
+	Comment        sql.NullString       `json:"comment"`
+	FeedEvent      sql.NullString       `json:"feed_event"`
+}
+
+func (q *Queries) CreateContractEvent(ctx context.Context, arg CreateContractEventParams) (Event, error) {
+	row := q.db.QueryRow(ctx, createContractEvent,
+		arg.ID,
+		arg.ActorID,
+		arg.Action,
+		arg.ResourceTypeID,
+		arg.ContractID,
+		arg.Data,
+		arg.GroupID,
+		arg.Caption,
+		arg.Post,
+		arg.Comment,
+		arg.FeedEvent,
+	)
+	var i Event
+	err := row.Scan(
+		&i.ID,
+		&i.Version,
+		&i.ActorID,
+		&i.ResourceTypeID,
+		&i.SubjectID,
+		&i.UserID,
+		&i.TokenID,
+		&i.CollectionID,
+		&i.Action,
+		&i.Data,
+		&i.Deleted,
+		&i.LastUpdated,
+		&i.CreatedAt,
+		&i.GalleryID,
+		&i.CommentID,
+		&i.AdmireID,
+		&i.FeedEventID,
+		&i.ExternalID,
+		&i.Caption,
+		&i.GroupID,
+		&i.PostID,
+		&i.ContractID,
+	)
+	return i, err
+}
+
+const createContractNotification = `-- name: CreateContractNotification :one
+INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id, post_id, comment_id, contract_id) VALUES ($1, $2, $3, $4, $5, $7, $8, $9, $6) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
+`
+
+type CreateContractNotificationParams struct {
+	ID         persist.DBID             `json:"id"`
+	OwnerID    persist.DBID             `json:"owner_id"`
+	Action     persist.Action           `json:"action"`
+	Data       persist.NotificationData `json:"data"`
+	EventIds   persist.DBIDList         `json:"event_ids"`
+	ContractID persist.DBID             `json:"contract_id"`
+	FeedEvent  sql.NullString           `json:"feed_event"`
+	Post       sql.NullString           `json:"post"`
+	Comment    sql.NullString           `json:"comment"`
+}
+
+func (q *Queries) CreateContractNotification(ctx context.Context, arg CreateContractNotificationParams) (Notification, error) {
+	row := q.db.QueryRow(ctx, createContractNotification,
+		arg.ID,
+		arg.OwnerID,
+		arg.Action,
+		arg.Data,
+		arg.EventIds,
+		arg.ContractID,
+		arg.FeedEvent,
+		arg.Post,
+		arg.Comment,
+	)
+	var i Notification
+	err := row.Scan(
+		&i.ID,
+		&i.Deleted,
+		&i.OwnerID,
+		&i.Version,
+		&i.LastUpdated,
+		&i.CreatedAt,
+		&i.Action,
+		&i.Data,
+		&i.EventIds,
+		&i.FeedEventID,
+		&i.CommentID,
+		&i.GalleryID,
+		&i.Seen,
+		&i.Amount,
+		&i.PostID,
+		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
@@ -657,7 +774,7 @@ func (q *Queries) CreateFeedEvent(ctx context.Context, arg CreateFeedEventParams
 }
 
 const createGalleryEvent = `-- name: CreateGalleryEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, gallery_id, subject_id, data, external_id, group_id, caption) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id
+INSERT INTO events (id, actor_id, action, resource_type_id, gallery_id, subject_id, data, external_id, group_id, caption) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
 `
 
 type CreateGalleryEventParams struct {
@@ -707,6 +824,56 @@ func (q *Queries) CreateGalleryEvent(ctx context.Context, arg CreateGalleryEvent
 		&i.Caption,
 		&i.GroupID,
 		&i.PostID,
+		&i.ContractID,
+	)
+	return i, err
+}
+
+const createMentionUserNotification = `-- name: CreateMentionUserNotification :one
+INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id, post_id, comment_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
+`
+
+type CreateMentionUserNotificationParams struct {
+	ID        persist.DBID             `json:"id"`
+	OwnerID   persist.DBID             `json:"owner_id"`
+	Action    persist.Action           `json:"action"`
+	Data      persist.NotificationData `json:"data"`
+	EventIds  persist.DBIDList         `json:"event_ids"`
+	FeedEvent sql.NullString           `json:"feed_event"`
+	Post      sql.NullString           `json:"post"`
+	Comment   sql.NullString           `json:"comment"`
+}
+
+func (q *Queries) CreateMentionUserNotification(ctx context.Context, arg CreateMentionUserNotificationParams) (Notification, error) {
+	row := q.db.QueryRow(ctx, createMentionUserNotification,
+		arg.ID,
+		arg.OwnerID,
+		arg.Action,
+		arg.Data,
+		arg.EventIds,
+		arg.FeedEvent,
+		arg.Post,
+		arg.Comment,
+	)
+	var i Notification
+	err := row.Scan(
+		&i.ID,
+		&i.Deleted,
+		&i.OwnerID,
+		&i.Version,
+		&i.LastUpdated,
+		&i.CreatedAt,
+		&i.Action,
+		&i.Data,
+		&i.EventIds,
+		&i.FeedEventID,
+		&i.CommentID,
+		&i.GalleryID,
+		&i.Seen,
+		&i.Amount,
+		&i.PostID,
+		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
@@ -760,7 +927,7 @@ func (q *Queries) CreatePushTokenForUser(ctx context.Context, arg CreatePushToke
 }
 
 const createSimpleNotification = `-- name: CreateSimpleNotification :one
-INSERT INTO notifications (id, owner_id, action, data, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id
+INSERT INTO notifications (id, owner_id, action, data, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
 `
 
 type CreateSimpleNotificationParams struct {
@@ -797,12 +964,13 @@ func (q *Queries) CreateSimpleNotification(ctx context.Context, arg CreateSimple
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const createTokenEvent = `-- name: CreateTokenEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, token_id, subject_id, data, group_id, caption, gallery_id, collection_id) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9, $10) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id
+INSERT INTO events (id, actor_id, action, resource_type_id, token_id, subject_id, data, group_id, caption, gallery_id, collection_id) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8, $9, $10) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
 `
 
 type CreateTokenEventParams struct {
@@ -854,12 +1022,13 @@ func (q *Queries) CreateTokenEvent(ctx context.Context, arg CreateTokenEventPara
 		&i.Caption,
 		&i.GroupID,
 		&i.PostID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const createTokenNotification = `-- name: CreateTokenNotification :one
-INSERT INTO notifications (id, owner_id, action, data, event_ids, token_id, amount) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id
+INSERT INTO notifications (id, owner_id, action, data, event_ids, token_id, amount) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
 `
 
 type CreateTokenNotificationParams struct {
@@ -900,12 +1069,13 @@ func (q *Queries) CreateTokenNotification(ctx context.Context, arg CreateTokenNo
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const createUserEvent = `-- name: CreateUserEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, user_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id
+INSERT INTO events (id, actor_id, action, resource_type_id, user_id, subject_id, post_id, comment_id, feed_event_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $5, $9, $10, $11, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
 `
 
 type CreateUserEventParams struct {
@@ -917,6 +1087,9 @@ type CreateUserEventParams struct {
 	Data           persist.EventData    `json:"data"`
 	GroupID        sql.NullString       `json:"group_id"`
 	Caption        sql.NullString       `json:"caption"`
+	Post           sql.NullString       `json:"post"`
+	Comment        sql.NullString       `json:"comment"`
+	FeedEvent      sql.NullString       `json:"feed_event"`
 }
 
 func (q *Queries) CreateUserEvent(ctx context.Context, arg CreateUserEventParams) (Event, error) {
@@ -929,6 +1102,9 @@ func (q *Queries) CreateUserEvent(ctx context.Context, arg CreateUserEventParams
 		arg.Data,
 		arg.GroupID,
 		arg.Caption,
+		arg.Post,
+		arg.Comment,
+		arg.FeedEvent,
 	)
 	var i Event
 	err := row.Scan(
@@ -953,12 +1129,13 @@ func (q *Queries) CreateUserEvent(ctx context.Context, arg CreateUserEventParams
 		&i.Caption,
 		&i.GroupID,
 		&i.PostID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const createViewGalleryNotification = `-- name: CreateViewGalleryNotification :one
-INSERT INTO notifications (id, owner_id, action, data, event_ids, gallery_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id
+INSERT INTO notifications (id, owner_id, action, data, event_ids, gallery_id) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id
 `
 
 type CreateViewGalleryNotificationParams struct {
@@ -997,6 +1174,7 @@ func (q *Queries) CreateViewGalleryNotification(ctx context.Context, arg CreateV
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
@@ -1320,6 +1498,49 @@ func (q *Queries) GetAllTokensWithContractsByIDs(ctx context.Context, arg GetAll
 			&i.ParentID,
 			&i.OverrideCreatorUserID,
 			&i.WalletAddress,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getAllUsersByIDs = `-- name: GetAllUsersByIDs :many
+SELECT id, deleted, version, last_updated, created_at, username, username_idempotent, wallets, bio, traits, universal, notification_settings, email_verified, email_unsubscriptions, featured_gallery, primary_wallet_id, user_experiences, profile_image_id FROM users WHERE username_idempotent = ANY($1::varchar[]) AND deleted = false
+`
+
+func (q *Queries) GetAllUsersByIDs(ctx context.Context, userIds []string) ([]User, error) {
+	rows, err := q.db.Query(ctx, getAllUsersByIDs, userIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []User
+	for rows.Next() {
+		var i User
+		if err := rows.Scan(
+			&i.ID,
+			&i.Deleted,
+			&i.Version,
+			&i.LastUpdated,
+			&i.CreatedAt,
+			&i.Username,
+			&i.UsernameIdempotent,
+			&i.Wallets,
+			&i.Bio,
+			&i.Traits,
+			&i.Universal,
+			&i.NotificationSettings,
+			&i.EmailVerified,
+			&i.EmailUnsubscriptions,
+			&i.FeaturedGallery,
+			&i.PrimaryWalletID,
+			&i.UserExperiences,
+			&i.ProfileImageID,
 		); err != nil {
 			return nil, err
 		}
@@ -1976,7 +2197,7 @@ func (q *Queries) GetEthereumWalletsForEnsProfileImagesByUserID(ctx context.Cont
 }
 
 const getEvent = `-- name: GetEvent :one
-SELECT id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id FROM events WHERE id = $1 AND deleted = false
+SELECT id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id FROM events WHERE id = $1 AND deleted = false
 `
 
 func (q *Queries) GetEvent(ctx context.Context, id persist.DBID) (Event, error) {
@@ -2004,12 +2225,13 @@ func (q *Queries) GetEvent(ctx context.Context, id persist.DBID) (Event, error) 
 		&i.Caption,
 		&i.GroupID,
 		&i.PostID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const getEventsInGroup = `-- name: GetEventsInGroup :many
-select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id from events where group_id = $1 and deleted = false order by(created_at, id) asc
+select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id from events where group_id = $1 and deleted = false order by(created_at, id) asc
 `
 
 func (q *Queries) GetEventsInGroup(ctx context.Context, groupID sql.NullString) ([]Event, error) {
@@ -2043,6 +2265,7 @@ func (q *Queries) GetEventsInGroup(ctx context.Context, groupID sql.NullString) 
 			&i.Caption,
 			&i.GroupID,
 			&i.PostID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}
@@ -2056,9 +2279,9 @@ func (q *Queries) GetEventsInGroup(ctx context.Context, groupID sql.NullString) 
 
 const getEventsInWindow = `-- name: GetEventsInWindow :many
 with recursive activity as (
-    select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id from events where events.id = $1 and deleted = false
+    select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id from events where events.id = $1 and deleted = false
     union
-    select e.id, e.version, e.actor_id, e.resource_type_id, e.subject_id, e.user_id, e.token_id, e.collection_id, e.action, e.data, e.deleted, e.last_updated, e.created_at, e.gallery_id, e.comment_id, e.admire_id, e.feed_event_id, e.external_id, e.caption, e.group_id, e.post_id from events e, activity a
+    select e.id, e.version, e.actor_id, e.resource_type_id, e.subject_id, e.user_id, e.token_id, e.collection_id, e.action, e.data, e.deleted, e.last_updated, e.created_at, e.gallery_id, e.comment_id, e.admire_id, e.feed_event_id, e.external_id, e.caption, e.group_id, e.post_id, e.contract_id from events e, activity a
     where e.actor_id = a.actor_id
         and e.action = any($3)
         and e.created_at < a.created_at
@@ -2067,7 +2290,7 @@ with recursive activity as (
         and e.caption is null
         and (not $4::bool or e.subject_id = a.subject_id)
 )
-select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id from events where id = any(select id from activity) order by (created_at, id) asc
+select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id from events where id = any(select id from activity) order by (created_at, id) asc
 `
 
 type GetEventsInWindowParams struct {
@@ -2113,6 +2336,7 @@ func (q *Queries) GetEventsInWindow(ctx context.Context, arg GetEventsInWindowPa
 			&i.Caption,
 			&i.GroupID,
 			&i.PostID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}
@@ -2269,9 +2493,9 @@ func (q *Queries) GetGalleryById(ctx context.Context, id persist.DBID) (Gallery,
 
 const getGalleryEventsInWindow = `-- name: GetGalleryEventsInWindow :many
 with recursive activity as (
-    select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id from events where events.id = $1 and deleted = false
+    select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id from events where events.id = $1 and deleted = false
     union
-    select e.id, e.version, e.actor_id, e.resource_type_id, e.subject_id, e.user_id, e.token_id, e.collection_id, e.action, e.data, e.deleted, e.last_updated, e.created_at, e.gallery_id, e.comment_id, e.admire_id, e.feed_event_id, e.external_id, e.caption, e.group_id, e.post_id from events e, activity a
+    select e.id, e.version, e.actor_id, e.resource_type_id, e.subject_id, e.user_id, e.token_id, e.collection_id, e.action, e.data, e.deleted, e.last_updated, e.created_at, e.gallery_id, e.comment_id, e.admire_id, e.feed_event_id, e.external_id, e.caption, e.group_id, e.post_id, e.contract_id from events e, activity a
     where e.actor_id = a.actor_id
         and e.action = any($3)
         and e.gallery_id = $4
@@ -2281,7 +2505,7 @@ with recursive activity as (
         and e.caption is null
         and (not $5::bool or e.subject_id = a.subject_id)
 )
-select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id from events where id = any(select id from activity) order by (created_at, id) asc
+select id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id from events where id = any(select id from activity) order by (created_at, id) asc
 `
 
 type GetGalleryEventsInWindowParams struct {
@@ -2329,6 +2553,7 @@ func (q *Queries) GetGalleryEventsInWindow(ctx context.Context, arg GetGalleryEv
 			&i.Caption,
 			&i.GroupID,
 			&i.PostID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}
@@ -2641,7 +2866,7 @@ func (q *Queries) GetMissingThumbnailTokensByIDRange(ctx context.Context, arg Ge
 }
 
 const getMostRecentNotificationByOwnerIDForAction = `-- name: GetMostRecentNotificationByOwnerIDForAction :one
-select id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id from notifications
+select id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id from notifications
     where owner_id = $1
     and action = $2
     and deleted = false
@@ -2687,12 +2912,13 @@ func (q *Queries) GetMostRecentNotificationByOwnerIDForAction(ctx context.Contex
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const getMostRecentNotificationByOwnerIDTokenIDForAction = `-- name: GetMostRecentNotificationByOwnerIDTokenIDForAction :one
-select id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id from notifications
+select id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id from notifications
     where owner_id = $1
     and token_id = $2
     and action = $3
@@ -2741,12 +2967,13 @@ func (q *Queries) GetMostRecentNotificationByOwnerIDTokenIDForAction(ctx context
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const getNotificationByID = `-- name: GetNotificationByID :one
-SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id FROM notifications WHERE id = $1 AND deleted = false
+SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id FROM notifications WHERE id = $1 AND deleted = false
 `
 
 func (q *Queries) GetNotificationByID(ctx context.Context, id persist.DBID) (Notification, error) {
@@ -2769,12 +2996,13 @@ func (q *Queries) GetNotificationByID(ctx context.Context, id persist.DBID) (Not
 		&i.Amount,
 		&i.PostID,
 		&i.TokenID,
+		&i.ContractID,
 	)
 	return i, err
 }
 
 const getNotificationsByOwnerIDForActionAfter = `-- name: GetNotificationsByOwnerIDForActionAfter :many
-SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id FROM notifications
+SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id FROM notifications
     WHERE owner_id = $1 AND action = $2 AND deleted = false AND created_at > $3
     ORDER BY created_at DESC
 `
@@ -2811,6 +3039,7 @@ func (q *Queries) GetNotificationsByOwnerIDForActionAfter(ctx context.Context, a
 			&i.Amount,
 			&i.PostID,
 			&i.TokenID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}
@@ -2972,7 +3201,7 @@ func (q *Queries) GetPushTokensByUserID(ctx context.Context, userID persist.DBID
 }
 
 const getRecentUnseenNotifications = `-- name: GetRecentUnseenNotifications :many
-SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id FROM notifications WHERE owner_id = $1 AND deleted = false AND seen = false and created_at > $2 order by created_at desc limit $3
+SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id FROM notifications WHERE owner_id = $1 AND deleted = false AND seen = false and created_at > $2 order by created_at desc limit $3
 `
 
 type GetRecentUnseenNotificationsParams struct {
@@ -3007,6 +3236,7 @@ func (q *Queries) GetRecentUnseenNotifications(ctx context.Context, arg GetRecen
 			&i.Amount,
 			&i.PostID,
 			&i.TokenID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}
@@ -3824,7 +4054,7 @@ func (q *Queries) GetUserExperiencesByUserID(ctx context.Context, id persist.DBI
 }
 
 const getUserNotifications = `-- name: GetUserNotifications :many
-SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id FROM notifications WHERE owner_id = $1 AND deleted = false
+SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id FROM notifications WHERE owner_id = $1 AND deleted = false
     AND (created_at, id) < ($3, $4)
     AND (created_at, id) > ($5, $6)
     ORDER BY CASE WHEN $7::bool THEN (created_at, id) END ASC,
@@ -3876,6 +4106,7 @@ func (q *Queries) GetUserNotifications(ctx context.Context, arg GetUserNotificat
 			&i.Amount,
 			&i.PostID,
 			&i.TokenID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}
@@ -3963,7 +4194,7 @@ func (q *Queries) GetUserRolesByUserId(ctx context.Context, arg GetUserRolesByUs
 }
 
 const getUserUnseenNotifications = `-- name: GetUserUnseenNotifications :many
-SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id FROM notifications WHERE owner_id = $1 AND deleted = false AND seen = false
+SELECT id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, contract_id FROM notifications WHERE owner_id = $1 AND deleted = false AND seen = false
     AND (created_at, id) < ($3, $4)
     AND (created_at, id) > ($5, $6)
     ORDER BY CASE WHEN $7::bool THEN (created_at, id) END ASC,
@@ -4015,6 +4246,7 @@ func (q *Queries) GetUserUnseenNotifications(ctx context.Context, arg GetUserUns
 			&i.Amount,
 			&i.PostID,
 			&i.TokenID,
+			&i.ContractID,
 		); err != nil {
 			return nil, err
 		}

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -512,7 +512,7 @@ func (q *Queries) CreateCollectionEvent(ctx context.Context, arg CreateCollectio
 }
 
 const createCommentEvent = `-- name: CreateCommentEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $9, $10, $5, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
+INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $10, $11, $6, $7, $8, $9) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id
 `
 
 type CreateCommentEventParams struct {
@@ -521,6 +521,7 @@ type CreateCommentEventParams struct {
 	Action         persist.Action       `json:"action"`
 	ResourceTypeID persist.ResourceType `json:"resource_type_id"`
 	CommentID      persist.DBID         `json:"comment_id"`
+	SubjectID      persist.DBID         `json:"subject_id"`
 	Data           persist.EventData    `json:"data"`
 	GroupID        sql.NullString       `json:"group_id"`
 	Caption        sql.NullString       `json:"caption"`
@@ -535,6 +536,7 @@ func (q *Queries) CreateCommentEvent(ctx context.Context, arg CreateCommentEvent
 		arg.Action,
 		arg.ResourceTypeID,
 		arg.CommentID,
+		arg.SubjectID,
 		arg.Data,
 		arg.GroupID,
 		arg.Caption,

--- a/db/migrations/core/000105_contract_event.up.sql
+++ b/db/migrations/core/000105_contract_event.up.sql
@@ -1,0 +1,2 @@
+alter table events add column contract_id varchar(255) references contracts(id);
+alter table notifications add column contract_id varchar(255) references contracts(id);

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -316,7 +316,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, contract_id, subject
 INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), $5, $6, $7, $8) RETURNING *;
 
 -- name: CreateCommentEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), $5, $6, $7, $8) RETURNING *;
+INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), $6, $7, $8, $9) RETURNING *;
 
 -- name: GetEvent :one
 SELECT * FROM events WHERE id = $1 AND deleted = false;

--- a/event/event.go
+++ b/event/event.go
@@ -442,6 +442,7 @@ func (h notificationHandler) handleDelayed(ctx context.Context, persistedEvent d
 
 	// Don't notify the user on self events
 	if persist.DBID(persist.NullStrToStr(persistedEvent.ActorID)) == owner && persistedEvent.Action != persist.ActionNewTokensReceived {
+
 		return nil
 	}
 
@@ -487,7 +488,7 @@ func (h notificationHandler) createNotificationDataForEvent(event db.Event) (dat
 		data.NewTokenID = event.Data.NewTokenID
 		data.NewTokenQuantity = event.Data.NewTokenQuantity
 	case persist.ActionReplyToComment:
-		data.OriginalCommentID = event.CommentID
+		data.OriginalCommentID = event.SubjectID
 	default:
 		logger.For(nil).Debugf("no notification data for event: %s", event.Action)
 	}
@@ -504,7 +505,7 @@ func (h notificationHandler) findOwnerForNotificationFromEvent(event db.Event) (
 		return gallery.OwnerUserID, nil
 	case persist.ResourceTypeComment:
 		if event.Action == persist.ActionReplyToComment {
-			comment, err := h.dataloaders.CommentByCommentID.Load(event.CommentID)
+			comment, err := h.dataloaders.CommentByCommentID.Load(event.SubjectID)
 			if err != nil {
 				return "", err
 			}

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -10560,6 +10560,7 @@ union RemoveProfileImagePayloadOrError =
 input PostTokensInput {
   tokenIds: [DBID!]
   caption: String
+  mentions: [MentionInput!]
 }
 
 type PostTokensPayload {
@@ -58258,7 +58259,7 @@ func (ec *executionContext) unmarshalInputPostTokensInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"tokenIds", "caption"}
+	fieldsInOrder := [...]string{"tokenIds", "caption", "mentions"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -58283,6 +58284,15 @@ func (ec *executionContext) unmarshalInputPostTokensInput(ctx context.Context, o
 				return it, err
 			}
 			it.Caption = data
+		case "mentions":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mentions"))
+			data, err := ec.unmarshalOMentionInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMentionInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Mentions = data
 		}
 	}
 

--- a/graphql/generated_test.go
+++ b/graphql/generated_test.go
@@ -298,6 +298,17 @@ type MagicLinkAuth struct {
 // GetToken returns MagicLinkAuth.Token, and is useful for accessing the field via an interface.
 func (v *MagicLinkAuth) GetToken() string { return v.Token }
 
+type MentionInput struct {
+	UserId      *persist.DBID `json:"userId"`
+	CommunityId *persist.DBID `json:"communityId"`
+}
+
+// GetUserId returns MentionInput.UserId, and is useful for accessing the field via an interface.
+func (v *MentionInput) GetUserId() *persist.DBID { return v.UserId }
+
+// GetCommunityId returns MentionInput.CommunityId, and is useful for accessing the field via an interface.
+func (v *MentionInput) GetCommunityId() *persist.DBID { return v.CommunityId }
+
 type MoveCollectionToGalleryInput struct {
 	SourceCollectionId persist.DBID `json:"sourceCollectionId"`
 	TargetGalleryId    persist.DBID `json:"targetGalleryId"`
@@ -321,6 +332,7 @@ func (v *OneTimeLoginTokenAuth) GetToken() string { return v.Token }
 type PostTokensInput struct {
 	TokenIds []persist.DBID `json:"tokenIds"`
 	Caption  *string        `json:"caption"`
+	Mentions []MentionInput `json:"mentions"`
 }
 
 // GetTokenIds returns PostTokensInput.TokenIds, and is useful for accessing the field via an interface.
@@ -328,6 +340,9 @@ func (v *PostTokensInput) GetTokenIds() []persist.DBID { return v.TokenIds }
 
 // GetCaption returns PostTokensInput.Caption, and is useful for accessing the field via an interface.
 func (v *PostTokensInput) GetCaption() *string { return v.Caption }
+
+// GetMentions returns PostTokensInput.Mentions, and is useful for accessing the field via an interface.
+func (v *PostTokensInput) GetMentions() []MentionInput { return v.Mentions }
 
 type PublishGalleryInput struct {
 	GalleryId persist.DBID `json:"galleryId"`

--- a/graphql/model/gqlidgen_gen.go
+++ b/graphql/model/gqlidgen_gen.go
@@ -104,6 +104,18 @@ func (r *SomeoneFollowedYouNotification) ID() GqlID {
 	return GqlID(fmt.Sprintf("SomeoneFollowedYouNotification:%s", r.Dbid))
 }
 
+func (r *SomeoneMentionedYouNotification) ID() GqlID {
+	return GqlID(fmt.Sprintf("SomeoneMentionedYouNotification:%s", r.Dbid))
+}
+
+func (r *SomeoneMentionedYourCommunityNotification) ID() GqlID {
+	return GqlID(fmt.Sprintf("SomeoneMentionedYourCommunityNotification:%s", r.Dbid))
+}
+
+func (r *SomeoneRepliedToYourCommentNotification) ID() GqlID {
+	return GqlID(fmt.Sprintf("SomeoneRepliedToYourCommentNotification:%s", r.Dbid))
+}
+
 func (r *SomeoneViewedYourGalleryNotification) ID() GqlID {
 	return GqlID(fmt.Sprintf("SomeoneViewedYourGalleryNotification:%s", r.Dbid))
 }
@@ -151,6 +163,9 @@ type NodeFetcher struct {
 	OnSomeoneCommentedOnYourPostNotification      func(ctx context.Context, dbid persist.DBID) (*SomeoneCommentedOnYourPostNotification, error)
 	OnSomeoneFollowedYouBackNotification          func(ctx context.Context, dbid persist.DBID) (*SomeoneFollowedYouBackNotification, error)
 	OnSomeoneFollowedYouNotification              func(ctx context.Context, dbid persist.DBID) (*SomeoneFollowedYouNotification, error)
+	OnSomeoneMentionedYouNotification             func(ctx context.Context, dbid persist.DBID) (*SomeoneMentionedYouNotification, error)
+	OnSomeoneMentionedYourCommunityNotification   func(ctx context.Context, dbid persist.DBID) (*SomeoneMentionedYourCommunityNotification, error)
+	OnSomeoneRepliedToYourCommentNotification     func(ctx context.Context, dbid persist.DBID) (*SomeoneRepliedToYourCommentNotification, error)
 	OnSomeoneViewedYourGalleryNotification        func(ctx context.Context, dbid persist.DBID) (*SomeoneViewedYourGalleryNotification, error)
 	OnToken                                       func(ctx context.Context, dbid persist.DBID) (*Token, error)
 	OnViewer                                      func(ctx context.Context, userId string) (*Viewer, error)
@@ -272,6 +287,21 @@ func (n *NodeFetcher) GetNodeByGqlID(ctx context.Context, id GqlID) (Node, error
 			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'SomeoneFollowedYouNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
 		}
 		return n.OnSomeoneFollowedYouNotification(ctx, persist.DBID(ids[0]))
+	case "SomeoneMentionedYouNotification":
+		if len(ids) != 1 {
+			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'SomeoneMentionedYouNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
+		}
+		return n.OnSomeoneMentionedYouNotification(ctx, persist.DBID(ids[0]))
+	case "SomeoneMentionedYourCommunityNotification":
+		if len(ids) != 1 {
+			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'SomeoneMentionedYourCommunityNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
+		}
+		return n.OnSomeoneMentionedYourCommunityNotification(ctx, persist.DBID(ids[0]))
+	case "SomeoneRepliedToYourCommentNotification":
+		if len(ids) != 1 {
+			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'SomeoneRepliedToYourCommentNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
+		}
+		return n.OnSomeoneRepliedToYourCommentNotification(ctx, persist.DBID(ids[0]))
 	case "SomeoneViewedYourGalleryNotification":
 		if len(ids) != 1 {
 			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'SomeoneViewedYourGalleryNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
@@ -341,6 +371,12 @@ func (n *NodeFetcher) ValidateHandlers() {
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneFollowedYouBackNotification")
 	case n.OnSomeoneFollowedYouNotification == nil:
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneFollowedYouNotification")
+	case n.OnSomeoneMentionedYouNotification == nil:
+		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneMentionedYouNotification")
+	case n.OnSomeoneMentionedYourCommunityNotification == nil:
+		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneMentionedYourCommunityNotification")
+	case n.OnSomeoneRepliedToYourCommentNotification == nil:
+		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneRepliedToYourCommentNotification")
 	case n.OnSomeoneViewedYourGalleryNotification == nil:
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneViewedYourGalleryNotification")
 	case n.OnToken == nil:

--- a/graphql/model/models.go
+++ b/graphql/model/models.go
@@ -106,6 +106,24 @@ type HelperNewTokensNotificationData struct {
 	NotificationData persist.NotificationData
 }
 
+type HelperSomeoneRepliedToYourCommentNotificationData struct {
+	OwnerID          persist.DBID
+	CommentID        persist.DBID
+	NotificationData persist.NotificationData
+}
+
+type HelperSomeoneMentionedYouNotificationData struct {
+	OwnerID   persist.DBID
+	PostID    *persist.DBID
+	CommentID *persist.DBID
+}
+type HelperSomeoneMentionedYourCommunityNotificationData struct {
+	OwnerID    persist.DBID
+	ContractID persist.DBID
+	PostID     *persist.DBID
+	CommentID  *persist.DBID
+}
+
 type HelperNotificationsConnectionData struct {
 	UserId persist.DBID
 }

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1496,6 +1496,11 @@ type MembershipTier struct {
 
 func (MembershipTier) IsNode() {}
 
+type MentionInput struct {
+	UserID      *persist.DBID `json:"userId"`
+	CommunityID *persist.DBID `json:"communityId"`
+}
+
 type MerchDiscountCode struct {
 	Code    string  `json:"code"`
 	TokenID *string `json:"tokenId"`
@@ -1957,6 +1962,46 @@ type SomeoneFollowedYouNotification struct {
 func (SomeoneFollowedYouNotification) IsNotification()        {}
 func (SomeoneFollowedYouNotification) IsNode()                {}
 func (SomeoneFollowedYouNotification) IsGroupedNotification() {}
+
+type SomeoneMentionedYouNotification struct {
+	HelperSomeoneMentionedYouNotificationData
+	Dbid         persist.DBID `json:"dbid"`
+	Seen         *bool        `json:"seen"`
+	CreationTime *time.Time   `json:"creationTime"`
+	UpdatedTime  *time.Time   `json:"updatedTime"`
+	Comment      *Comment     `json:"comment"`
+	Post         *Post        `json:"post"`
+}
+
+func (SomeoneMentionedYouNotification) IsNotification() {}
+func (SomeoneMentionedYouNotification) IsNode()         {}
+
+type SomeoneMentionedYourCommunityNotification struct {
+	HelperSomeoneMentionedYourCommunityNotificationData
+	Dbid         persist.DBID `json:"dbid"`
+	Seen         *bool        `json:"seen"`
+	CreationTime *time.Time   `json:"creationTime"`
+	UpdatedTime  *time.Time   `json:"updatedTime"`
+	Comment      *Comment     `json:"comment"`
+	Post         *Post        `json:"post"`
+	Community    *Community   `json:"community"`
+}
+
+func (SomeoneMentionedYourCommunityNotification) IsNotification() {}
+func (SomeoneMentionedYourCommunityNotification) IsNode()         {}
+
+type SomeoneRepliedToYourCommentNotification struct {
+	HelperSomeoneRepliedToYourCommentNotificationData
+	Dbid            persist.DBID `json:"dbid"`
+	Seen            *bool        `json:"seen"`
+	CreationTime    *time.Time   `json:"creationTime"`
+	UpdatedTime     *time.Time   `json:"updatedTime"`
+	Comment         *Comment     `json:"comment"`
+	OriginalComment *Comment     `json:"originalComment"`
+}
+
+func (SomeoneRepliedToYourCommentNotification) IsNotification() {}
+func (SomeoneRepliedToYourCommentNotification) IsNode()         {}
 
 type SomeoneViewedYourGalleryNotification struct {
 	HelperSomeoneViewedYourGalleryNotificationData

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1671,8 +1671,9 @@ type PostInteractionsEdge struct {
 }
 
 type PostTokensInput struct {
-	TokenIds []persist.DBID `json:"tokenIds"`
-	Caption  *string        `json:"caption"`
+	TokenIds []persist.DBID  `json:"tokenIds"`
+	Caption  *string         `json:"caption"`
+	Mentions []*MentionInput `json:"mentions"`
 }
 
 type PostTokensPayload struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -1393,7 +1393,7 @@ func (r *mutationResolver) CommentOnPost(ctx context.Context, postID persist.DBI
 
 // PostTokens is the resolver for the postTokens field.
 func (r *mutationResolver) PostTokens(ctx context.Context, input model.PostTokensInput) (model.PostTokensPayloadOrError, error) {
-	id, err := publicapi.For(ctx).Feed.PostTokens(ctx, input.TokenIds, input.Caption)
+	id, err := publicapi.For(ctx).Feed.PostTokens(ctx, input.TokenIds, input.Mentions, input.Caption)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -965,6 +965,70 @@ func notificationToModel(notif db.Notification) (model.Notification, error) {
 			Count:        &amount,
 			Token:        nil, // handled by dedicated resolver
 		}, nil
+	case persist.ActionReplyToComment:
+		return model.SomeoneRepliedToYourCommentNotification{
+			HelperSomeoneRepliedToYourCommentNotificationData: model.HelperSomeoneRepliedToYourCommentNotificationData{
+				OwnerID:          notif.OwnerID,
+				CommentID:        notif.CommentID,
+				NotificationData: notif.Data,
+			},
+			Dbid:            notif.ID,
+			Seen:            &notif.Seen,
+			CreationTime:    &notif.CreatedAt,
+			UpdatedTime:     &notif.LastUpdated,
+			Comment:         nil, // handled by dedicated resolver
+			OriginalComment: nil, // handled by dedicated resolver
+		}, nil
+	case persist.ActionMentionUser:
+		var postID *persist.DBID
+		var commentID *persist.DBID
+
+		if notif.PostID != "" {
+			postID = &notif.PostID
+		}
+		if notif.CommentID != "" {
+			commentID = &notif.CommentID
+		}
+		return model.SomeoneMentionedYouNotification{
+			HelperSomeoneMentionedYouNotificationData: model.HelperSomeoneMentionedYouNotificationData{
+				OwnerID:   notif.OwnerID,
+				PostID:    postID,
+				CommentID: commentID,
+			},
+			Dbid:         notif.ID,
+			Seen:         &notif.Seen,
+			CreationTime: &notif.CreatedAt,
+			UpdatedTime:  &notif.LastUpdated,
+			Post:         nil, // handled by dedicated resolver
+			Comment:      nil, // handled by dedicated resolver
+		}, nil
+
+	case persist.ActionMentionCommunity:
+		var postID *persist.DBID
+		var commentID *persist.DBID
+
+		if notif.PostID != "" {
+			postID = &notif.PostID
+		}
+		if notif.CommentID != "" {
+			commentID = &notif.CommentID
+		}
+		return model.SomeoneMentionedYourCommunityNotification{
+			HelperSomeoneMentionedYourCommunityNotificationData: model.HelperSomeoneMentionedYourCommunityNotificationData{
+				OwnerID:    notif.OwnerID,
+				ContractID: notif.CommentID,
+				PostID:     postID,
+				CommentID:  commentID,
+			},
+			Dbid:         notif.ID,
+			Seen:         &notif.Seen,
+			CreationTime: &notif.CreatedAt,
+			UpdatedTime:  &notif.LastUpdated,
+			Community:    nil, // handled by dedicated resolver
+			Comment:      nil, // handled by dedicated resolver
+			Post:         nil, // handled by dedicated resolver
+		}, nil
+
 	default:
 		return nil, fmt.Errorf("unknown notification action: %s", notif.Action)
 	}

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -134,6 +134,34 @@ var nodeFetcher = model.NodeFetcher{
 
 		return &notifConverted, nil
 	},
+	OnSomeoneMentionedYouNotification: func(ctx context.Context, dbid persist.DBID) (*model.SomeoneMentionedYouNotification, error) {
+		notif, err := resolveNotificationByID(ctx, dbid)
+		if err != nil {
+			return nil, err
+		}
+
+		notifConverted := notif.(model.SomeoneMentionedYouNotification)
+
+		return &notifConverted, nil
+	},
+	OnSomeoneMentionedYourCommunityNotification: func(ctx context.Context, dbid persist.DBID) (*model.SomeoneMentionedYourCommunityNotification, error) {
+		notif, err := resolveNotificationByID(ctx, dbid)
+		if err != nil {
+			return nil, err
+		}
+		notifConverted := notif.(model.SomeoneMentionedYourCommunityNotification)
+
+		return &notifConverted, nil
+	},
+	OnSomeoneRepliedToYourCommentNotification: func(ctx context.Context, dbid persist.DBID) (*model.SomeoneRepliedToYourCommentNotification, error) {
+		notif, err := resolveNotificationByID(ctx, dbid)
+		if err != nil {
+			return nil, err
+		}
+		notifConverted := notif.(model.SomeoneRepliedToYourCommentNotification)
+
+		return &notifConverted, nil
+	},
 }
 
 var defaultTokenSettings = persist.CollectionTokenSettings{}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2433,6 +2433,7 @@ union RemoveProfileImagePayloadOrError =
 input PostTokensInput {
   tokenIds: [DBID!]
   caption: String
+  mentions: [MentionInput!]
 }
 
 type PostTokensPayload {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1958,6 +1958,43 @@ type NewTokensNotification implements Notification & GroupedNotification & Node 
   token: Token @goField(forceResolver: true)
 }
 
+type SomeoneRepliedToYourCommentNotification implements Notification & Node @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  # Don't need a `who` here since the `comment` can provide that
+  comment: Comment @goField(forceResolver: true)
+  originalComment: Comment @goField(forceResolver: true)
+}
+
+type SomeoneMentionedYouNotification implements Notification & Node @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  # Don't need a `who` here since the `comment` or `post` can provide that
+  comment: Comment @goField(forceResolver: true)
+  post: Post @goField(forceResolver: true)
+}
+
+type SomeoneMentionedYourCommunityNotification implements Notification & Node @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  # Don't need a `who` here since the `comment` or `post` can provide that
+  comment: Comment @goField(forceResolver: true)
+  post: Post @goField(forceResolver: true)
+  community: Community @goField(forceResolver: true)
+}
+
 type ClearAllNotificationsPayload {
   notifications: [Notification]
 }
@@ -2427,6 +2464,11 @@ type DeletePostPayload {
 
 union DeletePostPayloadOrError = DeletePostPayload | ErrInvalidInput | ErrNotAuthorized
 
+input MentionInput {
+  userId: DBID
+  communityId: DBID
+}
+
 type Mutation {
   # User Mutations
   addUserWallet(
@@ -2508,10 +2550,15 @@ type Mutation {
     feedEventId: DBID!
     replyToID: DBID
     comment: String!
+    mentions: [MentionInput!]
   ): CommentOnFeedEventPayloadOrError @authRequired
   removeComment(commentId: DBID!): RemoveCommentPayloadOrError @authRequired
-  commentOnPost(postId: DBID!, replyToID: DBID, comment: String!): CommentOnPostPayloadOrError
-    @authRequired
+  commentOnPost(
+    postId: DBID!
+    replyToID: DBID
+    comment: String!
+    mentions: [MentionInput!]
+  ): CommentOnPostPayloadOrError @authRequired
 
   postTokens(input: PostTokensInput!): PostTokensPayloadOrError @authRequired
   deletePost(postId: DBID!): DeletePostPayloadOrError @authRequired

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -16,6 +16,7 @@ const (
 	ResourceTypeGallery
 	ResourceTypeAdmire
 	ResourceTypeComment
+	ResourceTypeContract
 	ActionUserCreated                     Action = "UserCreated"
 	ActionUserFollowedUsers               Action = "UserFollowedUsers"
 	ActionCollectorsNoteAddedToToken      Action = "CollectorsNoteAddedToToken"
@@ -26,6 +27,9 @@ const (
 	ActionAdmiredPost                     Action = "AdmiredPost"
 	ActionCommentedOnFeedEvent            Action = "CommentedOnFeedEvent"
 	ActionCommentedOnPost                 Action = "CommentedOnPost"
+	ActionReplyToComment                  Action = "RepliedToComment"
+	ActionMentionUser                     Action = "MentionUser"
+	ActionMentionCommunity                Action = "MentionCommunity"
 	ActionViewedGallery                   Action = "ViewedGallery"
 	ActionViewedToken                     Action = "ViewedToken"
 	ActionCollectionUpdated               Action = "CollectionUpdated"

--- a/service/persist/notification.go
+++ b/service/persist/notification.go
@@ -13,6 +13,7 @@ type NotificationData struct {
 	Refollowed        NullBool  `json:"refollowed,omitempty"`
 	NewTokenID        DBID      `json:"new_token_id,omitempty"`
 	NewTokenQuantity  HexString `json:"new_token_quantity,omitempty"`
+	OriginalCommentID DBID      `json:"original_comment_id,omitempty"`
 }
 
 func (n NotificationData) Validate() NotificationData {
@@ -23,6 +24,7 @@ func (n NotificationData) Validate() NotificationData {
 	result.UnauthedViewerIDs = uniqueStrings(n.UnauthedViewerIDs)
 	result.NewTokenID = n.NewTokenID
 	result.NewTokenQuantity = n.NewTokenQuantity
+	result.OriginalCommentID = n.OriginalCommentID
 
 	return result
 }
@@ -37,6 +39,7 @@ func (n NotificationData) Concat(other NotificationData) NotificationData {
 	result.Refollowed = other.Refollowed || n.Refollowed
 	result.NewTokenQuantity = other.NewTokenQuantity.Add(n.NewTokenQuantity)
 	result.NewTokenID = DBID(util.FirstNonEmptyString(other.NewTokenID.String(), n.NewTokenID.String()))
+	result.OriginalCommentID = DBID(util.FirstNonEmptyString(other.OriginalCommentID.String(), n.OriginalCommentID.String()))
 
 	return result.Validate()
 }

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -32,17 +32,23 @@ func (r *EventRepository) Add(ctx context.Context, event db.Event) (*db.Event, e
 		return r.AddCommentEvent(ctx, event)
 	case persist.ResourceTypeGallery:
 		return r.AddGalleryEvent(ctx, event)
+	case persist.ResourceTypeContract:
+		return r.AddContractEvent(ctx, event)
 	default:
 		return nil, persist.ErrUnknownResourceType{ResourceType: event.ResourceTypeID}
 	}
 }
 
 func (r *EventRepository) AddUserEvent(ctx context.Context, event db.Event) (*db.Event, error) {
+
 	event, err := r.Queries.CreateUserEvent(ctx, db.CreateUserEventParams{
 		ID:             persist.GenerateID(),
 		ActorID:        event.ActorID,
 		Action:         event.Action,
 		ResourceTypeID: event.ResourceTypeID,
+		Post:           util.ToNullString(event.PostID.String(), true),
+		Comment:        util.ToNullString(event.CommentID.String(), true),
+		FeedEvent:      util.ToNullString(event.FeedEventID.String(), true),
 		UserID:         event.SubjectID,
 		Data:           event.Data,
 		GroupID:        event.GroupID,
@@ -142,6 +148,24 @@ func (r *EventRepository) AddGalleryEvent(ctx context.Context, event db.Event) (
 		GalleryID:      event.GalleryID,
 		Data:           event.Data,
 		ExternalID:     event.ExternalID,
+		GroupID:        event.GroupID,
+		Caption:        event.Caption,
+	})
+	return &event, err
+}
+
+func (r *EventRepository) AddContractEvent(ctx context.Context, event db.Event) (*db.Event, error) {
+
+	event, err := r.Queries.CreateContractEvent(ctx, db.CreateContractEventParams{
+		ID:             persist.GenerateID(),
+		ActorID:        event.ActorID,
+		Action:         event.Action,
+		ResourceTypeID: event.ResourceTypeID,
+		Post:           util.ToNullString(event.PostID.String(), true),
+		Comment:        util.ToNullString(event.CommentID.String(), true),
+		FeedEvent:      util.ToNullString(event.FeedEventID.String(), true),
+		ContractID:     event.ContractID,
+		Data:           event.Data,
 		GroupID:        event.GroupID,
 		Caption:        event.Caption,
 	})

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -135,6 +135,7 @@ func (r *EventRepository) AddCommentEvent(ctx context.Context, event db.Event) (
 		Data:           event.Data,
 		GroupID:        event.GroupID,
 		Caption:        event.Caption,
+		SubjectID:      event.SubjectID,
 	})
 	return &event, err
 }


### PR DESCRIPTION
Changes:

- **Added** 3 notifications: `SomeoneRepliedToYourCommentNotification`, `SomeoneMentionedYouNotification`, and `SomeoneMentionedYourCommunityNotification` notifications. Mentions are manually passed into the mutations for creating comments and posts as opposed to being detected by the backend because a community can be mentioned and because there is not uniqueness between community names and user names we need to have specificity between the two
- **Added** `contract_id` to the `events` and `notifications` table for the new community notification

Considerations:

- None of these notifications include any sort of "who" field that shows who mentioned you or replied, because this information can be inferred by for example the post creator or comment creator. Do we want to double up anyway and add a resolving field for who the notification was kicked off by
- There is no notification kicked off for mentioning someone in a collectors note (and in turn the feed event associated with adding a collectors note) or a user bio. Other platforms tend to not notify in cases like this as well and tend to only notify in very timing dependent contexts. A bio or a description is not closely tied with time because it is supposed to represent some info for the user or token universally. A post or a comment however exists in time, when a post is posted is important to the context of a post and same for a comment. Is this how we intend to have mentions work as well? @kaitoo1 

TODO:

- Test `SomeoneMentionedYourCommunityNotification` 