### PR TITLE
Make copy of metadata map

### DIFF
--- a/service/multichain/reservoir/reservoir.go
+++ b/service/multichain/reservoir/reservoir.go
@@ -387,7 +387,12 @@ func (d *Provider) fetchReservoirMetadata(ctx context.Context, ti multichain.Cha
 	if err != nil {
 		return nil, err
 	}
-	meta := token.Metadata
+
+	meta := make(persist.TokenMetadata, len(token.Metadata))
+	for k, v := range token.Metadata {
+		meta[k] = v
+	}
+
 	if _, ok := util.FindFirstFieldFromMap(meta, "image", "image_url", "imageURL").(string); !ok {
 		meta["image_url"] = token.Image
 	}


### PR DESCRIPTION
Fixes runtime error caused by assignment to a nil map by creating a copy of the map. Tested by refreshing a base coin before and after the change.