### PR TITLE
Various fix it week fixes

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -5779,7 +5779,7 @@ FROM feed_entities
 WHERE actor_id = $1
         AND (created_at, id) < ($2, $3)
         AND (created_at, id) > ($4, $5)
-        AND (feed_entity_type != $6) -- Always exclude feed events
+        AND (feed_entity_type = $6)
 ORDER BY 
     CASE WHEN $7::bool THEN (created_at, id) END ASC,
     CASE WHEN NOT $7::bool THEN (created_at, id) END DESC
@@ -5792,7 +5792,7 @@ type PaginateUserFeedByUserIDParams struct {
 	CurBeforeID    persist.DBID `json:"cur_before_id"`
 	CurAfterTime   time.Time    `json:"cur_after_time"`
 	CurAfterID     persist.DBID `json:"cur_after_id"`
-	FeedEntityType int32        `json:"feed_entity_type"`
+	PostEntityType int32        `json:"post_entity_type"`
 	PagingForward  bool         `json:"paging_forward"`
 	Limit          int32        `json:"limit"`
 }
@@ -5804,7 +5804,7 @@ func (q *Queries) PaginateUserFeedByUserID(ctx context.Context, arg PaginateUser
 		arg.CurBeforeID,
 		arg.CurAfterTime,
 		arg.CurAfterID,
-		arg.FeedEntityType,
+		arg.PostEntityType,
 		arg.PagingForward,
 		arg.Limit,
 	)

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -5598,11 +5598,11 @@ SELECT id, feed_entity_type, created_at, actor_id
 FROM feed_entities
 WHERE (created_at, id) < ($1, $2)
         AND (created_at, id) > ($3, $4)
-        AND ($5::bool OR feed_entity_type != $6)
+        AND (feed_entity_type != $5) -- Always exclude feed events
 ORDER BY 
