### PR TITLE
Cursor refactor

### DIFF
--- a/publicapi/collection.go
+++ b/publicapi/collection.go
@@ -117,15 +117,16 @@ func (api CollectionAPI) GetTopCollectionsForCommunity(ctx context.Context, chai
 	}
 
 	var collectionIDs []persist.DBID
+	var cursor positionCursor
 	var paginator positionPaginator
 
 	// If a cursor is provided, we can skip querying the cache
 	if before != nil {
-		if _, collectionIDs, err = paginator.decodeCursor(*before); err != nil {
+		if err = cursor.Unpack(*before); err != nil {
 			return nil, pageInfo, err
 		}
 	} else if after != nil {
-		if _, collectionIDs, err = paginator.decodeCursor(*after); err != nil {
+		if err = cursor.Unpack(*after); err != nil {
 			return nil, pageInfo, err
 		}
 	} else {
@@ -143,9 +144,7 @@ func (api CollectionAPI) GetTopCollectionsForCommunity(ctx context.Context, chai
 	}
 
 	paginator.QueryFunc = func(params positionPagingParams) ([]any, error) {
-		cIDs, _ := util.Map(collectionIDs, func(id persist.DBID) (string, error) {
-			return id.String(), nil
-		})
+		cIDs := util.MapWithoutError(collectionIDs, func(id persist.DBID) string { return id.String() })
 		c, err := api.queries.GetVisibleCollectionsByIDsPaginate(ctx, db.GetVisibleCollectionsByIDsPaginateParams{
 			CollectionIds: cIDs,
 			CurBeforePos:  params.CursorBeforePos,
@@ -153,9 +152,7 @@ func (api CollectionAPI) GetTopCollectionsForCommunity(ctx context.Context, chai
 			PagingForward: params.PagingForward,
 			Limit:         params.Limit,
 		})
-		a, _ := util.Map(c, func(c db.Collection) (any, error) {
-			return c, nil
-		})
+		a := util.MapWithoutError(c, func(c db.Collection) any { return c })
 		return a, err
 	}
 
@@ -164,8 +161,8 @@ func (api CollectionAPI) GetTopCollectionsForCommunity(ctx context.Context, chai
 		posLookup[id] = i + 1 // Postgres uses 1-based indexing
 	}
 
-	paginator.CursorFunc = func(node any) (int, []persist.DBID, error) {
-		return posLookup[node.(db.Collection).ID], collectionIDs, nil
+	paginator.CursorFunc = func(node any) (int64, []persist.DBID, error) {
+		return int64(posLookup[node.(db.Collection).ID]), collectionIDs, nil
 	}
 
 	// The collections are sorted by ascending rank so we need to switch the cursor positions

--- a/publicapi/collection.go
+++ b/publicapi/collection.go
@@ -117,7 +117,7 @@ func (api CollectionAPI) GetTopCollectionsForCommunity(ctx context.Context, chai
 	}
 
 	var collectionIDs []persist.DBID
-	var cursor positionCursor
+	cursor := cursors.NewPositionCursor()
 	var paginator positionPaginator
 
 	// If a cursor is provided, we can skip querying the cache

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -352,13 +352,10 @@ func (api FeedAPI) TrendingFeed(ctx context.Context, before *string, after *stri
 
 	var (
 		err           error
+		cursor        feedPositionCursor
 		paginator     feedPaginator
-		entityTypes   []persist.FeedEntityType
-		entityIDs     []persist.DBID
 		entityIDToPos = make(map[persist.DBID]int)
 	)
-
-	hasCursors := before != nil || after != nil
 
 	now := time.Now()
 
@@ -367,7 +364,15 @@ func (api FeedAPI) TrendingFeed(ctx context.Context, before *string, after *stri
 		includePosts = shouldShowPosts(ctx)
 	}
 
-	if !hasCursors {
+	if before != nil {
+		if err = cursor.Unpack(*before); err != nil {
+			return nil, PageInfo{}, err
+		}
+	} else if after != nil {
+		if err = cursor.Unpack(*after); err != nil {
+			return nil, PageInfo{}, err
+		}
+	} else {
 		calcFunc := func(ctx context.Context) ([]persist.FeedEntityType, []persist.DBID, error) {
 			trendData, err := fetchFeedEntities(ctx, api.queries, feedParams{
 				IncludePosts:   includePosts,
@@ -382,8 +387,8 @@ func (api FeedAPI) TrendingFeed(ctx context.Context, before *string, after *stri
 				return timeFactor(e.CreatedAt, now) * engagementFactor(int(e.Interactions))
 			})
 
-			entityTypes = make([]persist.FeedEntityType, len(scored))
-			entityIDs = make([]persist.DBID, len(scored))
+			entityTypes := make([]persist.FeedEntityType, len(scored))
+			entityIDs := make([]persist.DBID, len(scored))
 
 			for i, e := range scored {
 				idx := len(scored) - i - 1
@@ -396,45 +401,41 @@ func (api FeedAPI) TrendingFeed(ctx context.Context, before *string, after *stri
 
 		l := newFeedCache(api.cache, includePosts, calcFunc)
 
-		entityTypes, entityIDs, err = l.Load(ctx)
+		cursor.EntityTypes, cursor.EntityIDs, err = l.Load(ctx)
 		if err != nil {
 			return nil, PageInfo{}, err
 		}
 	}
 
 	queryFunc := func(params feedPagingParams) ([]any, error) {
-		if hasCursors {
-			entityTypes = params.EntityTypes
-			entityIDs = params.EntityIDs
-		}
-		for i, id := range entityIDs {
+		for i, id := range cursor.EntityIDs {
 			entityIDToPos[id] = i
 		}
 
 		// Filter slices in place
 		if !includePosts {
 			idx := 0
-			for i := range entityTypes {
-				if entityTypes[i] != persist.PostTypeTag {
-					entityTypes[idx] = entityTypes[i]
-					entityIDs[idx] = entityIDs[i]
+			for i := range cursor.EntityTypes {
+				if cursor.EntityTypes[i] != persist.PostTypeTag {
+					cursor.EntityTypes[idx] = cursor.EntityTypes[i]
+					cursor.EntityIDs[idx] = cursor.EntityIDs[i]
 					idx++
 				}
 			}
-			entityTypes = entityTypes[:idx]
-			entityIDs = entityIDs[:idx]
+			cursor.EntityTypes = cursor.EntityTypes[:idx]
+			cursor.EntityIDs = cursor.EntityIDs[:idx]
 		}
 
-		return loadFeedEntities(ctx, api.loaders, entityTypes, entityIDs)
+		return loadFeedEntities(ctx, api.loaders, cursor.EntityTypes, cursor.EntityIDs)
 	}
 
-	cursorFunc := func(node any) (int, []persist.FeedEntityType, []persist.DBID, error) {
+	cursorFunc := func(node any) (int64, []persist.FeedEntityType, []persist.DBID, error) {
 		_, id, err := feedCursor(node)
 		pos, ok := entityIDToPos[id]
 		if !ok {
 			panic(fmt.Sprintf("could not find position for id=%s", id))
 		}
-		return pos, entityTypes, entityIDs, err
+		return int64(pos), cursor.EntityTypes, cursor.EntityIDs, err
 	}
 
 	paginator.QueryFunc = queryFunc
@@ -457,12 +458,9 @@ func (api FeedAPI) CuratedFeed(ctx context.Context, before, after *string, first
 
 	var (
 		paginator     feedPaginator
-		entityTypes   []persist.FeedEntityType
-		entityIDs     []persist.DBID
+		cursor        feedPositionCursor
 		entityIDToPos = make(map[persist.DBID]int)
 	)
-
-	hasCursors := before != nil || after != nil
 
 	now := time.Now()
 
@@ -471,7 +469,15 @@ func (api FeedAPI) CuratedFeed(ctx context.Context, before, after *string, first
 		includePosts = shouldShowPosts(ctx)
 	}
 
-	if !hasCursors {
+	if before != nil {
+		if err := cursor.Unpack(*before); err != nil {
+			return nil, PageInfo{}, err
+		}
+	} else if after != nil {
+		if err := cursor.Unpack(*after); err != nil {
+			return nil, PageInfo{}, err
+		}
+	} else {
 		trendData, err := fetchFeedEntities(ctx, api.queries, feedParams{
 			IncludePosts:   includePosts,
 			IncludeEvents:  !includePosts,
@@ -538,49 +544,45 @@ func (api FeedAPI) CuratedFeed(ctx context.Context, before, after *string, first
 
 		recommend.Shuffle(interleaved, 8)
 
-		entityTypes = make([]persist.FeedEntityType, len(interleaved))
-		entityIDs = make([]persist.DBID, len(interleaved))
+		cursor.EntityTypes = make([]persist.FeedEntityType, len(interleaved))
+		cursor.EntityIDs = make([]persist.DBID, len(interleaved))
 
 		for i, e := range interleaved {
 			idx := len(interleaved) - i - 1
-			entityTypes[idx] = persist.FeedEntityType(e.FeedEntityType)
-			entityIDs[idx] = e.ID
+			cursor.EntityTypes[idx] = persist.FeedEntityType(e.FeedEntityType)
+			cursor.EntityIDs[idx] = e.ID
 		}
 	}
 
 	queryFunc := func(params feedPagingParams) ([]any, error) {
-		if hasCursors {
-			entityTypes = params.EntityTypes
-			entityIDs = params.EntityIDs
-		}
-		for i, id := range entityIDs {
+		for i, id := range cursor.EntityIDs {
 			entityIDToPos[id] = i
 		}
 
 		// Filter slices in place
 		if !includePosts {
 			idx := 0
-			for i := range entityTypes {
-				if entityTypes[i] != persist.PostTypeTag {
-					entityTypes[idx] = entityTypes[i]
-					entityIDs[idx] = entityIDs[i]
+			for i := range cursor.EntityTypes {
+				if cursor.EntityTypes[i] != persist.PostTypeTag {
+					cursor.EntityTypes[idx] = cursor.EntityTypes[i]
+					cursor.EntityIDs[idx] = cursor.EntityIDs[i]
 					idx++
 				}
 			}
-			entityTypes = entityTypes[:idx]
-			entityIDs = entityIDs[:idx]
+			cursor.EntityTypes = cursor.EntityTypes[:idx]
+			cursor.EntityIDs = cursor.EntityIDs[:idx]
 		}
 
-		return loadFeedEntities(ctx, api.loaders, entityTypes, entityIDs)
+		return loadFeedEntities(ctx, api.loaders, cursor.EntityTypes, cursor.EntityIDs)
 	}
 
-	cursorFunc := func(node any) (int, []persist.FeedEntityType, []persist.DBID, error) {
+	cursorFunc := func(node any) (int64, []persist.FeedEntityType, []persist.DBID, error) {
 		_, id, err := feedCursor(node)
 		pos, ok := entityIDToPos[id]
 		if !ok {
 			panic(fmt.Sprintf("could not find position for id=%s", id))
 		}
-		return pos, entityTypes, entityIDs, err
+		return int64(pos), cursor.EntityTypes, cursor.EntityIDs, err
 	}
 
 	paginator.QueryFunc = queryFunc
@@ -822,58 +824,7 @@ type feedPagingParams struct {
 
 type feedPaginator struct {
 	QueryFunc  func(params feedPagingParams) ([]any, error)
-	CursorFunc func(node any) (pos int, feedEntityType []persist.FeedEntityType, ids []persist.DBID, err error)
-}
-
-func (p *feedPaginator) encodeCursor(pos int, typ []persist.FeedEntityType, ids []persist.DBID) (string, error) {
-	if len(typ) != len(ids) {
-		panic("type and ids must be the same length")
-	}
-	encoder := newCursorEncoder()
-	encoder.appendInt64(int64(pos))
-	encoder.appendInt64(int64(len(ids)))
-	for i := range typ {
-		encoder.appendInt64(int64(typ[i]))
-		encoder.appendDBID(ids[i])
-	}
-	return encoder.AsBase64(), nil
-}
-
-func (p *feedPaginator) decodeCursor(cursor string) (pos int, typs []persist.FeedEntityType, ids []persist.DBID, err error) {
-	decoder, err := newCursorDecoder(cursor)
-	if err != nil {
-		return 0, nil, nil, err
-	}
-
-	curPos, err := decoder.readInt64()
-	if err != nil {
-		return 0, nil, nil, err
-	}
-
-	totalItems, err := decoder.readInt64()
-	if err != nil {
-		return 0, nil, nil, err
-	}
-
-	typs = make([]persist.FeedEntityType, totalItems)
-	ids = make([]persist.DBID, totalItems)
-
-	for i := 0; i < int(totalItems); i++ {
-		typ, err := decoder.readInt64()
-		if err != nil {
-			return 0, nil, nil, err
-		}
-
-		id, err := decoder.readDBID()
-		if err != nil {
-			return 0, nil, nil, err
-		}
-
-		typs[i] = persist.FeedEntityType(typ)
-		ids[i] = id
-	}
-
-	return int(curPos), typs, ids, nil
+	CursorFunc func(node any) (pos int64, feedEntityType []persist.FeedEntityType, ids []persist.DBID, err error)
 }
 
 func (p *feedPaginator) paginate(before, after *string, first, last *int) ([]any, PageInfo, error) {
@@ -882,24 +833,25 @@ func (p *feedPaginator) paginate(before, after *string, first, last *int) ([]any
 		CurAfterPos:  defaultCursorAfterPosition,
 	}
 
+	var beforeCur feedPositionCursor
+	var afterCur feedPositionCursor
+
 	if before != nil {
-		curBeforePos, typs, ids, err := p.decodeCursor(*before)
-		if err != nil {
+		if err := beforeCur.Unpack(*before); err != nil {
 			return nil, PageInfo{}, err
 		}
-		args.CurBeforePos = curBeforePos
-		args.EntityTypes = typs
-		args.EntityIDs = ids
+		args.CurBeforePos = int(beforeCur.CurrentPosition)
+		args.EntityTypes = beforeCur.EntityTypes
+		args.EntityIDs = beforeCur.EntityIDs
 	}
 
 	if after != nil {
-		curAfterPos, typs, ids, err := p.decodeCursor(*after)
-		if err != nil {
+		if err := afterCur.Unpack(*after); err != nil {
 			return nil, PageInfo{}, err
 		}
-		args.CurAfterPos = curAfterPos
-		args.EntityTypes = typs
-		args.EntityIDs = ids
+		args.CurAfterPos = int(afterCur.CurrentPosition)
+		args.EntityTypes = afterCur.EntityTypes
+		args.EntityIDs = afterCur.EntityIDs
 	}
 
 	results, err := p.QueryFunc(args)
@@ -907,15 +859,7 @@ func (p *feedPaginator) paginate(before, after *string, first, last *int) ([]any
 		return nil, PageInfo{}, err
 	}
 
-	cursorFunc := func(node any) (string, error) {
-		pos, typs, ids, err := p.CursorFunc(node)
-		if err != nil {
-			return "", err
-		}
-		return p.encodeCursor(pos, typs, ids)
-	}
-
-	return pageFrom(results, nil, cursorFunc, before, after, first, last)
+	return pageFrom(results, nil, cursors.NewFeedPositionCursorer(p.CursorFunc), before, after, first, last)
 }
 
 type feedCache struct {
@@ -938,8 +882,12 @@ func newFeedCache(cache *redis.Cache, includePosts bool, f func(context.Context)
 				if err != nil {
 					return nil, err
 				}
-				var p feedPaginator
-				b, err := p.encodeCursor(0, types, ids)
+				cur := feedPositionCursor{
+					CurrentPosition: 0,
+					EntityTypes:     types,
+					EntityIDs:       ids,
+				}
+				b, err := cur.Pack()
 				return []byte(b), err
 			},
 		},
@@ -951,9 +899,9 @@ func (f feedCache) Load(ctx context.Context) ([]persist.FeedEntityType, []persis
 	if err != nil {
 		return nil, nil, err
 	}
-	var p feedPaginator
-	_, types, ids, err := p.decodeCursor(string(b))
-	return types, ids, err
+	var cur feedPositionCursor
+	err = cur.Unpack(string(b))
+	return cur.EntityTypes, cur.EntityIDs, err
 }
 
 func min(a, b int) int {

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -169,9 +169,9 @@ func (api InteractionAPI) PaginateInteractionsByFeedEventID(ctx context.Context,
 		return total, err
 	}
 
-	cursorFunc := func(i interface{}) (int32, time.Time, persist.DBID, error) {
+	cursorFunc := func(i interface{}) (int64, time.Time, persist.DBID, error) {
 		if row, ok := i.(db.PaginateInteractionsByFeedEventIDBatchRow); ok {
-			return row.Tag, row.CreatedAt, row.ID, nil
+			return int64(row.Tag), row.CreatedAt, row.ID, nil
 		}
 		return 0, time.Time{}, "", fmt.Errorf("interface{} is not the correct type")
 	}
@@ -263,9 +263,9 @@ func (api InteractionAPI) PaginateInteractionsByPostID(ctx context.Context, post
 		return total, err
 	}
 
-	cursorFunc := func(i interface{}) (int32, time.Time, persist.DBID, error) {
+	cursorFunc := func(i interface{}) (int64, time.Time, persist.DBID, error) {
 		if row, ok := i.(db.PaginateInteractionsByPostIDBatchRow); ok {
-			return row.Tag, row.CreatedAt, row.ID, nil
+			return int64(row.Tag), row.CreatedAt, row.ID, nil
 		}
 		return 0, time.Time{}, "", fmt.Errorf("interface{} is not the correct type")
 	}

--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -237,8 +237,14 @@ type timeIDPagingParams struct {
 
 func (p *timeIDPaginator) paginate(before *string, after *string, first *int, last *int) ([]any, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]any, error) {
-		beforeCur := timeIDCursor{Time: defaultCursorBeforeTime, ID: defaultCursorBeforeID}
-		afterCur := timeIDCursor{Time: defaultCursorAfterTime, ID: defaultCursorAfterID}
+		beforeCur := timeIDCursor{
+			Time: defaultCursorBeforeTime,
+			ID:   defaultCursorBeforeID,
+		}
+		afterCur := timeIDCursor{
+			Time: defaultCursorAfterTime,
+			ID:   defaultCursorAfterID,
+		}
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -279,8 +285,14 @@ func (p *sharedFollowersPaginator) paginate(before *string, after *string, first
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
 		// The shared followers query orders results in descending order when
 		// paging forward (vs. ascending order which is more typical).
-		beforeCur := timeIDCursor{Time: time.Date(1970, 1, 1, 1, 1, 1, 1, time.UTC), ID: defaultCursorBeforeID}
-		afterCur := timeIDCursor{Time: time.Date(3000, 1, 1, 1, 1, 1, 1, time.UTC), ID: defaultCursorAfterID}
+		beforeCur := timeIDCursor{
+			Time: time.Date(1970, 1, 1, 1, 1, 1, 1, time.UTC),
+			ID:   defaultCursorBeforeID,
+		}
+		afterCur := timeIDCursor{
+			Time: time.Date(3000, 1, 1, 1, 1, 1, 1, time.UTC),
+			ID:   defaultCursorAfterID,
+		}
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -346,8 +358,18 @@ type sharedContractsPaginator struct {
 
 func (p *sharedContractsPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := boolBootIntIDCursor{Bool1: false, Bool2: false, Int: -1, ID: defaultCursorBeforeID}
-		afterCur := boolBootIntIDCursor{Bool1: true, Bool2: true, Int: math.MaxInt32, ID: defaultCursorAfterID}
+		beforeCur := boolBootIntIDCursor{
+			Bool1: false,
+			Bool2: false,
+			Int:   -1,
+			ID:    defaultCursorBeforeID,
+		}
+		afterCur := boolBootIntIDCursor{
+			Bool1: true,
+			Bool2: true,
+			Int:   math.MaxInt32,
+			ID:    defaultCursorAfterID,
+		}
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -411,8 +433,16 @@ type boolTimeIDPaginator struct {
 
 func (p *boolTimeIDPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := boolTimeIDCursor{Bool: true, Time: defaultCursorBeforeTime, ID: defaultCursorBeforeID}
-		afterCur := boolTimeIDCursor{Bool: false, Time: defaultCursorAfterTime, ID: defaultCursorAfterID}
+		beforeCur := boolTimeIDCursor{
+			Bool: true,
+			Time: defaultCursorBeforeTime,
+			ID:   defaultCursorBeforeID,
+		}
+		afterCur := boolTimeIDCursor{
+			Bool: false,
+			Time: defaultCursorAfterTime,
+			ID:   defaultCursorAfterID,
+		}
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -561,8 +591,8 @@ func (p *positionPaginator) paginate(before *string, after *string, first *int, 
 			CurAfterPos:  defaultCursorAfterPosition,
 		}
 
-		beforeCur := positionCursor{}
-		afterCur := positionCursor{}
+		var beforeCur positionCursor
+		var afterCur positionCursor
 
 		for _, opt := range opts {
 			opt(&args)
@@ -628,8 +658,16 @@ type intTimeIDPagingParams struct {
 
 func (p *intTimeIDPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := intTimeIDCursor{Int: math.MaxInt32, Time: defaultCursorBeforeTime, ID: defaultCursorBeforeID}
-		afterCur := intTimeIDCursor{Int: 0, Time: defaultCursorAfterTime, ID: defaultCursorAfterID}
+		beforeCur := intTimeIDCursor{
+			Int:  math.MaxInt32,
+			Time: defaultCursorBeforeTime,
+			ID:   defaultCursorBeforeID,
+		}
+		afterCur := intTimeIDCursor{
+			Int:  0,
+			Time: defaultCursorAfterTime,
+			ID:   defaultCursorAfterID,
+		}
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {

--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -237,14 +237,12 @@ type timeIDPagingParams struct {
 
 func (p *timeIDPaginator) paginate(before *string, after *string, first *int, last *int) ([]any, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]any, error) {
-		beforeCur := timeIDCursor{
-			Time: defaultCursorBeforeTime,
-			ID:   defaultCursorBeforeID,
-		}
-		afterCur := timeIDCursor{
-			Time: defaultCursorAfterTime,
-			ID:   defaultCursorAfterID,
-		}
+		beforeCur := cursors.NewTimeIDCursor()
+		beforeCur.Time = defaultCursorBeforeTime
+		beforeCur.ID = defaultCursorBeforeID
+		afterCur := cursors.NewTimeIDCursor()
+		afterCur.Time = defaultCursorAfterTime
+		afterCur.ID = defaultCursorAfterID
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -272,7 +270,7 @@ func (p *timeIDPaginator) paginate(before *string, after *string, first *int, la
 
 	paginator := keysetPaginator{
 		QueryFunc:  queryFunc,
-		Cursorable: cursors.NewTimeIDCursorer(p.CursorFunc),
+		Cursorable: cursorables.NewTimeIDCursorer(p.CursorFunc),
 		CountFunc:  p.CountFunc,
 	}
 
@@ -285,14 +283,12 @@ func (p *sharedFollowersPaginator) paginate(before *string, after *string, first
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
 		// The shared followers query orders results in descending order when
 		// paging forward (vs. ascending order which is more typical).
-		beforeCur := timeIDCursor{
-			Time: time.Date(1970, 1, 1, 1, 1, 1, 1, time.UTC),
-			ID:   defaultCursorBeforeID,
-		}
-		afterCur := timeIDCursor{
-			Time: time.Date(3000, 1, 1, 1, 1, 1, 1, time.UTC),
-			ID:   defaultCursorAfterID,
-		}
+		beforeCur := cursors.NewTimeIDCursor()
+		beforeCur.Time = time.Date(1970, 1, 1, 1, 1, 1, 1, time.UTC)
+		beforeCur.ID = defaultCursorBeforeID
+		afterCur := cursors.NewTimeIDCursor()
+		afterCur.Time = time.Date(3000, 1, 1, 1, 1, 1, 1, time.UTC)
+		afterCur.ID = defaultCursorAfterID
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -320,7 +316,7 @@ func (p *sharedFollowersPaginator) paginate(before *string, after *string, first
 
 	paginator := keysetPaginator{
 		QueryFunc:  queryFunc,
-		Cursorable: cursors.NewTimeIDCursorer(p.CursorFunc),
+		Cursorable: cursorables.NewTimeIDCursorer(p.CursorFunc),
 		CountFunc:  p.CountFunc,
 	}
 
@@ -358,18 +354,16 @@ type sharedContractsPaginator struct {
 
 func (p *sharedContractsPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := boolBoolIntIDCursorer{
-			Bool1: false,
-			Bool2: false,
-			Int:   -1,
-			ID:    defaultCursorBeforeID,
-		}
-		afterCur := boolBoolIntIDCursorer{
-			Bool1: true,
-			Bool2: true,
-			Int:   math.MaxInt32,
-			ID:    defaultCursorAfterID,
-		}
+		beforeCur := cursors.NewBoolBoolIntIDCursor()
+		beforeCur.Bool1 = false
+		beforeCur.Bool2 = false
+		beforeCur.Int = -1
+		beforeCur.ID = defaultCursorBeforeID
+		afterCur := cursors.NewBoolBoolIntIDCursor()
+		afterCur.Bool1 = true
+		afterCur.Bool2 = true
+		afterCur.Int = math.MaxInt32
+		afterCur.ID = defaultCursorAfterID
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -401,7 +395,7 @@ func (p *sharedContractsPaginator) paginate(before *string, after *string, first
 
 	paginator := keysetPaginator{
 		QueryFunc:  queryFunc,
-		Cursorable: cursors.NewBoolBoolIntIDCursorer(p.CursorFunc),
+		Cursorable: cursorables.NewBoolBoolIntIDCursorer(p.CursorFunc),
 		CountFunc:  p.CountFunc,
 	}
 
@@ -433,16 +427,14 @@ type boolTimeIDPaginator struct {
 
 func (p *boolTimeIDPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := boolTimeIDCursor{
-			Bool: true,
-			Time: defaultCursorBeforeTime,
-			ID:   defaultCursorBeforeID,
-		}
-		afterCur := boolTimeIDCursor{
-			Bool: false,
-			Time: defaultCursorAfterTime,
-			ID:   defaultCursorAfterID,
-		}
+		beforeCur := cursors.NewBoolTimeIDCursor()
+		beforeCur.Bool = true
+		beforeCur.Time = defaultCursorBeforeTime
+		beforeCur.ID = defaultCursorBeforeID
+		afterCur := cursors.NewBoolTimeIDCursor()
+		afterCur.Bool = false
+		afterCur.Time = defaultCursorAfterTime
+		afterCur.ID = defaultCursorAfterID
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -472,7 +464,7 @@ func (p *boolTimeIDPaginator) paginate(before *string, after *string, first *int
 
 	paginator := keysetPaginator{
 		QueryFunc:  queryFunc,
-		Cursorable: cursors.NewBoolTimeIDCursorer(p.CursorFunc),
+		Cursorable: cursorables.NewBoolTimeIDCursorer(p.CursorFunc),
 		CountFunc:  p.CountFunc,
 	}
 
@@ -502,14 +494,12 @@ type lexicalPagingParams struct {
 
 func (p *lexicalPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := stringIDCursor{
-			String: defaultCursorBeforeKey,
-			ID:     defaultCursorBeforeID,
-		}
-		afterCur := stringIDCursor{
-			String: defaultCursorAfterKey,
-			ID:     defaultCursorAfterID,
-		}
+		beforeCur := cursors.NewStringIDCursor()
+		beforeCur.String = defaultCursorBeforeKey
+		beforeCur.ID = defaultCursorBeforeID
+		afterCur := cursors.NewStringIDCursor()
+		afterCur.String = defaultCursorAfterKey
+		afterCur.ID = defaultCursorAfterID
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -537,7 +527,7 @@ func (p *lexicalPaginator) paginate(before *string, after *string, first *int, l
 
 	paginator := keysetPaginator{
 		QueryFunc:  queryFunc,
-		Cursorable: cursors.NewStringIDCursorer(p.CursorFunc),
+		Cursorable: cursorables.NewStringIDCursorer(p.CursorFunc),
 		CountFunc:  p.CountFunc,
 	}
 
@@ -591,8 +581,8 @@ func (p *positionPaginator) paginate(before *string, after *string, first *int, 
 			CurAfterPos:  defaultCursorAfterPosition,
 		}
 
-		var beforeCur positionCursor
-		var afterCur positionCursor
+		beforeCur := cursors.NewPositionCursor()
+		afterCur := cursors.NewPositionCursor()
 
 		for _, opt := range opts {
 			opt(&args)
@@ -627,7 +617,7 @@ func (p *positionPaginator) paginate(before *string, after *string, first *int, 
 
 	paginator := keysetPaginator{
 		QueryFunc:  queryFunc,
-		Cursorable: cursors.NewPositionCursorer(p.CursorFunc),
+		Cursorable: cursorables.NewPositionCursorer(p.CursorFunc),
 		CountFunc:  p.CountFunc,
 	}
 
@@ -658,16 +648,14 @@ type intTimeIDPagingParams struct {
 
 func (p *intTimeIDPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := intTimeIDCursor{
-			Int:  math.MaxInt32,
-			Time: defaultCursorBeforeTime,
-			ID:   defaultCursorBeforeID,
-		}
-		afterCur := intTimeIDCursor{
-			Int:  0,
-			Time: defaultCursorAfterTime,
-			ID:   defaultCursorAfterID,
-		}
+		beforeCur := cursors.NewIntTimeIDCursor()
+		beforeCur.Int = math.MaxInt32
+		beforeCur.Time = defaultCursorBeforeTime
+		beforeCur.ID = defaultCursorBeforeID
+		afterCur := cursors.NewIntTimeIDCursor()
+		afterCur.Int = 0
+		afterCur.Time = defaultCursorAfterTime
+		afterCur.ID = defaultCursorAfterID
 
 		if before != nil {
 			if err := beforeCur.Unpack(*before); err != nil {
@@ -697,7 +685,7 @@ func (p *intTimeIDPaginator) paginate(before *string, after *string, first *int,
 
 	paginator := keysetPaginator{
 		QueryFunc:  queryFunc,
-		Cursorable: cursors.NewIntTimeIDCursorer(p.CursorFunc),
+		Cursorable: cursorables.NewIntTimeIDCursorer(p.CursorFunc),
 		CountFunc:  p.CountFunc,
 	}
 
@@ -785,12 +773,18 @@ type cursorDecoder struct {
 }
 
 func newCursorDecoder(base64Cursor string) (cursorDecoder, error) {
+	c := cursorDecoder{}
+	err := c.setReader(base64Cursor)
+	return c, err
+}
+
+func (c *cursorDecoder) setReader(base64Cursor string) error {
 	decoded, err := base64.RawStdEncoding.DecodeString(base64Cursor)
 	if err != nil {
-		return cursorDecoder{}, err
+		return err
 	}
-
-	return cursorDecoder{reader: bytes.NewReader(decoded)}, nil
+	c.reader = bytes.NewReader(decoded)
+	return nil
 }
 
 // readBool reads a bool from the underlying reader and advances the stream
@@ -891,63 +885,66 @@ type cursorer interface {
 	Unpack(string) error
 }
 type cursorable func(any) (cursorer, error)
-type curs struct{}
 
-var cursors curs
+type cursorN struct{}     // namespace for available cursors
+type cursorableN struct{} // namespace for available cursorables
 
-func (curs) NewTimeIDCursorer(f func(any) (time.Time, persist.DBID, error)) cursorable {
+var cursorables cursorableN
+var cursors cursorN
+
+func (cursorableN) NewTimeIDCursorer(f func(any) (time.Time, persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur timeIDCursor
+		cur := cursors.NewTimeIDCursor()
 		cur.Time, cur.ID, err = f(node)
-		return &cur, err
+		return cur, err
 	}
 }
 
-func (curs) NewBoolBoolIntIDCursorer(f func(any) (bool, bool, int64, persist.DBID, error)) cursorable {
+func (cursorableN) NewBoolBoolIntIDCursorer(f func(any) (bool, bool, int64, persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur boolBoolIntIDCursorer
+		cur := cursors.NewBoolBoolIntIDCursor()
 		cur.Bool1, cur.Bool2, cur.Int, cur.ID, err = f(node)
-		return &cur, err
+		return cur, err
 	}
 }
 
-func (curs) NewBoolTimeIDCursorer(f func(any) (bool, time.Time, persist.DBID, error)) cursorable {
+func (cursorableN) NewBoolTimeIDCursorer(f func(any) (bool, time.Time, persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur boolTimeIDCursor
+		cur := cursors.NewBoolTimeIDCursor()
 		cur.Bool, cur.Time, cur.ID, err = f(node)
-		return &cur, err
+		return cur, err
 	}
 }
 
-func (curs) NewStringIDCursorer(f func(any) (string, persist.DBID, error)) cursorable {
+func (cursorableN) NewStringIDCursorer(f func(any) (string, persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur stringIDCursor
+		cur := cursors.NewStringIDCursor()
 		cur.String, cur.ID, err = f(node)
-		return &cur, err
+		return cur, err
 	}
 }
 
-func (curs) NewIntTimeIDCursorer(f func(any) (int64, time.Time, persist.DBID, error)) cursorable {
+func (cursorableN) NewIntTimeIDCursorer(f func(any) (int64, time.Time, persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur intTimeIDCursor
+		cur := cursors.NewIntTimeIDCursor()
 		cur.Int, cur.Time, cur.ID, err = f(node)
-		return &cur, err
+		return cur, err
 	}
 }
 
-func (curs) NewPositionCursorer(f func(any) (int64, []persist.DBID, error)) cursorable {
+func (cursorableN) NewPositionCursorer(f func(any) (int64, []persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur positionCursor
+		cur := cursors.NewPositionCursor()
 		cur.CurrentPosition, cur.IDs, err = f(node)
-		return &cur, err
+		return cur, err
 	}
 }
 
-func (curs) NewFeedPositionCursorer(f func(any) (int64, []persist.FeedEntityType, []persist.DBID, error)) cursorable {
+func (cursorableN) NewFeedPositionCursorer(f func(any) (int64, []persist.FeedEntityType, []persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur feedPositionCursor
+		cur := cursors.NewFeedPositionCursor()
 		cur.CurrentPosition, cur.EntityTypes, cur.EntityIDs, err = f(node)
-		return &cur, err
+		return cur, err
 	}
 }
 
@@ -956,51 +953,33 @@ func (curs) NewFeedPositionCursorer(f func(any) (int64, []persist.FeedEntityType
 type timeIDCursor struct {
 	Time time.Time
 	ID   persist.DBID
+	unpackable
+	packable
 }
 
-func (c timeIDCursor) Pack() (string, error) { return pack(c.Time, c.ID) }
-func (c *timeIDCursor) Unpack(s string) error {
-	d, err := newCursorDecoder(s)
-	if err != nil {
-		return err
-	}
-	c.Time, err = d.readTime()
-	if err != nil {
-		return err
-	}
-	c.ID, err = d.readDBID()
-	return err
+func (cursorN) NewTimeIDCursor() *timeIDCursor {
+	c := timeIDCursor{unpackable: newUnpackable()}
+	c.unpackFs = []unpackF{unpackTo(&c.Time, c.d.readTime), unpackTo(&c.ID, c.d.readDBID)}
+	c.packVals = []any{&c.Time, &c.ID}
+	return &c
 }
 
 //------------------------------------------------------------------------------
 
-type boolBoolIntIDCursorer struct {
+type boolBoolIntIDCursor struct {
 	Bool1 bool
 	Bool2 bool
 	Int   int64
 	ID    persist.DBID
+	packable
+	unpackable
 }
 
-func (c boolBoolIntIDCursorer) Pack() (string, error) { return pack(c.Bool1, c.Bool2, c.Int, c.ID) }
-func (c *boolBoolIntIDCursorer) Unpack(s string) error {
-	d, err := newCursorDecoder(s)
-	if err != nil {
-		return err
-	}
-	c.Bool1, err = d.readBool()
-	if err != nil {
-		return err
-	}
-	c.Bool2, err = d.readBool()
-	if err != nil {
-		return err
-	}
-	c.Int, err = d.readInt64()
-	if err != nil {
-		return err
-	}
-	c.ID, err = d.readDBID()
-	return err
+func (cursorN) NewBoolBoolIntIDCursor() *boolBoolIntIDCursor {
+	c := boolBoolIntIDCursor{unpackable: newUnpackable()}
+	c.unpackFs = []unpackF{unpackTo(&c.Bool1, c.d.readBool), unpackTo(&c.Bool2, c.d.readBool), unpackTo(&c.Int, c.d.readInt64), unpackTo(&c.ID, c.d.readDBID)}
+	c.packVals = []any{&c.Bool1, &c.Bool2, &c.Int, &c.ID}
+	return &c
 }
 
 //------------------------------------------------------------------------------
@@ -1009,24 +988,15 @@ type boolTimeIDCursor struct {
 	Bool bool
 	Time time.Time
 	ID   persist.DBID
+	packable
+	unpackable
 }
 
-func (c boolTimeIDCursor) Pack() (string, error) { return pack(c.Bool, c.Time, c.ID) }
-func (c *boolTimeIDCursor) Unpack(s string) error {
-	d, err := newCursorDecoder(s)
-	if err != nil {
-		return err
-	}
-	c.Bool, err = d.readBool()
-	if err != nil {
-		return err
-	}
-	c.Time, err = d.readTime()
-	if err != nil {
-		return err
-	}
-	c.ID, err = d.readDBID()
-	return err
+func (cursorN) NewBoolTimeIDCursor() *boolTimeIDCursor {
+	c := boolTimeIDCursor{unpackable: newUnpackable()}
+	c.unpackFs = []unpackF{unpackTo(&c.Bool, c.d.readBool), unpackTo(&c.Time, c.d.readTime), unpackTo(&c.ID, c.d.readDBID)}
+	c.packVals = []any{&c.Bool, &c.Time, &c.ID}
+	return &c
 }
 
 //------------------------------------------------------------------------------
@@ -1034,20 +1004,15 @@ func (c *boolTimeIDCursor) Unpack(s string) error {
 type stringIDCursor struct {
 	String string
 	ID     persist.DBID
+	packable
+	unpackable
 }
 
-func (c stringIDCursor) Pack() (string, error) { return pack(c.String, c.ID) }
-func (c *stringIDCursor) Unpack(s string) error {
-	d, err := newCursorDecoder(s)
-	if err != nil {
-		return err
-	}
-	c.String, err = d.readString()
-	if err != nil {
-		return err
-	}
-	c.ID, err = d.readDBID()
-	return err
+func (cursorN) NewStringIDCursor() *stringIDCursor {
+	c := stringIDCursor{unpackable: newUnpackable()}
+	c.unpackFs = []unpackF{unpackTo(&c.String, c.d.readString), unpackTo(&c.ID, c.d.readDBID)}
+	c.packVals = []any{&c.String, &c.ID}
+	return &c
 }
 
 //------------------------------------------------------------------------------
@@ -1056,24 +1021,15 @@ type intTimeIDCursor struct {
 	Int  int64
 	Time time.Time
 	ID   persist.DBID
+	packable
+	unpackable
 }
 
-func (c intTimeIDCursor) Pack() (string, error) { return pack(c.Int, c.Time, c.ID) }
-func (c *intTimeIDCursor) Unpack(s string) error {
-	d, err := newCursorDecoder(s)
-	if err != nil {
-		return err
-	}
-	c.Int, err = d.readInt64()
-	if err != nil {
-		return err
-	}
-	c.Time, err = d.readTime()
-	if err != nil {
-		return err
-	}
-	c.ID, err = d.readDBID()
-	return err
+func (cursorN) NewIntTimeIDCursor() *intTimeIDCursor {
+	c := intTimeIDCursor{unpackable: newUnpackable()}
+	c.unpackFs = []unpackF{unpackTo(&c.Int, c.d.readInt64), unpackTo(&c.Time, c.d.readTime), unpackTo(&c.ID, c.d.readDBID)}
+	c.packVals = []any{&c.Int, &c.Time, &c.ID}
+	return &c
 }
 
 //------------------------------------------------------------------------------
@@ -1082,35 +1038,15 @@ type feedPositionCursor struct {
 	CurrentPosition int64
 	EntityTypes     []persist.FeedEntityType
 	EntityIDs       []persist.DBID
+	packable
+	unpackable
 }
 
-func (c feedPositionCursor) Pack() (string, error) {
-	return pack(c.CurrentPosition, c.EntityTypes, c.EntityIDs)
-}
-
-func (c *feedPositionCursor) Unpack(s string) (err error) {
-	d, err := newCursorDecoder(s)
-	if err != nil {
-		return err
-	}
-
-	c.CurrentPosition, err = d.readInt64()
-	if err != nil {
-		return err
-	}
-
-	c.EntityTypes, err = unpackSlice[persist.FeedEntityType](&d, func(d *cursorDecoder) (persist.FeedEntityType, error) {
-		return d.readFeedEntityType()
-	})
-	if err != nil {
-		return err
-	}
-
-	c.EntityIDs, err = unpackSlice[persist.DBID](&d, func(d *cursorDecoder) (persist.DBID, error) {
-		return d.readDBID()
-	})
-
-	return err
+func (cursorN) NewFeedPositionCursor() *feedPositionCursor {
+	c := feedPositionCursor{unpackable: newUnpackable()}
+	c.unpackFs = []unpackF{unpackTo(&c.CurrentPosition, c.d.readInt64), unpackSliceTo(&c.EntityTypes, &c.d, c.d.readFeedEntityType), unpackSliceTo(&c.EntityIDs, &c.d, c.d.readDBID)}
+	c.packVals = []any{&c.CurrentPosition, &c.EntityTypes, &c.EntityIDs}
+	return &c
 }
 
 //------------------------------------------------------------------------------
@@ -1118,65 +1054,61 @@ func (c *feedPositionCursor) Unpack(s string) (err error) {
 type positionCursor struct {
 	CurrentPosition int64
 	IDs             []persist.DBID
+	packable
+	unpackable
 }
 
-func (c positionCursor) Pack() (string, error) { return pack(c.CurrentPosition, c.IDs) }
-func (c *positionCursor) Unpack(s string) (err error) {
-	d, err := newCursorDecoder(s)
-	if err != nil {
-		return err
-	}
-
-	c.CurrentPosition, err = d.readInt64()
-	if err != nil {
-		return err
-	}
-
-	c.IDs, err = unpackSlice[persist.DBID](&d, func(d *cursorDecoder) (persist.DBID, error) {
-		return d.readDBID()
-	})
-
-	return err
+func (cursorN) NewPositionCursor() *positionCursor {
+	c := positionCursor{unpackable: newUnpackable()}
+	c.unpackFs = []unpackF{unpackTo(&c.CurrentPosition, c.d.readInt64), unpackSliceTo(&c.IDs, &c.d, c.d.readDBID)}
+	c.packVals = []any{&c.CurrentPosition, &c.IDs}
+	return &c
 }
 
 //------------------------------------------------------------------------------
 
-func pack(vals ...any) (string, error) {
-	e := newCursorEncoder()
+type packable struct {
+	packVals []any
+}
 
-	if err := packVals(&e, vals...); err != nil {
+func (p *packable) Pack() (string, error) {
+	e := newCursorEncoder()
+	if err := packVals(&e, p.packVals...); err != nil {
 		return "", err
 	}
-
 	return e.AsBase64(), nil
 }
 
 func packVal(e *cursorEncoder, val any) error {
 	switch v := val.(type) {
-	case bool:
-		e.appendBool(v)
-	case string:
-		e.appendString(v)
+	case *bool:
+		e.appendBool(*v)
+	case *string:
+		e.appendString(*v)
+	case *persist.DBID:
+		e.appendDBID(*v)
 	case persist.DBID:
 		e.appendDBID(v)
-	case uint64:
-		e.appendUInt64(v)
-	case int64:
-		e.appendInt64(v)
-	case int:
-		e.appendInt64(int64(v))
-	case time.Time:
-		if err := e.appendTime(v); err != nil {
+	case *uint64:
+		e.appendUInt64(*v)
+	case *int64:
+		e.appendInt64(*v)
+	case *int:
+		e.appendInt64(int64(*v))
+	case *time.Time:
+		if err := e.appendTime(*v); err != nil {
 			return err
 		}
+	case *persist.FeedEntityType:
+		e.appendFeedEntityType(*v)
 	case persist.FeedEntityType:
 		e.appendFeedEntityType(v)
-	case []persist.DBID:
-		if err := packSlice(e, v); err != nil {
+	case *[]persist.DBID:
+		if err := packSlice(e, *v...); err != nil {
 			return err
 		}
-	case []persist.FeedEntityType:
-		if err := packSlice(e, v); err != nil {
+	case *[]persist.FeedEntityType:
+		if err := packSlice(e, *v...); err != nil {
 			return err
 		}
 	default:
@@ -1195,26 +1127,61 @@ func packVals[T any](e *cursorEncoder, vals ...T) error {
 }
 
 // Encode the length of the slice as an int64, then encode each val
-func packSlice[T any](e *cursorEncoder, s []T) error {
+func packSlice[T any](e *cursorEncoder, s ...T) error {
 	e.appendInt64(int64(len(s)))
 	return packVals(e, s...)
 }
 
-func unpackSlice[T any](d *cursorDecoder, f func(d *cursorDecoder) (T, error)) ([]T, error) {
-	l, err := d.readInt64()
-	if err != nil {
-		return nil, err
+type unpackF func() error
+
+type unpackable struct {
+	d        cursorDecoder
+	unpackFs []unpackF
+}
+
+func (u *unpackable) Unpack(s string) (err error) {
+	if err = u.d.setReader(s); err != nil {
+		return err
 	}
-
-	items := make([]T, l)
-
-	for i := int64(0); i < l; i++ {
-		id, err := f(d)
-		if err != nil {
-			return nil, err
+	for _, f := range u.unpackFs {
+		if err = f(); err != nil {
+			return err
 		}
-		items[i] = id
 	}
+	return nil
+}
 
-	return items, nil
+func newUnpackable() unpackable {
+	d, _ := newCursorDecoder("")
+	return unpackable{d: d}
+}
+
+func unpackTo[T any](into *T, f func() (T, error)) unpackF {
+	return func() (err error) {
+		(*into), err = f()
+		return err
+	}
+}
+
+func unpackSliceTo[T any](into *[]T, d *cursorDecoder, f func() (T, error)) func() error {
+	return func() error {
+		l, err := d.readInt64()
+		if err != nil {
+			return err
+		}
+
+		items := make([]T, l)
+
+		for i := int64(0); i < l; i++ {
+			id, err := f()
+			if err != nil {
+				return err
+			}
+			items[i] = id
+		}
+
+		(*into) = items
+
+		return nil
+	}
 }

--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -358,13 +358,13 @@ type sharedContractsPaginator struct {
 
 func (p *sharedContractsPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
-		beforeCur := boolBootIntIDCursor{
+		beforeCur := boolBoolIntIDCursorer{
 			Bool1: false,
 			Bool2: false,
 			Int:   -1,
 			ID:    defaultCursorBeforeID,
 		}
-		afterCur := boolBootIntIDCursor{
+		afterCur := boolBoolIntIDCursorer{
 			Bool1: true,
 			Bool2: true,
 			Int:   math.MaxInt32,
@@ -905,7 +905,7 @@ func (curs) NewTimeIDCursorer(f func(any) (time.Time, persist.DBID, error)) curs
 
 func (curs) NewBoolBoolIntIDCursorer(f func(any) (bool, bool, int64, persist.DBID, error)) cursorable {
 	return func(node any) (c cursorer, err error) {
-		var cur boolBootIntIDCursor
+		var cur boolBoolIntIDCursorer
 		cur.Bool1, cur.Bool2, cur.Int, cur.ID, err = f(node)
 		return &cur, err
 	}
@@ -974,15 +974,15 @@ func (c *timeIDCursor) Unpack(s string) error {
 
 //------------------------------------------------------------------------------
 
-type boolBootIntIDCursor struct {
+type boolBoolIntIDCursorer struct {
 	Bool1 bool
 	Bool2 bool
 	Int   int64
 	ID    persist.DBID
 }
 
-func (c boolBootIntIDCursor) Pack() (string, error) { return pack(c.Bool1, c.Bool2, c.Int, c.ID) }
-func (c *boolBootIntIDCursor) Unpack(s string) error {
+func (c boolBoolIntIDCursorer) Pack() (string, error) { return pack(c.Bool1, c.Bool2, c.Int, c.ID) }
+func (c *boolBoolIntIDCursorer) Unpack(s string) error {
 	d, err := newCursorDecoder(s)
 	if err != nil {
 		return err

--- a/publicapi/pagination_test.go
+++ b/publicapi/pagination_test.go
@@ -11,27 +11,114 @@ import (
 
 func TestMain(t *testing.T) {
 	t.Run("test cursor pagination", func(t *testing.T) {
-		t.Run("cursor encodes expected types", func(t *testing.T) {
-			types := []struct {
-				title string
-				typ   any
-			}{
-				{title: "can encode time", typ: time.Now()},
-				{title: "can encode bool", typ: true},
-				{title: "can encode int", typ: 1},
-				{title: "can encode int64", typ: int64(1)},
-				{title: "can encode uint64", typ: uint64(1)},
-				{title: "can encode stirng", typ: "id"},
-				{title: "can encode dbid", typ: persist.DBID("id")},
-				{title: "can encode slice of dbids", typ: []persist.DBID{"id0", "id1"}},
-				{title: "can encode slice of feed entity types", typ: []persist.FeedEntityType{0, 1}},
-			}
-			for _, typ := range types {
-				t.Run(typ.title, func(t *testing.T) {
-					_, err := pack(typ.typ)
-					assert.NoError(t, err)
-				})
-			}
+		t.Run("cursor decodes expected types", func(t *testing.T) {
+			t.Run("can decode timeID", func(t *testing.T) {
+				curA := cursors.NewTimeIDCursor()
+				curA.Time = time.Now()
+				curA.ID = persist.GenerateID()
+				packed, err := curA.Pack()
+				assert.NoError(t, err)
+
+				curB := cursors.NewTimeIDCursor()
+				err = curB.Unpack(packed)
+
+				assert.NoError(t, curB.Unpack(packed))
+				// assert.True(t, curA.Time.Equal(curB.Time))
+				assert.Equal(t, curA.ID, curB.ID)
+			})
+
+			t.Run("can decode boolBoolIntID", func(t *testing.T) {
+				curA := cursors.NewBoolBoolIntIDCursor()
+				curA.Bool1 = true
+				curA.Bool2 = true
+				curA.Int = 1337
+				curA.ID = persist.GenerateID()
+				packed, err := curA.Pack()
+				assert.NoError(t, err)
+
+				curB := cursors.NewBoolBoolIntIDCursor()
+
+				assert.NoError(t, curB.Unpack(packed))
+				assert.Equal(t, curA.Int, curB.Int)
+			})
+
+			t.Run("can decode boolTimeID", func(t *testing.T) {
+				curA := cursors.NewBoolTimeIDCursor()
+				curA.Bool = true
+				curA.Time = time.Now()
+				curA.ID = persist.GenerateID()
+				packed, err := curA.Pack()
+				assert.NoError(t, err)
+
+				curB := cursors.NewBoolTimeIDCursor()
+
+				assert.NoError(t, curB.Unpack(packed))
+				assert.Equal(t, curA.Bool, curB.Bool)
+				assert.True(t, curA.Time.Equal(curB.Time))
+				assert.Equal(t, curA.ID, curB.ID)
+			})
+
+			t.Run("can decode stringID", func(t *testing.T) {
+				curA := cursors.NewStringIDCursor()
+				curA.String = "string"
+				curA.ID = persist.GenerateID()
+				packed, err := curA.Pack()
+				assert.NoError(t, err)
+
+				curB := cursors.NewStringIDCursor()
+
+				assert.NoError(t, curB.Unpack(packed))
+				assert.Equal(t, curA.String, curB.String)
+				assert.Equal(t, curA.ID, curB.ID)
+			})
+
+			t.Run("can decode intTimeID", func(t *testing.T) {
+				curA := cursors.NewIntTimeIDCursor()
+				curA.Int = 1337
+				curA.Time = time.Now()
+				curA.ID = persist.GenerateID()
+				packed, err := curA.Pack()
+				assert.NoError(t, err)
+
+				curB := cursors.NewIntTimeIDCursor()
+
+				assert.NoError(t, curB.Unpack(packed))
+				assert.Equal(t, curA.Int, curB.Int)
+				assert.True(t, curA.Time.Equal(curB.Time))
+				assert.Equal(t, curA.ID, curB.ID)
+			})
+
+			t.Run("can decode feedPosition", func(t *testing.T) {
+				curA := cursors.NewFeedPositionCursor()
+				curA.CurrentPosition = 2
+				curA.EntityTypes = []persist.FeedEntityType{0, 1}
+				curA.EntityIDs = []persist.DBID{"a", "b", "c", "d", "e"}
+				packed, err := curA.Pack()
+				assert.NoError(t, err)
+
+				curB := cursors.NewFeedPositionCursor()
+				err = curB.Unpack(packed)
+
+				assert.NoError(t, curB.Unpack(packed))
+				assert.Equal(t, curA.CurrentPosition, curB.CurrentPosition)
+				assert.Equal(t, curA.EntityTypes, curB.EntityTypes)
+				assert.Equal(t, curA.EntityIDs, curB.EntityIDs)
+			})
+
+			t.Run("can decode position", func(t *testing.T) {
+				curA := cursors.NewPositionCursor()
+				curA.CurrentPosition = 2
+				curA.IDs = []persist.DBID{"a", "b", "c", "d", "e"}
+				packed, err := curA.Pack()
+				assert.NoError(t, err)
+
+				curB := cursors.NewPositionCursor()
+				err = curB.Unpack(packed)
+
+				assert.NoError(t, curB.Unpack(packed))
+				assert.Equal(t, curA.CurrentPosition, curB.CurrentPosition)
+				assert.Equal(t, curA.IDs, curB.IDs)
+			})
 		})
 
 		t.Run("cursor pagination returns expected edges", func(t *testing.T) {

--- a/publicapi/pagination_test.go
+++ b/publicapi/pagination_test.go
@@ -12,18 +12,26 @@ import (
 func TestMain(t *testing.T) {
 	t.Run("test cursor pagination", func(t *testing.T) {
 		t.Run("cursor encodes expected types", func(t *testing.T) {
-			_, err := pack(
-				time.Now(),
-				true,
-				1,
-				int64(1),
-				uint64(1),
-				"id",
-				persist.DBID("id"),
-				[]persist.DBID{"id0", "id1"},
-				[]persist.FeedEntityType{0, 1},
-			)
-			assert.NoError(t, err)
+			types := []struct {
+				title string
+				typ   any
+			}{
+				{title: "can encode time", typ: time.Now()},
+				{title: "can encode bool", typ: true},
+				{title: "can encode int", typ: 1},
+				{title: "can encode int64", typ: int64(1)},
+				{title: "can encode uint64", typ: uint64(1)},
+				{title: "can encode stirng", typ: "id"},
+				{title: "can encode dbid", typ: persist.DBID("id")},
+				{title: "can encode slice of dbids", typ: []persist.DBID{"id0", "id1"}},
+				{title: "can encode slice of feed entity types", typ: []persist.FeedEntityType{0, 1}},
+			}
+			for _, typ := range types {
+				t.Run(typ.title, func(t *testing.T) {
+					_, err := pack(typ.typ)
+					assert.NoError(t, err)
+				})
+			}
 		})
 
 		t.Run("cursor pagination returns expected edges", func(t *testing.T) {

--- a/publicapi/pagination_test.go
+++ b/publicapi/pagination_test.go
@@ -23,7 +23,7 @@ func TestMain(t *testing.T) {
 				err = curB.Unpack(packed)
 
 				assert.NoError(t, curB.Unpack(packed))
-				// assert.True(t, curA.Time.Equal(curB.Time))
+				assert.True(t, curA.Time.Equal(curB.Time))
 				assert.Equal(t, curA.ID, curB.ID)
 			})
 

--- a/publicapi/pagination_test.go
+++ b/publicapi/pagination_test.go
@@ -2,19 +2,37 @@ package publicapi
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mikeydub/go-gallery/service/persist"
 )
 
 func TestMain(t *testing.T) {
 	t.Run("test cursor pagination", func(t *testing.T) {
+		t.Run("cursor encodes expected types", func(t *testing.T) {
+			_, err := pack(
+				time.Now(),
+				true,
+				1,
+				int64(1),
+				uint64(1),
+				"id",
+				persist.DBID("id"),
+				[]persist.DBID{"id0", "id1"},
+				[]persist.FeedEntityType{0, 1},
+			)
+			assert.NoError(t, err)
+		})
+
 		t.Run("cursor pagination returns expected edges", func(t *testing.T) {
 			t.Run("should return no edges if no edges", func(t *testing.T) {
 				edges := []string{}
 				first := 10
 				var last int
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, nil, nil, &first, &last)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, nil, nil, &first, &last)
 				assert.NoError(t, err)
 				assert.Equal(t, 0, len(actual))
 			})
@@ -23,7 +41,7 @@ func TestMain(t *testing.T) {
 				edges := []string{"a", "b", "c", "d", "e"}
 				expected := []string{"a", "b", "c", "d", "e"}
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, nil, nil, nil, nil)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, nil, nil, nil, nil)
 				assert.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -32,7 +50,7 @@ func TestMain(t *testing.T) {
 				edges := []string{"a", "b", "c", "d", "e"}
 				first := 0
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, nil, nil, &first, nil)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, nil, nil, &first, nil)
 				assert.NoError(t, err)
 				assert.Equal(t, 0, len(actual))
 			})
@@ -41,7 +59,7 @@ func TestMain(t *testing.T) {
 				edges := []string{"a", "b", "c", "d", "e"}
 				last := 0
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, nil, nil, nil, &last)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, nil, nil, nil, &last)
 				assert.NoError(t, err)
 				assert.Equal(t, 0, len(actual))
 			})
@@ -51,7 +69,7 @@ func TestMain(t *testing.T) {
 				first := 2
 				expected := []string{"a", "b"}
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, nil, nil, &first, nil)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, nil, nil, &first, nil)
 				assert.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -61,7 +79,7 @@ func TestMain(t *testing.T) {
 				last := 2
 				expected := []string{"d", "e"}
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, nil, nil, nil, &last)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, nil, nil, nil, &last)
 				assert.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -72,7 +90,7 @@ func TestMain(t *testing.T) {
 				after := "b"
 				expected := []string{"c", "d"}
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, nil, &after, &first, nil)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, nil, &after, &first, nil)
 				assert.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -83,7 +101,7 @@ func TestMain(t *testing.T) {
 				before := "d"
 				expected := []string{"b", "c"}
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, &before, nil, nil, &last)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, &before, nil, nil, &last)
 				assert.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -95,7 +113,7 @@ func TestMain(t *testing.T) {
 				after := "a"
 				expected := []string{"c", "d"}
 
-				actual, _, err := pageFrom(edges, nil, identityCursor, &before, &after, nil, &last)
+				actual, _, err := pageFrom(edges, nil, stubbedCursor, &before, &after, nil, &last)
 				assert.NoError(t, err)
 				assert.Equal(t, expected, actual)
 			})
@@ -106,7 +124,7 @@ func TestMain(t *testing.T) {
 				edges := []string{}
 				first := 10
 
-				_, pageInfo, err := pageFrom(edges, nil, identityCursor, nil, nil, &first, nil)
+				_, pageInfo, err := pageFrom(edges, nil, stubbedCursor, nil, nil, &first, nil)
 				assert.NoError(t, err)
 				assert.Equal(t, 0, pageInfo.Size)
 				assert.Equal(t, false, pageInfo.HasPreviousPage)
@@ -119,7 +137,7 @@ func TestMain(t *testing.T) {
 				edges := []string{"a", "b", "c", "d", "e"}
 				first := 10
 
-				_, pageInfo, err := pageFrom(edges, nil, identityCursor, nil, nil, &first, nil)
+				_, pageInfo, err := pageFrom(edges, nil, stubbedCursor, nil, nil, &first, nil)
 				assert.NoError(t, err)
 				assert.Equal(t, 5, pageInfo.Size)
 				assert.Equal(t, false, pageInfo.HasPreviousPage)
@@ -132,7 +150,7 @@ func TestMain(t *testing.T) {
 				edges := []string{"a", "b", "c", "d", "e"}
 				first := 2
 
-				_, pageInfo, err := pageFrom(edges, nil, identityCursor, nil, nil, &first, nil)
+				_, pageInfo, err := pageFrom(edges, nil, stubbedCursor, nil, nil, &first, nil)
 				assert.NoError(t, err)
 				assert.Equal(t, 2, pageInfo.Size)
 				assert.Equal(t, false, pageInfo.HasPreviousPage)
@@ -145,7 +163,7 @@ func TestMain(t *testing.T) {
 				edges := []string{"a", "b", "c", "d", "e"}
 				last := 2
 
-				_, pageInfo, err := pageFrom(edges, nil, identityCursor, nil, nil, nil, &last)
+				_, pageInfo, err := pageFrom(edges, nil, stubbedCursor, nil, nil, nil, &last)
 				assert.NoError(t, err)
 				assert.Equal(t, 2, pageInfo.Size)
 				assert.Equal(t, true, pageInfo.HasPreviousPage)
@@ -158,7 +176,7 @@ func TestMain(t *testing.T) {
 
 	t.Run("test keyset pagination", func(t *testing.T) {
 		t.Run("should exclude extra edges", func(t *testing.T) {
-			p := newStubKeysetPaginator([]any{"a", "b", "c", "d", "e", "extra"})
+			p := newStubPaginator([]any{"a", "b", "c", "d", "e", "extra"})
 			expected := []string{"a", "b", "c", "d", "e"}
 			first := 5
 
@@ -174,7 +192,7 @@ func TestMain(t *testing.T) {
 		})
 
 		t.Run("should return expected page info when paging forward", func(t *testing.T) {
-			p := newStubKeysetPaginator([]any{"a", "b", "c", "d", "e", "extra"})
+			p := newStubPaginator([]any{"a", "b", "c", "d", "e", "extra"})
 			first := 5
 
 			_, pageInfo, err := p.paginate(nil, nil, &first, nil)
@@ -187,7 +205,7 @@ func TestMain(t *testing.T) {
 		})
 
 		t.Run("should return expected edge order when paging backwards", func(t *testing.T) {
-			p := newStubKeysetPaginator([]any{"e", "d", "c", "b", "a", "extra"})
+			p := newStubPaginator([]any{"e", "d", "c", "b", "a", "extra"})
 			expected := []string{"a", "b", "c", "d", "e"}
 			last := 5
 
@@ -203,7 +221,7 @@ func TestMain(t *testing.T) {
 		})
 
 		t.Run("should return expected page info when paging backwards", func(t *testing.T) {
-			p := newStubKeysetPaginator([]any{"e", "d", "c", "b", "a", "extra"})
+			p := newStubPaginator([]any{"e", "d", "c", "b", "a", "extra"})
 			last := 5
 
 			_, pageInfo, err := p.paginate(nil, nil, nil, &last)
@@ -217,20 +235,21 @@ func TestMain(t *testing.T) {
 	})
 }
 
-func identityCursor(s string) (string, error) {
-	return s, nil
-}
+type stubCursor struct{ ID string }
 
-func newStubKeysetPaginator(ret []any) keysetPaginator {
+func (p stubCursor) Pack() (string, error) { return p.ID, nil }
+func (p stubCursor) Unpack(s string) error { panic("not implemented") }
+
+var stubbedCursor = func(node any) (c cursorer, err error) { return stubCursor{ID: node.(string)}, nil }
+
+func newStubPaginator(ret []any) keysetPaginator {
 	var p keysetPaginator
 
 	p.QueryFunc = func(int32, bool) ([]any, error) {
 		return ret, nil
 	}
 
-	p.CursorFunc = func(a any) (string, error) {
-		return a.(string), nil
-	}
+	p.Cursorable = stubbedCursor
 
 	return p
 }

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -149,8 +149,9 @@ func newDBIDCache(cache *redis.Cache, key string, ttl time.Duration, f func(cont
 				if err != nil {
 					return nil, err
 				}
-
-				cur := positionCursor{CurrentPosition: 0, IDs: ids}
+				cur := cursors.NewPositionCursor()
+				cur.CurrentPosition = 0
+				cur.IDs = ids
 				b, err := cur.Pack()
 				return []byte(b), err
 			},
@@ -163,7 +164,7 @@ func (d dbidCache) Load(ctx context.Context) ([]persist.DBID, error) {
 	if err != nil {
 		return nil, err
 	}
-	var cur positionCursor
+	cur := cursors.NewPositionCursor()
 	err = cur.Unpack(string(b))
 	return cur.IDs, err
 }

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -150,8 +150,8 @@ func newDBIDCache(cache *redis.Cache, key string, ttl time.Duration, f func(cont
 					return nil, err
 				}
 
-				var p positionPaginator
-				b, err := p.encodeCursor(0, ids)
+				cur := positionCursor{CurrentPosition: 0, IDs: ids}
+				b, err := cur.Pack()
 				return []byte(b), err
 			},
 		},
@@ -163,7 +163,7 @@ func (d dbidCache) Load(ctx context.Context) ([]persist.DBID, error) {
 	if err != nil {
 		return nil, err
 	}
-	var p positionPaginator
-	_, ids, err := p.decodeCursor(string(b))
-	return ids, err
+	var cur positionCursor
+	err = cur.Unpack(string(b))
+	return cur.IDs, err
 }

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -1227,7 +1227,7 @@ func (api UserAPI) RecommendUsers(ctx context.Context, before, after *string, fi
 		return nil, PageInfo{}, err
 	}
 
-	var cursor positionCursor
+	cursor := cursors.NewPositionCursor()
 	var paginator positionPaginator
 
 	// If we have a cursor, we can page through the original set of recommended users

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -808,9 +808,9 @@ func (api UserAPI) SharedCommunities(ctx context.Context, userID persist.DBID, b
 		return int(total), err
 	}
 
-	cursorFunc := func(i any) (bool, bool, int, persist.DBID, error) {
+	cursorFunc := func(i any) (bool, bool, int64, persist.DBID, error) {
 		if row, ok := i.(db.GetSharedContractsBatchPaginateRow); ok {
-			return row.DisplayedByUserA, row.DisplayedByUserB, int(row.OwnedCount), row.ID, nil
+			return row.DisplayedByUserA, row.DisplayedByUserB, int64(row.OwnedCount), row.ID, nil
 		}
 		return false, false, 0, "", fmt.Errorf("node is not a db.GetSharedContractsBatchPaginateRow")
 	}
@@ -1227,16 +1227,16 @@ func (api UserAPI) RecommendUsers(ctx context.Context, before, after *string, fi
 		return nil, PageInfo{}, err
 	}
 
-	paginator := positionPaginator{}
-	var userIDs []persist.DBID
+	var cursor positionCursor
+	var paginator positionPaginator
 
 	// If we have a cursor, we can page through the original set of recommended users
 	if before != nil {
-		if _, userIDs, err = paginator.decodeCursor(*before); err != nil {
+		if err = cursor.Unpack(*before); err != nil {
 			return nil, PageInfo{}, err
 		}
 	} else if after != nil {
-		if _, userIDs, err = paginator.decodeCursor(*after); err != nil {
+		if err = cursor.Unpack(*after); err != nil {
 			return nil, PageInfo{}, err
 		}
 	} else {
@@ -1246,16 +1246,16 @@ func (api UserAPI) RecommendUsers(ctx context.Context, before, after *string, fi
 			return nil, PageInfo{}, err
 		}
 
-		userIDs, err = recommend.For(ctx).RecommendFromFollowingShuffled(ctx, curUserID, follows)
+		cursor.IDs, err = recommend.For(ctx).RecommendFromFollowingShuffled(ctx, curUserID, follows)
 		if err != nil {
 			return nil, PageInfo{}, err
 		}
 	}
 
 	positionLookup := map[persist.DBID]int{}
-	idsAsString := make([]string, len(userIDs))
+	idsAsString := make([]string, len(cursor.IDs))
 
-	for i, id := range userIDs {
+	for i, id := range cursor.IDs {
 		// Postgres uses 1-based indexing
 		positionLookup[id] = i + 1
 		idsAsString[i] = id.String()
@@ -1281,9 +1281,9 @@ func (api UserAPI) RecommendUsers(ctx context.Context, before, after *string, fi
 		return results, nil
 	}
 
-	paginator.CursorFunc = func(node any) (int, []persist.DBID, error) {
+	paginator.CursorFunc = func(node any) (int64, []persist.DBID, error) {
 		if user, ok := node.(db.User); ok {
-			return positionLookup[user.ID], userIDs, nil
+			return int64(positionLookup[user.ID]), cursor.IDs, nil
 		}
 		return 0, nil, fmt.Errorf("node is not a db.User")
 	}


### PR DESCRIPTION
This PR factors out cursor logic from the paginators and adds a cursor interface that cursor types can implement:
```go
type cursorer interface {
	Pack() (string, error) // Encodes the cursor as a string
	Unpack(string) error // Decodes the cursor into the receiver
}
```
This should pave the path for comparing cursors and faster cursor searches. At the moment, cursor equality is handled by comparing the cursor strings instead of the structs themselves. Most cursors do support this besides the more complex cursors that contain slices since go doesn't support slice comparisons out of the box. I figure I can save this for when we implement sorting + binary search.