### PR TITLE
Allow opt-in roles

### DIFF
--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -183,6 +183,14 @@ type Notification interface {
 	IsNotification()
 }
 
+type OptInForRolesPayloadOrError interface {
+	IsOptInForRolesPayloadOrError()
+}
+
+type OptOutForRolesPayloadOrError interface {
+	IsOptOutForRolesPayloadOrError()
+}
+
 type PostOrError interface {
 	IsPostOrError()
 }
@@ -1014,6 +1022,8 @@ func (ErrInvalidInput) IsUpdateEmailPayloadOrError()                     {}
 func (ErrInvalidInput) IsResendVerificationEmailPayloadOrError()         {}
 func (ErrInvalidInput) IsUpdateEmailNotificationSettingsPayloadOrError() {}
 func (ErrInvalidInput) IsUnsubscribeFromEmailTypePayloadOrError()        {}
+func (ErrInvalidInput) IsOptInForRolesPayloadOrError()                   {}
+func (ErrInvalidInput) IsOptOutForRolesPayloadOrError()                  {}
 func (ErrInvalidInput) IsRedeemMerchPayloadOrError()                     {}
 func (ErrInvalidInput) IsCreateGalleryPayloadOrError()                   {}
 func (ErrInvalidInput) IsUpdateGalleryInfoPayloadOrError()               {}
