### PR TITLE
Retry reading user matrices on 401

### DIFF
--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -254,7 +254,7 @@ func (p *Personalization) updateMatrices(m *personalizationMatrices) {
 }
 
 func (p *Personalization) update(ctx context.Context) {
-	exists, err := p.b.Exists(ctx, gcpObjectName)
+	exists, err := p.b.ExistsRetry(ctx, gcpObjectName)
 	if !exists || err != nil {
 		panic(fmt.Sprintf("personalization data does not exist: %s", err))
 	}

--- a/service/store/cloudstorage.go
+++ b/service/store/cloudstorage.go
@@ -5,8 +5,12 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
+	"net/http"
 
 	"cloud.google.com/go/storage"
+	"google.golang.org/api/googleapi"
+
+	"github.com/mikeydub/go-gallery/util/retry"
 )
 
 var ObjAttrsOptions objectAttrsOptions
@@ -19,12 +23,24 @@ func NewBucketStorer(c *storage.Client, bucketName string) BucketStorer {
 	return BucketStorer{c.Bucket(string(bucketName))}
 }
 
+// Exists checks if an object exists in the bucket
 func (s BucketStorer) Exists(ctx context.Context, objName string) (bool, error) {
 	_, err := s.Metadata(ctx, objName)
 	if err != nil && err != storage.ErrObjectNotExist {
 		return false, err
 	}
 	return err != storage.ErrObjectNotExist, nil
+}
+
+// ExistsRetry checks if an object exists, but retries on Unauthorized errors.
+// While writes to GCP are strongly consistent, access is only eventually consistent: https://cloud.google.com/storage/docs/consistency.
+// and can take up to several minutes to take effect.
+func (s BucketStorer) ExistsRetry(ctx context.Context, objName string) (exists bool, err error) {
+	retry.RetryFunc(ctx, func(ctx context.Context) error {
+		exists, err = s.Exists(ctx, objName)
+		return err
+	}, isUnauthorizedError, retry.DefaultRetry)
+	return exists, err
 }
 
 func (s BucketStorer) Metadata(ctx context.Context, objName string) (*storage.ObjectAttrs, error) {
@@ -95,4 +111,13 @@ func (objectAttrsOptions) WithContentEncoding(enc string) func(*storage.ObjectAt
 	return func(a *storage.ObjectAttrs) {
 		a.ContentEncoding = enc
 	}
+}
+
+func isUnauthorizedError(err error) bool {
+	if gcpErr, ok := err.(*googleapi.Error); ok {
+		if gcpErr.Code == http.StatusUnauthorized {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Fixes issue where the backend fails to start because it can't read the data needed for the For You Feed because access isn't granted to the file yet.