-    CASE WHEN $7::bool THEN (created_at, id) END ASC,
-    CASE WHEN NOT $7::bool THEN (created_at, id) END DESC
-LIMIT $8
+    CASE WHEN $6::bool THEN (created_at, id) END ASC,
+    CASE WHEN NOT $6::bool THEN (created_at, id) END DESC
+LIMIT $7
 `
 
 type PaginateGlobalFeedParams struct {
@@ -5610,8 +5610,7 @@ type PaginateGlobalFeedParams struct {
 	CurBeforeID    persist.DBID `json:"cur_before_id"`
 	CurAfterTime   time.Time    `json:"cur_after_time"`
 	CurAfterID     persist.DBID `json:"cur_after_id"`
-	IncludePosts   bool         `json:"include_posts"`
-	PostEntityType int32        `json:"post_entity_type"`
+	FeedEntityType int32        `json:"feed_entity_type"`
 	PagingForward  bool         `json:"paging_forward"`
 	Limit          int32        `json:"limit"`
 }
@@ -5622,8 +5621,7 @@ func (q *Queries) PaginateGlobalFeed(ctx context.Context, arg PaginateGlobalFeed
 		arg.CurBeforeID,
 		arg.CurAfterTime,
 		arg.CurAfterID,
-		arg.IncludePosts,
-		arg.PostEntityType,
+		arg.FeedEntityType,
 		arg.PagingForward,
 		arg.Limit,
 	)
@@ -5657,23 +5655,20 @@ select fe.id, fe.feed_entity_type, fe.created_at, fe.actor_id from feed_entities
       and fl.follower = $1
       and (fe.created_at, fe.id) < ($2, $3)
       and (fe.created_at, fe.id) > ($4, $5)
-      and ($6::bool or feed_entity_type != $7)
 order by
-    case when $8::bool then (fe.created_at, fe.id) end asc,
-    case when not $8::bool then (fe.created_at, fe.id) end desc
-limit $9
+    case when $6::bool then (fe.created_at, fe.id) end asc,
+    case when not $6::bool then (fe.created_at, fe.id) end desc
+limit $7
 `
 
 type PaginatePersonalFeedByUserIDParams struct {
-	Follower       persist.DBID `json:"follower"`
-	CurBeforeTime  time.Time    `json:"cur_before_time"`
-	CurBeforeID    persist.DBID `json:"cur_before_id"`
-	CurAfterTime   time.Time    `json:"cur_after_time"`
-	CurAfterID     persist.DBID `json:"cur_after_id"`
-	IncludePosts   bool         `json:"include_posts"`
-	PostEntityType int32        `json:"post_entity_type"`
-	PagingForward  bool         `json:"paging_forward"`
-	Limit          int32        `json:"limit"`
+	Follower      persist.DBID `json:"follower"`
+	CurBeforeTime time.Time    `json:"cur_before_time"`
+	CurBeforeID   persist.DBID `json:"cur_before_id"`
+	CurAfterTime  time.Time    `json:"cur_after_time"`
+	CurAfterID    persist.DBID `json:"cur_after_id"`
+	PagingForward bool         `json:"paging_forward"`
+	Limit         int32        `json:"limit"`
 }
 
 func (q *Queries) PaginatePersonalFeedByUserID(ctx context.Context, arg PaginatePersonalFeedByUserIDParams) ([]FeedEntity, error) {
@@ -5683,8 +5678,6 @@ func (q *Queries) PaginatePersonalFeedByUserID(ctx context.Context, arg Paginate
 		arg.CurBeforeID,
 		arg.CurAfterTime,
 		arg.CurAfterID,
-		arg.IncludePosts,
-		arg.PostEntityType,
 		arg.PagingForward,
 		arg.Limit,
 	)
@@ -5789,11 +5782,11 @@ FROM feed_entities
 WHERE actor_id = $1
         AND (created_at, id) < ($2, $3)
         AND (created_at, id) > ($4, $5)
-        AND ($6::bool OR feed_entity_type != $7)
+        AND (feed_entity_type != $6) -- Always exclude feed events
 ORDER BY 
-    CASE WHEN $8::bool THEN (created_at, id) END ASC,
-    CASE WHEN NOT $8::bool THEN (created_at, id) END DESC
-LIMIT $9
+    CASE WHEN $7::bool THEN (created_at, id) END ASC,
+    CASE WHEN NOT $7::bool THEN (created_at, id) END DESC
+LIMIT $8
 `
 
 type PaginateUserFeedByUserIDParams struct {
@@ -5802,8 +5795,7 @@ type PaginateUserFeedByUserIDParams struct {
 	CurBeforeID    persist.DBID `json:"cur_before_id"`
 	CurAfterTime   time.Time    `json:"cur_after_time"`
 	CurAfterID     persist.DBID `json:"cur_after_id"`
-	IncludePosts   bool         `json:"include_posts"`
-	PostEntityType int32        `json:"post_entity_type"`
+	FeedEntityType int32        `json:"feed_entity_type"`
 	PagingForward  bool         `json:"paging_forward"`
 	Limit          int32        `json:"limit"`
 }
@@ -5815,8 +5807,7 @@ func (q *Queries) PaginateUserFeedByUserID(ctx context.Context, arg PaginateUser
 		arg.CurBeforeID,
 		arg.CurAfterTime,
 		arg.CurAfterID,
-		arg.IncludePosts,
-		arg.PostEntityType,
+		arg.FeedEntityType,
 		arg.PagingForward,
 		arg.Limit,
 	)

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -5598,21 +5598,19 @@ SELECT id, feed_entity_type, created_at, actor_id
 FROM feed_entities
 WHERE (created_at, id) < ($1, $2)
         AND (created_at, id) > ($3, $4)
-        AND (feed_entity_type != $5) -- Always exclude feed events
 ORDER BY 
-    CASE WHEN $6::bool THEN (created_at, id) END ASC,
-    CASE WHEN NOT $6::bool THEN (created_at, id) END DESC
-LIMIT $7
+    CASE WHEN $5::bool THEN (created_at, id) END ASC,
+    CASE WHEN NOT $5::bool THEN (created_at, id) END DESC
+LIMIT $6
 `
 
 type PaginateGlobalFeedParams struct {
-	CurBeforeTime  time.Time    `json:"cur_before_time"`
-	CurBeforeID    persist.DBID `json:"cur_before_id"`
-	CurAfterTime   time.Time    `json:"cur_after_time"`
-	CurAfterID     persist.DBID `json:"cur_after_id"`
-	FeedEntityType int32        `json:"feed_entity_type"`
-	PagingForward  bool         `json:"paging_forward"`
-	Limit          int32        `json:"limit"`
+	CurBeforeTime time.Time    `json:"cur_before_time"`
+	CurBeforeID   persist.DBID `json:"cur_before_id"`
+	CurAfterTime  time.Time    `json:"cur_after_time"`
+	CurAfterID    persist.DBID `json:"cur_after_id"`
+	PagingForward bool         `json:"paging_forward"`
+	Limit         int32        `json:"limit"`
 }
 
 func (q *Queries) PaginateGlobalFeed(ctx context.Context, arg PaginateGlobalFeedParams) ([]FeedEntity, error) {
@@ -5621,7 +5619,6 @@ func (q *Queries) PaginateGlobalFeed(ctx context.Context, arg PaginateGlobalFeed
 		arg.CurBeforeID,
 		arg.CurAfterTime,
 		arg.CurAfterID,
-		arg.FeedEntityType,
 		arg.PagingForward,
 		arg.Limit,
 	)

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -422,7 +422,7 @@ SELECT *
 FROM feed_entities
 WHERE (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
         AND (created_at, id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
-        AND (@include_posts::bool OR feed_entity_type != @post_entity_type)
+        AND (feed_entity_type != @feed_entity_type) -- Always exclude feed events
 ORDER BY 
     CASE WHEN sqlc.arg('paging_forward')::bool THEN (created_at, id) END ASC,
     CASE WHEN NOT sqlc.arg('paging_forward')::bool THEN (created_at, id) END DESC
@@ -435,7 +435,6 @@ select fe.* from feed_entities fe, follows fl
       and fl.follower = sqlc.arg('follower')
       and (fe.created_at, fe.id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
       and (fe.created_at, fe.id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
-      and (@include_posts::bool or feed_entity_type != @post_entity_type)
 order by
     case when sqlc.arg('paging_forward')::bool then (fe.created_at, fe.id) end asc,
     case when not sqlc.arg('paging_forward')::bool then (fe.created_at, fe.id) end desc
@@ -447,7 +446,7 @@ FROM feed_entities
 WHERE actor_id = sqlc.arg('owner_id')
         AND (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
         AND (created_at, id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
-        AND (@include_posts::bool OR feed_entity_type != @post_entity_type)
+        AND (feed_entity_type != @feed_entity_type) -- Always exclude feed events
 ORDER BY 
     CASE WHEN sqlc.arg('paging_forward')::bool THEN (created_at, id) END ASC,
     CASE WHEN NOT sqlc.arg('paging_forward')::bool THEN (created_at, id) END DESC

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -445,7 +445,7 @@ FROM feed_entities
 WHERE actor_id = sqlc.arg('owner_id')
         AND (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
         AND (created_at, id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
-        AND (feed_entity_type != @feed_entity_type) -- Always exclude feed events
+        AND (feed_entity_type = @post_entity_type)
 ORDER BY 
     CASE WHEN sqlc.arg('paging_forward')::bool THEN (created_at, id) END ASC,
     CASE WHEN NOT sqlc.arg('paging_forward')::bool THEN (created_at, id) END DESC

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -422,7 +422,6 @@ SELECT *
 FROM feed_entities
 WHERE (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
         AND (created_at, id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
-        AND (feed_entity_type != @feed_entity_type) -- Always exclude feed events
 ORDER BY 
     CASE WHEN sqlc.arg('paging_forward')::bool THEN (created_at, id) END ASC,
     CASE WHEN NOT sqlc.arg('paging_forward')::bool THEN (created_at, id) END DESC

--- a/feed/server.go
+++ b/feed/server.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	"github.com/gin-gonic/gin"
@@ -46,9 +45,7 @@ func handleEvent(queries *db.Queries, taskClient *cloudtasks.Client) gin.Handler
 		}
 
 		// Send event to feedbot
-		err = task.CreateTaskForFeedbot(c.Request.Context(),
-			time.Now(), task.FeedbotMessage{FeedEventID: event.ID, Action: event.Action}, taskClient,
-		)
+		err = task.CreateTaskForFeedbot(c.Request.Context(), task.FeedbotMessage{FeedEventID: event.ID, Action: event.Action}, taskClient)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -460,6 +460,10 @@ type ComplexityRoot struct {
 		SocialAccountType func(childComplexity int) int
 	}
 
+	ErrNoAvatarRecordSet struct {
+		Message func(childComplexity int) int
+	}
+
 	ErrNoCookie struct {
 		Message func(childComplexity int) int
 	}
@@ -3206,6 +3210,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ErrNeedsToReconnectSocial.SocialAccountType(childComplexity), true
+
+	case "ErrNoAvatarRecordSet.message":
+		if e.complexity.ErrNoAvatarRecordSet.Message == nil {
+			break
+		}
+
+		return e.complexity.ErrNoAvatarRecordSet.Message(childComplexity), true
 
 	case "ErrNoCookie.message":
 		if e.complexity.ErrNoCookie.Message == nil {
@@ -10812,6 +10823,10 @@ type RemoveProfileImagePayload {
   viewer: Viewer
 }
 
+type ErrNoAvatarRecordSet implements Error {
+  message: String!
+}
+
 union SetProfileImagePayloadOrError =
     SetProfileImagePayload
   | ErrAuthenticationFailed
@@ -10819,6 +10834,7 @@ union SetProfileImagePayloadOrError =
   | ErrInvalidInput
   | ErrTokenNotFound
   | ErrNotAuthorized
+  | ErrNoAvatarRecordSet
 
 union RemoveProfileImagePayloadOrError =
     RemoveProfileImagePayload
@@ -23290,6 +23306,50 @@ func (ec *executionContext) _ErrNeedsToReconnectSocial_message(ctx context.Conte
 func (ec *executionContext) fieldContext_ErrNeedsToReconnectSocial_message(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ErrNeedsToReconnectSocial",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ErrNoAvatarRecordSet_message(ctx context.Context, field graphql.CollectedField, obj *model.ErrNoAvatarRecordSet) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ErrNoAvatarRecordSet_message(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Message, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ErrNoAvatarRecordSet_message(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ErrNoAvatarRecordSet",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -62155,6 +62215,13 @@ func (ec *executionContext) _Error(ctx context.Context, sel ast.SelectionSet, ob
 			return graphql.Null
 		}
 		return ec._ErrPushTokenBelongsToAnotherUser(ctx, sel, obj)
+	case model.ErrNoAvatarRecordSet:
+		return ec._ErrNoAvatarRecordSet(ctx, sel, &obj)
+	case *model.ErrNoAvatarRecordSet:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ErrNoAvatarRecordSet(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -63940,6 +64007,13 @@ func (ec *executionContext) _SetProfileImagePayloadOrError(ctx context.Context, 
 			return graphql.Null
 		}
 		return ec._ErrNotAuthorized(ctx, sel, obj)
+	case model.ErrNoAvatarRecordSet:
+		return ec._ErrNoAvatarRecordSet(ctx, sel, &obj)
+	case *model.ErrNoAvatarRecordSet:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ErrNoAvatarRecordSet(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -67797,6 +67871,34 @@ func (ec *executionContext) _ErrNeedsToReconnectSocial(ctx context.Context, sel 
 		case "message":
 
 			out.Values[i] = ec._ErrNeedsToReconnectSocial_message(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var errNoAvatarRecordSetImplementors = []string{"ErrNoAvatarRecordSet", "Error", "SetProfileImagePayloadOrError"}
+
+func (ec *executionContext) _ErrNoAvatarRecordSet(ctx context.Context, sel ast.SelectionSet, obj *model.ErrNoAvatarRecordSet) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, errNoAvatarRecordSetImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ErrNoAvatarRecordSet")
+		case "message":
+
+			out.Values[i] = ec._ErrNoAvatarRecordSet_message(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -8441,13 +8441,11 @@ type GalleryUser implements Node @goEmbedHelper {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection @goField(forceResolver: true)
   sharedFollowers(before: String, after: String, first: Int, last: Int): UsersConnection
-    @authRequired
     @goField(forceResolver: true)
   sharedCommunities(before: String, after: String, first: Int, last: Int): CommunitiesConnection
-    @authRequired
     @goField(forceResolver: true)
   createdCommunities(
     input: CreatedCommunitiesInput!
@@ -9028,7 +9026,7 @@ type Viewer implements Node @goGqlId(fields: ["userId"]) @goEmbedHelper {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection @goField(forceResolver: true)
 
   email: UserEmail @goField(forceResolver: true)
@@ -9578,7 +9576,10 @@ type PostComposerDraftDetailsPayload @goEmbedHelper {
   tokenDescription: String
 }
 
-union PostComposerDraftDetailsPayloadOrError = PostComposerDraftDetailsPayload | ErrInvalidInput | ErrCommunityNotFound
+union PostComposerDraftDetailsPayloadOrError =
+    PostComposerDraftDetailsPayload
+  | ErrInvalidInput
+  | ErrCommunityNotFound
 
 type Query {
   node(id: ID!): Node
@@ -9603,7 +9604,7 @@ type Query {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection
   # Paging forward i.e. providing the ` + "`" + `first` + "`" + ` argument will return events in order of descending popularity.
   trendingFeed(
@@ -9611,14 +9612,14 @@ type Query {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection
   curatedFeed(
     before: String
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection
   feedEventById(id: DBID!): FeedEventByIdOrError
   postById(id: DBID!): PostOrError
@@ -28631,28 +28632,8 @@ func (ec *executionContext) _GalleryUser_sharedFollowers(ctx context.Context, fi
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.GalleryUser().SharedFollowers(rctx, obj, fc.Args["before"].(*string), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["last"].(*int))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.AuthRequired == nil {
-				return nil, errors.New("directive authRequired is not implemented")
-			}
-			return ec.directives.AuthRequired(ctx, obj, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*model.UsersConnection); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/mikeydub/go-gallery/graphql/model.UsersConnection`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.GalleryUser().SharedFollowers(rctx, obj, fc.Args["before"].(*string), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["last"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -28709,28 +28690,8 @@ func (ec *executionContext) _GalleryUser_sharedCommunities(ctx context.Context, 
 		}
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		directive0 := func(rctx context.Context) (interface{}, error) {
-			ctx = rctx // use context from middleware stack in children
-			return ec.resolvers.GalleryUser().SharedCommunities(rctx, obj, fc.Args["before"].(*string), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["last"].(*int))
-		}
-		directive1 := func(ctx context.Context) (interface{}, error) {
-			if ec.directives.AuthRequired == nil {
-				return nil, errors.New("directive authRequired is not implemented")
-			}
-			return ec.directives.AuthRequired(ctx, obj, directive0)
-		}
-
-		tmp, err := directive1(rctx)
-		if err != nil {
-			return nil, graphql.ErrorOnPath(ctx, err)
-		}
-		if tmp == nil {
-			return nil, nil
-		}
-		if data, ok := tmp.(*model.CommunitiesConnection); ok {
-			return data, nil
-		}
-		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/mikeydub/go-gallery/graphql/model.CommunitiesConnection`, tmp)
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.GalleryUser().SharedCommunities(rctx, obj, fc.Args["before"].(*string), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["last"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -377,42 +377,8 @@ func testUpdateGalleryWithPublish(t *testing.T) {
 	assert.NotNil(t, vPayload.User)
 	assert.NotNil(t, vPayload.User.Feed)
 	assert.NotNil(t, vPayload.User.Feed.Edges)
-	assert.Len(t, vPayload.User.Feed.Edges, 1)
-	node := vPayload.User.Feed.Edges[0].Node
-	assert.NotNil(t, node)
-	feedEvent := (*node).(*viewerQueryViewerUserGalleryUserFeedFeedConnectionEdgesFeedEdgeNodeFeedEvent)
-	assert.Equal(t, "newCaption", *feedEvent.Caption)
-	edata := *(*feedEvent.EventData).(*viewerQueryViewerUserGalleryUserFeedFeedConnectionEdgesFeedEdgeNodeFeedEventEventDataGalleryUpdatedFeedEventData)
-	assert.EqualValues(t, persist.ActionGalleryUpdated, *edata.Action)
-
-	nameIncluded := false
-	descIncluded := false
-
-	for _, c := range edata.SubEventDatas {
-		ac := c.GetAction()
-		if persist.Action(*ac) == persist.ActionCollectionCreated {
-			ca := c.(*viewerQueryViewerUserGalleryUserFeedFeedConnectionEdgesFeedEdgeNodeFeedEventEventDataGalleryUpdatedFeedEventDataSubEventDatasCollectionCreatedFeedEventData)
-			assert.Greater(t, len(ca.NewTokens), 0)
-		}
-		if persist.Action(*ac) == persist.ActionTokensAddedToCollection {
-			ca := c.(*viewerQueryViewerUserGalleryUserFeedFeedConnectionEdgesFeedEdgeNodeFeedEventEventDataGalleryUpdatedFeedEventDataSubEventDatasTokensAddedToCollectionFeedEventData)
-			assert.Greater(t, len(ca.NewTokens), 0)
-		}
-		if persist.Action(*ac) == persist.ActionGalleryInfoUpdated {
-			ca := c.(*viewerQueryViewerUserGalleryUserFeedFeedConnectionEdgesFeedEdgeNodeFeedEventEventDataGalleryUpdatedFeedEventDataSubEventDatasGalleryInfoUpdatedFeedEventData)
-			if ca.NewDescription != nil {
-				assert.Equal(t, "newDesc", *ca.NewDescription)
-				descIncluded = true
-			}
-			if ca.NewName != nil {
-				assert.Equal(t, "newName", *ca.NewName)
-				nameIncluded = true
-			}
-		}
-	}
-
-	assert.True(t, nameIncluded)
-	assert.True(t, descIncluded)
+	// Assert that feed events aren't shown on the user's activity feed
+	assert.Len(t, vPayload.User.Feed.Edges, 0)
 }
 
 func testCreateGallery(t *testing.T) {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1096,6 +1096,13 @@ func (ErrNeedsToReconnectSocial) IsMintPremiumCardToWalletPayloadOrError()      
 func (ErrNeedsToReconnectSocial) IsDisconnectSocialAccountPayloadOrError()      {}
 func (ErrNeedsToReconnectSocial) IsFollowAllSocialConnectionsPayloadOrError()   {}
 
+type ErrNoAvatarRecordSet struct {
+	Message string `json:"message"`
+}
+
+func (ErrNoAvatarRecordSet) IsError()                         {}
+func (ErrNoAvatarRecordSet) IsSetProfileImagePayloadOrError() {}
+
 type ErrNoCookie struct {
 	Message string `json:"message"`
 }

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -581,8 +581,8 @@ func (r *galleryUserResolver) Following(ctx context.Context, obj *model.GalleryU
 }
 
 // Feed is the resolver for the feed field.
-func (r *galleryUserResolver) Feed(ctx context.Context, obj *model.GalleryUser, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
-	events, pageInfo, err := publicapi.For(ctx).Feed.UserFeed(ctx, obj.Dbid, before, after, first, last, includePosts)
+func (r *galleryUserResolver) Feed(ctx context.Context, obj *model.GalleryUser, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+	events, pageInfo, err := publicapi.For(ctx).Feed.UserFeed(ctx, obj.Dbid, before, after, first, last)
 	if err != nil {
 		return nil, err
 	}
@@ -2264,8 +2264,8 @@ func (r *queryResolver) GalleryOfTheWeekWinners(ctx context.Context) ([]*model.G
 }
 
 // GlobalFeed is the resolver for the globalFeed field.
-func (r *queryResolver) GlobalFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
-	events, pageInfo, err := publicapi.For(ctx).Feed.GlobalFeed(ctx, before, after, first, last, includePosts)
+func (r *queryResolver) GlobalFeed(ctx context.Context, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+	events, pageInfo, err := publicapi.For(ctx).Feed.GlobalFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
 	}
@@ -2282,7 +2282,7 @@ func (r *queryResolver) GlobalFeed(ctx context.Context, before *string, after *s
 }
 
 // TrendingFeed is the resolver for the trendingFeed field.
-func (r *queryResolver) TrendingFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
+func (r *queryResolver) TrendingFeed(ctx context.Context, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
 	events, pageInfo, err := publicapi.For(ctx).Feed.TrendingFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
@@ -2300,7 +2300,7 @@ func (r *queryResolver) TrendingFeed(ctx context.Context, before *string, after 
 }
 
 // CuratedFeed is the resolver for the curatedFeed field.
-func (r *queryResolver) CuratedFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
+func (r *queryResolver) CuratedFeed(ctx context.Context, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
 	events, pageInfo, err := publicapi.For(ctx).Feed.CuratedFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
@@ -2898,8 +2898,8 @@ func (r *viewerResolver) ViewerGalleries(ctx context.Context, obj *model.Viewer)
 }
 
 // Feed is the resolver for the feed field.
-func (r *viewerResolver) Feed(ctx context.Context, obj *model.Viewer, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
-	events, pageInfo, err := publicapi.For(ctx).Feed.PersonalFeed(ctx, before, after, first, last, includePosts)
+func (r *viewerResolver) Feed(ctx context.Context, obj *model.Viewer, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+	events, pageInfo, err := publicapi.For(ctx).Feed.PersonalFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -581,7 +581,7 @@ func (r *galleryUserResolver) Following(ctx context.Context, obj *model.GalleryU
 }
 
 // Feed is the resolver for the feed field.
-func (r *galleryUserResolver) Feed(ctx context.Context, obj *model.GalleryUser, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+func (r *galleryUserResolver) Feed(ctx context.Context, obj *model.GalleryUser, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
 	events, pageInfo, err := publicapi.For(ctx).Feed.UserFeed(ctx, obj.Dbid, before, after, first, last)
 	if err != nil {
 		return nil, err
@@ -2264,7 +2264,7 @@ func (r *queryResolver) GalleryOfTheWeekWinners(ctx context.Context) ([]*model.G
 }
 
 // GlobalFeed is the resolver for the globalFeed field.
-func (r *queryResolver) GlobalFeed(ctx context.Context, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+func (r *queryResolver) GlobalFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
 	events, pageInfo, err := publicapi.For(ctx).Feed.GlobalFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
@@ -2282,7 +2282,7 @@ func (r *queryResolver) GlobalFeed(ctx context.Context, before *string, after *s
 }
 
 // TrendingFeed is the resolver for the trendingFeed field.
-func (r *queryResolver) TrendingFeed(ctx context.Context, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+func (r *queryResolver) TrendingFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
 	events, pageInfo, err := publicapi.For(ctx).Feed.TrendingFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
@@ -2300,7 +2300,7 @@ func (r *queryResolver) TrendingFeed(ctx context.Context, before *string, after 
 }
 
 // CuratedFeed is the resolver for the curatedFeed field.
-func (r *queryResolver) CuratedFeed(ctx context.Context, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+func (r *queryResolver) CuratedFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
 	events, pageInfo, err := publicapi.For(ctx).Feed.CuratedFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
@@ -2898,7 +2898,7 @@ func (r *viewerResolver) ViewerGalleries(ctx context.Context, obj *model.Viewer)
 }
 
 // Feed is the resolver for the feed field.
-func (r *viewerResolver) Feed(ctx context.Context, obj *model.Viewer, before *string, after *string, first *int, last *int, _ bool) (*model.FeedConnection, error) {
+func (r *viewerResolver) Feed(ctx context.Context, obj *model.Viewer, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
 	events, pageInfo, err := publicapi.For(ctx).Feed.PersonalFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/emails"
+	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/mediamapper"
 	"github.com/mikeydub/go-gallery/service/notifications"
@@ -212,6 +213,8 @@ func errorToGraphqlType(ctx context.Context, err error, gqlTypeName string) (gql
 		mappedErr = model.ErrEmailUnverified{Message: message}
 	case errors.Is(err, auth.ErrEmailAlreadyUsed):
 		mappedErr = model.ErrEmailAlreadyUsed{Message: message}
+	case errors.Is(err, eth.ErrNoAvatarRecord) || errors.Is(err, eth.ErrNoResolution):
+		mappedErr = model.ErrNoAvatarRecordSet{Message: message}
 	}
 
 	if mappedErr != nil {
@@ -930,7 +933,7 @@ func notificationToModel(notif db.Notification) (model.Notification, error) {
 			CreationTime: &notif.CreatedAt,
 			UpdatedTime:  &notif.LastUpdated,
 			Count:        &amount,
-			Token:         nil, // handled by dedicated resolver
+			Token:        nil, // handled by dedicated resolver
 			Admirers:     nil, // handled by dedicated resolver
 		}, nil
 	case persist.ActionCommentedOnPost:

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2486,6 +2486,10 @@ type RemoveProfileImagePayload {
   viewer: Viewer
 }
 
+type ErrNoAvatarRecordSet implements Error {
+  message: String!
+}
+
 union SetProfileImagePayloadOrError =
     SetProfileImagePayload
   | ErrAuthenticationFailed
@@ -2493,6 +2497,7 @@ union SetProfileImagePayloadOrError =
   | ErrInvalidInput
   | ErrTokenNotFound
   | ErrNotAuthorized
+  | ErrNoAvatarRecordSet
 
 union RemoveProfileImagePayloadOrError =
     RemoveProfileImagePayload

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -115,7 +115,7 @@ type GalleryUser implements Node @goEmbedHelper {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection @goField(forceResolver: true)
   sharedFollowers(before: String, after: String, first: Int, last: Int): UsersConnection
     @authRequired
@@ -702,7 +702,7 @@ type Viewer implements Node @goGqlId(fields: ["userId"]) @goEmbedHelper {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection @goField(forceResolver: true)
 
   email: UserEmail @goField(forceResolver: true)
@@ -1280,7 +1280,7 @@ type Query {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection
   # Paging forward i.e. providing the `first` argument will return events in order of descending popularity.
   trendingFeed(
@@ -1288,14 +1288,14 @@ type Query {
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection
   curatedFeed(
     before: String
     after: String
     first: Int
     last: Int
-    includePosts: Boolean! = false
+    includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection
   feedEventById(id: DBID!): FeedEventByIdOrError
   postById(id: DBID!): PostOrError

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -118,10 +118,8 @@ type GalleryUser implements Node @goEmbedHelper {
     includePosts: Boolean! = false @deprecated(reason: "Posts are always included now.")
   ): FeedConnection @goField(forceResolver: true)
   sharedFollowers(before: String, after: String, first: Int, last: Int): UsersConnection
-    @authRequired
     @goField(forceResolver: true)
   sharedCommunities(before: String, after: String, first: Int, last: Int): CommunitiesConnection
-    @authRequired
     @goField(forceResolver: true)
   createdCommunities(
     input: CreatedCommunitiesInput!

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -311,7 +311,7 @@ func (api FeedAPI) GetRawEventById(ctx context.Context, eventID persist.DBID) (*
 	return &event, nil
 }
 
-func (api FeedAPI) PersonalFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) ([]any, PageInfo, error) {
+func (api FeedAPI) PersonalFeed(ctx context.Context, before *string, after *string, first *int, last *int) ([]any, PageInfo, error) {
 	userID, err := getAuthenticatedUserID(ctx)
 	if err != nil {
 		return nil, PageInfo{}, err
@@ -328,22 +328,15 @@ func (api FeedAPI) PersonalFeed(ctx context.Context, before *string, after *stri
 		return nil, PageInfo{}, err
 	}
 
-	// Include posts for admins always during the soft launch
-	if !includePosts {
-		includePosts = shouldShowPosts(ctx)
-	}
-
 	queryFunc := func(params timeIDPagingParams) ([]interface{}, error) {
 		keys, err := api.queries.PaginatePersonalFeedByUserID(ctx, db.PaginatePersonalFeedByUserIDParams{
-			Follower:       userID,
-			Limit:          params.Limit,
-			CurBeforeTime:  params.CursorBeforeTime,
-			CurBeforeID:    params.CursorBeforeID,
-			CurAfterTime:   params.CursorAfterTime,
-			CurAfterID:     params.CursorAfterID,
-			PagingForward:  params.PagingForward,
-			IncludePosts:   includePosts,
-			PostEntityType: int32(persist.PostTypeTag),
+			Follower:      userID,
+			Limit:         params.Limit,
+			CurBeforeTime: params.CursorBeforeTime,
+			CurBeforeID:   params.CursorBeforeID,
+			CurAfterTime:  params.CursorAfterTime,
+			CurAfterID:    params.CursorAfterID,
+			PagingForward: params.PagingForward,
 		})
 
 		if err != nil {
@@ -362,7 +355,7 @@ func (api FeedAPI) PersonalFeed(ctx context.Context, before *string, after *stri
 }
 
 func (api FeedAPI) UserFeed(ctx context.Context, userID persist.DBID, before *string, after *string,
-	first *int, last *int, includePosts bool) ([]any, PageInfo, error) {
+	first *int, last *int) ([]any, PageInfo, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
 		"userID": validate.WithTag(userID, "required"),
@@ -374,11 +367,6 @@ func (api FeedAPI) UserFeed(ctx context.Context, userID persist.DBID, before *st
 		return nil, PageInfo{}, err
 	}
 
-	// Include posts for admins always during the soft launch
-	if !includePosts {
-		includePosts = shouldShowPosts(ctx)
-	}
-
 	queryFunc := func(params timeIDPagingParams) ([]interface{}, error) {
 		keys, err := api.queries.PaginateUserFeedByUserID(ctx, db.PaginateUserFeedByUserIDParams{
 			OwnerID:        userID,
@@ -388,8 +376,7 @@ func (api FeedAPI) UserFeed(ctx context.Context, userID persist.DBID, before *st
 			CurAfterTime:   params.CursorAfterTime,
 			CurAfterID:     params.CursorAfterID,
 			PagingForward:  params.PagingForward,
-			IncludePosts:   includePosts,
-			PostEntityType: int32(persist.PostTypeTag),
+			FeedEntityType: int32(persist.FeedEventTypeTag),
 		})
 		if err != nil {
 			return nil, err
@@ -406,15 +393,10 @@ func (api FeedAPI) UserFeed(ctx context.Context, userID persist.DBID, before *st
 	return paginator.paginate(before, after, first, last)
 }
 
-func (api FeedAPI) GlobalFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) ([]any, PageInfo, error) {
+func (api FeedAPI) GlobalFeed(ctx context.Context, before *string, after *string, first *int, last *int) ([]any, PageInfo, error) {
 	// Validate
 	if err := validatePaginationParams(api.validator, first, last); err != nil {
 		return nil, PageInfo{}, err
-	}
-
-	// Include posts for admins always during the soft launch
-	if !includePosts {
-		includePosts = shouldShowPosts(ctx)
 	}
 
 	queryFunc := func(params timeIDPagingParams) ([]interface{}, error) {
@@ -425,8 +407,7 @@ func (api FeedAPI) GlobalFeed(ctx context.Context, before *string, after *string
 			CurAfterTime:   params.CursorAfterTime,
 			CurAfterID:     params.CursorAfterID,
 			PagingForward:  params.PagingForward,
-			IncludePosts:   includePosts,
-			PostEntityType: int32(persist.PostTypeTag),
+			FeedEntityType: int32(persist.FeedEventTypeTag),
 		})
 
 		if err != nil {
@@ -1004,27 +985,4 @@ func (f feedCache) Load(ctx context.Context) ([]persist.FeedEntityType, []persis
 	cur := cursors.NewFeedPositionCursor()
 	err = cur.Unpack(string(b))
 	return cur.EntityTypes, cur.EntityIDs, err
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func shouldShowPosts(ctx context.Context) bool {
-	for _, role := range getUserRoles(ctx) {
-		if role == persist.RoleAdmin || role == persist.RoleBetaTester {
-			return true
-		}
-	}
-	return false
 }

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -401,13 +401,12 @@ func (api FeedAPI) GlobalFeed(ctx context.Context, before *string, after *string
 
 	queryFunc := func(params timeIDPagingParams) ([]interface{}, error) {
 		keys, err := api.queries.PaginateGlobalFeed(ctx, db.PaginateGlobalFeedParams{
-			Limit:          params.Limit,
-			CurBeforeTime:  params.CursorBeforeTime,
-			CurBeforeID:    params.CursorBeforeID,
-			CurAfterTime:   params.CursorAfterTime,
-			CurAfterID:     params.CursorAfterID,
-			PagingForward:  params.PagingForward,
-			FeedEntityType: int32(persist.FeedEventTypeTag),
+			Limit:         params.Limit,
+			CurBeforeTime: params.CursorBeforeTime,
+			CurBeforeID:   params.CursorBeforeID,
+			CurAfterTime:  params.CursorAfterTime,
+			CurAfterID:    params.CursorAfterID,
+			PagingForward: params.PagingForward,
 		})
 
 		if err != nil {

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -376,7 +376,7 @@ func (api FeedAPI) UserFeed(ctx context.Context, userID persist.DBID, before *st
 			CurAfterTime:   params.CursorAfterTime,
 			CurAfterID:     params.CursorAfterID,
 			PagingForward:  params.PagingForward,
-			FeedEntityType: int32(persist.FeedEventTypeTag),
+			PostEntityType: int32(persist.PostTypeTag),
 		})
 		if err != nil {
 			return nil, err

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -783,10 +783,11 @@ func (api UserAPI) GetFollowingByUserId(ctx context.Context, userID persist.DBID
 }
 
 func (api UserAPI) SharedFollowers(ctx context.Context, userID persist.DBID, before, after *string, first, last *int) ([]db.User, PageInfo, error) {
-	// Validate
-	curUserID, err := getAuthenticatedUserID(ctx)
-	if err != nil {
-		return nil, PageInfo{}, err
+	curUserID, _ := getAuthenticatedUserID(ctx)
+
+	// If the user is not logged in, return an empty list of users
+	if curUserID == "" {
+		return []db.User{}, PageInfo{}, nil
 	}
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
@@ -861,9 +862,11 @@ func (api UserAPI) SharedFollowers(ctx context.Context, userID persist.DBID, bef
 
 func (api UserAPI) SharedCommunities(ctx context.Context, userID persist.DBID, before, after *string, first, last *int) ([]db.Contract, PageInfo, error) {
 	// Validate
-	curUserID, err := getAuthenticatedUserID(ctx)
-	if err != nil {
-		return nil, PageInfo{}, err
+	curUserID, _ := getAuthenticatedUserID(ctx)
+
+	// If the user is not logged in, return an empty list of users
+	if curUserID == "" {
+		return []db.Contract{}, PageInfo{}, nil
 	}
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{

--- a/secrets/dev/feedbot-env.yaml
+++ b/secrets/dev/feedbot-env.yaml
@@ -8,7 +8,6 @@ GALLERY_API: ENC[AES256_GCM,data:QKd4z7mttesvSTk2lvJ/p9nL9xBSP5kjXzTMl+8znFzJ8W1
 FEEDBOT_SECRET: ENC[AES256_GCM,data:If1XUl/oN/KpYh6vDFjD7gAf,iv:dOwy1Ly+KoknuWWiakKO19lAl3y4b39dGy6Tkz6eizE=,tag:PIecFoecrWX1jIxtUbcH4Q==,type:str]
 SENTRY_DSN: ENC[AES256_GCM,data:2IIsruhh4uUvFr7S2KUznCzb3BwZZfyqqTWYcemLWc8WBu3kKq4aj8y/oyUk0sguDxiEC70IheddVUoOY+/cO4LZDitY4D1hgzo=,iv:Oo0V+x2cJfK0J4Igc7UXuKFohwvX26ap5KhGskRFg8M=,tag:IccURAny7WtNmB8Iezkn6Q==,type:str]
 SENTRY_TRACES_SAMPLE_RATE: ENC[AES256_GCM,data:FVUj,iv:XCRbgFpAKgPCz0ftT3A4ZRiooBoO5Z9MadtBRxM0S/4=,tag:kLIHg9l56Gdb0P20A5vY4g==,type:str]
-SLACK_WEBHOOK_URL: ENC[AES256_GCM,data:DqE20qzC9nWDKoRuuhuAxmBBXtMsvJ1c6B66u+qQMFE+4xvissQe0gRB1u1jFxgkIlJbsiVUrpci+pAHSTbAf+3T3WvLB1Re/eHXppmrQqGA,iv:ULCJwS2gHZdf+G1Z6RnZB3CiRWcMswobluHtx96LpSo=,tag:DOxENPB4Wc0xcWBKyfgTeA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -18,8 +17,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-09-23T02:30:10Z"
-    mac: ENC[AES256_GCM,data:qKFa9TY4zgAYwFcuavhR0DFoORiMbVcRRt+MARBV81iM+ez4awiotkAfsspDPrq8XFpJqigb95xNJEyhbERurVvdyIPtCiFIsglOOiPatTl0p3GjhXITIibL+Frx92LcBj81HwmURXrB0b1tfYqXHoFaLRgkNNj8hWsnN4hM9Lc=,iv:mIUcz5c1E7RaN2h3y0IE7uFuFgcF6+UD55ePK71TGpk=,tag:z68JuOxNs0Z6CMUepzaaSw==,type:str]
+    lastmodified: "2023-09-27T17:13:50Z"
+    mac: ENC[AES256_GCM,data:m3SXtJSDipVHGGuFRQnWoHaOQQpY1eeE57bfUhai5UZGS2AVgGrPqteo2xmhAUzX4ps7zCIInw3nXA3C+APMcs0FMmFbRSdJ5AnRTnF1r/233v0XBZd+c/a/ivgXbSSoN5uSrOpRjOwMbRgQcf3LT1mYijiD5xY712BOsDf43k8=,iv:oJaiWa/cqNlSuj/afzMN3pkQGv5b1oSnccf9yPWZyTQ=,tag:9JqZZIILO5RrzH33ZQyYjA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/eth/eth.go
+++ b/service/eth/eth.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/rpc"
 )
 
-var ErrNoResolution = errors.New("no resolution")
+var ErrNoResolution = errors.New("unable to resolve ENS doman from address")
 var ErrUnknownEnsAvatarURI = errors.New("unknown ENS avatar uri")
 var ErrChainNotSupported = errors.New("chain not supported")
 var ErrUnknownTokenType = errors.New("unknown token type")

--- a/service/task/cloudtask.go
+++ b/service/task/cloudtask.go
@@ -123,24 +123,25 @@ func CreateTaskForPushNotification(ctx context.Context, message PushNotification
 	return submitTask(ctx, client, queue, url, withJSON(message), withTrace(span), withBasicAuth(secret))
 }
 
-func CreateTaskForFeed(ctx context.Context, scheduleOn time.Time, message FeedMessage, client *gcptasks.Client) error {
+func CreateTaskForFeed(ctx context.Context, message FeedMessage, client *gcptasks.Client) error {
 	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForFeed")
 	defer tracing.FinishSpan(span)
 	tracing.AddEventDataToSpan(span, map[string]any{"Event ID": message.ID})
 	queue := env.GetString("GCLOUD_FEED_QUEUE")
 	url := fmt.Sprintf("%s/tasks/feed-event", env.GetString("FEED_URL"))
 	secret := env.GetString("FEED_SECRET")
-	return submitTask(ctx, client, queue, url, withScheduleOn(scheduleOn), withJSON(message), withTrace(span), withBasicAuth(secret))
+	delay := time.Duration(env.GetInt("GCLOUD_FEED_BUFFER_SECS")) * time.Second
+	return submitTask(ctx, client, queue, url, withDelay(delay), withJSON(message), withTrace(span), withBasicAuth(secret))
 }
 
-func CreateTaskForFeedbot(ctx context.Context, scheduleOn time.Time, message FeedbotMessage, client *gcptasks.Client) error {
+func CreateTaskForFeedbot(ctx context.Context, message FeedbotMessage, client *gcptasks.Client) error {
 	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForFeedbot")
 	defer tracing.FinishSpan(span)
 	tracing.AddEventDataToSpan(span, map[string]any{"Event ID": message.FeedEventID})
 	queue := env.GetString("GCLOUD_FEEDBOT_TASK_QUEUE")
 	url := fmt.Sprintf("%s/tasks/feed-event", env.GetString("FEEDBOT_URL"))
 	secret := env.GetString("FEEDBOT_SECRET")
-	return submitTask(ctx, client, queue, url, withScheduleOn(scheduleOn), withJSON(message), withTrace(span), withBasicAuth(secret))
+	return submitTask(ctx, client, queue, url, withJSON(message), withTrace(span), withBasicAuth(secret))
 }
 
 func CreateTaskForTokenProcessing(ctx context.Context, message TokenProcessingUserMessage, client *gcptasks.Client) error {
@@ -175,7 +176,7 @@ func CreateTaskForTokenTokenProcessing(ctx context.Context, message TokenProcess
 	defer tracing.FinishSpan(span)
 	queue := env.GetString("TOKEN_PROCESSING_QUEUE")
 	url := fmt.Sprintf("%s/media/tokenmanage/process/token", env.GetString("TOKEN_PROCESSING_URL"))
-	return submitTask(ctx, client, queue, url, withJSON(message), withTrace(span), withScheduleOn(time.Now().Add(delay)))
+	return submitTask(ctx, client, queue, url, withJSON(message), withTrace(span), withDelay(delay))
 }
 
 func CreateTaskForWalletRemoval(ctx context.Context, message TokenProcessingWalletRemovalMessage, client *gcptasks.Client) error {
@@ -211,7 +212,7 @@ func CreateTaskForSlackPostFeedBot(ctx context.Context, message FeedbotSlackPost
 	queue := env.GetString("GCLOUD_FEEDBOT_TASK_QUEUE")
 	url := fmt.Sprintf("%s/tasks/slack-post", env.GetString("FEEDBOT_URL"))
 	secret := env.GetString("FEEDBOT_SECRET")
-	return submitTask(ctx, client, queue, url, withJSON(message), withTrace(span), withBasicAuth(secret))
+	return submitTask(ctx, client, queue, url, withJSON(message), withTrace(span), withBasicAuth(secret), withDelay(2*time.Minute))
 }
 
 // NewClient returns a new task client with tracing enabled.
@@ -253,8 +254,9 @@ func NewClient(ctx context.Context) *gcptasks.Client {
 	return client
 }
 
-func withScheduleOn(scheduleOn time.Time) func(*taskspb.Task) error {
+func withDelay(delay time.Duration) func(*taskspb.Task) error {
 	return func(t *taskspb.Task) error {
+		scheduleOn := time.Now().Add(delay)
 		t.ScheduleTime = timestamppb.New(scheduleOn)
 		return nil
 	}


### PR DESCRIPTION
**Changes**
* Posts and feed events are always shown on Global Feed
* Posts and feed events are always shown on Following Feed
* Posts are now only shown on Activity Feed
* Adds `deprecated` directive to `includePosts` param wherever it appears
* Maps ENS PFP errors to GraphQL error type to reduce noise in Sentry
* Removes `authRequired` directive from `sharedCommunities` and `sharedFollowers` fields on `GalleryUser` - now returns no results if the user isn't authenticated, to reduce noise in Sentry
* Dev posts are no longer posted to Slack
* Changes `withScheduleOn` option to `withDelay` in `cloudtask.go`