@@ -1090,6 +1100,8 @@ func (ErrNotAuthorized) IsSyncCreatedTokensForExistingContractPayloadOrError() {
 func (ErrNotAuthorized) IsError()                                              {}
 func (ErrNotAuthorized) IsAddRolesToUserPayloadOrError()                       {}
 func (ErrNotAuthorized) IsRevokeRolesFromUserPayloadOrError()                  {}
+func (ErrNotAuthorized) IsOptInForRolesPayloadOrError()                        {}
+func (ErrNotAuthorized) IsOptOutForRolesPayloadOrError()                       {}
 func (ErrNotAuthorized) IsUploadPersistedQueriesPayloadOrError()               {}
 func (ErrNotAuthorized) IsSyncTokensForUsernamePayloadOrError()                {}
 func (ErrNotAuthorized) IsSyncCreatedTokensForUsernamePayloadOrError()         {}
@@ -1611,6 +1623,18 @@ type NotificationsConnection struct {
 type OneTimeLoginTokenAuth struct {
 	Token string `json:"token"`
 }
+
+type OptInForRolesPayload struct {
+	User *GalleryUser `json:"user"`
+}
+
+func (OptInForRolesPayload) IsOptInForRolesPayloadOrError() {}
+
+type OptOutForRolesPayload struct {
+	User *GalleryUser `json:"user"`
+}
+
+func (OptOutForRolesPayload) IsOptOutForRolesPayloadOrError() {}
 
 type OwnerAtBlock struct {
 	Owner       GalleryUserOrAddress `json:"owner"`

--- a/graphql/model/remapgen_gen.go
+++ b/graphql/model/remapgen_gen.go
@@ -213,6 +213,16 @@ var typeConversionMap = map[string]func(object interface{}) (objectAsType interf
 		return obj, ok
 	},
 
+	"OptInForRolesPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(OptInForRolesPayloadOrError)
+		return obj, ok
+	},
+
+	"OptOutForRolesPayloadOrError": func(object interface{}) (interface{}, bool) {
+		obj, ok := object.(OptOutForRolesPayloadOrError)
+		return obj, ok
+	},
+
 	"PostOrError": func(object interface{}) (interface{}, bool) {
 		obj, ok := object.(PostOrError)
 		return obj, ok

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -1702,6 +1702,34 @@ func (r *mutationResolver) RedeemMerch(ctx context.Context, input model.RedeemMe
 	return output, nil
 }
 
+// OptInForRoles is the resolver for the optInForRoles field.
+func (r *mutationResolver) OptInForRoles(ctx context.Context, roles []persist.Role) (model.OptInForRolesPayloadOrError, error) {
+	user, err := publicapi.For(ctx).User.OptInForRoles(ctx, roles)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := model.OptInForRolesPayload{
+		User: userToModel(ctx, *user),
+	}
+
+	return payload, nil
+}
+
+// OptOutForRoles is the resolver for the optOutForRoles field.
+func (r *mutationResolver) OptOutForRoles(ctx context.Context, roles []persist.Role) (model.OptOutForRolesPayloadOrError, error) {
+	user, err := publicapi.For(ctx).User.OptOutForRoles(ctx, roles)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := model.OptOutForRolesPayload{
+		User: userToModel(ctx, *user),
+	}
+
+	return payload, nil
+}
+
 // AddRolesToUser is the resolver for the addRolesToUser field.
 func (r *mutationResolver) AddRolesToUser(ctx context.Context, username string, roles []*persist.Role) (model.AddRolesToUserPayloadOrError, error) {
 	user, err := publicapi.For(ctx).Admin.AddRolesToUser(ctx, username, roles)
@@ -2579,7 +2607,6 @@ func (r *tokenResolver) Media(ctx context.Context, obj *model.Token) (model.Medi
 		return mediaToModel(ctx, tokenMedia, fallbackMedia, highDef), err
 	}
 	return mediaToModel(ctx, tokenMedia, obj.HelperTokenData.Token.FallbackMedia, highDef), nil
-
 }
 
 // Owner is the resolver for the owner field.

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2083,6 +2083,17 @@ union UnsubscribeFromEmailTypePayloadOrError = UnsubscribeFromEmailTypePayload |
 union AddRolesToUserPayloadOrError = GalleryUser | ErrNotAuthorized
 union RevokeRolesFromUserPayloadOrError = GalleryUser | ErrNotAuthorized
 
+type OptInForRolesPayload {
+  user: GalleryUser
+}
+
+type OptOutForRolesPayload {
+  user: GalleryUser
+}
+
+union OptInForRolesPayloadOrError = OptInForRolesPayload | ErrNotAuthorized | ErrInvalidInput
+union OptOutForRolesPayloadOrError = OptOutForRolesPayload | ErrNotAuthorized | ErrInvalidInput
+
 input UploadPersistedQueriesInput {
   persistedQueries: String
 }
@@ -2588,6 +2599,9 @@ type Mutation {
   verifyEmailMagicLink(input: VerifyEmailMagicLinkInput!): VerifyEmailMagicLinkPayloadOrError
 
   redeemMerch(input: RedeemMerchInput!): RedeemMerchPayloadOrError @authRequired
+
+  optInForRoles(roles: [Role!]!): OptInForRolesPayloadOrError @authRequired
+  optOutForRoles(roles: [Role!]!): OptOutForRolesPayloadOrError @authRequired
 
   # Retool Specific Mutations
   addRolesToUser(username: String!, roles: [Role]): AddRolesToUserPayloadOrError @retoolAuth

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -156,3 +156,7 @@ func (api AuthAPI) GenerateQRCodeLoginToken(ctx context.Context) (string, error)
 
 	return auth.GenerateOneTimeLoginToken(ctx, userID, "qr_code", 5*time.Minute)
 }
+
+func (api AuthAPI) ForceAuthTokenRefresh(ctx context.Context, userID persist.DBID) error {
+	return auth.ForceAuthTokenRefresh(ctx, api.authRefreshCache, userID)
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -141,6 +141,7 @@ func RegisterCustomValidators(v *validator.Validate) {
 	v.RegisterValidation("sorted_asc", SortedAscValidator)
 	v.RegisterValidation("chain", ChainValidator)
 	v.RegisterValidation("role", IsValidRole)
+	v.RegisterValidation("opt_in_role", IsOptInRole)
 	v.RegisterValidation("created_collections", CreatedCollectionsValidator)
 	v.RegisterValidation("http", HTTPValidator)
 	v.RegisterAlias("collection_name", "max=200")
@@ -158,6 +159,12 @@ func RegisterCustomValidators(v *validator.Validate) {
 var IsValidRole validator.Func = func(fl validator.FieldLevel) bool {
 	role := persist.Role(fl.Field().String())
 	return role == persist.RoleAdmin || role == persist.RoleBetaTester
+}
+
+// IsOptInRole designates roles that users can opt themselves into
+var IsOptInRole validator.Func = func(fl validator.FieldLevel) bool {
+	role := persist.Role(fl.Field().String())
+	return role == persist.RoleBetaTester
 }
 
 func ChainAddressValidator(sl validator.StructLevel) {


### PR DESCRIPTION
This PR adds the `optInForRoles` and `optOutForRoles` mutations, which allow users to add and remove roles from themselves (but only for a set of defined "opt-in" roles -- currently limited to just the `BETA_TESTER` role).

I copied/pasted from the admin role management stuff a bit more than I'd have liked, but I think we can refactor into role helper methods at some point in the future.