### PR TITLE
Update base keywords

### DIFF
--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -422,11 +422,15 @@ func (c Chain) NormalizeAddress(addr Address) string {
 
 // BaseKeywords are the keywords that are default for discovering media for a given chain
 func (c Chain) BaseKeywords() (image []string, anim []string) {
+	defaultImageKeyWords := []string{"image_url", "image"}
+	defaultAnimKeyWords := []string{"animation_url", "animation", "video"}
 	switch c {
 	case ChainTezos:
 		return []string{"displayUri", "image", "thumbnailUri", "artifactUri", "uri"}, []string{"artifactUri", "displayUri", "uri", "image"}
+	case ChainBase:
+		return append(defaultImageKeyWords, "imageOriginal"), append(defaultAnimKeyWords, "mediaOriginal")
 	default:
-		return []string{"image_url", "image"}, []string{"animation_url", "animation", "video"}
+		return defaultImageKeyWords, defaultAnimKeyWords
 	}
 }
 


### PR DESCRIPTION
This PR updates the base metadata keywords to include `imageOriginal` and `mediaOriginal`. The former is the second most used key for Base metadata, and the latter is used sparingly but is used in the collection with Duane King's broken token. I'm not sure if these are specific to the Reservoir provider or for Base because we only use Reservoir for Base, but I made them Base specific for now.