### PR TITLE
Fix for null post captions

### DIFF
--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -716,7 +716,7 @@ func postsToConnection(ctx context.Context, posts []db.Post, contractID persist.
 		cval, _ := p.Caption.Value()
 
 		var caption *string
-		if caption != nil {
+		if cval != nil {
 			caption = util.ToPointer(cval.(string))
 		}
 

--- a/publicapi/contract.go
+++ b/publicapi/contract.go
@@ -298,8 +298,8 @@ func (api ContractAPI) GetCommunityPostsByContractID(ctx context.Context, contra
 		}
 
 		results := make([]interface{}, len(posts))
-		for i, owner := range posts {
-			results[i] = owner
+		for i, post := range posts {
+			results[i] = post
 		}
 
 		return results, nil
@@ -314,7 +314,7 @@ func (api ContractAPI) GetCommunityPostsByContractID(ctx context.Context, contra
 		if user, ok := i.(db.Post); ok {
 			return user.CreatedAt, user.ID, nil
 		}
-		return time.Time{}, "", fmt.Errorf("interface{} is not a token")
+		return time.Time{}, "", fmt.Errorf("interface{} is not a post")
 	}
 
 	paginator := timeIDPaginator{


### PR DESCRIPTION
Post captions were showing up null on the community page (as reported by @kaitoo1). This fixes the issue! And updates a couple of copy/pasted variable names.