### PR TITLE
refresh contract with alchemy metadata

### DIFF
--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -65,12 +65,17 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+type OpenseaCollection struct {
+	CollectionName string `json:"collectionName"`
+}
+
 type ContractMetadata struct {
-	Name             string                  `json:"name"`
-	Symbol           string                  `json:"symbol"`
-	TotalSupply      string                  `json:"totalSupply"`
-	TokenType        string                  `json:"tokenType"`
-	ContractDeployer persist.EthereumAddress `json:"contractDeployer"`
+	Name              string                  `json:"name"`
+	Symbol            string                  `json:"symbol"`
+	TotalSupply       string                  `json:"totalSupply"`
+	TokenType         string                  `json:"tokenType"`
+	ContractDeployer  persist.EthereumAddress `json:"contractDeployer"`
+	OpenseaCollection OpenseaCollection       `json:"openSea"`
 }
 
 type Contract struct {


### PR DESCRIPTION
Changes:

- **Added** alchemy metadata call for refreshing contracts when they don't have a `name` or `symbol` function