### PR TITLE
Handle token loading

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -1717,31 +1717,31 @@ func (b *GetGalleryTokenMediasByGalleryIDBatchBatchResults) Close() error {
 	return b.br.Close()
 }
 
-const getMediaByTokenID = `-- name: GetMediaByTokenID :batchone
+const getMediaByTokenIDIgnoringStatus = `-- name: GetMediaByTokenIDIgnoringStatus :batchone
 select m.id, m.created_at, m.last_updated, m.version, m.contract_id, m.token_id, m.chain, m.active, m.metadata, m.media, m.name, m.description, m.processing_job_id, m.deleted
 from token_medias m
-where m.id = (select token_media_id from tokens where tokens.id = $1) and m.active and not m.deleted
+where m.id = (select token_media_id from tokens where tokens.id = $1) and not m.deleted
 `
 
-type GetMediaByTokenIDBatchResults struct {
+type GetMediaByTokenIDIgnoringStatusBatchResults struct {
 	br     pgx.BatchResults
 	tot    int
 	closed bool
 }
 
-func (q *Queries) GetMediaByTokenID(ctx context.Context, id []persist.DBID) *GetMediaByTokenIDBatchResults {
+func (q *Queries) GetMediaByTokenIDIgnoringStatus(ctx context.Context, id []persist.DBID) *GetMediaByTokenIDIgnoringStatusBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range id {
 		vals := []interface{}{
 			a,
 		}
-		batch.Queue(getMediaByTokenID, vals...)
+		batch.Queue(getMediaByTokenIDIgnoringStatus, vals...)
 	}
 	br := q.db.SendBatch(ctx, batch)
-	return &GetMediaByTokenIDBatchResults{br, len(id), false}
+	return &GetMediaByTokenIDIgnoringStatusBatchResults{br, len(id), false}
 }
 
-func (b *GetMediaByTokenIDBatchResults) QueryRow(f func(int, TokenMedia, error)) {
+func (b *GetMediaByTokenIDIgnoringStatusBatchResults) QueryRow(f func(int, TokenMedia, error)) {
 	defer b.br.Close()
 	for t := 0; t < b.tot; t++ {
 		var i TokenMedia
@@ -1774,7 +1774,7 @@ func (b *GetMediaByTokenIDBatchResults) QueryRow(f func(int, TokenMedia, error))
 	}
 }
 
-func (b *GetMediaByTokenIDBatchResults) Close() error {
+func (b *GetMediaByTokenIDIgnoringStatusBatchResults) Close() error {
 	b.closed = true
 	return b.br.Close()
 }

--- a/db/gen/coredb/gallery.sql.go
+++ b/db/gen/coredb/gallery.sql.go
@@ -184,7 +184,7 @@ const galleryRepoGetPreviewsForUserID = `-- name: GalleryRepoGetPreviewsForUserI
 select coalesce(nullif(tm.media->>'thumbnail_url', ''), nullif(tm.media->>'media_url', ''))::varchar as thumbnail_url from galleries g,
     unnest(g.collections) with ordinality as collection_ids(id, ord) inner join collections c on c.id = collection_ids.id and c.deleted = false,
     unnest(c.nfts) with ordinality as token_ids(id, ord) inner join tokens t on t.id = token_ids.id and t.displayable and t.deleted = false
