### PR TITLE
mention data

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -868,7 +868,7 @@ func (b *GetCollectionsByGalleryIdBatchBatchResults) Close() error {
 }
 
 const getCommentByCommentIDBatch = `-- name: GetCommentByCommentIDBatch :batchone
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed FROM comments WHERE id = $1 and deleted = false
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, mentions FROM comments WHERE id = $1 and deleted = false
 `
 
 type GetCommentByCommentIDBatchBatchResults struct {
@@ -912,6 +912,7 @@ func (b *GetCommentByCommentIDBatchBatchResults) QueryRow(f func(int, Comment, e
 			&i.LastUpdated,
 			&i.PostID,
 			&i.Removed,
+			&i.Mentions,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -2077,7 +2078,7 @@ func (b *GetOwnersByContractIdBatchPaginateBatchResults) Close() error {
 }
 
 const getPostByIdBatch = `-- name: GetPostByIdBatch :batchone
-SELECT id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted FROM posts WHERE id = $1 AND deleted = false
+SELECT id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted, mentions FROM posts WHERE id = $1 AND deleted = false
 `
 
 type GetPostByIdBatchBatchResults struct {
@@ -2119,6 +2120,7 @@ func (b *GetPostByIdBatchBatchResults) QueryRow(f func(int, Post, error)) {
 			&i.CreatedAt,
 			&i.LastUpdated,
 			&i.Deleted,
+			&i.Mentions,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -3844,7 +3846,7 @@ func (b *PaginateAdmiresByPostIDBatchBatchResults) Close() error {
 }
 
 const paginateCommentsByFeedEventIDBatch = `-- name: PaginateCommentsByFeedEventIDBatch :batchmany
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed FROM comments WHERE feed_event_id = $1 AND reply_to is null AND deleted = false
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, mentions FROM comments WHERE feed_event_id = $1 AND reply_to is null AND deleted = false
     AND (created_at, id) < ($2, $3)
     AND (created_at, id) > ($4, $5)
     ORDER BY CASE WHEN $6::bool THEN (created_at, id) END ASC,
@@ -3916,6 +3918,7 @@ func (b *PaginateCommentsByFeedEventIDBatchBatchResults) Query(f func(int, []Com
 					&i.LastUpdated,
 					&i.PostID,
 					&i.Removed,
+					&i.Mentions,
 				); err != nil {
 					return err
 				}
@@ -3935,7 +3938,7 @@ func (b *PaginateCommentsByFeedEventIDBatchBatchResults) Close() error {
 }
 
 const paginateCommentsByPostIDBatch = `-- name: PaginateCommentsByPostIDBatch :batchmany
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed FROM comments WHERE post_id = $1 AND reply_to is null AND deleted = false
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, mentions FROM comments WHERE post_id = $1 AND reply_to is null AND deleted = false
     AND (created_at, id) < ($2, $3)
     AND (created_at, id) > ($4, $5)
     ORDER BY CASE WHEN $6::bool THEN (created_at, id) END ASC,
@@ -4007,6 +4010,7 @@ func (b *PaginateCommentsByPostIDBatchBatchResults) Query(f func(int, []Comment,
 					&i.LastUpdated,
 					&i.PostID,
 					&i.Removed,
+					&i.Mentions,
 				); err != nil {
 					return err
 				}
@@ -4222,7 +4226,7 @@ func (b *PaginateInteractionsByPostIDBatchBatchResults) Close() error {
 }
 
 const paginatePostsByContractID = `-- name: PaginatePostsByContractID :batchmany
-SELECT posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted
+SELECT posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.mentions
 FROM posts
 WHERE $1 = ANY(posts.contract_ids)
 AND posts.deleted = false
@@ -4296,6 +4300,7 @@ func (b *PaginatePostsByContractIDBatchResults) Query(f func(int, []Post, error)
 					&i.CreatedAt,
 					&i.LastUpdated,
 					&i.Deleted,
+					&i.Mentions,
 				); err != nil {
 					return err
 				}
@@ -4315,7 +4320,7 @@ func (b *PaginatePostsByContractIDBatchResults) Close() error {
 }
 
 const paginateRepliesByCommentIDBatch = `-- name: PaginateRepliesByCommentIDBatch :batchmany
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed FROM comments WHERE reply_to = $1 AND deleted = false
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, mentions FROM comments WHERE reply_to = $1 AND deleted = false
     AND (created_at, id) < ($2, $3)
     AND (created_at, id) > ($4, $5)
     ORDER BY CASE WHEN $6::bool THEN (created_at, id) END ASC,
@@ -4387,6 +4392,7 @@ func (b *PaginateRepliesByCommentIDBatchBatchResults) Query(f func(int, []Commen
 					&i.LastUpdated,
 					&i.PostID,
 					&i.Removed,
+					&i.Mentions,
 				); err != nil {
 					return err
 				}

--- a/db/gen/coredb/contract_gallery.sql.go
+++ b/db/gen/coredb/contract_gallery.sql.go
@@ -108,9 +108,9 @@ insert into contracts(id, deleted, version, created_at, address, symbol, name, o
     , unnest($10::bool[])
 )
 on conflict (chain, address) where parent_id is null
-do update set symbol = excluded.symbol
+do update set symbol = coalesce(nullif(excluded.symbol, ''), nullif(contracts.symbol, ''))
   , version = excluded.version
-  , name = excluded.name
+  , name = coalesce(nullif(excluded.name, ''), nullif(contracts.name, ''))
   , owner_address =
       case
           when nullif(contracts.owner_address, '') is null or ($11::bool and nullif (excluded.owner_address, '') is not null)
@@ -118,8 +118,8 @@ do update set symbol = excluded.symbol
           else
             contracts.owner_address
       end
-  , description = excluded.description
-  , profile_image_url = excluded.profile_image_url
+  , description = coalesce(nullif(excluded.description, ''), nullif(contracts.description, ''))
+  , profile_image_url = coalesce(nullif(excluded.profile_image_url, ''), nullif(contracts.profile_image_url, ''))
   , deleted = excluded.deleted
   , last_updated = now()
 returning id, deleted, version, created_at, last_updated, name, symbol, address, creator_address, chain, profile_banner_url, profile_image_url, badge_url, description, owner_address, is_provider_marked_spam, parent_id, override_creator_user_id

--- a/db/gen/coredb/gallery.sql.go
+++ b/db/gen/coredb/gallery.sql.go
@@ -184,7 +184,7 @@ const galleryRepoGetPreviewsForUserID = `-- name: GalleryRepoGetPreviewsForUserI
 select coalesce(nullif(tm.media->>'thumbnail_url', ''), nullif(tm.media->>'media_url', ''))::varchar as thumbnail_url from galleries g,
     unnest(g.collections) with ordinality as collection_ids(id, ord) inner join collections c on c.id = collection_ids.id and c.deleted = false,
     unnest(c.nfts) with ordinality as token_ids(id, ord) inner join tokens t on t.id = token_ids.id and t.displayable and t.deleted = false
-    inner join token_medias tm on t.token_media_id = tm.id and tm.media ->> 'thumbnail_url' != ''
+    inner join token_medias tm on t.token_media_id = tm.id and (tm.media ->> 'thumbnail_url' != '' or tm.media ->> 'media_url' != '')
     where g.owner_user_id = $1 and g.deleted = false
     order by collection_ids.ord, token_ids.ord limit $2
 `

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -48,17 +48,18 @@ type Collection struct {
 }
 
 type Comment struct {
-	ID          persist.DBID `json:"id"`
-	Version     int32        `json:"version"`
-	FeedEventID persist.DBID `json:"feed_event_id"`
-	ActorID     persist.DBID `json:"actor_id"`
-	ReplyTo     persist.DBID `json:"reply_to"`
-	Comment     string       `json:"comment"`
-	Deleted     bool         `json:"deleted"`
-	CreatedAt   time.Time    `json:"created_at"`
-	LastUpdated time.Time    `json:"last_updated"`
-	PostID      persist.DBID `json:"post_id"`
-	Removed     bool         `json:"removed"`
+	ID          persist.DBID     `json:"id"`
+	Version     int32            `json:"version"`
+	FeedEventID persist.DBID     `json:"feed_event_id"`
+	ActorID     persist.DBID     `json:"actor_id"`
+	ReplyTo     persist.DBID     `json:"reply_to"`
+	Comment     string           `json:"comment"`
+	Deleted     bool             `json:"deleted"`
+	CreatedAt   time.Time        `json:"created_at"`
+	LastUpdated time.Time        `json:"last_updated"`
+	PostID      persist.DBID     `json:"post_id"`
+	Removed     bool             `json:"removed"`
+	Mentions    persist.Mentions `json:"mentions"`
 }
 
 type Contract struct {
@@ -383,6 +384,7 @@ type Post struct {
 	CreatedAt   time.Time        `json:"created_at"`
 	LastUpdated time.Time        `json:"last_updated"`
 	Deleted     bool             `json:"deleted"`
+	Mentions    persist.Mentions `json:"mentions"`
 }
 
 type ProfileImage struct {

--- a/db/gen/coredb/recommend.sql.go
+++ b/db/gen/coredb/recommend.sql.go
@@ -104,6 +104,7 @@ from feed_entity_score_view f2
 where created_at > (select last_updated from refreshed limit 1)
   and ($2::bool or f2.actor_id != $3)
   and ($4::bool or f2.feed_entity_type != $5)
+  and ($6::bool or f2.feed_entity_type != $7)
   and not (f2.action = any($8::varchar[]))
 `
 

--- a/db/migrations/core/000106_comments_deletable.up.sql
+++ b/db/migrations/core/000106_comments_deletable.up.sql
@@ -5,4 +5,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS comments_created_at_id_post_id_idx ON comments
 
 alter table comments add column removed bool default false not null;
 
+alter table comments add column mentions jsonb default '{}'::jsonb not null;
+alter table posts add column mentions jsonb default '{}'::jsonb not null;
+
 

--- a/db/queries/core/contract_gallery.sql
+++ b/db/queries/core/contract_gallery.sql
@@ -14,9 +14,9 @@ insert into contracts(id, deleted, version, created_at, address, symbol, name, o
     , unnest(@provider_marked_spam::bool[])
 )
 on conflict (chain, address) where parent_id is null
-do update set symbol = excluded.symbol
+do update set symbol = coalesce(nullif(excluded.symbol, ''), nullif(contracts.symbol, ''))
   , version = excluded.version
-  , name = excluded.name
+  , name = coalesce(nullif(excluded.name, ''), nullif(contracts.name, ''))
   , owner_address =
       case
           when nullif(contracts.owner_address, '') is null or (@can_overwrite_owner_address::bool and nullif (excluded.owner_address, '') is not null)
@@ -24,8 +24,8 @@ do update set symbol = excluded.symbol
           else
             contracts.owner_address
       end
-  , description = excluded.description
-  , profile_image_url = excluded.profile_image_url
+  , description = coalesce(nullif(excluded.description, ''), nullif(contracts.description, ''))
+  , profile_image_url = coalesce(nullif(excluded.profile_image_url, ''), nullif(contracts.profile_image_url, ''))
   , deleted = excluded.deleted
   , last_updated = now()
 returning *;

--- a/db/queries/core/gallery.sql
+++ b/db/queries/core/gallery.sql
@@ -26,10 +26,10 @@ select c.id from galleries g, unnest(g.collections) with ordinality as u(coll, c
 select * from galleries g where g.owner_user_id = $1 and g.deleted = false order by position;
 
 -- name: GalleryRepoGetPreviewsForUserID :many
-select (tm.media ->> 'thumbnail_url')::text from galleries g,
+select coalesce(nullif(tm.media->>'thumbnail_url', ''), nullif(tm.media->>'media_url', ''))::varchar as thumbnail_url from galleries g,
     unnest(g.collections) with ordinality as collection_ids(id, ord) inner join collections c on c.id = collection_ids.id and c.deleted = false,
     unnest(c.nfts) with ordinality as token_ids(id, ord) inner join tokens t on t.id = token_ids.id and t.displayable and t.deleted = false
-    inner join token_medias tm on t.token_media_id = tm.id and tm.media ->> 'thumbnail_url' != ''
+    inner join token_medias tm on t.token_media_id = tm.id and (tm.media ->> 'thumbnail_url' != '' or tm.media ->> 'media_url' != '')
     where g.owner_user_id = $1 and g.deleted = false
     order by collection_ids.ord, token_ids.ord limit $2;
 

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -727,7 +727,7 @@ SELECT * FROM admires WHERE actor_id = $1 AND feed_event_id = $2 AND deleted = f
 SELECT * FROM admires WHERE actor_id = $1 AND post_id = $2 AND deleted = false;
 
 -- name: InsertPost :one
-insert into posts(id, token_ids, contract_ids, actor_id, caption, created_at) values ($1, $2, $3, $4, $5, now()) returning id;
+insert into posts(id, token_ids, contract_ids, actor_id, caption, mentions, created_at) values ($1, $2, $3, $4, $5, $6, now()) returning id;
 
 -- name: DeletePostByID :exec
 update posts set deleted = true where id = $1;

--- a/db/queries/core/recommend.sql
+++ b/db/queries/core/recommend.sql
@@ -88,4 +88,5 @@ from feed_entity_score_view f2
 where created_at > (select last_updated from refreshed limit 1)
   and (@include_viewer::bool or f2.actor_id != @viewer_id)
   and (@include_posts::bool or f2.feed_entity_type != @post_entity_type)
+  and (@include_events::bool or f2.feed_entity_type != @feed_entity_type)
   and not (f2.action = any(@excluded_feed_actions::varchar[]));

--- a/emails/t__utils_test.go
+++ b/emails/t__utils_test.go
@@ -201,7 +201,7 @@ func seedAdmireNotif(ctx context.Context, t *testing.T, q *coredb.Queries, userI
 
 func seedCommentNotif(ctx context.Context, t *testing.T, q *coredb.Queries, repos *postgres.Repositories, userID persist.DBID, userID2 persist.DBID) {
 
-	commentID, err := repos.CommentRepository.CreateComment(ctx, feedEvent.ID, "", userID2, nil, "test comment")
+	commentID, err := repos.CommentRepository.CreateComment(ctx, feedEvent.ID, "", userID2, nil, "test comment", nil)
 
 	if err != nil {
 		t.Fatalf("failed to create admire event: %s", err)

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -752,9 +752,8 @@ type ComplexityRoot struct {
 	}
 
 	Mention struct {
-		Community func(childComplexity int) int
-		Index     func(childComplexity int) int
-		User      func(childComplexity int) int
+		Entity func(childComplexity int) int
+		Index  func(childComplexity int) int
 	}
 
 	MerchDiscountCode struct {
@@ -1654,8 +1653,7 @@ type GalleryUserResolver interface {
 	IsMemberOfCommunity(ctx context.Context, obj *model.GalleryUser, communityID persist.DBID) (bool, error)
 }
 type MentionResolver interface {
-	User(ctx context.Context, obj *model.Mention) (*model.GalleryUser, error)
-	Community(ctx context.Context, obj *model.Mention) (*model.Community, error)
+	Entity(ctx context.Context, obj *model.Mention) (model.MentionEntity, error)
 }
 type MutationResolver interface {
 	AddUserWallet(ctx context.Context, chainAddress persist.ChainAddress, authMechanism model.AuthMechanism) (model.AddUserWalletPayloadOrError, error)
@@ -4324,12 +4322,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.MembershipTier.TokenID(childComplexity), true
 
-	case "Mention.community":
-		if e.complexity.Mention.Community == nil {
+	case "Mention.entity":
+		if e.complexity.Mention.Entity == nil {
 			break
 		}
 
-		return e.complexity.Mention.Community(childComplexity), true
+		return e.complexity.Mention.Entity(childComplexity), true
 
 	case "Mention.index":
 		if e.complexity.Mention.Index == nil {
@@ -4337,13 +4335,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mention.Index(childComplexity), true
-
-	case "Mention.user":
-		if e.complexity.Mention.User == nil {
-			break
-		}
-
-		return e.complexity.Mention.User(childComplexity), true
 
 	case "MerchDiscountCode.code":
 		if e.complexity.MerchDiscountCode.Code == nil {
@@ -8880,9 +8871,10 @@ type Comment implements Node @goEmbedHelper {
   deleted: Boolean
 }
 
+union MentionEntity = GalleryUser | Community
+
 type Mention @goEmbedHelper {
-  user: GalleryUser @goField(forceResolver: true)
-  community: Community @goField(forceResolver: true)
+  entity: MentionEntity @goField(forceResolver: true)
   index: CompleteIndex
 }
 
@@ -18575,10 +18567,8 @@ func (ec *executionContext) fieldContext_Comment_mentions(ctx context.Context, f
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "user":
-				return ec.fieldContext_Mention_user(ctx, field)
-			case "community":
-				return ec.fieldContext_Mention_community(ctx, field)
+			case "entity":
+				return ec.fieldContext_Mention_entity(ctx, field)
 			case "index":
 				return ec.fieldContext_Mention_index(ctx, field)
 			}
@@ -30716,8 +30706,8 @@ func (ec *executionContext) fieldContext_MembershipTier_owners(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Mention_user(ctx context.Context, field graphql.CollectedField, obj *model.Mention) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mention_user(ctx, field)
+func (ec *executionContext) _Mention_entity(ctx context.Context, field graphql.CollectedField, obj *model.Mention) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mention_entity(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -30730,7 +30720,7 @@ func (ec *executionContext) _Mention_user(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mention().User(rctx, obj)
+		return ec.resolvers.Mention().Entity(rctx, obj)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -30739,152 +30729,19 @@ func (ec *executionContext) _Mention_user(ctx context.Context, field graphql.Col
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.GalleryUser)
+	res := resTmp.(model.MentionEntity)
 	fc.Result = res
-	return ec.marshalOGalleryUser2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryUser(ctx, field.Selections, res)
+	return ec.marshalOMentionEntity2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMentionEntity(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Mention_user(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Mention_entity(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Mention",
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_GalleryUser_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_GalleryUser_dbid(ctx, field)
-			case "username":
-				return ec.fieldContext_GalleryUser_username(ctx, field)
-			case "profileImage":
-				return ec.fieldContext_GalleryUser_profileImage(ctx, field)
-			case "potentialEnsProfileImage":
-				return ec.fieldContext_GalleryUser_potentialEnsProfileImage(ctx, field)
-			case "bio":
-				return ec.fieldContext_GalleryUser_bio(ctx, field)
-			case "traits":
-				return ec.fieldContext_GalleryUser_traits(ctx, field)
-			case "universal":
-				return ec.fieldContext_GalleryUser_universal(ctx, field)
-			case "roles":
-				return ec.fieldContext_GalleryUser_roles(ctx, field)
-			case "socialAccounts":
-				return ec.fieldContext_GalleryUser_socialAccounts(ctx, field)
-			case "tokens":
-				return ec.fieldContext_GalleryUser_tokens(ctx, field)
-			case "tokensByChain":
-				return ec.fieldContext_GalleryUser_tokensByChain(ctx, field)
-			case "wallets":
-				return ec.fieldContext_GalleryUser_wallets(ctx, field)
-			case "primaryWallet":
-				return ec.fieldContext_GalleryUser_primaryWallet(ctx, field)
-			case "featuredGallery":
-				return ec.fieldContext_GalleryUser_featuredGallery(ctx, field)
-			case "galleries":
-				return ec.fieldContext_GalleryUser_galleries(ctx, field)
-			case "badges":
-				return ec.fieldContext_GalleryUser_badges(ctx, field)
-			case "isAuthenticatedUser":
-				return ec.fieldContext_GalleryUser_isAuthenticatedUser(ctx, field)
-			case "followers":
-				return ec.fieldContext_GalleryUser_followers(ctx, field)
-			case "following":
-				return ec.fieldContext_GalleryUser_following(ctx, field)
-			case "feed":
-				return ec.fieldContext_GalleryUser_feed(ctx, field)
-			case "sharedFollowers":
-				return ec.fieldContext_GalleryUser_sharedFollowers(ctx, field)
-			case "sharedCommunities":
-				return ec.fieldContext_GalleryUser_sharedCommunities(ctx, field)
-			case "createdCommunities":
-				return ec.fieldContext_GalleryUser_createdCommunities(ctx, field)
-			case "isMemberOfCommunity":
-				return ec.fieldContext_GalleryUser_isMemberOfCommunity(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type GalleryUser", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mention_community(ctx context.Context, field graphql.CollectedField, obj *model.Mention) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mention_community(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mention().Community(rctx, obj)
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Community)
-	fc.Result = res
-	return ec.marshalOCommunity2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommunity(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mention_community(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mention",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "dbid":
-				return ec.fieldContext_Community_dbid(ctx, field)
-			case "id":
-				return ec.fieldContext_Community_id(ctx, field)
-			case "lastUpdated":
-				return ec.fieldContext_Community_lastUpdated(ctx, field)
-			case "contract":
-				return ec.fieldContext_Community_contract(ctx, field)
-			case "contractAddress":
-				return ec.fieldContext_Community_contractAddress(ctx, field)
-			case "creatorAddress":
-				return ec.fieldContext_Community_creatorAddress(ctx, field)
-			case "creator":
-				return ec.fieldContext_Community_creator(ctx, field)
-			case "chain":
-				return ec.fieldContext_Community_chain(ctx, field)
-			case "name":
-				return ec.fieldContext_Community_name(ctx, field)
-			case "description":
-				return ec.fieldContext_Community_description(ctx, field)
-			case "previewImage":
-				return ec.fieldContext_Community_previewImage(ctx, field)
-			case "profileImageURL":
-				return ec.fieldContext_Community_profileImageURL(ctx, field)
-			case "profileBannerURL":
-				return ec.fieldContext_Community_profileBannerURL(ctx, field)
-			case "badgeURL":
-				return ec.fieldContext_Community_badgeURL(ctx, field)
-			case "parentCommunity":
-				return ec.fieldContext_Community_parentCommunity(ctx, field)
-			case "subCommunities":
-				return ec.fieldContext_Community_subCommunities(ctx, field)
-			case "tokensInCommunity":
-				return ec.fieldContext_Community_tokensInCommunity(ctx, field)
-			case "owners":
-				return ec.fieldContext_Community_owners(ctx, field)
-			case "posts":
-				return ec.fieldContext_Community_posts(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Community", field.Name)
+			return nil, errors.New("field of type MentionEntity does not have child fields")
 		},
 	}
 	return fc, nil
@@ -38163,10 +38020,8 @@ func (ec *executionContext) fieldContext_Post_mentions(ctx context.Context, fiel
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "user":
-				return ec.fieldContext_Mention_user(ctx, field)
-			case "community":
-				return ec.fieldContext_Mention_community(ctx, field)
+			case "entity":
+				return ec.fieldContext_Mention_entity(ctx, field)
 			case "index":
 				return ec.fieldContext_Mention_index(ctx, field)
 			}
@@ -60663,6 +60518,29 @@ func (ec *executionContext) _MediaSubtype(ctx context.Context, sel ast.Selection
 	}
 }
 
+func (ec *executionContext) _MentionEntity(ctx context.Context, sel ast.SelectionSet, obj model.MentionEntity) graphql.Marshaler {
+	switch obj := (obj).(type) {
+	case nil:
+		return graphql.Null
+	case model.GalleryUser:
+		return ec._GalleryUser(ctx, sel, &obj)
+	case *model.GalleryUser:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._GalleryUser(ctx, sel, obj)
+	case model.Community:
+		return ec._Community(ctx, sel, &obj)
+	case *model.Community:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Community(ctx, sel, obj)
+	default:
+		panic(fmt.Errorf("unexpected type %T", obj))
+	}
+}
+
 func (ec *executionContext) _MentionSource(ctx context.Context, sel ast.SelectionSet, obj model.MentionSource) graphql.Marshaler {
 	switch obj := (obj).(type) {
 	case nil:
@@ -64444,7 +64322,7 @@ func (ec *executionContext) _CommunitiesConnection(ctx context.Context, sel ast.
 	return out
 }
 
-var communityImplementors = []string{"Community", "Node", "CommunityByAddressOrError"}
+var communityImplementors = []string{"Community", "Node", "CommunityByAddressOrError", "MentionEntity"}
 
 func (ec *executionContext) _Community(ctx context.Context, sel ast.SelectionSet, obj *model.Community) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, communityImplementors)
@@ -66668,7 +66546,7 @@ func (ec *executionContext) _GalleryUpdatedFeedEventData(ctx context.Context, se
 	return out
 }
 
-var galleryUserImplementors = []string{"GalleryUser", "Node", "GalleryUserOrWallet", "GalleryUserOrAddress", "UserByUsernameOrError", "UserByIdOrError", "UserByAddressOrError", "AddRolesToUserPayloadOrError", "RevokeRolesFromUserPayloadOrError"}
+var galleryUserImplementors = []string{"GalleryUser", "Node", "GalleryUserOrWallet", "GalleryUserOrAddress", "UserByUsernameOrError", "UserByIdOrError", "UserByAddressOrError", "MentionEntity", "AddRolesToUserPayloadOrError", "RevokeRolesFromUserPayloadOrError"}
 
 func (ec *executionContext) _GalleryUser(ctx context.Context, sel ast.SelectionSet, obj *model.GalleryUser) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, galleryUserImplementors)
@@ -67647,7 +67525,7 @@ func (ec *executionContext) _Mention(ctx context.Context, sel ast.SelectionSet, 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Mention")
-		case "user":
+		case "entity":
 			field := field
 
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
@@ -67656,24 +67534,7 @@ func (ec *executionContext) _Mention(ctx context.Context, sel ast.SelectionSet, 
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Mention_user(ctx, field, obj)
-				return res
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
-		case "community":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Mention_community(ctx, field, obj)
+				res = ec._Mention_entity(ctx, field, obj)
 				return res
 			}
 
@@ -76784,6 +76645,13 @@ func (ec *executionContext) marshalOMention2ᚖgithubᚗcomᚋmikeydubᚋgoᚑga
 		return graphql.Null
 	}
 	return ec._Mention(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOMentionEntity2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMentionEntity(ctx context.Context, sel ast.SelectionSet, v model.MentionEntity) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._MentionEntity(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOMentionInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMentionInputᚄ(ctx context.Context, v interface{}) ([]*model.MentionInput, error) {

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -63,6 +63,7 @@ type ResolverRoot interface {
 	GalleryInfoUpdatedFeedEventData() GalleryInfoUpdatedFeedEventDataResolver
 	GalleryUpdatedFeedEventData() GalleryUpdatedFeedEventDataResolver
 	GalleryUser() GalleryUserResolver
+	Mention() MentionResolver
 	Mutation() MutationResolver
 	NewTokensNotification() NewTokensNotificationResolver
 	OwnerAtBlock() OwnerAtBlockResolver
@@ -124,6 +125,11 @@ type ComplexityRoot struct {
 		Source       func(childComplexity int) int
 	}
 
+	AdmireEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
 	AdmireFeedEventPayload struct {
 		Admire    func(childComplexity int) int
 		FeedEvent func(childComplexity int) int
@@ -134,6 +140,11 @@ type ComplexityRoot struct {
 		Admire func(childComplexity int) int
 		Post   func(childComplexity int) int
 		Viewer func(childComplexity int) int
+	}
+
+	AdmiresConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
 	}
 
 	AudioMedia struct {
@@ -265,9 +276,15 @@ type ComplexityRoot struct {
 		Deleted      func(childComplexity int) int
 		ID           func(childComplexity int) int
 		LastUpdated  func(childComplexity int) int
+		Mentions     func(childComplexity int) int
 		Replies      func(childComplexity int, before *string, after *string, first *int, last *int) int
 		ReplyTo      func(childComplexity int) int
 		Source       func(childComplexity int) int
+	}
+
+	CommentEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
 	}
 
 	CommentOnFeedEventPayload struct {
@@ -282,6 +299,11 @@ type ComplexityRoot struct {
 		Post           func(childComplexity int) int
 		ReplyToComment func(childComplexity int) int
 		Viewer         func(childComplexity int) int
+	}
+
+	CommentsConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
 	}
 
 	CommunitiesConnection struct {
@@ -322,6 +344,11 @@ type ComplexityRoot struct {
 
 	CommunitySearchResult struct {
 		Community func(childComplexity int) int
+	}
+
+	CompleteIndex struct {
+		Index  func(childComplexity int) int
+		Length func(childComplexity int) int
 	}
 
 	ConnectSocialAccountPayload struct {
@@ -531,39 +558,6 @@ type ComplexityRoot struct {
 		ViewerAdmire          func(childComplexity int) int
 	}
 
-	FeedEventAdmireEdge struct {
-		Cursor func(childComplexity int) int
-		Event  func(childComplexity int) int
-		Node   func(childComplexity int) int
-	}
-
-	FeedEventAdmiresConnection struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
-	}
-
-	FeedEventCommentEdge struct {
-		Cursor func(childComplexity int) int
-		Event  func(childComplexity int) int
-		Node   func(childComplexity int) int
-	}
-
-	FeedEventCommentsConnection struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
-	}
-
-	FeedEventInteractionsConnection struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
-	}
-
-	FeedEventInteractionsEdge struct {
-		Cursor func(childComplexity int) int
-		Event  func(childComplexity int) int
-		Node   func(childComplexity int) int
-	}
-
 	FollowAllSocialConnectionsPayload struct {
 		Viewer func(childComplexity int) int
 	}
@@ -695,6 +689,16 @@ type ComplexityRoot struct {
 		PreviewURLs      func(childComplexity int) int
 	}
 
+	InteractionsConnection struct {
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
+	}
+
+	InteractionsEdge struct {
+		Cursor func(childComplexity int) int
+		Node   func(childComplexity int) int
+	}
+
 	InvalidMedia struct {
 		ContentRenderURL func(childComplexity int) int
 		Dimensions       func(childComplexity int) int
@@ -745,6 +749,12 @@ type ComplexityRoot struct {
 		Name     func(childComplexity int) int
 		Owners   func(childComplexity int) int
 		TokenID  func(childComplexity int) int
+	}
+
+	Mention struct {
+		Community func(childComplexity int) int
+		Index     func(childComplexity int) int
+		User      func(childComplexity int) int
 	}
 
 	MerchDiscountCode struct {
@@ -909,46 +919,14 @@ type ComplexityRoot struct {
 		Dbid         func(childComplexity int) int
 		ID           func(childComplexity int) int
 		Interactions func(childComplexity int, before *string, after *string, first *int, last *int) int
+		Mentions     func(childComplexity int) int
 		Tokens       func(childComplexity int) int
 		ViewerAdmire func(childComplexity int) int
-	}
-
-	PostAdmireEdge struct {
-		Cursor func(childComplexity int) int
-		Node   func(childComplexity int) int
-		Post   func(childComplexity int) int
-	}
-
-	PostAdmiresConnection struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
-	}
-
-	PostCommentEdge struct {
-		Cursor func(childComplexity int) int
-		Node   func(childComplexity int) int
-		Post   func(childComplexity int) int
-	}
-
-	PostCommentsConnection struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
 	}
 
 	PostEdge struct {
 		Cursor func(childComplexity int) int
 		Node   func(childComplexity int) int
-	}
-
-	PostInteractionsConnection struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
-	}
-
-	PostInteractionsEdge struct {
-		Cursor func(childComplexity int) int
-		Node   func(childComplexity int) int
-		Post   func(childComplexity int) int
 	}
 
 	PostTokensPayload struct {
@@ -1589,7 +1567,8 @@ type CommentResolver interface {
 	ReplyTo(ctx context.Context, obj *model.Comment) (*model.Comment, error)
 	Commenter(ctx context.Context, obj *model.Comment) (*model.GalleryUser, error)
 
-	Replies(ctx context.Context, obj *model.Comment, before *string, after *string, first *int, last *int) (model.CommentsConnection, error)
+	Mentions(ctx context.Context, obj *model.Comment) ([]*model.Mention, error)
+	Replies(ctx context.Context, obj *model.Comment, before *string, after *string, first *int, last *int) (*model.CommentsConnection, error)
 	Source(ctx context.Context, obj *model.Comment) (model.CommentSource, error)
 }
 type CommentOnFeedEventPayloadResolver interface {
@@ -1625,10 +1604,10 @@ type EntityResolver interface {
 }
 type FeedEventResolver interface {
 	EventData(ctx context.Context, obj *model.FeedEvent) (model.FeedEventData, error)
-	Admires(ctx context.Context, obj *model.FeedEvent, before *string, after *string, first *int, last *int) (*model.FeedEventAdmiresConnection, error)
-	Comments(ctx context.Context, obj *model.FeedEvent, before *string, after *string, first *int, last *int) (*model.FeedEventCommentsConnection, error)
+	Admires(ctx context.Context, obj *model.FeedEvent, before *string, after *string, first *int, last *int) (*model.AdmiresConnection, error)
+	Comments(ctx context.Context, obj *model.FeedEvent, before *string, after *string, first *int, last *int) (*model.CommentsConnection, error)
 
-	Interactions(ctx context.Context, obj *model.FeedEvent, before *string, after *string, first *int, last *int) (*model.FeedEventInteractionsConnection, error)
+	Interactions(ctx context.Context, obj *model.FeedEvent, before *string, after *string, first *int, last *int) (*model.InteractionsConnection, error)
 	ViewerAdmire(ctx context.Context, obj *model.FeedEvent) (*model.Admire, error)
 	HasViewerAdmiredEvent(ctx context.Context, obj *model.FeedEvent) (*bool, error)
 }
@@ -1673,6 +1652,10 @@ type GalleryUserResolver interface {
 	SharedCommunities(ctx context.Context, obj *model.GalleryUser, before *string, after *string, first *int, last *int) (*model.CommunitiesConnection, error)
 	CreatedCommunities(ctx context.Context, obj *model.GalleryUser, input model.CreatedCommunitiesInput, before *string, after *string, first *int, last *int) (*model.CommunitiesConnection, error)
 	IsMemberOfCommunity(ctx context.Context, obj *model.GalleryUser, communityID persist.DBID) (bool, error)
+}
+type MentionResolver interface {
+	User(ctx context.Context, obj *model.Mention) (*model.GalleryUser, error)
+	Community(ctx context.Context, obj *model.Mention) (*model.Community, error)
 }
 type MutationResolver interface {
 	AddUserWallet(ctx context.Context, chainAddress persist.ChainAddress, authMechanism model.AuthMechanism) (model.AddUserWalletPayloadOrError, error)
@@ -1760,9 +1743,10 @@ type PostResolver interface {
 
 	Tokens(ctx context.Context, obj *model.Post) ([]*model.Token, error)
 
-	Admires(ctx context.Context, obj *model.Post, before *string, after *string, first *int, last *int) (*model.PostAdmiresConnection, error)
-	Comments(ctx context.Context, obj *model.Post, before *string, after *string, first *int, last *int) (*model.PostCommentsConnection, error)
-	Interactions(ctx context.Context, obj *model.Post, before *string, after *string, first *int, last *int) (*model.PostInteractionsConnection, error)
+	Mentions(ctx context.Context, obj *model.Post) ([]*model.Mention, error)
+	Admires(ctx context.Context, obj *model.Post, before *string, after *string, first *int, last *int) (*model.AdmiresConnection, error)
+	Comments(ctx context.Context, obj *model.Post, before *string, after *string, first *int, last *int) (*model.CommentsConnection, error)
+	Interactions(ctx context.Context, obj *model.Post, before *string, after *string, first *int, last *int) (*model.InteractionsConnection, error)
 	ViewerAdmire(ctx context.Context, obj *model.Post) (*model.Admire, error)
 }
 type PreviewURLSetResolver interface {
@@ -1989,6 +1973,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Admire.Source(childComplexity), true
 
+	case "AdmireEdge.cursor":
+		if e.complexity.AdmireEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.AdmireEdge.Cursor(childComplexity), true
+
+	case "AdmireEdge.node":
+		if e.complexity.AdmireEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.AdmireEdge.Node(childComplexity), true
+
 	case "AdmireFeedEventPayload.admire":
 		if e.complexity.AdmireFeedEventPayload.Admire == nil {
 			break
@@ -2030,6 +2028,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AdmirePostPayload.Viewer(childComplexity), true
+
+	case "AdmiresConnection.edges":
+		if e.complexity.AdmiresConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.AdmiresConnection.Edges(childComplexity), true
+
+	case "AdmiresConnection.pageInfo":
+		if e.complexity.AdmiresConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.AdmiresConnection.PageInfo(childComplexity), true
 
 	case "AudioMedia.contentRenderURL":
 		if e.complexity.AudioMedia.ContentRenderURL == nil {
@@ -2533,6 +2545,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Comment.LastUpdated(childComplexity), true
 
+	case "Comment.mentions":
+		if e.complexity.Comment.Mentions == nil {
+			break
+		}
+
+		return e.complexity.Comment.Mentions(childComplexity), true
+
 	case "Comment.replies":
 		if e.complexity.Comment.Replies == nil {
 			break
@@ -2558,6 +2577,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Comment.Source(childComplexity), true
+
+	case "CommentEdge.cursor":
+		if e.complexity.CommentEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.CommentEdge.Cursor(childComplexity), true
+
+	case "CommentEdge.node":
+		if e.complexity.CommentEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.CommentEdge.Node(childComplexity), true
 
 	case "CommentOnFeedEventPayload.comment":
 		if e.complexity.CommentOnFeedEventPayload.Comment == nil {
@@ -2614,6 +2647,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CommentOnPostPayload.Viewer(childComplexity), true
+
+	case "CommentsConnection.edges":
+		if e.complexity.CommentsConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.CommentsConnection.Edges(childComplexity), true
+
+	case "CommentsConnection.pageInfo":
+		if e.complexity.CommentsConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.CommentsConnection.PageInfo(childComplexity), true
 
 	case "CommunitiesConnection.edges":
 		if e.complexity.CommunitiesConnection.Edges == nil {
@@ -2809,6 +2856,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CommunitySearchResult.Community(childComplexity), true
+
+	case "CompleteIndex.index":
+		if e.complexity.CompleteIndex.Index == nil {
+			break
+		}
+
+		return e.complexity.CompleteIndex.Index(childComplexity), true
+
+	case "CompleteIndex.length":
+		if e.complexity.CompleteIndex.Length == nil {
+			break
+		}
+
+		return e.complexity.CompleteIndex.Length(childComplexity), true
 
 	case "ConnectSocialAccountPayload.viewer":
 		if e.complexity.ConnectSocialAccountPayload.Viewer == nil {
@@ -3401,111 +3462,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.FeedEvent.ViewerAdmire(childComplexity), true
-
-	case "FeedEventAdmireEdge.cursor":
-		if e.complexity.FeedEventAdmireEdge.Cursor == nil {
-			break
-		}
-
-		return e.complexity.FeedEventAdmireEdge.Cursor(childComplexity), true
-
-	case "FeedEventAdmireEdge.event":
-		if e.complexity.FeedEventAdmireEdge.Event == nil {
-			break
-		}
-
-		return e.complexity.FeedEventAdmireEdge.Event(childComplexity), true
-
-	case "FeedEventAdmireEdge.node":
-		if e.complexity.FeedEventAdmireEdge.Node == nil {
-			break
-		}
-
-		return e.complexity.FeedEventAdmireEdge.Node(childComplexity), true
-
-	case "FeedEventAdmiresConnection.edges":
-		if e.complexity.FeedEventAdmiresConnection.Edges == nil {
-			break
-		}
-
-		return e.complexity.FeedEventAdmiresConnection.Edges(childComplexity), true
-
-	case "FeedEventAdmiresConnection.pageInfo":
-		if e.complexity.FeedEventAdmiresConnection.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.FeedEventAdmiresConnection.PageInfo(childComplexity), true
-
-	case "FeedEventCommentEdge.cursor":
-		if e.complexity.FeedEventCommentEdge.Cursor == nil {
-			break
-		}
-
-		return e.complexity.FeedEventCommentEdge.Cursor(childComplexity), true
-
-	case "FeedEventCommentEdge.event":
-		if e.complexity.FeedEventCommentEdge.Event == nil {
-			break
-		}
-
-		return e.complexity.FeedEventCommentEdge.Event(childComplexity), true
-
-	case "FeedEventCommentEdge.node":
-		if e.complexity.FeedEventCommentEdge.Node == nil {
-			break
-		}
-
-		return e.complexity.FeedEventCommentEdge.Node(childComplexity), true
-
-	case "FeedEventCommentsConnection.edges":
-		if e.complexity.FeedEventCommentsConnection.Edges == nil {
-			break
-		}
-
-		return e.complexity.FeedEventCommentsConnection.Edges(childComplexity), true
-
-	case "FeedEventCommentsConnection.pageInfo":
-		if e.complexity.FeedEventCommentsConnection.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.FeedEventCommentsConnection.PageInfo(childComplexity), true
-
-	case "FeedEventInteractionsConnection.edges":
-		if e.complexity.FeedEventInteractionsConnection.Edges == nil {
-			break
-		}
-
-		return e.complexity.FeedEventInteractionsConnection.Edges(childComplexity), true
-
-	case "FeedEventInteractionsConnection.pageInfo":
-		if e.complexity.FeedEventInteractionsConnection.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.FeedEventInteractionsConnection.PageInfo(childComplexity), true
-
-	case "FeedEventInteractionsEdge.cursor":
-		if e.complexity.FeedEventInteractionsEdge.Cursor == nil {
-			break
-		}
-
-		return e.complexity.FeedEventInteractionsEdge.Cursor(childComplexity), true
-
-	case "FeedEventInteractionsEdge.event":
-		if e.complexity.FeedEventInteractionsEdge.Event == nil {
-			break
-		}
-
-		return e.complexity.FeedEventInteractionsEdge.Event(childComplexity), true
-
-	case "FeedEventInteractionsEdge.node":
-		if e.complexity.FeedEventInteractionsEdge.Node == nil {
-			break
-		}
-
-		return e.complexity.FeedEventInteractionsEdge.Node(childComplexity), true
 
 	case "FollowAllSocialConnectionsPayload.viewer":
 		if e.complexity.FollowAllSocialConnectionsPayload.Viewer == nil {
@@ -4123,6 +4079,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ImageMedia.PreviewURLs(childComplexity), true
 
+	case "InteractionsConnection.edges":
+		if e.complexity.InteractionsConnection.Edges == nil {
+			break
+		}
+
+		return e.complexity.InteractionsConnection.Edges(childComplexity), true
+
+	case "InteractionsConnection.pageInfo":
+		if e.complexity.InteractionsConnection.PageInfo == nil {
+			break
+		}
+
+		return e.complexity.InteractionsConnection.PageInfo(childComplexity), true
+
+	case "InteractionsEdge.cursor":
+		if e.complexity.InteractionsEdge.Cursor == nil {
+			break
+		}
+
+		return e.complexity.InteractionsEdge.Cursor(childComplexity), true
+
+	case "InteractionsEdge.node":
+		if e.complexity.InteractionsEdge.Node == nil {
+			break
+		}
+
+		return e.complexity.InteractionsEdge.Node(childComplexity), true
+
 	case "InvalidMedia.contentRenderURL":
 		if e.complexity.InvalidMedia.ContentRenderURL == nil {
 			break
@@ -4339,6 +4323,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.MembershipTier.TokenID(childComplexity), true
+
+	case "Mention.community":
+		if e.complexity.Mention.Community == nil {
+			break
+		}
+
+		return e.complexity.Mention.Community(childComplexity), true
+
+	case "Mention.index":
+		if e.complexity.Mention.Index == nil {
+			break
+		}
+
+		return e.complexity.Mention.Index(childComplexity), true
+
+	case "Mention.user":
+		if e.complexity.Mention.User == nil {
+			break
+		}
+
+		return e.complexity.Mention.User(childComplexity), true
 
 	case "MerchDiscountCode.code":
 		if e.complexity.MerchDiscountCode.Code == nil {
@@ -5554,6 +5559,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Post.Interactions(childComplexity, args["before"].(*string), args["after"].(*string), args["first"].(*int), args["last"].(*int)), true
 
+	case "Post.mentions":
+		if e.complexity.Post.Mentions == nil {
+			break
+		}
+
+		return e.complexity.Post.Mentions(childComplexity), true
+
 	case "Post.tokens":
 		if e.complexity.Post.Tokens == nil {
 			break
@@ -5568,76 +5580,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Post.ViewerAdmire(childComplexity), true
 
-	case "PostAdmireEdge.cursor":
-		if e.complexity.PostAdmireEdge.Cursor == nil {
-			break
-		}
-
-		return e.complexity.PostAdmireEdge.Cursor(childComplexity), true
-
-	case "PostAdmireEdge.node":
-		if e.complexity.PostAdmireEdge.Node == nil {
-			break
-		}
-
-		return e.complexity.PostAdmireEdge.Node(childComplexity), true
-
-	case "PostAdmireEdge.post":
-		if e.complexity.PostAdmireEdge.Post == nil {
-			break
-		}
-
-		return e.complexity.PostAdmireEdge.Post(childComplexity), true
-
-	case "PostAdmiresConnection.edges":
-		if e.complexity.PostAdmiresConnection.Edges == nil {
-			break
-		}
-
-		return e.complexity.PostAdmiresConnection.Edges(childComplexity), true
-
-	case "PostAdmiresConnection.pageInfo":
-		if e.complexity.PostAdmiresConnection.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.PostAdmiresConnection.PageInfo(childComplexity), true
-
-	case "PostCommentEdge.cursor":
-		if e.complexity.PostCommentEdge.Cursor == nil {
-			break
-		}
-
-		return e.complexity.PostCommentEdge.Cursor(childComplexity), true
-
-	case "PostCommentEdge.node":
-		if e.complexity.PostCommentEdge.Node == nil {
-			break
-		}
-
-		return e.complexity.PostCommentEdge.Node(childComplexity), true
-
-	case "PostCommentEdge.post":
-		if e.complexity.PostCommentEdge.Post == nil {
-			break
-		}
-
-		return e.complexity.PostCommentEdge.Post(childComplexity), true
-
-	case "PostCommentsConnection.edges":
-		if e.complexity.PostCommentsConnection.Edges == nil {
-			break
-		}
-
-		return e.complexity.PostCommentsConnection.Edges(childComplexity), true
-
-	case "PostCommentsConnection.pageInfo":
-		if e.complexity.PostCommentsConnection.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.PostCommentsConnection.PageInfo(childComplexity), true
-
 	case "PostEdge.cursor":
 		if e.complexity.PostEdge.Cursor == nil {
 			break
@@ -5651,41 +5593,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PostEdge.Node(childComplexity), true
-
-	case "PostInteractionsConnection.edges":
-		if e.complexity.PostInteractionsConnection.Edges == nil {
-			break
-		}
-
-		return e.complexity.PostInteractionsConnection.Edges(childComplexity), true
-
-	case "PostInteractionsConnection.pageInfo":
-		if e.complexity.PostInteractionsConnection.PageInfo == nil {
-			break
-		}
-
-		return e.complexity.PostInteractionsConnection.PageInfo(childComplexity), true
-
-	case "PostInteractionsEdge.cursor":
-		if e.complexity.PostInteractionsEdge.Cursor == nil {
-			break
-		}
-
-		return e.complexity.PostInteractionsEdge.Cursor(childComplexity), true
-
-	case "PostInteractionsEdge.node":
-		if e.complexity.PostInteractionsEdge.Node == nil {
-			break
-		}
-
-		return e.complexity.PostInteractionsEdge.Node(childComplexity), true
-
-	case "PostInteractionsEdge.post":
-		if e.complexity.PostInteractionsEdge.Post == nil {
-			break
-		}
-
-		return e.complexity.PostInteractionsEdge.Post(childComplexity), true
 
 	case "PostTokensPayload.post":
 		if e.complexity.PostTokensPayload.Post == nil {
@@ -8024,6 +7931,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCollectionLayoutInput,
 		ec.unmarshalInputCollectionSectionLayoutInput,
 		ec.unmarshalInputCollectionTokenSettingsInput,
+		ec.unmarshalInputCompleteIndexInput,
 		ec.unmarshalInputCreateCollectionInGalleryInput,
 		ec.unmarshalInputCreateCollectionInput,
 		ec.unmarshalInputCreateGalleryInput,
@@ -8963,12 +8871,24 @@ type Comment implements Node @goEmbedHelper {
   replyTo: Comment @goField(forceResolver: true)
   commenter: GalleryUser @goField(forceResolver: true)
   comment: String
+  mentions: [Mention] @goField(forceResolver: true)
   replies(before: String, after: String, first: Int, last: Int): CommentsConnection
     @goField(forceResolver: true)
   source: CommentSource @goField(forceResolver: true)
 
-  # deleted is included becasue we want still return deleted comments but render them differently
+  # deleted is included because we want to still return deleted comments to show on the frontend but render them differently
   deleted: Boolean
+}
+
+type Mention @goEmbedHelper {
+  user: GalleryUser @goField(forceResolver: true)
+  community: Community @goField(forceResolver: true)
+  index: CompleteIndex
+}
+
+type CompleteIndex {
+  index: Int!
+  length: Int!
 }
 
 # Actions a user can take on a resource
@@ -8986,73 +8906,35 @@ type FollowInfo {
   followedBack: Boolean
 }
 
-type FeedEventAdmireEdge {
-  node: Admire
-  event: FeedEvent
-  cursor: String
-}
-
-type FeedEventAdmiresConnection {
-  edges: [FeedEventAdmireEdge]
-  pageInfo: PageInfo!
-}
-
-union CommentsConnection = FeedEventCommentsConnection | PostCommentsConnection
-
-type FeedEventCommentEdge {
-  node: Comment
-  event: FeedEvent
-  cursor: String
-}
-
-type FeedEventCommentsConnection {
-  edges: [FeedEventCommentEdge]
-  pageInfo: PageInfo!
-}
-
-type PostAdmireEdge {
+type AdmireEdge {
   node: Admire
   cursor: String
-  post: Post
 }
 
-type PostCommentEdge {
-  node: Comment
-  cursor: String
-  post: Post
-}
-
-type PostCommentsConnection {
-  edges: [PostCommentEdge]
+type AdmiresConnection {
+  edges: [AdmireEdge]
   pageInfo: PageInfo!
 }
 
-type PostAdmiresConnection {
-  edges: [PostAdmireEdge]
+type CommentEdge {
+  node: Comment
+  cursor: String
+}
+
+type CommentsConnection {
+  edges: [CommentEdge]
   pageInfo: PageInfo!
 }
 
 union Interaction = Admire | Comment
 
-type FeedEventInteractionsEdge {
-  node: Interaction
-  event: FeedEvent
-  cursor: String
-}
-
-type FeedEventInteractionsConnection {
-  edges: [FeedEventInteractionsEdge]
-  pageInfo: PageInfo!
-}
-
-type PostInteractionsEdge {
+type InteractionsEdge {
   node: Interaction
   cursor: String
-  post: Post
 }
 
-type PostInteractionsConnection {
-  edges: [PostInteractionsEdge]
+type InteractionsConnection {
+  edges: [InteractionsEdge]
   pageInfo: PageInfo!
 }
 
@@ -9079,18 +8961,14 @@ type FeedEvent implements Node @key(fields: "dbid") {
   dbid: DBID!
 
   eventData: FeedEventData @goField(forceResolver: true)
-  admires(before: String, after: String, first: Int, last: Int): FeedEventAdmiresConnection
+  admires(before: String, after: String, first: Int, last: Int): AdmiresConnection
     @goField(forceResolver: true)
-  comments(before: String, after: String, first: Int, last: Int): FeedEventCommentsConnection
+  comments(before: String, after: String, first: Int, last: Int): CommentsConnection
     @goField(forceResolver: true)
   caption: String
 
-  interactions(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): FeedEventInteractionsConnection @goField(forceResolver: true)
+  interactions(before: String, after: String, first: Int, last: Int): InteractionsConnection
+    @goField(forceResolver: true)
 
   viewerAdmire: Admire @goField(forceResolver: true)
 
@@ -9109,12 +8987,14 @@ type Post implements Node @key(fields: "dbid") @goEmbedHelper {
   tokens: [Token] @goField(forceResolver: true)
 
   caption: String
-  admires(before: String, after: String, first: Int, last: Int): PostAdmiresConnection
+  mentions: [Mention] @goField(forceResolver: true)
+
+  admires(before: String, after: String, first: Int, last: Int): AdmiresConnection
     @goField(forceResolver: true)
-  comments(before: String, after: String, first: Int, last: Int): PostCommentsConnection
+  comments(before: String, after: String, first: Int, last: Int): CommentsConnection
     @goField(forceResolver: true)
 
-  interactions(before: String, after: String, first: Int, last: Int): PostInteractionsConnection
+  interactions(before: String, after: String, first: Int, last: Int): InteractionsConnection
     @goField(forceResolver: true)
 
   viewerAdmire: Admire @goField(forceResolver: true)
@@ -10632,8 +10512,14 @@ type DeletePostPayload {
 union DeletePostPayloadOrError = DeletePostPayload | ErrInvalidInput | ErrNotAuthorized
 
 input MentionInput {
+  index: CompleteIndexInput
   userId: DBID
   communityId: DBID
+}
+
+input CompleteIndexInput {
+  index: Int!
+  length: Int!
 }
 
 type Mutation {
@@ -14445,6 +14331,102 @@ func (ec *executionContext) fieldContext_Admire_source(ctx context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _AdmireEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.AdmireEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AdmireEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Admire)
+	fc.Result = res
+	return ec.marshalOAdmire2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmire(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AdmireEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AdmireEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Admire_id(ctx, field)
+			case "dbid":
+				return ec.fieldContext_Admire_dbid(ctx, field)
+			case "creationTime":
+				return ec.fieldContext_Admire_creationTime(ctx, field)
+			case "lastUpdated":
+				return ec.fieldContext_Admire_lastUpdated(ctx, field)
+			case "admirer":
+				return ec.fieldContext_Admire_admirer(ctx, field)
+			case "source":
+				return ec.fieldContext_Admire_source(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Admire", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AdmireEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.AdmireEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AdmireEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AdmireEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AdmireEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AdmireFeedEventPayload_viewer(ctx context.Context, field graphql.CollectedField, obj *model.AdmireFeedEventPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_AdmireFeedEventPayload_viewer(ctx, field)
 	if err != nil {
@@ -14735,6 +14717,8 @@ func (ec *executionContext) fieldContext_AdmirePostPayload_post(ctx context.Cont
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -14800,6 +14784,111 @@ func (ec *executionContext) fieldContext_AdmirePostPayload_admire(ctx context.Co
 				return ec.fieldContext_Admire_source(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Admire", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AdmiresConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.AdmiresConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AdmiresConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.AdmireEdge)
+	fc.Result = res
+	return ec.marshalOAdmireEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmireEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AdmiresConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AdmiresConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "node":
+				return ec.fieldContext_AdmireEdge_node(ctx, field)
+			case "cursor":
+				return ec.fieldContext_AdmireEdge_cursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AdmireEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AdmiresConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.AdmiresConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AdmiresConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AdmiresConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AdmiresConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "total":
+				return ec.fieldContext_PageInfo_total(ctx, field)
+			case "size":
+				return ec.fieldContext_PageInfo_size(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
 		},
 	}
 	return fc, nil
@@ -18301,6 +18390,8 @@ func (ec *executionContext) fieldContext_Comment_replyTo(ctx context.Context, fi
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -18448,6 +18539,55 @@ func (ec *executionContext) fieldContext_Comment_comment(ctx context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _Comment_mentions(ctx context.Context, field graphql.CollectedField, obj *model.Comment) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Comment_mentions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Comment().Mentions(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Mention)
+	fc.Result = res
+	return ec.marshalOMention2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMention(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Comment_mentions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Comment",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "user":
+				return ec.fieldContext_Mention_user(ctx, field)
+			case "community":
+				return ec.fieldContext_Mention_community(ctx, field)
+			case "index":
+				return ec.fieldContext_Mention_index(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Mention", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Comment_replies(ctx context.Context, field graphql.CollectedField, obj *model.Comment) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Comment_replies(ctx, field)
 	if err != nil {
@@ -18471,9 +18611,9 @@ func (ec *executionContext) _Comment_replies(ctx context.Context, field graphql.
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(model.CommentsConnection)
+	res := resTmp.(*model.CommentsConnection)
 	fc.Result = res
-	return ec.marshalOCommentsConnection2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentsConnection(ctx, field.Selections, res)
+	return ec.marshalOCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Comment_replies(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -18483,7 +18623,13 @@ func (ec *executionContext) fieldContext_Comment_replies(ctx context.Context, fi
 		IsMethod:   true,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type CommentsConnection does not have child fields")
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_CommentsConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_CommentsConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CommentsConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -18577,6 +18723,112 @@ func (ec *executionContext) fieldContext_Comment_deleted(ctx context.Context, fi
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CommentEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.CommentEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CommentEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Comment)
+	fc.Result = res
+	return ec.marshalOComment2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐComment(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CommentEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CommentEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Comment_id(ctx, field)
+			case "dbid":
+				return ec.fieldContext_Comment_dbid(ctx, field)
+			case "creationTime":
+				return ec.fieldContext_Comment_creationTime(ctx, field)
+			case "lastUpdated":
+				return ec.fieldContext_Comment_lastUpdated(ctx, field)
+			case "replyTo":
+				return ec.fieldContext_Comment_replyTo(ctx, field)
+			case "commenter":
+				return ec.fieldContext_Comment_commenter(ctx, field)
+			case "comment":
+				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
+			case "replies":
+				return ec.fieldContext_Comment_replies(ctx, field)
+			case "source":
+				return ec.fieldContext_Comment_source(ctx, field)
+			case "deleted":
+				return ec.fieldContext_Comment_deleted(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Comment", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CommentEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.CommentEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CommentEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CommentEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CommentEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -18695,6 +18947,8 @@ func (ec *executionContext) fieldContext_CommentOnFeedEventPayload_comment(ctx c
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -18758,6 +19012,8 @@ func (ec *executionContext) fieldContext_CommentOnFeedEventPayload_replyToCommen
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -18943,6 +19199,8 @@ func (ec *executionContext) fieldContext_CommentOnPostPayload_post(ctx context.C
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -19008,6 +19266,8 @@ func (ec *executionContext) fieldContext_CommentOnPostPayload_comment(ctx contex
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -19071,6 +19331,8 @@ func (ec *executionContext) fieldContext_CommentOnPostPayload_replyToComment(ctx
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -19079,6 +19341,111 @@ func (ec *executionContext) fieldContext_CommentOnPostPayload_replyToComment(ctx
 				return ec.fieldContext_Comment_deleted(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Comment", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CommentsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.CommentsConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CommentsConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.CommentEdge)
+	fc.Result = res
+	return ec.marshalOCommentEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CommentsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CommentsConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "node":
+				return ec.fieldContext_CommentEdge_node(ctx, field)
+			case "cursor":
+				return ec.fieldContext_CommentEdge_cursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CommentEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CommentsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.CommentsConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CommentsConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CommentsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CommentsConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "total":
+				return ec.fieldContext_PageInfo_total(ctx, field)
+			case "size":
+				return ec.fieldContext_PageInfo_size(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
 		},
 	}
 	return fc, nil
@@ -20361,6 +20728,94 @@ func (ec *executionContext) fieldContext_CommunitySearchResult_community(ctx con
 				return ec.fieldContext_Community_posts(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Community", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompleteIndex_index(ctx context.Context, field graphql.CollectedField, obj *model.CompleteIndex) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompleteIndex_index(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Index, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompleteIndex_index(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompleteIndex",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CompleteIndex_length(ctx context.Context, field graphql.CollectedField, obj *model.CompleteIndex) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CompleteIndex_length(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Length, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CompleteIndex_length(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CompleteIndex",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -21943,6 +22398,8 @@ func (ec *executionContext) fieldContext_Entity_findPostByDbid(ctx context.Conte
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -23930,9 +24387,9 @@ func (ec *executionContext) _FeedEvent_admires(ctx context.Context, field graphq
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.FeedEventAdmiresConnection)
+	res := resTmp.(*model.AdmiresConnection)
 	fc.Result = res
-	return ec.marshalOFeedEventAdmiresConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventAdmiresConnection(ctx, field.Selections, res)
+	return ec.marshalOAdmiresConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmiresConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FeedEvent_admires(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -23944,11 +24401,11 @@ func (ec *executionContext) fieldContext_FeedEvent_admires(ctx context.Context, 
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "edges":
-				return ec.fieldContext_FeedEventAdmiresConnection_edges(ctx, field)
+				return ec.fieldContext_AdmiresConnection_edges(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_FeedEventAdmiresConnection_pageInfo(ctx, field)
+				return ec.fieldContext_AdmiresConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEventAdmiresConnection", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type AdmiresConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -23988,9 +24445,9 @@ func (ec *executionContext) _FeedEvent_comments(ctx context.Context, field graph
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.FeedEventCommentsConnection)
+	res := resTmp.(*model.CommentsConnection)
 	fc.Result = res
-	return ec.marshalOFeedEventCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventCommentsConnection(ctx, field.Selections, res)
+	return ec.marshalOCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FeedEvent_comments(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24002,11 +24459,11 @@ func (ec *executionContext) fieldContext_FeedEvent_comments(ctx context.Context,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "edges":
-				return ec.fieldContext_FeedEventCommentsConnection_edges(ctx, field)
+				return ec.fieldContext_CommentsConnection_edges(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_FeedEventCommentsConnection_pageInfo(ctx, field)
+				return ec.fieldContext_CommentsConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEventCommentsConnection", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type CommentsConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -24087,9 +24544,9 @@ func (ec *executionContext) _FeedEvent_interactions(ctx context.Context, field g
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.FeedEventInteractionsConnection)
+	res := resTmp.(*model.InteractionsConnection)
 	fc.Result = res
-	return ec.marshalOFeedEventInteractionsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventInteractionsConnection(ctx, field.Selections, res)
+	return ec.marshalOInteractionsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteractionsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FeedEvent_interactions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -24101,11 +24558,11 @@ func (ec *executionContext) fieldContext_FeedEvent_interactions(ctx context.Cont
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "edges":
-				return ec.fieldContext_FeedEventInteractionsConnection_edges(ctx, field)
+				return ec.fieldContext_InteractionsConnection_edges(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_FeedEventInteractionsConnection_pageInfo(ctx, field)
+				return ec.fieldContext_InteractionsConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEventInteractionsConnection", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type InteractionsConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -24213,792 +24670,6 @@ func (ec *executionContext) fieldContext_FeedEvent_hasViewerAdmiredEvent(ctx con
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventAdmireEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventAdmireEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventAdmireEdge_node(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Admire)
-	fc.Result = res
-	return ec.marshalOAdmire2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmire(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventAdmireEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventAdmireEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Admire_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_Admire_dbid(ctx, field)
-			case "creationTime":
-				return ec.fieldContext_Admire_creationTime(ctx, field)
-			case "lastUpdated":
-				return ec.fieldContext_Admire_lastUpdated(ctx, field)
-			case "admirer":
-				return ec.fieldContext_Admire_admirer(ctx, field)
-			case "source":
-				return ec.fieldContext_Admire_source(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Admire", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventAdmireEdge_event(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventAdmireEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventAdmireEdge_event(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Event, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.FeedEvent)
-	fc.Result = res
-	return ec.marshalOFeedEvent2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEvent(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventAdmireEdge_event(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventAdmireEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_FeedEvent_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_FeedEvent_dbid(ctx, field)
-			case "eventData":
-				return ec.fieldContext_FeedEvent_eventData(ctx, field)
-			case "admires":
-				return ec.fieldContext_FeedEvent_admires(ctx, field)
-			case "comments":
-				return ec.fieldContext_FeedEvent_comments(ctx, field)
-			case "caption":
-				return ec.fieldContext_FeedEvent_caption(ctx, field)
-			case "interactions":
-				return ec.fieldContext_FeedEvent_interactions(ctx, field)
-			case "viewerAdmire":
-				return ec.fieldContext_FeedEvent_viewerAdmire(ctx, field)
-			case "hasViewerAdmiredEvent":
-				return ec.fieldContext_FeedEvent_hasViewerAdmiredEvent(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEvent", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventAdmireEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventAdmireEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventAdmireEdge_cursor(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Cursor, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventAdmireEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventAdmireEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventAdmiresConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventAdmiresConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventAdmiresConnection_edges(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Edges, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.FeedEventAdmireEdge)
-	fc.Result = res
-	return ec.marshalOFeedEventAdmireEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventAdmireEdge(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventAdmiresConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventAdmiresConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "node":
-				return ec.fieldContext_FeedEventAdmireEdge_node(ctx, field)
-			case "event":
-				return ec.fieldContext_FeedEventAdmireEdge_event(ctx, field)
-			case "cursor":
-				return ec.fieldContext_FeedEventAdmireEdge_cursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEventAdmireEdge", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventAdmiresConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventAdmiresConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventAdmiresConnection_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventAdmiresConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventAdmiresConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "total":
-				return ec.fieldContext_PageInfo_total(ctx, field)
-			case "size":
-				return ec.fieldContext_PageInfo_size(ctx, field)
-			case "hasPreviousPage":
-				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			case "startCursor":
-				return ec.fieldContext_PageInfo_startCursor(ctx, field)
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventCommentEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventCommentEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventCommentEdge_node(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Comment)
-	fc.Result = res
-	return ec.marshalOComment2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐComment(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventCommentEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventCommentEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Comment_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_Comment_dbid(ctx, field)
-			case "creationTime":
-				return ec.fieldContext_Comment_creationTime(ctx, field)
-			case "lastUpdated":
-				return ec.fieldContext_Comment_lastUpdated(ctx, field)
-			case "replyTo":
-				return ec.fieldContext_Comment_replyTo(ctx, field)
-			case "commenter":
-				return ec.fieldContext_Comment_commenter(ctx, field)
-			case "comment":
-				return ec.fieldContext_Comment_comment(ctx, field)
-			case "replies":
-				return ec.fieldContext_Comment_replies(ctx, field)
-			case "source":
-				return ec.fieldContext_Comment_source(ctx, field)
-			case "deleted":
-				return ec.fieldContext_Comment_deleted(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Comment", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventCommentEdge_event(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventCommentEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventCommentEdge_event(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Event, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.FeedEvent)
-	fc.Result = res
-	return ec.marshalOFeedEvent2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEvent(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventCommentEdge_event(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventCommentEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_FeedEvent_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_FeedEvent_dbid(ctx, field)
-			case "eventData":
-				return ec.fieldContext_FeedEvent_eventData(ctx, field)
-			case "admires":
-				return ec.fieldContext_FeedEvent_admires(ctx, field)
-			case "comments":
-				return ec.fieldContext_FeedEvent_comments(ctx, field)
-			case "caption":
-				return ec.fieldContext_FeedEvent_caption(ctx, field)
-			case "interactions":
-				return ec.fieldContext_FeedEvent_interactions(ctx, field)
-			case "viewerAdmire":
-				return ec.fieldContext_FeedEvent_viewerAdmire(ctx, field)
-			case "hasViewerAdmiredEvent":
-				return ec.fieldContext_FeedEvent_hasViewerAdmiredEvent(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEvent", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventCommentEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventCommentEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventCommentEdge_cursor(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Cursor, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventCommentEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventCommentEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventCommentsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventCommentsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventCommentsConnection_edges(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Edges, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.FeedEventCommentEdge)
-	fc.Result = res
-	return ec.marshalOFeedEventCommentEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventCommentEdge(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventCommentsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventCommentsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "node":
-				return ec.fieldContext_FeedEventCommentEdge_node(ctx, field)
-			case "event":
-				return ec.fieldContext_FeedEventCommentEdge_event(ctx, field)
-			case "cursor":
-				return ec.fieldContext_FeedEventCommentEdge_cursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEventCommentEdge", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventCommentsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventCommentsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventCommentsConnection_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventCommentsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventCommentsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "total":
-				return ec.fieldContext_PageInfo_total(ctx, field)
-			case "size":
-				return ec.fieldContext_PageInfo_size(ctx, field)
-			case "hasPreviousPage":
-				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			case "startCursor":
-				return ec.fieldContext_PageInfo_startCursor(ctx, field)
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventInteractionsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventInteractionsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventInteractionsConnection_edges(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Edges, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.FeedEventInteractionsEdge)
-	fc.Result = res
-	return ec.marshalOFeedEventInteractionsEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventInteractionsEdge(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventInteractionsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventInteractionsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "node":
-				return ec.fieldContext_FeedEventInteractionsEdge_node(ctx, field)
-			case "event":
-				return ec.fieldContext_FeedEventInteractionsEdge_event(ctx, field)
-			case "cursor":
-				return ec.fieldContext_FeedEventInteractionsEdge_cursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEventInteractionsEdge", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventInteractionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventInteractionsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventInteractionsConnection_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventInteractionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventInteractionsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "total":
-				return ec.fieldContext_PageInfo_total(ctx, field)
-			case "size":
-				return ec.fieldContext_PageInfo_size(ctx, field)
-			case "hasPreviousPage":
-				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			case "startCursor":
-				return ec.fieldContext_PageInfo_startCursor(ctx, field)
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventInteractionsEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventInteractionsEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventInteractionsEdge_node(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(model.Interaction)
-	fc.Result = res
-	return ec.marshalOInteraction2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteraction(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventInteractionsEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventInteractionsEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Interaction does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventInteractionsEdge_event(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventInteractionsEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventInteractionsEdge_event(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Event, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.FeedEvent)
-	fc.Result = res
-	return ec.marshalOFeedEvent2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEvent(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventInteractionsEdge_event(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventInteractionsEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_FeedEvent_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_FeedEvent_dbid(ctx, field)
-			case "eventData":
-				return ec.fieldContext_FeedEvent_eventData(ctx, field)
-			case "admires":
-				return ec.fieldContext_FeedEvent_admires(ctx, field)
-			case "comments":
-				return ec.fieldContext_FeedEvent_comments(ctx, field)
-			case "caption":
-				return ec.fieldContext_FeedEvent_caption(ctx, field)
-			case "interactions":
-				return ec.fieldContext_FeedEvent_interactions(ctx, field)
-			case "viewerAdmire":
-				return ec.fieldContext_FeedEvent_viewerAdmire(ctx, field)
-			case "hasViewerAdmiredEvent":
-				return ec.fieldContext_FeedEvent_hasViewerAdmiredEvent(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FeedEvent", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FeedEventInteractionsEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.FeedEventInteractionsEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FeedEventInteractionsEdge_cursor(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Cursor, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FeedEventInteractionsEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FeedEventInteractionsEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -29442,6 +29113,193 @@ func (ec *executionContext) fieldContext_ImageMedia_fallbackMedia(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _InteractionsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.InteractionsConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InteractionsConnection_edges(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Edges, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.InteractionsEdge)
+	fc.Result = res
+	return ec.marshalOInteractionsEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteractionsEdge(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InteractionsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InteractionsConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "node":
+				return ec.fieldContext_InteractionsEdge_node(ctx, field)
+			case "cursor":
+				return ec.fieldContext_InteractionsEdge_cursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type InteractionsEdge", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InteractionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.InteractionsConnection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InteractionsConnection_pageInfo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PageInfo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PageInfo)
+	fc.Result = res
+	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InteractionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InteractionsConnection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "total":
+				return ec.fieldContext_PageInfo_total(ctx, field)
+			case "size":
+				return ec.fieldContext_PageInfo_size(ctx, field)
+			case "hasPreviousPage":
+				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
+			case "hasNextPage":
+				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
+			case "startCursor":
+				return ec.fieldContext_PageInfo_startCursor(ctx, field)
+			case "endCursor":
+				return ec.fieldContext_PageInfo_endCursor(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InteractionsEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.InteractionsEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InteractionsEdge_node(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Node, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(model.Interaction)
+	fc.Result = res
+	return ec.marshalOInteraction2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteraction(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InteractionsEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InteractionsEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Interaction does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _InteractionsEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.InteractionsEdge) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_InteractionsEdge_cursor(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cursor, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_InteractionsEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "InteractionsEdge",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _InvalidMedia_previewURLs(ctx context.Context, field graphql.CollectedField, obj *model.InvalidMedia) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_InvalidMedia_previewURLs(ctx, field)
 	if err != nil {
@@ -30853,6 +30711,227 @@ func (ec *executionContext) fieldContext_MembershipTier_owners(ctx context.Conte
 				return ec.fieldContext_TokenHolder_previewTokens(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TokenHolder", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mention_user(ctx context.Context, field graphql.CollectedField, obj *model.Mention) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mention_user(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mention().User(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.GalleryUser)
+	fc.Result = res
+	return ec.marshalOGalleryUser2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGalleryUser(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mention_user(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mention",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_GalleryUser_id(ctx, field)
+			case "dbid":
+				return ec.fieldContext_GalleryUser_dbid(ctx, field)
+			case "username":
+				return ec.fieldContext_GalleryUser_username(ctx, field)
+			case "profileImage":
+				return ec.fieldContext_GalleryUser_profileImage(ctx, field)
+			case "potentialEnsProfileImage":
+				return ec.fieldContext_GalleryUser_potentialEnsProfileImage(ctx, field)
+			case "bio":
+				return ec.fieldContext_GalleryUser_bio(ctx, field)
+			case "traits":
+				return ec.fieldContext_GalleryUser_traits(ctx, field)
+			case "universal":
+				return ec.fieldContext_GalleryUser_universal(ctx, field)
+			case "roles":
+				return ec.fieldContext_GalleryUser_roles(ctx, field)
+			case "socialAccounts":
+				return ec.fieldContext_GalleryUser_socialAccounts(ctx, field)
+			case "tokens":
+				return ec.fieldContext_GalleryUser_tokens(ctx, field)
+			case "tokensByChain":
+				return ec.fieldContext_GalleryUser_tokensByChain(ctx, field)
+			case "wallets":
+				return ec.fieldContext_GalleryUser_wallets(ctx, field)
+			case "primaryWallet":
+				return ec.fieldContext_GalleryUser_primaryWallet(ctx, field)
+			case "featuredGallery":
+				return ec.fieldContext_GalleryUser_featuredGallery(ctx, field)
+			case "galleries":
+				return ec.fieldContext_GalleryUser_galleries(ctx, field)
+			case "badges":
+				return ec.fieldContext_GalleryUser_badges(ctx, field)
+			case "isAuthenticatedUser":
+				return ec.fieldContext_GalleryUser_isAuthenticatedUser(ctx, field)
+			case "followers":
+				return ec.fieldContext_GalleryUser_followers(ctx, field)
+			case "following":
+				return ec.fieldContext_GalleryUser_following(ctx, field)
+			case "feed":
+				return ec.fieldContext_GalleryUser_feed(ctx, field)
+			case "sharedFollowers":
+				return ec.fieldContext_GalleryUser_sharedFollowers(ctx, field)
+			case "sharedCommunities":
+				return ec.fieldContext_GalleryUser_sharedCommunities(ctx, field)
+			case "createdCommunities":
+				return ec.fieldContext_GalleryUser_createdCommunities(ctx, field)
+			case "isMemberOfCommunity":
+				return ec.fieldContext_GalleryUser_isMemberOfCommunity(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type GalleryUser", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mention_community(ctx context.Context, field graphql.CollectedField, obj *model.Mention) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mention_community(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mention().Community(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Community)
+	fc.Result = res
+	return ec.marshalOCommunity2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommunity(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mention_community(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mention",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "dbid":
+				return ec.fieldContext_Community_dbid(ctx, field)
+			case "id":
+				return ec.fieldContext_Community_id(ctx, field)
+			case "lastUpdated":
+				return ec.fieldContext_Community_lastUpdated(ctx, field)
+			case "contract":
+				return ec.fieldContext_Community_contract(ctx, field)
+			case "contractAddress":
+				return ec.fieldContext_Community_contractAddress(ctx, field)
+			case "creatorAddress":
+				return ec.fieldContext_Community_creatorAddress(ctx, field)
+			case "creator":
+				return ec.fieldContext_Community_creator(ctx, field)
+			case "chain":
+				return ec.fieldContext_Community_chain(ctx, field)
+			case "name":
+				return ec.fieldContext_Community_name(ctx, field)
+			case "description":
+				return ec.fieldContext_Community_description(ctx, field)
+			case "previewImage":
+				return ec.fieldContext_Community_previewImage(ctx, field)
+			case "profileImageURL":
+				return ec.fieldContext_Community_profileImageURL(ctx, field)
+			case "profileBannerURL":
+				return ec.fieldContext_Community_profileBannerURL(ctx, field)
+			case "badgeURL":
+				return ec.fieldContext_Community_badgeURL(ctx, field)
+			case "parentCommunity":
+				return ec.fieldContext_Community_parentCommunity(ctx, field)
+			case "subCommunities":
+				return ec.fieldContext_Community_subCommunities(ctx, field)
+			case "tokensInCommunity":
+				return ec.fieldContext_Community_tokensInCommunity(ctx, field)
+			case "owners":
+				return ec.fieldContext_Community_owners(ctx, field)
+			case "posts":
+				return ec.fieldContext_Community_posts(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Community", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mention_index(ctx context.Context, field graphql.CollectedField, obj *model.Mention) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mention_index(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Index, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.CompleteIndex)
+	fc.Result = res
+	return ec.marshalOCompleteIndex2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCompleteIndex(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mention_index(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mention",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "index":
+				return ec.fieldContext_CompleteIndex_index(ctx, field)
+			case "length":
+				return ec.fieldContext_CompleteIndex_length(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CompleteIndex", field.Name)
 		},
 	}
 	return fc, nil
@@ -38048,6 +38127,55 @@ func (ec *executionContext) fieldContext_Post_caption(ctx context.Context, field
 	return fc, nil
 }
 
+func (ec *executionContext) _Post_mentions(ctx context.Context, field graphql.CollectedField, obj *model.Post) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Post_mentions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Post().Mentions(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*model.Mention)
+	fc.Result = res
+	return ec.marshalOMention2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMention(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Post_mentions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Post",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "user":
+				return ec.fieldContext_Mention_user(ctx, field)
+			case "community":
+				return ec.fieldContext_Mention_community(ctx, field)
+			case "index":
+				return ec.fieldContext_Mention_index(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Mention", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Post_admires(ctx context.Context, field graphql.CollectedField, obj *model.Post) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Post_admires(ctx, field)
 	if err != nil {
@@ -38071,9 +38199,9 @@ func (ec *executionContext) _Post_admires(ctx context.Context, field graphql.Col
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.PostAdmiresConnection)
+	res := resTmp.(*model.AdmiresConnection)
 	fc.Result = res
-	return ec.marshalOPostAdmiresConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostAdmiresConnection(ctx, field.Selections, res)
+	return ec.marshalOAdmiresConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmiresConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Post_admires(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -38085,11 +38213,11 @@ func (ec *executionContext) fieldContext_Post_admires(ctx context.Context, field
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "edges":
-				return ec.fieldContext_PostAdmiresConnection_edges(ctx, field)
+				return ec.fieldContext_AdmiresConnection_edges(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_PostAdmiresConnection_pageInfo(ctx, field)
+				return ec.fieldContext_AdmiresConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type PostAdmiresConnection", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type AdmiresConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -38129,9 +38257,9 @@ func (ec *executionContext) _Post_comments(ctx context.Context, field graphql.Co
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.PostCommentsConnection)
+	res := resTmp.(*model.CommentsConnection)
 	fc.Result = res
-	return ec.marshalOPostCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostCommentsConnection(ctx, field.Selections, res)
+	return ec.marshalOCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Post_comments(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -38143,11 +38271,11 @@ func (ec *executionContext) fieldContext_Post_comments(ctx context.Context, fiel
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "edges":
-				return ec.fieldContext_PostCommentsConnection_edges(ctx, field)
+				return ec.fieldContext_CommentsConnection_edges(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_PostCommentsConnection_pageInfo(ctx, field)
+				return ec.fieldContext_CommentsConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type PostCommentsConnection", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type CommentsConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -38187,9 +38315,9 @@ func (ec *executionContext) _Post_interactions(ctx context.Context, field graphq
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.PostInteractionsConnection)
+	res := resTmp.(*model.InteractionsConnection)
 	fc.Result = res
-	return ec.marshalOPostInteractionsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostInteractionsConnection(ctx, field.Selections, res)
+	return ec.marshalOInteractionsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteractionsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Post_interactions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -38201,11 +38329,11 @@ func (ec *executionContext) fieldContext_Post_interactions(ctx context.Context, 
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "edges":
-				return ec.fieldContext_PostInteractionsConnection_edges(ctx, field)
+				return ec.fieldContext_InteractionsConnection_edges(ctx, field)
 			case "pageInfo":
-				return ec.fieldContext_PostInteractionsConnection_pageInfo(ctx, field)
+				return ec.fieldContext_InteractionsConnection_pageInfo(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type PostInteractionsConnection", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type InteractionsConnection", field.Name)
 		},
 	}
 	defer func() {
@@ -38272,546 +38400,6 @@ func (ec *executionContext) fieldContext_Post_viewerAdmire(ctx context.Context, 
 				return ec.fieldContext_Admire_source(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Admire", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostAdmireEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.PostAdmireEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostAdmireEdge_node(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Admire)
-	fc.Result = res
-	return ec.marshalOAdmire2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmire(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostAdmireEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostAdmireEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Admire_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_Admire_dbid(ctx, field)
-			case "creationTime":
-				return ec.fieldContext_Admire_creationTime(ctx, field)
-			case "lastUpdated":
-				return ec.fieldContext_Admire_lastUpdated(ctx, field)
-			case "admirer":
-				return ec.fieldContext_Admire_admirer(ctx, field)
-			case "source":
-				return ec.fieldContext_Admire_source(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Admire", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostAdmireEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.PostAdmireEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostAdmireEdge_cursor(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Cursor, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostAdmireEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostAdmireEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostAdmireEdge_post(ctx context.Context, field graphql.CollectedField, obj *model.PostAdmireEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostAdmireEdge_post(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Post, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Post)
-	fc.Result = res
-	return ec.marshalOPost2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPost(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostAdmireEdge_post(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostAdmireEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Post_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_Post_dbid(ctx, field)
-			case "author":
-				return ec.fieldContext_Post_author(ctx, field)
-			case "creationTime":
-				return ec.fieldContext_Post_creationTime(ctx, field)
-			case "tokens":
-				return ec.fieldContext_Post_tokens(ctx, field)
-			case "caption":
-				return ec.fieldContext_Post_caption(ctx, field)
-			case "admires":
-				return ec.fieldContext_Post_admires(ctx, field)
-			case "comments":
-				return ec.fieldContext_Post_comments(ctx, field)
-			case "interactions":
-				return ec.fieldContext_Post_interactions(ctx, field)
-			case "viewerAdmire":
-				return ec.fieldContext_Post_viewerAdmire(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostAdmiresConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.PostAdmiresConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostAdmiresConnection_edges(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Edges, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.PostAdmireEdge)
-	fc.Result = res
-	return ec.marshalOPostAdmireEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostAdmireEdge(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostAdmiresConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostAdmiresConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "node":
-				return ec.fieldContext_PostAdmireEdge_node(ctx, field)
-			case "cursor":
-				return ec.fieldContext_PostAdmireEdge_cursor(ctx, field)
-			case "post":
-				return ec.fieldContext_PostAdmireEdge_post(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PostAdmireEdge", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostAdmiresConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.PostAdmiresConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostAdmiresConnection_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostAdmiresConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostAdmiresConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "total":
-				return ec.fieldContext_PageInfo_total(ctx, field)
-			case "size":
-				return ec.fieldContext_PageInfo_size(ctx, field)
-			case "hasPreviousPage":
-				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			case "startCursor":
-				return ec.fieldContext_PageInfo_startCursor(ctx, field)
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostCommentEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.PostCommentEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostCommentEdge_node(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Comment)
-	fc.Result = res
-	return ec.marshalOComment2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐComment(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostCommentEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostCommentEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Comment_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_Comment_dbid(ctx, field)
-			case "creationTime":
-				return ec.fieldContext_Comment_creationTime(ctx, field)
-			case "lastUpdated":
-				return ec.fieldContext_Comment_lastUpdated(ctx, field)
-			case "replyTo":
-				return ec.fieldContext_Comment_replyTo(ctx, field)
-			case "commenter":
-				return ec.fieldContext_Comment_commenter(ctx, field)
-			case "comment":
-				return ec.fieldContext_Comment_comment(ctx, field)
-			case "replies":
-				return ec.fieldContext_Comment_replies(ctx, field)
-			case "source":
-				return ec.fieldContext_Comment_source(ctx, field)
-			case "deleted":
-				return ec.fieldContext_Comment_deleted(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Comment", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostCommentEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.PostCommentEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostCommentEdge_cursor(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Cursor, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostCommentEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostCommentEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostCommentEdge_post(ctx context.Context, field graphql.CollectedField, obj *model.PostCommentEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostCommentEdge_post(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Post, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Post)
-	fc.Result = res
-	return ec.marshalOPost2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPost(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostCommentEdge_post(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostCommentEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Post_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_Post_dbid(ctx, field)
-			case "author":
-				return ec.fieldContext_Post_author(ctx, field)
-			case "creationTime":
-				return ec.fieldContext_Post_creationTime(ctx, field)
-			case "tokens":
-				return ec.fieldContext_Post_tokens(ctx, field)
-			case "caption":
-				return ec.fieldContext_Post_caption(ctx, field)
-			case "admires":
-				return ec.fieldContext_Post_admires(ctx, field)
-			case "comments":
-				return ec.fieldContext_Post_comments(ctx, field)
-			case "interactions":
-				return ec.fieldContext_Post_interactions(ctx, field)
-			case "viewerAdmire":
-				return ec.fieldContext_Post_viewerAdmire(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostCommentsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.PostCommentsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostCommentsConnection_edges(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Edges, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.PostCommentEdge)
-	fc.Result = res
-	return ec.marshalOPostCommentEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostCommentEdge(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostCommentsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostCommentsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "node":
-				return ec.fieldContext_PostCommentEdge_node(ctx, field)
-			case "cursor":
-				return ec.fieldContext_PostCommentEdge_cursor(ctx, field)
-			case "post":
-				return ec.fieldContext_PostCommentEdge_post(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PostCommentEdge", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostCommentsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.PostCommentsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostCommentsConnection_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostCommentsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostCommentsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "total":
-				return ec.fieldContext_PageInfo_total(ctx, field)
-			case "size":
-				return ec.fieldContext_PageInfo_size(ctx, field)
-			case "hasPreviousPage":
-				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			case "startCursor":
-				return ec.fieldContext_PageInfo_startCursor(ctx, field)
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
 		},
 	}
 	return fc, nil
@@ -38899,258 +38487,6 @@ func (ec *executionContext) fieldContext_PostEdge_cursor(ctx context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _PostInteractionsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.PostInteractionsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostInteractionsConnection_edges(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Edges, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*model.PostInteractionsEdge)
-	fc.Result = res
-	return ec.marshalOPostInteractionsEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostInteractionsEdge(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostInteractionsConnection_edges(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostInteractionsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "node":
-				return ec.fieldContext_PostInteractionsEdge_node(ctx, field)
-			case "cursor":
-				return ec.fieldContext_PostInteractionsEdge_cursor(ctx, field)
-			case "post":
-				return ec.fieldContext_PostInteractionsEdge_post(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PostInteractionsEdge", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostInteractionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *model.PostInteractionsConnection) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostInteractionsConnection_pageInfo(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.PageInfo)
-	fc.Result = res
-	return ec.marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPageInfo(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostInteractionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostInteractionsConnection",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "total":
-				return ec.fieldContext_PageInfo_total(ctx, field)
-			case "size":
-				return ec.fieldContext_PageInfo_size(ctx, field)
-			case "hasPreviousPage":
-				return ec.fieldContext_PageInfo_hasPreviousPage(ctx, field)
-			case "hasNextPage":
-				return ec.fieldContext_PageInfo_hasNextPage(ctx, field)
-			case "startCursor":
-				return ec.fieldContext_PageInfo_startCursor(ctx, field)
-			case "endCursor":
-				return ec.fieldContext_PageInfo_endCursor(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostInteractionsEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.PostInteractionsEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostInteractionsEdge_node(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Node, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(model.Interaction)
-	fc.Result = res
-	return ec.marshalOInteraction2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteraction(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostInteractionsEdge_node(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostInteractionsEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Interaction does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostInteractionsEdge_cursor(ctx context.Context, field graphql.CollectedField, obj *model.PostInteractionsEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostInteractionsEdge_cursor(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Cursor, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostInteractionsEdge_cursor(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostInteractionsEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostInteractionsEdge_post(ctx context.Context, field graphql.CollectedField, obj *model.PostInteractionsEdge) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_PostInteractionsEdge_post(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Post, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*model.Post)
-	fc.Result = res
-	return ec.marshalOPost2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPost(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_PostInteractionsEdge_post(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostInteractionsEdge",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Post_id(ctx, field)
-			case "dbid":
-				return ec.fieldContext_Post_dbid(ctx, field)
-			case "author":
-				return ec.fieldContext_Post_author(ctx, field)
-			case "creationTime":
-				return ec.fieldContext_Post_creationTime(ctx, field)
-			case "tokens":
-				return ec.fieldContext_Post_tokens(ctx, field)
-			case "caption":
-				return ec.fieldContext_Post_caption(ctx, field)
-			case "admires":
-				return ec.fieldContext_Post_admires(ctx, field)
-			case "comments":
-				return ec.fieldContext_Post_comments(ctx, field)
-			case "interactions":
-				return ec.fieldContext_Post_interactions(ctx, field)
-			case "viewerAdmire":
-				return ec.fieldContext_Post_viewerAdmire(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _PostTokensPayload_post(ctx context.Context, field graphql.CollectedField, obj *model.PostTokensPayload) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PostTokensPayload_post(ctx, field)
 	if err != nil {
@@ -39202,6 +38538,8 @@ func (ec *executionContext) fieldContext_PostTokensPayload_post(ctx context.Cont
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -42359,6 +41697,8 @@ func (ec *executionContext) fieldContext_RemoveAdmirePayload_post(ctx context.Co
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -42546,6 +41886,8 @@ func (ec *executionContext) fieldContext_RemoveCommentPayload_post(ctx context.C
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -44644,6 +43986,8 @@ func (ec *executionContext) fieldContext_SomeoneAdmiredYourPostNotification_post
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -44978,6 +44322,8 @@ func (ec *executionContext) fieldContext_SomeoneCommentedOnYourFeedEventNotifica
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -45313,6 +44659,8 @@ func (ec *executionContext) fieldContext_SomeoneCommentedOnYourPostNotification_
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -45374,6 +44722,8 @@ func (ec *executionContext) fieldContext_SomeoneCommentedOnYourPostNotification_
 				return ec.fieldContext_Post_tokens(ctx, field)
 			case "caption":
 				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
 			case "admires":
 				return ec.fieldContext_Post_admires(ctx, field)
 			case "comments":
@@ -46855,6 +46205,8 @@ func (ec *executionContext) fieldContext_SomeoneRepliedToYourCommentNotification
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -46918,6 +46270,8 @@ func (ec *executionContext) fieldContext_SomeoneRepliedToYourCommentNotification
 				return ec.fieldContext_Comment_commenter(ctx, field)
 			case "comment":
 				return ec.fieldContext_Comment_comment(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Comment_mentions(ctx, field)
 			case "replies":
 				return ec.fieldContext_Comment_replies(ctx, field)
 			case "source":
@@ -57506,6 +56860,44 @@ func (ec *executionContext) unmarshalInputCollectionTokenSettingsInput(ctx conte
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputCompleteIndexInput(ctx context.Context, obj interface{}) (model.CompleteIndexInput, error) {
+	var it model.CompleteIndexInput
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"index", "length"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "index":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("index"))
+			data, err := ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Index = data
+		case "length":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("length"))
+			data, err := ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Length = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputCreateCollectionInGalleryInput(ctx context.Context, obj interface{}) (model.CreateCollectionInGalleryInput, error) {
 	var it model.CreateCollectionInGalleryInput
 	asMap := map[string]interface{}{}
@@ -58245,13 +57637,22 @@ func (ec *executionContext) unmarshalInputMentionInput(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"userId", "communityId"}
+	fieldsInOrder := [...]string{"index", "userId", "communityId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
+		case "index":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("index"))
+			data, err := ec.unmarshalOCompleteIndexInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCompleteIndexInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Index = data
 		case "userId":
 			var err error
 
@@ -60145,29 +59546,6 @@ func (ec *executionContext) _CommentSource(ctx context.Context, sel ast.Selectio
 			return graphql.Null
 		}
 		return ec._FeedEvent(ctx, sel, obj)
-	default:
-		panic(fmt.Errorf("unexpected type %T", obj))
-	}
-}
-
-func (ec *executionContext) _CommentsConnection(ctx context.Context, sel ast.SelectionSet, obj model.CommentsConnection) graphql.Marshaler {
-	switch obj := (obj).(type) {
-	case nil:
-		return graphql.Null
-	case model.FeedEventCommentsConnection:
-		return ec._FeedEventCommentsConnection(ctx, sel, &obj)
-	case *model.FeedEventCommentsConnection:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._FeedEventCommentsConnection(ctx, sel, obj)
-	case model.PostCommentsConnection:
-		return ec._PostCommentsConnection(ctx, sel, &obj)
-	case *model.PostCommentsConnection:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._PostCommentsConnection(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -63641,6 +63019,35 @@ func (ec *executionContext) _Admire(ctx context.Context, sel ast.SelectionSet, o
 	return out
 }
 
+var admireEdgeImplementors = []string{"AdmireEdge"}
+
+func (ec *executionContext) _AdmireEdge(ctx context.Context, sel ast.SelectionSet, obj *model.AdmireEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, admireEdgeImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AdmireEdge")
+		case "node":
+
+			out.Values[i] = ec._AdmireEdge_node(ctx, field, obj)
+
+		case "cursor":
+
+			out.Values[i] = ec._AdmireEdge_cursor(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var admireFeedEventPayloadImplementors = []string{"AdmireFeedEventPayload", "AdmireFeedEventPayloadOrError"}
 
 func (ec *executionContext) _AdmireFeedEventPayload(ctx context.Context, sel ast.SelectionSet, obj *model.AdmireFeedEventPayload) graphql.Marshaler {
@@ -63748,6 +63155,38 @@ func (ec *executionContext) _AdmirePostPayload(ctx context.Context, sel ast.Sele
 				return innerFunc(ctx)
 
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var admiresConnectionImplementors = []string{"AdmiresConnection"}
+
+func (ec *executionContext) _AdmiresConnection(ctx context.Context, sel ast.SelectionSet, obj *model.AdmiresConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, admiresConnectionImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AdmiresConnection")
+		case "edges":
+
+			out.Values[i] = ec._AdmiresConnection_edges(ctx, field, obj)
+
+		case "pageInfo":
+
+			out.Values[i] = ec._AdmiresConnection_pageInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -64694,6 +64133,23 @@ func (ec *executionContext) _Comment(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Values[i] = ec._Comment_comment(ctx, field, obj)
 
+		case "mentions":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Comment_mentions(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "replies":
 			field := field
 
@@ -64731,6 +64187,35 @@ func (ec *executionContext) _Comment(ctx context.Context, sel ast.SelectionSet, 
 		case "deleted":
 
 			out.Values[i] = ec._Comment_deleted(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var commentEdgeImplementors = []string{"CommentEdge"}
+
+func (ec *executionContext) _CommentEdge(ctx context.Context, sel ast.SelectionSet, obj *model.CommentEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, commentEdgeImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CommentEdge")
+		case "node":
+
+			out.Values[i] = ec._CommentEdge_node(ctx, field, obj)
+
+		case "cursor":
+
+			out.Values[i] = ec._CommentEdge_cursor(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -64884,6 +64369,38 @@ func (ec *executionContext) _CommentOnPostPayload(ctx context.Context, sel ast.S
 				return innerFunc(ctx)
 
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var commentsConnectionImplementors = []string{"CommentsConnection"}
+
+func (ec *executionContext) _CommentsConnection(ctx context.Context, sel ast.SelectionSet, obj *model.CommentsConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, commentsConnectionImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CommentsConnection")
+		case "edges":
+
+			out.Values[i] = ec._CommentsConnection_edges(ctx, field, obj)
+
+		case "pageInfo":
+
+			out.Values[i] = ec._CommentsConnection_pageInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -65176,6 +64693,41 @@ func (ec *executionContext) _CommunitySearchResult(ctx context.Context, sel ast.
 
 			out.Values[i] = ec._CommunitySearchResult_community(ctx, field, obj)
 
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var completeIndexImplementors = []string{"CompleteIndex"}
+
+func (ec *executionContext) _CompleteIndex(ctx context.Context, sel ast.SelectionSet, obj *model.CompleteIndex) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, completeIndexImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CompleteIndex")
+		case "index":
+
+			out.Values[i] = ec._CompleteIndex_index(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "length":
+
+			out.Values[i] = ec._CompleteIndex_length(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -66689,201 +66241,6 @@ func (ec *executionContext) _FeedEvent(ctx context.Context, sel ast.SelectionSet
 	return out
 }
 
-var feedEventAdmireEdgeImplementors = []string{"FeedEventAdmireEdge"}
-
-func (ec *executionContext) _FeedEventAdmireEdge(ctx context.Context, sel ast.SelectionSet, obj *model.FeedEventAdmireEdge) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, feedEventAdmireEdgeImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("FeedEventAdmireEdge")
-		case "node":
-
-			out.Values[i] = ec._FeedEventAdmireEdge_node(ctx, field, obj)
-
-		case "event":
-
-			out.Values[i] = ec._FeedEventAdmireEdge_event(ctx, field, obj)
-
-		case "cursor":
-
-			out.Values[i] = ec._FeedEventAdmireEdge_cursor(ctx, field, obj)
-
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var feedEventAdmiresConnectionImplementors = []string{"FeedEventAdmiresConnection"}
-
-func (ec *executionContext) _FeedEventAdmiresConnection(ctx context.Context, sel ast.SelectionSet, obj *model.FeedEventAdmiresConnection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, feedEventAdmiresConnectionImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("FeedEventAdmiresConnection")
-		case "edges":
-
-			out.Values[i] = ec._FeedEventAdmiresConnection_edges(ctx, field, obj)
-
-		case "pageInfo":
-
-			out.Values[i] = ec._FeedEventAdmiresConnection_pageInfo(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var feedEventCommentEdgeImplementors = []string{"FeedEventCommentEdge"}
-
-func (ec *executionContext) _FeedEventCommentEdge(ctx context.Context, sel ast.SelectionSet, obj *model.FeedEventCommentEdge) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, feedEventCommentEdgeImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("FeedEventCommentEdge")
-		case "node":
-
-			out.Values[i] = ec._FeedEventCommentEdge_node(ctx, field, obj)
-
-		case "event":
-
-			out.Values[i] = ec._FeedEventCommentEdge_event(ctx, field, obj)
-
-		case "cursor":
-
-			out.Values[i] = ec._FeedEventCommentEdge_cursor(ctx, field, obj)
-
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var feedEventCommentsConnectionImplementors = []string{"FeedEventCommentsConnection", "CommentsConnection"}
-
-func (ec *executionContext) _FeedEventCommentsConnection(ctx context.Context, sel ast.SelectionSet, obj *model.FeedEventCommentsConnection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, feedEventCommentsConnectionImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("FeedEventCommentsConnection")
-		case "edges":
-
-			out.Values[i] = ec._FeedEventCommentsConnection_edges(ctx, field, obj)
-
-		case "pageInfo":
-
-			out.Values[i] = ec._FeedEventCommentsConnection_pageInfo(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var feedEventInteractionsConnectionImplementors = []string{"FeedEventInteractionsConnection"}
-
-func (ec *executionContext) _FeedEventInteractionsConnection(ctx context.Context, sel ast.SelectionSet, obj *model.FeedEventInteractionsConnection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, feedEventInteractionsConnectionImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("FeedEventInteractionsConnection")
-		case "edges":
-
-			out.Values[i] = ec._FeedEventInteractionsConnection_edges(ctx, field, obj)
-
-		case "pageInfo":
-
-			out.Values[i] = ec._FeedEventInteractionsConnection_pageInfo(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var feedEventInteractionsEdgeImplementors = []string{"FeedEventInteractionsEdge"}
-
-func (ec *executionContext) _FeedEventInteractionsEdge(ctx context.Context, sel ast.SelectionSet, obj *model.FeedEventInteractionsEdge) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, feedEventInteractionsEdgeImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("FeedEventInteractionsEdge")
-		case "node":
-
-			out.Values[i] = ec._FeedEventInteractionsEdge_node(ctx, field, obj)
-
-		case "event":
-
-			out.Values[i] = ec._FeedEventInteractionsEdge_event(ctx, field, obj)
-
-		case "cursor":
-
-			out.Values[i] = ec._FeedEventInteractionsEdge_cursor(ctx, field, obj)
-
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
 var followAllSocialConnectionsPayloadImplementors = []string{"FollowAllSocialConnectionsPayload", "FollowAllSocialConnectionsPayloadOrError"}
 
 func (ec *executionContext) _FollowAllSocialConnectionsPayload(ctx context.Context, sel ast.SelectionSet, obj *model.FollowAllSocialConnectionsPayload) graphql.Marshaler {
@@ -67921,6 +67278,67 @@ func (ec *executionContext) _ImageMedia(ctx context.Context, sel ast.SelectionSe
 	return out
 }
 
+var interactionsConnectionImplementors = []string{"InteractionsConnection"}
+
+func (ec *executionContext) _InteractionsConnection(ctx context.Context, sel ast.SelectionSet, obj *model.InteractionsConnection) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, interactionsConnectionImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InteractionsConnection")
+		case "edges":
+
+			out.Values[i] = ec._InteractionsConnection_edges(ctx, field, obj)
+
+		case "pageInfo":
+
+			out.Values[i] = ec._InteractionsConnection_pageInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var interactionsEdgeImplementors = []string{"InteractionsEdge"}
+
+func (ec *executionContext) _InteractionsEdge(ctx context.Context, sel ast.SelectionSet, obj *model.InteractionsEdge) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, interactionsEdgeImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("InteractionsEdge")
+		case "node":
+
+			out.Values[i] = ec._InteractionsEdge_node(ctx, field, obj)
+
+		case "cursor":
+
+			out.Values[i] = ec._InteractionsEdge_cursor(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var invalidMediaImplementors = []string{"InvalidMedia", "MediaSubtype", "Media"}
 
 func (ec *executionContext) _InvalidMedia(ctx context.Context, sel ast.SelectionSet, obj *model.InvalidMedia) graphql.Marshaler {
@@ -68207,6 +67625,65 @@ func (ec *executionContext) _MembershipTier(ctx context.Context, sel ast.Selecti
 		case "owners":
 
 			out.Values[i] = ec._MembershipTier_owners(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var mentionImplementors = []string{"Mention"}
+
+func (ec *executionContext) _Mention(ctx context.Context, sel ast.SelectionSet, obj *model.Mention) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, mentionImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Mention")
+		case "user":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Mention_user(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "community":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Mention_community(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "index":
+
+			out.Values[i] = ec._Mention_index(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -69234,6 +68711,23 @@ func (ec *executionContext) _Post(ctx context.Context, sel ast.SelectionSet, obj
 
 			out.Values[i] = ec._Post_caption(ctx, field, obj)
 
+		case "mentions":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Post_mentions(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		case "admires":
 			field := field
 
@@ -69313,136 +68807,6 @@ func (ec *executionContext) _Post(ctx context.Context, sel ast.SelectionSet, obj
 	return out
 }
 
-var postAdmireEdgeImplementors = []string{"PostAdmireEdge"}
-
-func (ec *executionContext) _PostAdmireEdge(ctx context.Context, sel ast.SelectionSet, obj *model.PostAdmireEdge) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, postAdmireEdgeImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("PostAdmireEdge")
-		case "node":
-
-			out.Values[i] = ec._PostAdmireEdge_node(ctx, field, obj)
-
-		case "cursor":
-
-			out.Values[i] = ec._PostAdmireEdge_cursor(ctx, field, obj)
-
-		case "post":
-
-			out.Values[i] = ec._PostAdmireEdge_post(ctx, field, obj)
-
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var postAdmiresConnectionImplementors = []string{"PostAdmiresConnection"}
-
-func (ec *executionContext) _PostAdmiresConnection(ctx context.Context, sel ast.SelectionSet, obj *model.PostAdmiresConnection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, postAdmiresConnectionImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("PostAdmiresConnection")
-		case "edges":
-
-			out.Values[i] = ec._PostAdmiresConnection_edges(ctx, field, obj)
-
-		case "pageInfo":
-
-			out.Values[i] = ec._PostAdmiresConnection_pageInfo(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var postCommentEdgeImplementors = []string{"PostCommentEdge"}
-
-func (ec *executionContext) _PostCommentEdge(ctx context.Context, sel ast.SelectionSet, obj *model.PostCommentEdge) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, postCommentEdgeImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("PostCommentEdge")
-		case "node":
-
-			out.Values[i] = ec._PostCommentEdge_node(ctx, field, obj)
-
-		case "cursor":
-
-			out.Values[i] = ec._PostCommentEdge_cursor(ctx, field, obj)
-
-		case "post":
-
-			out.Values[i] = ec._PostCommentEdge_post(ctx, field, obj)
-
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var postCommentsConnectionImplementors = []string{"PostCommentsConnection", "CommentsConnection"}
-
-func (ec *executionContext) _PostCommentsConnection(ctx context.Context, sel ast.SelectionSet, obj *model.PostCommentsConnection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, postCommentsConnectionImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("PostCommentsConnection")
-		case "edges":
-
-			out.Values[i] = ec._PostCommentsConnection_edges(ctx, field, obj)
-
-		case "pageInfo":
-
-			out.Values[i] = ec._PostCommentsConnection_pageInfo(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
 var postEdgeImplementors = []string{"PostEdge"}
 
 func (ec *executionContext) _PostEdge(ctx context.Context, sel ast.SelectionSet, obj *model.PostEdge) graphql.Marshaler {
@@ -69460,71 +68824,6 @@ func (ec *executionContext) _PostEdge(ctx context.Context, sel ast.SelectionSet,
 		case "cursor":
 
 			out.Values[i] = ec._PostEdge_cursor(ctx, field, obj)
-
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var postInteractionsConnectionImplementors = []string{"PostInteractionsConnection"}
-
-func (ec *executionContext) _PostInteractionsConnection(ctx context.Context, sel ast.SelectionSet, obj *model.PostInteractionsConnection) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, postInteractionsConnectionImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("PostInteractionsConnection")
-		case "edges":
-
-			out.Values[i] = ec._PostInteractionsConnection_edges(ctx, field, obj)
-
-		case "pageInfo":
-
-			out.Values[i] = ec._PostInteractionsConnection_pageInfo(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var postInteractionsEdgeImplementors = []string{"PostInteractionsEdge"}
-
-func (ec *executionContext) _PostInteractionsEdge(ctx context.Context, sel ast.SelectionSet, obj *model.PostInteractionsEdge) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.OperationContext, sel, postInteractionsEdgeImplementors)
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("PostInteractionsEdge")
-		case "node":
-
-			out.Values[i] = ec._PostInteractionsEdge_node(ctx, field, obj)
-
-		case "cursor":
-
-			out.Values[i] = ec._PostInteractionsEdge_cursor(ctx, field, obj)
-
-		case "post":
-
-			out.Values[i] = ec._PostInteractionsEdge_post(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -75669,6 +74968,54 @@ func (ec *executionContext) marshalOAdmire2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgal
 	return ec._Admire(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOAdmireEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmireEdge(ctx context.Context, sel ast.SelectionSet, v []*model.AdmireEdge) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOAdmireEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmireEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOAdmireEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmireEdge(ctx context.Context, sel ast.SelectionSet, v *model.AdmireEdge) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AdmireEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOAdmireFeedEventPayloadOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmireFeedEventPayloadOrError(ctx context.Context, sel ast.SelectionSet, v model.AdmireFeedEventPayloadOrError) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -75688,6 +75035,13 @@ func (ec *executionContext) marshalOAdmireSource2githubᚗcomᚋmikeydubᚋgoᚑ
 		return graphql.Null
 	}
 	return ec._AdmireSource(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOAdmiresConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAdmiresConnection(ctx context.Context, sel ast.SelectionSet, v *model.AdmiresConnection) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._AdmiresConnection(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOBadge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐBadge(ctx context.Context, sel ast.SelectionSet, v []*model.Badge) graphql.Marshaler {
@@ -76235,6 +75589,54 @@ func (ec *executionContext) marshalOComment2ᚖgithubᚗcomᚋmikeydubᚋgoᚑga
 	return ec._Comment(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOCommentEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentEdge(ctx context.Context, sel ast.SelectionSet, v []*model.CommentEdge) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOCommentEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOCommentEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentEdge(ctx context.Context, sel ast.SelectionSet, v *model.CommentEdge) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CommentEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOCommentOnFeedEventPayloadOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentOnFeedEventPayloadOrError(ctx context.Context, sel ast.SelectionSet, v model.CommentOnFeedEventPayloadOrError) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -76256,7 +75658,7 @@ func (ec *executionContext) marshalOCommentSource2githubᚗcomᚋmikeydubᚋgo�
 	return ec._CommentSource(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOCommentsConnection2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentsConnection(ctx context.Context, sel ast.SelectionSet, v model.CommentsConnection) graphql.Marshaler {
+func (ec *executionContext) marshalOCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCommentsConnection(ctx context.Context, sel ast.SelectionSet, v *model.CommentsConnection) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -76384,6 +75786,21 @@ func (ec *executionContext) marshalOCommunitySearchResult2ᚕᚖgithubᚗcomᚋm
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalOCompleteIndex2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCompleteIndex(ctx context.Context, sel ast.SelectionSet, v *model.CompleteIndex) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._CompleteIndex(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOCompleteIndexInput2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐCompleteIndexInput(ctx context.Context, v interface{}) (*model.CompleteIndexInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputCompleteIndexInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOConnectSocialAccountPayloadOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐConnectSocialAccountPayloadOrError(ctx context.Context, sel ast.SelectionSet, v model.ConnectSocialAccountPayloadOrError) graphql.Marshaler {
@@ -76686,121 +76103,11 @@ func (ec *executionContext) marshalOFeedEvent2ᚖgithubᚗcomᚋmikeydubᚋgoᚑ
 	return ec._FeedEvent(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOFeedEventAdmireEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventAdmireEdge(ctx context.Context, sel ast.SelectionSet, v []*model.FeedEventAdmireEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOFeedEventAdmireEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventAdmireEdge(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOFeedEventAdmireEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventAdmireEdge(ctx context.Context, sel ast.SelectionSet, v *model.FeedEventAdmireEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._FeedEventAdmireEdge(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOFeedEventAdmiresConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventAdmiresConnection(ctx context.Context, sel ast.SelectionSet, v *model.FeedEventAdmiresConnection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._FeedEventAdmiresConnection(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalOFeedEventByIdOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventByIDOrError(ctx context.Context, sel ast.SelectionSet, v model.FeedEventByIDOrError) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
 	return ec._FeedEventByIdOrError(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOFeedEventCommentEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventCommentEdge(ctx context.Context, sel ast.SelectionSet, v []*model.FeedEventCommentEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOFeedEventCommentEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventCommentEdge(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOFeedEventCommentEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventCommentEdge(ctx context.Context, sel ast.SelectionSet, v *model.FeedEventCommentEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._FeedEventCommentEdge(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOFeedEventCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventCommentsConnection(ctx context.Context, sel ast.SelectionSet, v *model.FeedEventCommentsConnection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._FeedEventCommentsConnection(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOFeedEventData2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventData(ctx context.Context, sel ast.SelectionSet, v model.FeedEventData) graphql.Marshaler {
@@ -76855,61 +76162,6 @@ func (ec *executionContext) marshalOFeedEventData2ᚕgithubᚗcomᚋmikeydubᚋg
 	}
 
 	return ret
-}
-
-func (ec *executionContext) marshalOFeedEventInteractionsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventInteractionsConnection(ctx context.Context, sel ast.SelectionSet, v *model.FeedEventInteractionsConnection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._FeedEventInteractionsConnection(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOFeedEventInteractionsEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventInteractionsEdge(ctx context.Context, sel ast.SelectionSet, v []*model.FeedEventInteractionsEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOFeedEventInteractionsEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventInteractionsEdge(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOFeedEventInteractionsEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventInteractionsEdge(ctx context.Context, sel ast.SelectionSet, v *model.FeedEventInteractionsEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._FeedEventInteractionsEdge(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOFeedEventOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐFeedEventOrError(ctx context.Context, sel ast.SelectionSet, v model.FeedEventOrError) graphql.Marshaler {
@@ -77340,6 +76592,61 @@ func (ec *executionContext) marshalOInteraction2githubᚗcomᚋmikeydubᚋgoᚑg
 	return ec._Interaction(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOInteractionsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteractionsConnection(ctx context.Context, sel ast.SelectionSet, v *model.InteractionsConnection) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._InteractionsConnection(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOInteractionsEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteractionsEdge(ctx context.Context, sel ast.SelectionSet, v []*model.InteractionsEdge) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOInteractionsEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteractionsEdge(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOInteractionsEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐInteractionsEdge(ctx context.Context, sel ast.SelectionSet, v *model.InteractionsEdge) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._InteractionsEdge(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOLensSocialAccount2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐLensSocialAccount(ctx context.Context, sel ast.SelectionSet, v *model.LensSocialAccount) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -77429,6 +76736,54 @@ func (ec *executionContext) marshalOMembershipTier2ᚖgithubᚗcomᚋmikeydubᚋ
 		return graphql.Null
 	}
 	return ec._MembershipTier(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOMention2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMention(ctx context.Context, sel ast.SelectionSet, v []*model.Mention) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalOMention2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMention(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	return ret
+}
+
+func (ec *executionContext) marshalOMention2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMention(ctx context.Context, sel ast.SelectionSet, v *model.Mention) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Mention(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOMentionInput2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐMentionInputᚄ(ctx context.Context, v interface{}) ([]*model.MentionInput, error) {
@@ -77777,116 +77132,6 @@ func (ec *executionContext) marshalOPost2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalle
 	return ec._Post(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOPostAdmireEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostAdmireEdge(ctx context.Context, sel ast.SelectionSet, v []*model.PostAdmireEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOPostAdmireEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostAdmireEdge(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOPostAdmireEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostAdmireEdge(ctx context.Context, sel ast.SelectionSet, v *model.PostAdmireEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._PostAdmireEdge(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOPostAdmiresConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostAdmiresConnection(ctx context.Context, sel ast.SelectionSet, v *model.PostAdmiresConnection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._PostAdmiresConnection(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOPostCommentEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostCommentEdge(ctx context.Context, sel ast.SelectionSet, v []*model.PostCommentEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOPostCommentEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostCommentEdge(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOPostCommentEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostCommentEdge(ctx context.Context, sel ast.SelectionSet, v *model.PostCommentEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._PostCommentEdge(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOPostCommentsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostCommentsConnection(ctx context.Context, sel ast.SelectionSet, v *model.PostCommentsConnection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._PostCommentsConnection(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalOPostEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostEdge(ctx context.Context, sel ast.SelectionSet, v []*model.PostEdge) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -77933,61 +77178,6 @@ func (ec *executionContext) marshalOPostEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑg
 		return graphql.Null
 	}
 	return ec._PostEdge(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOPostInteractionsConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostInteractionsConnection(ctx context.Context, sel ast.SelectionSet, v *model.PostInteractionsConnection) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._PostInteractionsConnection(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOPostInteractionsEdge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostInteractionsEdge(ctx context.Context, sel ast.SelectionSet, v []*model.PostInteractionsEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalOPostInteractionsEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostInteractionsEdge(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	return ret
-}
-
-func (ec *executionContext) marshalOPostInteractionsEdge2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostInteractionsEdge(ctx context.Context, sel ast.SelectionSet, v *model.PostInteractionsEdge) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._PostInteractionsEdge(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOPostOrError2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPostOrError(ctx context.Context, sel ast.SelectionSet, v model.PostOrError) graphql.Marshaler {

--- a/graphql/generated_test.go
+++ b/graphql/generated_test.go
@@ -119,6 +119,17 @@ func (v *CollectionTokenSettingsInput) GetRenderLive() bool { return v.RenderLiv
 // GetHighDefinition returns CollectionTokenSettingsInput.HighDefinition, and is useful for accessing the field via an interface.
 func (v *CollectionTokenSettingsInput) GetHighDefinition() bool { return v.HighDefinition }
 
+type CompleteIndexInput struct {
+	Index  int `json:"index"`
+	Length int `json:"length"`
+}
+
+// GetIndex returns CompleteIndexInput.Index, and is useful for accessing the field via an interface.
+func (v *CompleteIndexInput) GetIndex() int { return v.Index }
+
+// GetLength returns CompleteIndexInput.Length, and is useful for accessing the field via an interface.
+func (v *CompleteIndexInput) GetLength() int { return v.Length }
+
 type CreateCollectionInGalleryInput struct {
 	Name           string                         `json:"name"`
 	CollectorsNote string                         `json:"collectorsNote"`
@@ -299,9 +310,13 @@ type MagicLinkAuth struct {
 func (v *MagicLinkAuth) GetToken() string { return v.Token }
 
 type MentionInput struct {
-	UserId      *persist.DBID `json:"userId"`
-	CommunityId *persist.DBID `json:"communityId"`
+	Index       *CompleteIndexInput `json:"index"`
+	UserId      *persist.DBID       `json:"userId"`
+	CommunityId *persist.DBID       `json:"communityId"`
 }
+
+// GetIndex returns MentionInput.Index, and is useful for accessing the field via an interface.
+func (v *MentionInput) GetIndex() *CompleteIndexInput { return v.Index }
 
 // GetUserId returns MentionInput.UserId, and is useful for accessing the field via an interface.
 func (v *MentionInput) GetUserId() *persist.DBID { return v.UserId }

--- a/graphql/model/models.go
+++ b/graphql/model/models.go
@@ -62,6 +62,12 @@ type HelperCommentData struct {
 	PostID      *persist.DBID
 	FeedEventID *persist.DBID
 	ReplyToID   *persist.DBID
+	Mentions    persist.Mentions
+}
+
+type HelperMentionData struct {
+	UserID      *persist.DBID
+	CommunityID *persist.DBID
 }
 
 type HelperAdmireData struct {
@@ -178,6 +184,7 @@ type HelperEnsProfileImageData struct {
 type HelperPostData struct {
 	TokenIDs persist.DBIDList
 	AuthorID persist.DBID
+	Mentions persist.Mentions
 }
 
 type ErrInvalidIDFormat struct {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -63,10 +63,6 @@ type CommentSource interface {
 	IsCommentSource()
 }
 
-type CommentsConnection interface {
-	IsCommentsConnection()
-}
-
 type CommunityByAddressOrError interface {
 	IsCommunityByAddressOrError()
 }
@@ -473,6 +469,11 @@ type Admire struct {
 func (Admire) IsNode()        {}
 func (Admire) IsInteraction() {}
 
+type AdmireEdge struct {
+	Node   *Admire `json:"node"`
+	Cursor *string `json:"cursor"`
+}
+
 type AdmireFeedEventPayload struct {
 	Viewer    *Viewer    `json:"viewer"`
 	Admire    *Admire    `json:"admire"`
@@ -488,6 +489,11 @@ type AdmirePostPayload struct {
 }
 
 func (AdmirePostPayload) IsAdmirePostPayloadOrError() {}
+
+type AdmiresConnection struct {
+	Edges    []*AdmireEdge `json:"edges"`
+	PageInfo *PageInfo     `json:"pageInfo"`
+}
 
 type AudioMedia struct {
 	PreviewURLs      *PreviewURLSet   `json:"previewURLs"`
@@ -648,20 +654,26 @@ func (CollectorsNoteAddedToTokenFeedEventData) IsFeedEventData() {}
 
 type Comment struct {
 	HelperCommentData
-	Dbid         persist.DBID       `json:"dbid"`
-	CreationTime *time.Time         `json:"creationTime"`
-	LastUpdated  *time.Time         `json:"lastUpdated"`
-	ReplyTo      *Comment           `json:"replyTo"`
-	Commenter    *GalleryUser       `json:"commenter"`
-	Comment      *string            `json:"comment"`
-	Replies      CommentsConnection `json:"replies"`
-	Source       CommentSource      `json:"source"`
-	Deleted      *bool              `json:"deleted"`
+	Dbid         persist.DBID        `json:"dbid"`
+	CreationTime *time.Time          `json:"creationTime"`
+	LastUpdated  *time.Time          `json:"lastUpdated"`
+	ReplyTo      *Comment            `json:"replyTo"`
+	Commenter    *GalleryUser        `json:"commenter"`
+	Comment      *string             `json:"comment"`
+	Mentions     []*Mention          `json:"mentions"`
+	Replies      *CommentsConnection `json:"replies"`
+	Source       CommentSource       `json:"source"`
+	Deleted      *bool               `json:"deleted"`
 }
 
 func (Comment) IsNode()          {}
 func (Comment) IsInteraction()   {}
 func (Comment) IsMentionSource() {}
+
+type CommentEdge struct {
+	Node   *Comment `json:"node"`
+	Cursor *string  `json:"cursor"`
+}
 
 type CommentOnFeedEventPayload struct {
 	Viewer         *Viewer    `json:"viewer"`
@@ -680,6 +692,11 @@ type CommentOnPostPayload struct {
 }
 
 func (CommentOnPostPayload) IsCommentOnPostPayloadOrError() {}
+
+type CommentsConnection struct {
+	Edges    []*CommentEdge `json:"edges"`
+	PageInfo *PageInfo      `json:"pageInfo"`
+}
 
 type CommunitiesConnection struct {
 	Edges    []*CommunityEdge `json:"edges"`
@@ -722,6 +739,16 @@ type CommunityLink struct {
 
 type CommunitySearchResult struct {
 	Community *Community `json:"community"`
+}
+
+type CompleteIndex struct {
+	Index  int `json:"index"`
+	Length int `json:"length"`
+}
+
+type CompleteIndexInput struct {
+	Index  int `json:"index"`
+	Length int `json:"length"`
 }
 
 type ConnectSocialAccountPayload struct {
@@ -1229,14 +1256,14 @@ type FeedEdge struct {
 }
 
 type FeedEvent struct {
-	Dbid                  persist.DBID                     `json:"dbid"`
-	EventData             FeedEventData                    `json:"eventData"`
-	Admires               *FeedEventAdmiresConnection      `json:"admires"`
-	Comments              *FeedEventCommentsConnection     `json:"comments"`
-	Caption               *string                          `json:"caption"`
-	Interactions          *FeedEventInteractionsConnection `json:"interactions"`
-	ViewerAdmire          *Admire                          `json:"viewerAdmire"`
-	HasViewerAdmiredEvent *bool                            `json:"hasViewerAdmiredEvent"`
+	Dbid                  persist.DBID            `json:"dbid"`
+	EventData             FeedEventData           `json:"eventData"`
+	Admires               *AdmiresConnection      `json:"admires"`
+	Comments              *CommentsConnection     `json:"comments"`
+	Caption               *string                 `json:"caption"`
+	Interactions          *InteractionsConnection `json:"interactions"`
+	ViewerAdmire          *Admire                 `json:"viewerAdmire"`
+	HasViewerAdmiredEvent *bool                   `json:"hasViewerAdmiredEvent"`
 }
 
 func (FeedEvent) IsAdmireSource()         {}
@@ -1245,41 +1272,6 @@ func (FeedEvent) IsNode()                 {}
 func (FeedEvent) IsFeedEventOrError()     {}
 func (FeedEvent) IsFeedEventByIDOrError() {}
 func (FeedEvent) IsEntity()               {}
-
-type FeedEventAdmireEdge struct {
-	Node   *Admire    `json:"node"`
-	Event  *FeedEvent `json:"event"`
-	Cursor *string    `json:"cursor"`
-}
-
-type FeedEventAdmiresConnection struct {
-	Edges    []*FeedEventAdmireEdge `json:"edges"`
-	PageInfo *PageInfo              `json:"pageInfo"`
-}
-
-type FeedEventCommentEdge struct {
-	Node   *Comment   `json:"node"`
-	Event  *FeedEvent `json:"event"`
-	Cursor *string    `json:"cursor"`
-}
-
-type FeedEventCommentsConnection struct {
-	Edges    []*FeedEventCommentEdge `json:"edges"`
-	PageInfo *PageInfo               `json:"pageInfo"`
-}
-
-func (FeedEventCommentsConnection) IsCommentsConnection() {}
-
-type FeedEventInteractionsConnection struct {
-	Edges    []*FeedEventInteractionsEdge `json:"edges"`
-	PageInfo *PageInfo                    `json:"pageInfo"`
-}
-
-type FeedEventInteractionsEdge struct {
-	Node   Interaction `json:"node"`
-	Event  *FeedEvent  `json:"event"`
-	Cursor *string     `json:"cursor"`
-}
 
 type FollowAllSocialConnectionsPayload struct {
 	Viewer *Viewer `json:"viewer"`
@@ -1456,6 +1448,16 @@ type ImageMedia struct {
 func (ImageMedia) IsMediaSubtype() {}
 func (ImageMedia) IsMedia()        {}
 
+type InteractionsConnection struct {
+	Edges    []*InteractionsEdge `json:"edges"`
+	PageInfo *PageInfo           `json:"pageInfo"`
+}
+
+type InteractionsEdge struct {
+	Node   Interaction `json:"node"`
+	Cursor *string     `json:"cursor"`
+}
+
 type InvalidMedia struct {
 	PreviewURLs      *PreviewURLSet   `json:"previewURLs"`
 	MediaURL         *string          `json:"mediaURL"`
@@ -1523,9 +1525,17 @@ type MembershipTier struct {
 
 func (MembershipTier) IsNode() {}
 
+type Mention struct {
+	HelperMentionData
+	User      *GalleryUser   `json:"user"`
+	Community *Community     `json:"community"`
+	Index     *CompleteIndex `json:"index"`
+}
+
 type MentionInput struct {
-	UserID      *persist.DBID `json:"userId"`
-	CommunityID *persist.DBID `json:"communityId"`
+	Index       *CompleteIndexInput `json:"index"`
+	UserID      *persist.DBID       `json:"userId"`
+	CommunityID *persist.DBID       `json:"communityId"`
 }
 
 type MerchDiscountCode struct {
@@ -1643,15 +1653,16 @@ func (PDFMedia) IsMedia()        {}
 
 type Post struct {
 	HelperPostData
-	Dbid         persist.DBID                `json:"dbid"`
-	Author       *GalleryUser                `json:"author"`
-	CreationTime *time.Time                  `json:"creationTime"`
-	Tokens       []*Token                    `json:"tokens"`
-	Caption      *string                     `json:"caption"`
-	Admires      *PostAdmiresConnection      `json:"admires"`
-	Comments     *PostCommentsConnection     `json:"comments"`
-	Interactions *PostInteractionsConnection `json:"interactions"`
-	ViewerAdmire *Admire                     `json:"viewerAdmire"`
+	Dbid         persist.DBID            `json:"dbid"`
+	Author       *GalleryUser            `json:"author"`
+	CreationTime *time.Time              `json:"creationTime"`
+	Tokens       []*Token                `json:"tokens"`
+	Caption      *string                 `json:"caption"`
+	Mentions     []*Mention              `json:"mentions"`
+	Admires      *AdmiresConnection      `json:"admires"`
+	Comments     *CommentsConnection     `json:"comments"`
+	Interactions *InteractionsConnection `json:"interactions"`
+	ViewerAdmire *Admire                 `json:"viewerAdmire"`
 }
 
 func (Post) IsAdmireSource()     {}
@@ -1662,44 +1673,9 @@ func (Post) IsFeedEventOrError() {}
 func (Post) IsMentionSource()    {}
 func (Post) IsEntity()           {}
 
-type PostAdmireEdge struct {
-	Node   *Admire `json:"node"`
-	Cursor *string `json:"cursor"`
-	Post   *Post   `json:"post"`
-}
-
-type PostAdmiresConnection struct {
-	Edges    []*PostAdmireEdge `json:"edges"`
-	PageInfo *PageInfo         `json:"pageInfo"`
-}
-
-type PostCommentEdge struct {
-	Node   *Comment `json:"node"`
-	Cursor *string  `json:"cursor"`
-	Post   *Post    `json:"post"`
-}
-
-type PostCommentsConnection struct {
-	Edges    []*PostCommentEdge `json:"edges"`
-	PageInfo *PageInfo          `json:"pageInfo"`
-}
-
-func (PostCommentsConnection) IsCommentsConnection() {}
-
 type PostEdge struct {
 	Node   PostOrError `json:"node"`
 	Cursor *string     `json:"cursor"`
-}
-
-type PostInteractionsConnection struct {
-	Edges    []*PostInteractionsEdge `json:"edges"`
-	PageInfo *PageInfo               `json:"pageInfo"`
-}
-
-type PostInteractionsEdge struct {
-	Node   Interaction `json:"node"`
-	Cursor *string     `json:"cursor"`
-	Post   *Post       `json:"post"`
 }
 
 type PostTokensInput struct {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -166,6 +166,10 @@ type MediaSubtype interface {
 	IsMediaSubtype()
 }
 
+type MentionEntity interface {
+	IsMentionEntity()
+}
+
 type MentionSource interface {
 	IsMentionSource()
 }
@@ -727,6 +731,7 @@ type Community struct {
 
 func (Community) IsNode()                      {}
 func (Community) IsCommunityByAddressOrError() {}
+func (Community) IsMentionEntity()             {}
 
 type CommunityEdge struct {
 	Node   *Community `json:"node"`
@@ -1384,6 +1389,7 @@ func (GalleryUser) IsGalleryUserOrAddress()              {}
 func (GalleryUser) IsUserByUsernameOrError()             {}
 func (GalleryUser) IsUserByIDOrError()                   {}
 func (GalleryUser) IsUserByAddressOrError()              {}
+func (GalleryUser) IsMentionEntity()                     {}
 func (GalleryUser) IsAddRolesToUserPayloadOrError()      {}
 func (GalleryUser) IsRevokeRolesFromUserPayloadOrError() {}
 
@@ -1527,9 +1533,8 @@ func (MembershipTier) IsNode() {}
 
 type Mention struct {
 	HelperMentionData
-	User      *GalleryUser   `json:"user"`
-	Community *Community     `json:"community"`
-	Index     *CompleteIndex `json:"index"`
+	Entity MentionEntity  `json:"entity"`
+	Index  *CompleteIndex `json:"index"`
 }
 
 type MentionInput struct {

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -68,11 +68,6 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
-	"CommentsConnection": func(object interface{}) (interface{}, bool) {
-		obj, ok := object.(CommentsConnection)
-		return obj, ok
-	},
-
 	"CommunityByAddressOrError": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(CommunityByAddressOrError)
 		return obj, ok

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -193,6 +193,11 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
+	"MentionEntity": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(MentionEntity)
+		return obj, ok
+	},
+
 	"MentionSource": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(MentionSource)
 		return obj, ok

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -688,20 +688,15 @@ func (r *galleryUserResolver) IsMemberOfCommunity(ctx context.Context, obj *mode
 	return publicapi.For(ctx).User.IsMemberOfCommunity(ctx, obj.Dbid, communityID)
 }
 
-// User is the resolver for the user field.
-func (r *mentionResolver) User(ctx context.Context, obj *model.Mention) (*model.GalleryUser, error) {
-	if obj.HelperMentionData.UserID == nil {
-		return nil, nil
+// Entity is the resolver for the entity field.
+func (r *mentionResolver) Entity(ctx context.Context, obj *model.Mention) (model.MentionEntity, error) {
+	if obj.CommunityID != nil {
+		return resolveCommunityByID(ctx, *obj.CommunityID)
 	}
-	return resolveGalleryUserByUserID(ctx, *obj.HelperMentionData.UserID)
-}
-
-// Community is the resolver for the community field.
-func (r *mentionResolver) Community(ctx context.Context, obj *model.Mention) (*model.Community, error) {
-	if obj.HelperMentionData.CommunityID == nil {
-		return nil, nil
+	if obj.UserID != nil {
+		return resolveGalleryUserByUserID(ctx, *obj.UserID)
 	}
-	return resolveCommunityByID(ctx, *obj.HelperMentionData.CommunityID)
+	return nil, fmt.Errorf("mention has no entity")
 }
 
 // AddUserWallet is the resolver for the addUserWallet field.

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -659,7 +659,7 @@ func postsToConnection(ctx context.Context, posts []db.Post, contractID persist.
 		cval, _ := p.Caption.Value()
 
 		var caption *string
-		if caption != nil {
+		if cval != nil {
 			caption = util.ToPointer(cval.(string))
 		}
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -813,12 +813,24 @@ type Comment implements Node @goEmbedHelper {
   replyTo: Comment @goField(forceResolver: true)
   commenter: GalleryUser @goField(forceResolver: true)
   comment: String
+  mentions: [Mention] @goField(forceResolver: true)
   replies(before: String, after: String, first: Int, last: Int): CommentsConnection
     @goField(forceResolver: true)
   source: CommentSource @goField(forceResolver: true)
 
   # deleted is included because we want to still return deleted comments to show on the frontend but render them differently
   deleted: Boolean
+}
+
+type Mention @goEmbedHelper {
+  user: GalleryUser @goField(forceResolver: true)
+  community: Community @goField(forceResolver: true)
+  index: CompleteIndex
+}
+
+type CompleteIndex {
+  index: Int!
+  length: Int!
 }
 
 # Actions a user can take on a resource
@@ -836,73 +848,35 @@ type FollowInfo {
   followedBack: Boolean
 }
 
-type FeedEventAdmireEdge {
-  node: Admire
-  event: FeedEvent
-  cursor: String
-}
-
-type FeedEventAdmiresConnection {
-  edges: [FeedEventAdmireEdge]
-  pageInfo: PageInfo!
-}
-
-union CommentsConnection = FeedEventCommentsConnection | PostCommentsConnection
-
-type FeedEventCommentEdge {
-  node: Comment
-  event: FeedEvent
-  cursor: String
-}
-
-type FeedEventCommentsConnection {
-  edges: [FeedEventCommentEdge]
-  pageInfo: PageInfo!
-}
-
-type PostAdmireEdge {
+type AdmireEdge {
   node: Admire
   cursor: String
-  post: Post
 }
 
-type PostCommentEdge {
-  node: Comment
-  cursor: String
-  post: Post
-}
-
-type PostCommentsConnection {
-  edges: [PostCommentEdge]
+type AdmiresConnection {
+  edges: [AdmireEdge]
   pageInfo: PageInfo!
 }
 
-type PostAdmiresConnection {
-  edges: [PostAdmireEdge]
+type CommentEdge {
+  node: Comment
+  cursor: String
+}
+
+type CommentsConnection {
+  edges: [CommentEdge]
   pageInfo: PageInfo!
 }
 
 union Interaction = Admire | Comment
 
-type FeedEventInteractionsEdge {
-  node: Interaction
-  event: FeedEvent
-  cursor: String
-}
-
-type FeedEventInteractionsConnection {
-  edges: [FeedEventInteractionsEdge]
-  pageInfo: PageInfo!
-}
-
-type PostInteractionsEdge {
+type InteractionsEdge {
   node: Interaction
   cursor: String
-  post: Post
 }
 
-type PostInteractionsConnection {
-  edges: [PostInteractionsEdge]
+type InteractionsConnection {
+  edges: [InteractionsEdge]
   pageInfo: PageInfo!
 }
 
@@ -929,18 +903,14 @@ type FeedEvent implements Node @key(fields: "dbid") {
   dbid: DBID!
 
   eventData: FeedEventData @goField(forceResolver: true)
-  admires(before: String, after: String, first: Int, last: Int): FeedEventAdmiresConnection
+  admires(before: String, after: String, first: Int, last: Int): AdmiresConnection
     @goField(forceResolver: true)
-  comments(before: String, after: String, first: Int, last: Int): FeedEventCommentsConnection
+  comments(before: String, after: String, first: Int, last: Int): CommentsConnection
     @goField(forceResolver: true)
   caption: String
 
-  interactions(
-    before: String
-    after: String
-    first: Int
-    last: Int
-  ): FeedEventInteractionsConnection @goField(forceResolver: true)
+  interactions(before: String, after: String, first: Int, last: Int): InteractionsConnection
+    @goField(forceResolver: true)
 
   viewerAdmire: Admire @goField(forceResolver: true)
 
@@ -959,12 +929,14 @@ type Post implements Node @key(fields: "dbid") @goEmbedHelper {
   tokens: [Token] @goField(forceResolver: true)
 
   caption: String
-  admires(before: String, after: String, first: Int, last: Int): PostAdmiresConnection
+  mentions: [Mention] @goField(forceResolver: true)
+
+  admires(before: String, after: String, first: Int, last: Int): AdmiresConnection
     @goField(forceResolver: true)
-  comments(before: String, after: String, first: Int, last: Int): PostCommentsConnection
+  comments(before: String, after: String, first: Int, last: Int): CommentsConnection
     @goField(forceResolver: true)
 
-  interactions(before: String, after: String, first: Int, last: Int): PostInteractionsConnection
+  interactions(before: String, after: String, first: Int, last: Int): InteractionsConnection
     @goField(forceResolver: true)
 
   viewerAdmire: Admire @goField(forceResolver: true)
@@ -2482,8 +2454,14 @@ type DeletePostPayload {
 union DeletePostPayloadOrError = DeletePostPayload | ErrInvalidInput | ErrNotAuthorized
 
 input MentionInput {
+  index: CompleteIndexInput
   userId: DBID
   communityId: DBID
+}
+
+input CompleteIndexInput {
+  index: Int!
+  length: Int!
 }
 
 type Mutation {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -822,9 +822,10 @@ type Comment implements Node @goEmbedHelper {
   deleted: Boolean
 }
 
+union MentionEntity = GalleryUser | Community
+
 type Mention @goEmbedHelper {
-  user: GalleryUser @goField(forceResolver: true)
-  community: Community @goField(forceResolver: true)
+  entity: MentionEntity @goField(forceResolver: true)
   index: CompleteIndex
 }
 

--- a/indexer/contracts.go
+++ b/indexer/contracts.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/multichain/alchemy"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/mikeydub/go-gallery/util"
@@ -93,8 +95,16 @@ func updateContractMetadata(contractsRepo persist.ContractRepository, ethClient 
 
 func updateMetadataForContract(c context.Context, input UpdateContractMetadataInput, ethClient *ethclient.Client, httpClient *http.Client, contractsRepo persist.ContractRepository) error {
 	newMetadata, err := rpc.GetTokenContractMetadata(c, input.Address, ethClient)
-	if err != nil {
-		return err
+	if err != nil || newMetadata.Name == "" {
+		alchMetadata, err := getAlchemyContractMetadata(c, httpClient, input.Address)
+		if err != nil {
+			return err
+		}
+		if newMetadata == nil {
+			newMetadata = new(rpc.TokenContractMetadata)
+		}
+		newMetadata.Name = util.FirstNonEmptyString(alchMetadata.Name, alchMetadata.OpenseaCollection.CollectionName)
+		newMetadata.Symbol = util.FirstNonEmptyString(alchMetadata.Symbol, newMetadata.Symbol)
 	}
 
 	latestBlock, err := ethClient.BlockNumber(c)
@@ -121,6 +131,32 @@ func updateMetadataForContract(c context.Context, input UpdateContractMetadataIn
 	// TODO creator address
 
 	return contractsRepo.UpdateByAddress(c, input.Address, up)
+}
+
+func getAlchemyContractMetadata(ctx context.Context, httpClient *http.Client, addr persist.EthereumAddress) (alchemy.ContractMetadata, error) {
+
+	u := fmt.Sprintf("%s/getContractMetadata", env.GetString("ALCHEMY_API_URL"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return alchemy.ContractMetadata{}, err
+	}
+
+	q := req.URL.Query()
+	q.Add("contractAddress", string(addr))
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return alchemy.ContractMetadata{}, err
+	}
+
+	var metadata alchemy.GetContractMetadataResponse
+	err = json.NewDecoder(resp.Body).Decode(&metadata)
+	if err != nil {
+		return alchemy.ContractMetadata{}, err
+	}
+
+	return metadata.ContractMetadata, nil
 }
 
 func GetContractOwner(ctx context.Context, address persist.EthereumAddress, ethClient *ethclient.Client, httpClient *http.Client) (persist.EthereumAddress, persist.ContractOwnerMethod, error) {

--- a/publicapi/contract.go
+++ b/publicapi/contract.go
@@ -298,8 +298,8 @@ func (api ContractAPI) GetCommunityPostsByContractID(ctx context.Context, contra
 		}
 
 		results := make([]interface{}, len(posts))
-		for i, owner := range posts {
-			results[i] = owner
+		for i, post := range posts {
+			results[i] = post
 		}
 
 		return results, nil
@@ -314,7 +314,7 @@ func (api ContractAPI) GetCommunityPostsByContractID(ctx context.Context, contra
 		if user, ok := i.(db.Post); ok {
 			return user.CreatedAt, user.ID, nil
 		}
-		return time.Time{}, "", fmt.Errorf("interface{} is not a token")
+		return time.Time{}, "", fmt.Errorf("interface{} is not a post")
 	}
 
 	paginator := timeIDPaginator{

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -132,12 +132,18 @@ func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, ment
 		return c.ID, nil
 	})
 
+	dbMentions, err := mentionInputsToMentions(mentions)
+	if err != nil {
+		return "", err
+	}
+
 	id, err := api.queries.InsertPost(ctx, db.InsertPostParams{
 		ID:          persist.GenerateID(),
 		TokenIds:    tokenIDs,
 		ContractIds: contractIDs,
 		ActorID:     actorID,
 		Caption:     cap,
+		Mentions:    dbMentions,
 	})
 	if err != nil {
 		return "", err

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -976,8 +976,8 @@ func mentionInputsToMentions(ms []*model.MentionInput) (map[persist.DBID]persist
 		mention := persist.Mention{}
 		if m.Index != nil {
 			mention.Index = &persist.CompleteIndex{
-				Index:  m.Index.Start,
-				Length: m.Index.End,
+				Index:  m.Index.Index,
+				Length: m.Index.Length,
 			}
 		}
 		if m.CommunityID != nil {

--- a/server/inject.go
+++ b/server/inject.go
@@ -125,9 +125,10 @@ func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.
 		wire.Bind(new(multichain.Verifier), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(fallbackProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(alchemyProvider)),
-		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(indexerProvider)),
+		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(fallbackProvider)),
 		wire.Bind(new(multichain.ContractRefresher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(indexerProvider)),
+		wire.Bind(new(multichain.ContractsOwnerFetcher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.OpenSeaChildContractFetcher), util.ToPointer(openseaProvider)),
 		ethRequirements,
@@ -144,10 +145,11 @@ func ethRequirements(
 	cf multichain.ContractsFetcher,
 	cr multichain.ContractRefresher,
 	tmf multichain.TokenMetadataFetcher,
+	tcof multichain.ContractsOwnerFetcher,
 	tdf multichain.TokenDescriptorsFetcher,
 	osccf multichain.OpenSeaChildContractFetcher,
 ) ethProviderList {
-	return ethProviderList{nr, v, tof, toc, cf, cr, tmf, tdf, osccf}
+	return ethProviderList{nr, v, tof, toc, cf, cr, tmf, tcof, tdf, osccf}
 }
 
 // tezosProviderSet is a wire injector that creates the set of Tezos providers
@@ -302,6 +304,7 @@ func zoraProvidersConfig(zoraProvider *zora.Provider) zoraProviderList {
 		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(zoraProvider)),
+		wire.Bind(new(multichain.ContractsOwnerFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(zoraProvider)),
 		zoraRequirements,
 	)
@@ -313,9 +316,10 @@ func zoraRequirements(
 	nr multichain.ContractsFetcher,
 	tof multichain.TokensOwnerFetcher,
 	toc multichain.TokensContractFetcher,
+	tcof multichain.ContractsOwnerFetcher,
 	tmf multichain.TokenMetadataFetcher,
 ) zoraProviderList {
-	return zoraProviderList{nr, tof, toc, tmf}
+	return zoraProviderList{nr, tof, toc, tcof, tmf}
 }
 
 func baseProviderSet(*http.Client) baseProviderList {

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -93,7 +93,7 @@ var (
 
 // ethProvidersConfig is a wire injector that binds multichain interfaces to their concrete Ethereum implementations
 func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.Provider, fallbackProvider multichain.SyncFailureFallbackProvider, alchemyProvider *alchemy.Provider) ethProviderList {
-	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, alchemyProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider, openseaProvider)
+	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, alchemyProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider, openseaProvider)
 	return serverEthProviderList
 }
 
@@ -176,7 +176,7 @@ func zoraProviderSet(serverEnvInit envInit, client *http.Client) zoraProviderLis
 
 // zoraProvidersConfig is a wire injector that binds multichain interfaces to their concrete zora implementations
 func zoraProvidersConfig(zoraProvider *zora.Provider) zoraProviderList {
-	serverZoraProviderList := zoraRequirements(zoraProvider, zoraProvider, zoraProvider, zoraProvider)
+	serverZoraProviderList := zoraRequirements(zoraProvider, zoraProvider, zoraProvider, zoraProvider, zoraProvider)
 	return serverZoraProviderList
 }
 
@@ -307,10 +307,11 @@ func ethRequirements(
 	cf multichain.ContractsFetcher,
 	cr multichain.ContractRefresher,
 	tmf multichain.TokenMetadataFetcher,
+	tcof multichain.ContractsOwnerFetcher,
 	tdf multichain.TokenDescriptorsFetcher,
 	osccf multichain.OpenSeaChildContractFetcher,
 ) ethProviderList {
-	return ethProviderList{nr, v, tof, toc, cf, cr, tmf, tdf, osccf}
+	return ethProviderList{nr, v, tof, toc, cf, cr, tmf, tcof, tdf, osccf}
 }
 
 // tezosRequirements is the set of provider interfaces required for Tezos
@@ -357,9 +358,10 @@ func zoraRequirements(
 	nr multichain.ContractsFetcher,
 	tof multichain.TokensOwnerFetcher,
 	toc multichain.TokensContractFetcher,
+	tcof multichain.ContractsOwnerFetcher,
 	tmf multichain.TokenMetadataFetcher,
 ) zoraProviderList {
-	return zoraProviderList{nr, tof, toc, tmf}
+	return zoraProviderList{nr, tof, toc, tcof, tmf}
 }
 
 // zoraRequirements is the set of provider interfaces required for zora

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -103,6 +103,7 @@ func (d *Provider) GetTokenDescriptorsByTokenIdentifiers(ctx context.Context, ti
 
 // GetContractByAddress retrieves an ethereum contract by address
 func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
+	logger.For(ctx).Warn("ETH")
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/contracts/get?address=%s", d.indexerBaseURL, addr), nil)
 	if err != nil {
 		return multichain.ChainAgnosticContract{}, err

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -36,6 +36,12 @@ const staleCommunityTime = time.Minute * 30
 
 const maxCommunitySize = 10_000
 
+var contractNameBlacklist = map[string]bool{
+	"unidentified contract": true,
+	"unknown contract":      true,
+	"unknown":               true,
+}
+
 // SendTokens is called to process a user's batch of tokens
 type SendTokens func(context.Context, task.TokenProcessingUserMessage) error
 
@@ -171,6 +177,9 @@ type TokensContractFetcher interface {
 
 type ContractsFetcher interface {
 	GetContractByAddress(ctx context.Context, contract persist.Address) (ChainAgnosticContract, error)
+}
+
+type ContractsOwnerFetcher interface {
 	GetContractsByOwnerAddress(ctx context.Context, owner persist.Address) ([]ChainAgnosticContract, error)
 }
 
@@ -185,6 +194,7 @@ type OpenSeaChildContractFetcher interface {
 
 // ContractRefresher supports refreshes of a contract
 type ContractRefresher interface {
+	ContractsFetcher
 	RefreshContract(context.Context, persist.Address) error
 }
 
@@ -1218,7 +1228,7 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 			}
 
 			// contract
-			if contract.Name != "" && finalContractDescriptors.Name == "" {
+			if (contract.Name != "" && !contractNameBlacklist[strings.ToLower(contract.Name)]) && finalContractDescriptors.Name == "" {
 				finalContractDescriptors.Name = contract.Name
 			}
 			if contract.Description != "" && finalContractDescriptors.Description == "" {
@@ -1229,6 +1239,9 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 			}
 			if contract.CreatorAddress != "" && finalContractDescriptors.CreatorAddress == "" {
 				finalContractDescriptors.CreatorAddress = contract.CreatorAddress
+			}
+			if contract.ProfileImageURL != "" && finalContractDescriptors.ProfileImageURL == "" {
+				finalContractDescriptors.ProfileImageURL = contract.ProfileImageURL
 			}
 		} else {
 			logger.For(ctx).Infof("token %s-%s-%d not found for refresh (err: %s)", ti.TokenID, ti.ContractAddress, ti.Chain, err)
@@ -1246,11 +1259,13 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 	}
 
 	if err := p.Repos.ContractRepository.UpsertByAddress(ctx, ti.ContractAddress, ti.Chain, persist.ContractGallery{
-		Chain:        ti.Chain,
-		Address:      persist.Address(ti.Chain.NormalizeAddress(ti.ContractAddress)),
-		Symbol:       persist.NullString(finalContractDescriptors.Symbol),
-		Name:         persist.NullString(finalContractDescriptors.Name),
-		OwnerAddress: finalContractDescriptors.CreatorAddress,
+		Chain:           ti.Chain,
+		Address:         persist.Address(ti.Chain.NormalizeAddress(ti.ContractAddress)),
+		Symbol:          persist.NullString(finalContractDescriptors.Symbol),
+		Name:            persist.NullString(finalContractDescriptors.Name),
+		Description:     persist.NullString(finalContractDescriptors.Description),
+		ProfileImageURL: persist.NullString(finalContractDescriptors.ProfileImageURL),
+		OwnerAddress:    finalContractDescriptors.CreatorAddress,
 	}); err != nil {
 		return err
 	}
@@ -1260,12 +1275,23 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 // RefreshContract refreshes a contract on the given chain using the chain provider for that chain
 func (p *Provider) RefreshContract(ctx context.Context, ci persist.ContractIdentifiers) error {
 	contractRefreshers := matchingProvidersForChain[ContractRefresher](p.Chains, ci.Chain)
+	contractFetchers := matchingProvidersForChain[ContractsFetcher](p.Chains, ci.Chain)
+	var contracts []chainContracts
 	for _, refresher := range contractRefreshers {
 		if err := refresher.RefreshContract(ctx, ci.ContractAddress); err != nil {
 			return err
 		}
 	}
-	return nil
+	for i, fetcher := range contractFetchers {
+		c, err := fetcher.GetContractByAddress(ctx, ci.ContractAddress)
+		if err != nil {
+			return err
+		}
+		contracts = append(contracts, chainContracts{priority: i, chain: ci.Chain, contracts: []ChainAgnosticContract{c}})
+	}
+
+	_, err := p.processContracts(ctx, contracts, false)
+	return err
 }
 
 // RefreshTokensForContract refreshes all tokens in a given contract
@@ -1363,7 +1389,7 @@ func (p *Provider) SyncContractsOwnedByUser(ctx context.Context, userID persist.
 	}
 	contractsFromProviders := []chainContracts{}
 
-	contractFetchers := matchingProvidersByChains[ContractsFetcher](p.Chains, chains...)
+	contractFetchers := matchingProvidersByChains[ContractsOwnerFetcher](p.Chains, chains...)
 	searchAddresses := p.matchingWallets(user.Wallets, chains)
 	providerPool := pool.NewWithResults[ContractOwnerResult]().WithContext(ctx)
 
@@ -1789,7 +1815,7 @@ func contractsToNewDedupedContracts(contracts []chainContracts) []persist.Contra
 			if contract.Descriptors.Symbol != "" {
 				meta.Symbol = contract.Descriptors.Symbol
 			}
-			if contract.Descriptors.Name != "" {
+			if contract.Descriptors.Name != "" && !contractNameBlacklist[strings.ToLower(contract.Descriptors.Name)] {
 				meta.Name = contract.Descriptors.Name
 			}
 			if contract.Descriptors.CreatorAddress != "" {

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -329,9 +329,6 @@ func (p *Provider) GetContractByAddress(ctx context.Context, contract persist.Ad
 	}
 	return contractToContract(ctx, c, p.ethClient)
 }
-func (d *Provider) GetCommunityOwners(ctx context.Context, communityID persist.Address, limit, offset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
-	return []multichain.ChainAgnosticCommunityOwner{}, nil
-}
 
 func (d *Provider) GetOwnedTokensByContract(context.Context, persist.Address, persist.Address, int, int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	return []multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, nil

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -492,21 +492,6 @@ func (d *Provider) GetOwnedTokensByContract(ctx context.Context, contractAddress
 	return tokens, contract, nil
 }
 
-func (d *Provider) GetCommunityOwners(ctx context.Context, contractAddress persist.Address, maxLimit, maxOffset int) ([]multichain.ChainAgnosticCommunityOwner, error) {
-	tokens, _, err := d.GetTokensByContractAddress(ctx, contractAddress, maxLimit, maxOffset)
-	if err != nil {
-		return nil, err
-	}
-	owners := make([]multichain.ChainAgnosticCommunityOwner, len(tokens))
-	for i, token := range tokens {
-		owners[i] = multichain.ChainAgnosticCommunityOwner{
-			Address: token.OwnerAddress,
-		}
-	}
-	return owners, nil
-
-}
-
 /*
 gql example
 {

--- a/service/persist/comment.go
+++ b/service/persist/comment.go
@@ -2,6 +2,8 @@ package persist
 
 import (
 	"context"
+	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -15,6 +17,42 @@ type Comment struct {
 	ReplyTo     DBID      `json:"reply_to"`
 	Comment     string    `json:"comment"`
 	Deleted     bool      `json:"deleted"`
+}
+
+type Mentions map[DBID]Mention
+
+func (m Mentions) Value() (driver.Value, error) {
+	return json.Marshal(m)
+}
+
+func (m *Mentions) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	return json.Unmarshal(value.([]uint8), m)
+}
+
+type MentionType string
+
+const (
+	MentionTypeUser      MentionType = "user"
+	MentionTypeCommunity MentionType = "community"
+)
+
+type Mention struct {
+	MentionType MentionType    `json:"mention_type"`
+	Index       *CompleteIndex `json:"index,omitempty"`
+}
+
+func (m Mention) Value() (driver.Value, error) {
+	return json.Marshal(m)
+}
+
+func (m *Mention) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	return json.Unmarshal(value.([]uint8), m)
 }
 
 type CommentRepository interface {

--- a/service/persist/persist.go
+++ b/service/persist/persist.go
@@ -49,6 +49,22 @@ type NullInt32 int32
 // NullBool represents a bool that may be null in the DB
 type NullBool bool
 
+type CompleteIndex struct {
+	Index  int `json:"start"`
+	Length int `json:"end"`
+}
+
+func (c CompleteIndex) Value() (driver.Value, error) {
+	return json.Marshal(c)
+}
+
+func (c *CompleteIndex) Scan(value interface{}) error {
+	if value == nil {
+		return nil
+	}
+	return json.Unmarshal(value.([]uint8), c)
+}
+
 // GenerateID generates a application-wide unique ID
 func GenerateID() DBID {
 	id, err := ksuid.NewRandom()

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -238,3 +238,5 @@ sql:
             go_type: 'github.com/mikeydub/go-gallery/service/persist.Socials'
           - column: '*.*.pii_socials'
             go_type: 'github.com/mikeydub/go-gallery/service/persist.Socials'
+          - column: '*.*.mentions'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.Mentions'


### PR DESCRIPTION
Changes:

- **Added** mentions to the `comments` an `posts` tables in the db which will be JSONB for the mention data
- **Added** resolvers for mentions

In the way this is implemented, a `Mention` is either a user or a community and then there is an optional `index` (optional just in case we want to allow mentions in the future that are like tags on a picture instead of direct text mentions) that represents the start of where the mention is and its length. This works fine but fails in a few ways:

1. A user edits the comment (we don't have this built out but just theorizing if we wanted to edit comments) and the indexes need to get shifted and mentions the same.
2. A user changes their username, the mention is still able to reference the new user but there will be a mismatch between the real username and what the mention looks like to the user. A user could hover on a mention and it might be confusing because the mention looks different than what shows up in the hover popup.

An alternative method that has its own different problems is to interpolate the mentions by some key. For example:

1. Frontend gets comment after user searches for user while typing the mention: `Love it, @kaito` 
2. Frontend or backend replaces the mention with the DBID or some generated ID: `Love it, @{2aY8sb...}`
3. Frontend requests comments to be rendered, backend sends to frontend something that can be used to turn use that ID and get the actual entity it points to, community or user
4. When frontend renders the comment, each `@{id}` is replaced with the data (username or community name) from the resolved entity that is being mentioned.

Problems with this method:

1. This method requires that the frontend resolves the mentions to properly render the comment. In the indexing method, the comment look acceptable without resolving any mentions (although the mentions might not be bolded) but in this method the comment will look like a hacker wrote it unless the frontend resolves the mentions and fills in the comment with data from the user or community.
2. I feel like this method is slightly less "typed" because some of the important mention information is stored on the comment itself and the comment is just a string. In the indexing method, the comment doesn't know or care about mentions, it is the mention's responsibility only to understand the comment. The roles are reversed here.
3. What if a user really wants to include `@{2aY8sb...}` raw in their comment because that random string somehow means something to them but we keep replacing it with a gallery user's username :(

But the other problems are solved because now a comment can be edited and the comment can still be interpolated correctly because indexes are not involved and mentions can even be removed from the comment with the mention data being unchanged. Obviously the username changing is not an issue because the username will come from resolving the current user by ID.