### PR TITLE
Exclude events from view

### DIFF
--- a/db/gen/coredb/recommend.sql.go
+++ b/db/gen/coredb/recommend.sql.go
@@ -104,6 +104,7 @@ from feed_entity_score_view f2
 where created_at > (select last_updated from refreshed limit 1)
   and ($2::bool or f2.actor_id != $3)
   and ($4::bool or f2.feed_entity_type != $5)
+  and ($6::bool or f2.feed_entity_type != $7)
   and not (f2.action = any($8::varchar[]))
 `
 

--- a/db/queries/core/recommend.sql
+++ b/db/queries/core/recommend.sql
@@ -88,4 +88,5 @@ from feed_entity_score_view f2
 where created_at > (select last_updated from refreshed limit 1)
   and (@include_viewer::bool or f2.actor_id != @viewer_id)
   and (@include_posts::bool or f2.feed_entity_type != @post_entity_type)
+  and (@include_events::bool or f2.feed_entity_type != @feed_entity_type)
   and not (f2.action = any(@excluded_feed_actions::varchar[]));


### PR DESCRIPTION
Fix bugs where events were still shown on the feed because events were still included in the view