### PR TITLE
[GAL-4030] Exclude events for curated feed

### DIFF
--- a/db/queries/core/recommend.sql
+++ b/db/queries/core/recommend.sql
@@ -80,6 +80,7 @@ from feed_entity_scores f1
 where f1.created_at > @window_end::timestamptz
   and (@include_viewer::bool or f1.actor_id != @viewer_id)
   and (@include_posts::bool or f1.feed_entity_type != @post_entity_type)
+  and (@include_events::bool or f1.feed_entity_type != @feed_entity_type)
   and not (f1.action = any(@excluded_feed_actions::varchar[]))
 union
 select *


### PR DESCRIPTION
Excludes events from the curated feed if posts are enabled for the user, but will still display events if posts are not enabled. The trending feed will continue to show events, @kaitoo1 should we start excluding events from the trending feed too? We revert to the trending feed if the user isn't logged in.