### PR TITLE
Include viewer in feed

### DIFF
--- a/db/gen/coredb/recommend.sql.go
+++ b/db/gen/coredb/recommend.sql.go
@@ -94,31 +94,21 @@ with refreshed as (
 select feed_entity_scores.id, feed_entity_scores.created_at, feed_entity_scores.actor_id, feed_entity_scores.action, feed_entity_scores.contract_ids, feed_entity_scores.interactions, feed_entity_scores.feed_entity_type, feed_entity_scores.last_updated, posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted
 from feed_entity_scores
 join posts on feed_entity_scores.id = posts.id
-where feed_entity_scores.created_at > $1::timestamptz
-  and ($2::bool or feed_entity_scores.actor_id != $3)
-  and not posts.deleted
+where feed_entity_scores.created_at > $1::timestamptz and not posts.deleted
 union
 select feed_entity_scores.id, feed_entity_scores.created_at, feed_entity_scores.actor_id, feed_entity_scores.action, feed_entity_scores.contract_ids, feed_entity_scores.interactions, feed_entity_scores.feed_entity_type, feed_entity_scores.last_updated, posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted
 from feed_entity_score_view feed_entity_scores
 join posts on feed_entity_scores.id = posts.id
-where feed_entity_scores.created_at > (select last_updated from refreshed limit 1)
-  and ($2::bool or feed_entity_scores.actor_id != $3)
-  and not posts.deleted
+where feed_entity_scores.created_at > (select last_updated from refreshed limit 1) and not posts.deleted
 `
-
-type GetFeedEntityScoresParams struct {
-	WindowEnd     time.Time    `json:"window_end"`
-	IncludeViewer bool         `json:"include_viewer"`
-	ViewerID      persist.DBID `json:"viewer_id"`
-}
 
 type GetFeedEntityScoresRow struct {
 	FeedEntityScore FeedEntityScore `json:"feedentityscore"`
 	Post            Post            `json:"post"`
 }
 
-func (q *Queries) GetFeedEntityScores(ctx context.Context, arg GetFeedEntityScoresParams) ([]GetFeedEntityScoresRow, error) {
-	rows, err := q.db.Query(ctx, getFeedEntityScores, arg.WindowEnd, arg.IncludeViewer, arg.ViewerID)
+func (q *Queries) GetFeedEntityScores(ctx context.Context, windowEnd time.Time) ([]GetFeedEntityScoresRow, error) {
+	rows, err := q.db.Query(ctx, getFeedEntityScores, windowEnd)
 	if err != nil {
 		return nil, err
 	}

--- a/db/queries/core/recommend.sql
+++ b/db/queries/core/recommend.sql
@@ -78,13 +78,9 @@ with refreshed as (
 select sqlc.embed(feed_entity_scores), sqlc.embed(posts)
 from feed_entity_scores
 join posts on feed_entity_scores.id = posts.id
-where feed_entity_scores.created_at > @window_end::timestamptz
-  and (@include_viewer::bool or feed_entity_scores.actor_id != @viewer_id)
-  and not posts.deleted
+where feed_entity_scores.created_at > @window_end::timestamptz and not posts.deleted
 union
 select sqlc.embed(feed_entity_scores), sqlc.embed(posts)
 from feed_entity_score_view feed_entity_scores
 join posts on feed_entity_scores.id = posts.id
-where feed_entity_scores.created_at > (select last_updated from refreshed limit 1)
-  and (@include_viewer::bool or feed_entity_scores.actor_id != @viewer_id)
-  and not posts.deleted;
+where feed_entity_scores.created_at > (select last_updated from refreshed limit 1) and not posts.deleted;

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2306,7 +2306,7 @@ func (r *queryResolver) TrendingFeed(ctx context.Context, before *string, after 
 
 // CuratedFeed is the resolver for the curatedFeed field.
 func (r *queryResolver) CuratedFeed(ctx context.Context, before *string, after *string, first *int, last *int, includePosts bool) (*model.FeedConnection, error) {
-	events, pageInfo, err := publicapi.For(ctx).Feed.CuratedFeed(ctx, before, after, first, last)
+	events, pageInfo, err := publicapi.For(ctx).Feed.ForYouFeed(ctx, before, after, first, last)
 	if err != nil {
 		return nil, err
 	}

--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -196,6 +196,11 @@ func (p *Personalization) RelevanceTo(userID persist.DBID, e db.FeedEntityScore)
 		return 0
 	}
 
+	// If scoring themselves, return 1 which is the max score
+	if userID == e.ActorID {
+		return 1.0
+	}
+
 	var relevanceScore float64
 
 	for _, contractID := range e.ContractIds {
@@ -208,7 +213,7 @@ func (p *Personalization) RelevanceTo(userID persist.DBID, e db.FeedEntityScore)
 	}
 
 	edgeScore, _ := p.scoreEdge(userID, e.ActorID)
-	return relevanceScore + edgeScore
+	return (relevanceScore + edgeScore) / 2.0
 }
 
 func (p *Personalization) scoreEdge(viewerID, queryID persist.DBID) (float64, error) {
@@ -219,7 +224,7 @@ func (p *Personalization) scoreEdge(viewerID, queryID persist.DBID) (float64, er
 	}
 	socialScore := calcSocialScore(p.pM.userM, vIdx, qIdx)
 	similarityScore := calcSimilarityScore(p.pM.simM, vIdx, qIdx)
-	return socialScore + similarityScore, nil
+	return (socialScore + similarityScore) / 2.0, nil
 }
 
 func (p *Personalization) scoreRelevance(viewerID, contractID persist.DBID) (float64, error) {
@@ -288,6 +293,9 @@ func (p *Personalization) readCache(ctx context.Context) {
 
 // calcSocialScore determines if vIdx is in the same friend circle as qIdx by running a bfs on userM
 func calcSocialScore(userM *sparse.CSR, vIdx, qIdx int) float64 {
+	if vIdx == qIdx {
+		return 1
+	}
 	return bfs(userM, vIdx, qIdx)
 }
 
@@ -314,7 +322,7 @@ func calcSimilarityScore(simM *sparse.CSR, vIdx, qIdx int) float64 {
 }
 
 // idLookup uses a slice to lookup a value by its index
-// Its purpose is to avoid using a map because indexing a slice is suprisingly much quicker than a map lookup.
+// Its purpose is to avoid using a map because indexing a slice is surprisingly much quicker than a map lookup.
 // It should be pretty space efficient: with one million users, it should take: 1 million users * 1 byte = 1MB of memory.
 type idLookup struct {
 	l []uint8


### PR DESCRIPTION
**Changes**
* Viewer is now included in the For You Feed
* Viewer posts are only ranked using the post's engagement instead of the post's engagement and relevance to the user
* Normalizes personalization scores to 1.0
* Reduces the shuffle window size from 8 to 4