### PR TITLE
Handle empty cursor

### DIFF
--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -1139,6 +1139,9 @@ type unpackable struct {
 }
 
 func (u *unpackable) Unpack(s string) (err error) {
+	if s == "" {
+		return nil
+	}
 	if err = u.d.setReader(s); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes EOF panic when an empty cursor string is passed