### PR TITLE
Chore: Remove chain from tokenprocessing message

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -893,7 +893,7 @@ func testSyncOnlySubmitsNewTokens(t *testing.T) {
 	h := handlerWithProviders(t, tokenRecorder.Send, provider)
 	c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 	// Ideally this compares against expected values, but mocks seems to behave weirdly with slices
-	tokenRecorder.On("Send", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Times(1).Return(nil)
+	tokenRecorder.On("Send", mock.Anything, mock.Anything, mock.Anything).Times(1).Return(nil)
 
 	_, err := syncTokensMutation(context.Background(), c, []Chain{ChainEthereum})
 

--- a/graphql/stub_test.go
+++ b/graphql/stub_test.go
@@ -167,6 +167,7 @@ func (r *sendTokensRecorder) Send(ctx context.Context, userID persist.DBID, toke
 
 // submitUserTokensNoop is useful when the code under test doesn't require tokenprocessing
 func submitUserTokensNoop(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
+	return nil
 }
 
 // sendTokensToHTTPHandler makes an HTTP request to the passed handler

--- a/graphql/stub_test.go
+++ b/graphql/stub_test.go
@@ -159,21 +159,20 @@ type sendTokensRecorder struct {
 	Tasks            []task.TokenProcessingUserMessage
 }
 
-func (r *sendTokensRecorder) Send(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error {
-	r.Called(ctx, userID, tokenIDs, chains)
-	r.Tasks = append(r.Tasks, task.TokenProcessingUserMessage{UserID: userID, TokenIDs: tokenIDs, Chains: chains})
+func (r *sendTokensRecorder) Send(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
+	r.Called(ctx, userID, tokenIDs)
+	r.Tasks = append(r.Tasks, task.TokenProcessingUserMessage{UserID: userID, TokenIDs: tokenIDs})
 	return nil
 }
 
 // submitUserTokensNoop is useful when the code under test doesn't require tokenprocessing
-func submitUserTokensNoop(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error {
-	return nil
+func submitUserTokensNoop(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
 }
 
 // sendTokensToHTTPHandler makes an HTTP request to the passed handler
 func sendTokensToHTTPHandler(handler http.Handler, method, endpoint string) multichain.SubmitUserTokensF {
-	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error {
-		m := task.TokenProcessingUserMessage{UserID: userID, TokenIDs: tokenIDs, Chains: chains}
+	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
+		m := task.TokenProcessingUserMessage{UserID: userID, TokenIDs: tokenIDs}
 		byt, _ := json.Marshal(m)
 		r := bytes.NewReader(byt)
 		req := httptest.NewRequest(method, endpoint, r)
@@ -189,9 +188,9 @@ func sendTokensToHTTPHandler(handler http.Handler, method, endpoint string) mult
 
 // sendTokensToTokenProcessing processes a batch of tokens synchronously through tokenprocessing
 func sendTokensToTokenProcessing(ctx context.Context, c *server.Clients, provider *multichain.Provider) multichain.SubmitUserTokensF {
-	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error {
+	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
 		h := tokenprocessing.CoreInitServer(ctx, c, provider)
-		return sendTokensToHTTPHandler(h, http.MethodPost, "/media/process")(ctx, userID, tokenIDs, chains)
+		return sendTokensToHTTPHandler(h, http.MethodPost, "/media/process")(ctx, userID, tokenIDs)
 	}
 }
 

--- a/server/inject.go
+++ b/server/inject.go
@@ -505,10 +505,10 @@ func newTokenProcessingCache() *redis.Cache {
 }
 
 func newManagedTokens(ctx context.Context, tm *tokenmanage.Manager) multichain.SubmitUserTokensF {
-	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error {
+	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
 		if len(tokenIDs) == 0 {
 			return nil
 		}
-		return tm.SubmitUser(ctx, userID, tokenIDs, chains)
+		return tm.SubmitUser(ctx, userID, tokenIDs)
 	}
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -471,10 +471,10 @@ func newTokenProcessingCache() *redis.Cache {
 }
 
 func newManagedTokens(ctx context.Context, tm *tokenmanage.Manager) multichain.SubmitUserTokensF {
-	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error {
+	return func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
 		if len(tokenIDs) == 0 {
 			return nil
 		}
-		return tm.SubmitUser(ctx, userID, tokenIDs, chains)
+		return tm.SubmitUser(ctx, userID, tokenIDs)
 	}
 }

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -42,8 +42,7 @@ var contractNameBlacklist = map[string]bool{
 }
 
 // SubmitUserTokensF is called to process a user's batch of tokens
-// TODO: Remove chains when made optional on tokenprocessing
-type SubmitUserTokensF func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error
+type SubmitUserTokensF func(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error
 
 type Provider struct {
 	Repos   *postgres.Repositories
@@ -818,7 +817,7 @@ func (p *Provider) processTokensForUsers(ctx context.Context, users map[persist.
 		newUserTokens[userID] = newPersistedTokens
 		newPersistedTokenIDs := util.MapWithoutError(newPersistedTokens, func(t persist.TokenGallery) persist.DBID { return t.ID })
 
-		err = p.SubmitUserTokens(ctx, userID, newPersistedTokenIDs, chains)
+		err = p.SubmitUserTokens(ctx, userID, newPersistedTokenIDs)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -37,8 +37,6 @@ type FeedbotMessage struct {
 type TokenProcessingUserMessage struct {
 	UserID   persist.DBID   `json:"user_id" binding:"required"`
 	TokenIDs []persist.DBID `json:"token_ids" binding:"required"`
-	// TODO: chains isn't used anymore, remove once the backend is updated to stop sending it
-	Chains []persist.Chain `json:"chains" binding:"-"`
 }
 
 type TokenProcessingTokenInstanceMessage struct {

--- a/service/tokenmanage/tokenmanage.go
+++ b/service/tokenmanage/tokenmanage.go
@@ -85,9 +85,9 @@ func (m Manager) StartProcessing(ctx context.Context, tokenID persist.DBID, atte
 }
 
 // SubmitUser enqueues a user's tokens for processing.
-func (m Manager) SubmitUser(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID, chains []persist.Chain) error {
+func (m Manager) SubmitUser(ctx context.Context, userID persist.DBID, tokenIDs []persist.DBID) error {
 	m.processRegistry.setManyEnqueue(ctx, tokenIDs)
-	message := task.TokenProcessingUserMessage{UserID: userID, TokenIDs: tokenIDs, Chains: chains}
+	message := task.TokenProcessingUserMessage{UserID: userID, TokenIDs: tokenIDs}
 	return task.CreateTaskForTokenProcessing(ctx, message, m.taskClient)
 }
 


### PR DESCRIPTION
Removes `chain` from the tokenprocessing messages. We used to require this to figure out which keywords to collect media from depending on the chain, but it isn't needed anymore.