-    inner join token_medias tm on t.token_media_id = tm.id and tm.media ->> 'thumbnail_url' != ''
+    inner join token_medias tm on t.token_media_id = tm.id and (tm.media ->> 'thumbnail_url' != '' or tm.media ->> 'media_url' != '')
     where g.owner_user_id = $1 and g.deleted = false
     order by collection_ids.ord, token_ids.ord limit $2
 `

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1325,10 +1325,10 @@ ORDER BY tokens.id;
 -- name: GetReprocessJobRangeByID :one
 select * from reprocess_jobs where id = $1;
 
--- name: GetMediaByTokenID :batchone
+-- name: GetMediaByTokenIDIgnoringStatus :batchone
 select m.*
 from token_medias m
-where m.id = (select token_media_id from tokens where tokens.id = $1) and m.active and not m.deleted;
+where m.id = (select token_media_id from tokens where tokens.id = $1) and not m.deleted;
 
 -- name: UpsertSession :one
 insert into sessions (id, user_id,

--- a/graphql/dataloader/dataloaders.go
+++ b/graphql/dataloader/dataloaders.go
@@ -1331,7 +1331,7 @@ func loadMediaByTokenID(q *db.Queries) func(context.Context, []persist.DBID) ([]
 		results := make([]db.TokenMedia, len(tokenIDs))
 		errors := make([]error, len(tokenIDs))
 
-		b := q.GetMediaByTokenID(ctx, tokenIDs)
+		b := q.GetMediaByTokenIDIgnoringStatus(ctx, tokenIDs)
 		defer b.Close()
 
 		b.QueryRow(func(i int, media db.TokenMedia, err error) {

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -22,7 +22,6 @@ import (
 	"roci.dev/fracdex"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
-	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/event"
 	"github.com/mikeydub/go-gallery/graphql/dataloader"
 	"github.com/mikeydub/go-gallery/graphql/model"
@@ -1651,7 +1650,7 @@ func imageMetadataRequest(chain persist.Chain) []multichain.FieldRequest[string]
 
 func standardizeURI(u string) string {
 	if strings.HasPrefix(u, "ipfs://") {
-		return ipfs.PathGatewayFrom(env.GetString("IPFS_URL"), u, true)
+		return ipfs.DefaultGatewayFrom(u)
 	}
 	return u
 }

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -32,6 +32,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:LyMmdnDJFb8J+IIirhxgyxpnt9SD+ovgQ+
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:2UQG+XdUTUJyKN/Pqzbr9lwsMK6LgQ0w6RIABW0AJ9cfiRKfRUfI12jsxdPUsFni2iDTzUUkrRYmVTLogUPttSSOItC+c+AidA==,iv:z1sdLMlu4x9BY4Haikocg5URwh0vcZGr4mz1rtBcj9c=,tag:Hrh5trTAEipJAFS0+tRSng==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:/uXGQ8AtiJ++fGJUngC6EcjBVuSJBNbp8g7yWcEMG9U=,iv:WdVJGHWQPDB4HAkqgCkKWqON9OsURBQixJG5Tc0eHoU=,tag:LgHf3JUslmtFPHV1PJvyNQ==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:RlpUUwAGFdbl2iF/WpJtKhz07/e5crKjzlVTeieOTZs=,iv:nwc5p/quTfMueloGzBAzEMz/ipbZ+hEF7VfuRy28IDE=,tag:7GiecjhouJhsrUfzq0Xgqg==,type:str]
+IPFS_URL: ENC[AES256_GCM,data:GsS7oEtpGfCsto3MMnazFe3e1u915Pd3ht98zyqS,iv:D7sYQUPTr49703idsBrq9R7Xo2O8lMfTVWYo8N2ETZI=,tag:p4ESwjOSi+au+3Ef+p2r8w==,type:str]
 FALLBACK_IPFS_URL: ENC[AES256_GCM,data:Ho3ZYGLpsRh9qgAgInOnUgQscfn/mnBgNl1y5rcp/onQkrZd,iv:O0QWly+fiaQrcclaWx+0sX0+VJE/Ex23VqClP5dxxz4=,tag:Fd/dlF4LvFPmCjaeAESY9w==,type:str]
 FRONTEND_APQ_UPLOAD_AUTH_TOKEN: ENC[AES256_GCM,data:ZILBnusB44G4Pjr2FciMPA0UG8ZorPjr4a+wEoRA,iv:7bESHVXi8uUuGGQpPGhlT/+amGG07TNZSN9p0y+GGEs=,tag:LczHWZvOyxsRz6sHCkfd0Q==,type:str]
 GCLOUD_PUSH_NOTIFICATIONS_QUEUE: ENC[AES256_GCM,data:P9LGA9PBH4XWX/J/cHAzU9O0HeQ7qqq1mMA6zV31/1Q0wQd8hOEg91MgBAKpCTpz20SS+BkkDM7A4Kjp97ohkK24YtMeKyYi,iv:9FqsEmP/dM8iQLIKStlB9W8+u19ospRRWL4FTo/Ir7s=,tag:SGdWohUao1oWJMcajQ34CQ==,type:str]
@@ -53,8 +54,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-08-08T20:14:38Z"
-    mac: ENC[AES256_GCM,data:mdz+M/o2hlmDeN3YvymQ5RTnQmaE1qKL3hqeuHLfHZNLaFXmQvrnI0SC1HbJAcwPgnWBIEQP56hmiuzs8pa0uV3VTvvU8NWafaPhWI7iN1RVgrcABFdJ+GEUfH0Q3Vzt6MB9dSBOVfrCb0FEYv2eaYBIC1LBdFUNEXxwT7v4k/g=,iv:2rIcYmtSfytvofUa4uVu8AdO8mSrvhikMbBnRxSjYdE=,tag:2YqJdA78Nm5HZYw9a3++iw==,type:str]
+    lastmodified: "2023-08-30T21:30:22Z"
+    mac: ENC[AES256_GCM,data:nbfZrLmPXTyw0fJCty9/uhJnlqgc/9GtAWmG+HdmNmjL2I46TzFrPIf2I1gDdNWz75jGbV+1D4UHCVpdXCdM9G6238x67FKWOzSB7Tb51O8Utm6Qj3BJxgfAbM0N2JlN2YQ6RBI4r5D2JhUA/oAveQQ+jEiAGo6FxpWKF/r8ndY=,iv:/+aFcDovcwya9UEEYNS4dZu2lpxQo+7m0ZTSJ9hghQQ=,tag:v2LYlKgkOmdzWJqV6H5Bgw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-backend.yaml
+++ b/secrets/local/local/app-local-backend.yaml
@@ -30,6 +30,7 @@ ALCHEMY_OPTIMISM_API_URL: ENC[AES256_GCM,data:+24oDGDLQag/aUv9s0V4cgJs1HrsL18Tey
 ALCHEMY_POLYGON_API_URL: ENC[AES256_GCM,data:gBSa+668Z1lrPwjq5VJ0vHiPXMukvLj9ay4T2m34wdX0Z/orvEAS5k9HQpdMqaqIENHWjm5uDNMJg0w7gHZSItWk49eIZwp6Yg==,iv:0oTpjbOgryuK+QtploVvXFvL0CKNx9URRswylUP1t9Q=,tag:g6r7gecO+rvLFE6R1iwetA==,type:str]
 INFURA_API_SECRET: ENC[AES256_GCM,data:PQ9I9fE8J18u639MwVoKYrLRdhS1edztvFLbVc8Jwvo=,iv:JP61Q3I/gcNdpAuSnnD+TNTLL9zyVNrqYMgyOloJzic=,tag:m0kgCT3SUkH1fe4XEuXa6A==,type:str]
 INFURA_API_KEY: ENC[AES256_GCM,data:HFSgGADftArV6i9aMoNT90ET54CknSrsNp1xdfAEDqs=,iv:14VPi8bN1pFe4+Uy8H8P/1ZVD3SvVUvdRSw16Cb5Bx8=,tag:yiuIS1jx6tEfu+E2lJt6CQ==,type:str]
+IPFS_URL: ENC[AES256_GCM,data:xnUYB6j8tq0+MavkKa9pE9rQzt1gIAPTnKectv+7,iv:1JKADdtnEjjGi760wGyPxgpHN0sDHW6pU6C4knuBBrc=,tag:OGanwhnQrLMSOdSmvBkWAQ==,type:str]
 FALLBACK_IPFS_URL: ENC[AES256_GCM,data:ZB8he/CU+9N3ZXcQxNH34dbBqhXV2hlWzdIcPV0j+t/rH+zU,iv:thwzVgWpCKKgRWENK5JKSqieq9P7ZBwKxDYrSCtbvPg=,tag:XqVcX9GBYONeZHCKJoUGhg==,type:str]
 GCLOUD_PUSH_NOTIFICATIONS_QUEUE: ENC[AES256_GCM,data:jORXj/WQ9VNKPR7+E2wlPQo6ZETReW2J2uvEisXeSM6s4XWt6Uy1+Tm0svYFPR8LpXsgI234FumPPBDsUzVF,iv:gcobzMFCdF+52We5lImQCHfj10B8wH4Cz8IexSBR27I=,tag:5DlXF+tRsK+FQlgLNXU0PQ==,type:str]
 PUSH_NOTIFICATIONS_URL: ENC[AES256_GCM,data:rTGFTKHhTM0h9SdgCwsYTZbu/PuvrpWPademi+jcqho=,iv:ZsgKwDkT8fAHLMlRTHMpz30eKjNq9zB0v/y+1rnLpc4=,tag:df0T/7l3OVg2sPypPNIQ4g==,type:str]
@@ -49,8 +50,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-08-03T19:03:11Z"
-    mac: ENC[AES256_GCM,data:LAL0kq4WgDA+l4htAGPJ68rfzMp1LlfOcdHL3JW5J1f614U/p60Tajza8oD/wGDAjZnYAGuV4wIX6sZzPX8jb0qrkqDxY+fceVtTLH2C+9+IjpgO4Zi4Vrbqxcd5Zrz44E4k6HmMZZoWb6gTHG1N5ajHJfb2zGhvtEsiaPyC1qY=,iv:JuzYaoWWfIwOlZ+LlN25icTr7jXap24jgoNNf5mraN8=,tag:O5BYyLbRGI/gLotbPmDHcQ==,type:str]
+    lastmodified: "2023-08-30T20:26:07Z"
+    mac: ENC[AES256_GCM,data:+yt0JbrnMNxuuiYGw7HHH/CVeOxAjZlsDw9jtURvmPoAm57jstdVzcKqXE1vgJXxLCkWbeUJ1E0he9CTmv688GVLTJXCMeAdHrR7yK+zgQ/wtWC0/P1PcBueuIfc24LpCOXHwsUJ3GBebtY3zjFvuOzCPkoaJ75IxJ/IlNCZcjY=,iv:pS9jM1WDp839FYfksmj+C7N5cMIwxKbwH/Mut+PbUrs=,tag:y7+wg/PkiPjt8L55MFqh0g==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -201,7 +201,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti mu
 
 	greq := graphql.NewRequest(treq)
 	greq.Var("address", ti.ContractAddress)
-	greq.Var("tokenId", ti.TokenID)
+	greq.Var("tokenId", ti.TokenID.Base10String())
 
 	resp := getTokenResponse{}
 	err := d.zgql.Run(ctx, greq, &resp)

--- a/service/rpc/ipfs/ipfs.go
+++ b/service/rpc/ipfs/ipfs.go
@@ -153,6 +153,11 @@ func defaultHTTPClient() *http.Client {
 	}
 }
 
+// DefaultGatewayFrom rewrites an IPFS URL to a gateway URL using the default gateway
+func DefaultGatewayFrom(ipfsURL string) string {
+	return PathGatewayFrom(env.GetString("IPFS_URL"), ipfsURL, true)
+}
+
 // PathGatewayFrom is a helper function that rewrites an IPFS URI to an IPFS gateway URL
 // If includeQueryParams is true, the query parameters will be included in the gateway URL
 func PathGatewayFrom(gatewayHost, ipfsURL string, includeQueryParams bool) string {


### PR DESCRIPTION
**Changes**
* Media resolver now differentiates between missing media and broken media
* Media resolver now defines a grace period for how long a token can't have media before assuming that media is invalid
* Media resolver now rewrites fallback IPFS and Arweave URLs to HTTP so that browsers can render them
* Media resolver now returns fallback media even when fetching media fails instead of returning no fallback