### PR TITLE
search for users by multiple chains when necessary

### DIFF
--- a/autosocial/orchestrator/handler.go
+++ b/autosocial/orchestrator/handler.go
@@ -56,7 +56,7 @@ func processAllUsers(pg *pgxpool.Pool, ctc *cloudtasks.Client) gin.HandlerFunc {
 				if !ok {
 					it = make(map[persist.SocialProvider][]persist.ChainAddress)
 				}
-				it[persist.SocialProviderFarcaster] = append(it[persist.SocialProviderFarcaster], persist.NewChainAddress(walletAddress, persist.ChainBTC))
+				it[persist.SocialProviderFarcaster] = append(it[persist.SocialProviderFarcaster], persist.NewChainAddress(walletAddress, persist.ChainETH))
 				send[userID] = it
 			}
 

--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -3373,7 +3373,7 @@ const getUserByAddressBatch = `-- name: GetUserByAddressBatch :batchone
 select users.id, users.deleted, users.version, users.last_updated, users.created_at, users.username, users.username_idempotent, users.wallets, users.bio, users.traits, users.universal, users.notification_settings, users.email_verified, users.email_unsubscriptions, users.featured_gallery, users.primary_wallet_id, users.user_experiences, users.profile_image_id
 from users, wallets
 where wallets.address = $1
-	and wallets.chain = $2::int
+	and wallets.chain = any($2)
 	and array[wallets.id] <@ users.wallets
 	and wallets.deleted = false
 	and users.deleted = false
@@ -3386,8 +3386,8 @@ type GetUserByAddressBatchBatchResults struct {
 }
 
 type GetUserByAddressBatchParams struct {
-	Address persist.Address `json:"address"`
-	Chain   int32           `json:"chain"`
+	Address     persist.Address     `json:"address"`
+	Multichains persist.Multichains `json:"multichains"`
 }
 
 func (q *Queries) GetUserByAddressBatch(ctx context.Context, arg []GetUserByAddressBatchParams) *GetUserByAddressBatchBatchResults {
@@ -3395,7 +3395,7 @@ func (q *Queries) GetUserByAddressBatch(ctx context.Context, arg []GetUserByAddr
 	for _, a := range arg {
 		vals := []interface{}{
 			a.Address,
-			a.Chain,
+			a.Multichains,
 		}
 		batch.Queue(getUserByAddressBatch, vals...)
 	}

--- a/server/inject.go
+++ b/server/inject.go
@@ -56,7 +56,6 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 	wire.Build(
 		setEnv,
 		wire.Value(&http.Client{Timeout: 0}), // HTTP client shared between providers
-		defaultWalletOverrides,
 		task.NewClient,
 		newCommunitiesCache,
 		postgres.NewRepositories,
@@ -439,19 +438,6 @@ func newMultichainSet(
 	chainToProviders[persist.ChainPolygon] = dedupe(polygonProviders)
 	chainToProviders[persist.ChainArbitrum] = dedupe(arbitrumProviders)
 	return chainToProviders
-}
-
-// defaultWalletOverrides is a wire provider for wallet overrides
-func defaultWalletOverrides() multichain.WalletOverrideMap {
-	return multichain.WalletOverrideMap{
-		persist.ChainPOAP:     persist.EvmChains,
-		persist.ChainOptimism: persist.EvmChains,
-		persist.ChainPolygon:  persist.EvmChains,
-		persist.ChainArbitrum: persist.EvmChains,
-		persist.ChainETH:      persist.EvmChains,
-		persist.ChainZora:     persist.EvmChains,
-		persist.ChainBase:     persist.EvmChains,
-	}
 }
 
 func ethFallbackProvider(httpClient *http.Client, r *redis.Cache) multichain.SyncFailureFallbackProvider {

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -55,7 +55,6 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 	serverPolygonProviderList := polygonProviderSet(httpClient)
 	serverArbitrumProviderList := arbitrumProviderSet(httpClient)
 	v := newMultichainSet(serverEthProviderList, serverOptimismProviderList, serverTezosProviderList, serverPoapProviderList, serverZoraProviderList, serverBaseProviderList, serverPolygonProviderList, serverArbitrumProviderList)
-	v2 := defaultWalletOverrides()
 	manager := tokenmanage.New(ctx, client)
 	submitUserTokensF := newManagedTokens(ctx, manager)
 	provider := &multichain.Provider{
@@ -63,7 +62,6 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 		Queries:          queries,
 		Cache:            cache,
 		Chains:           v,
-		WalletOverrides:  v2,
 		SubmitUserTokens: submitUserTokensF,
 	}
 	return provider, func() {
@@ -426,11 +424,6 @@ func newMultichainSet(
 	chainToProviders[persist.ChainPolygon] = dedupe(polygonProviders)
 	chainToProviders[persist.ChainArbitrum] = dedupe(arbitrumProviders)
 	return chainToProviders
-}
-
-// defaultWalletOverrides is a wire provider for wallet overrides
-func defaultWalletOverrides() multichain.WalletOverrideMap {
-	return multichain.WalletOverrideMap{persist.ChainPOAP: persist.EvmChains, persist.ChainOptimism: persist.EvmChains, persist.ChainPolygon: persist.EvmChains, persist.ChainArbitrum: persist.EvmChains, persist.ChainETH: persist.EvmChains, persist.ChainZora: persist.EvmChains, persist.ChainBase: persist.EvmChains}
 }
 
 func newIndexerProvider(e envInit, httpClient *http.Client, ethClient *ethclient.Client, taskClient *cloudtasks.Client) *eth.Provider {

--- a/service/persist/postgres/auth.go
+++ b/service/persist/postgres/auth.go
@@ -3,8 +3,9 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"time"
+
+	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 
 	"github.com/mikeydub/go-gallery/service/persist"
 )
@@ -22,7 +23,7 @@ func NewNonceRepository(db *sql.DB, queries *db.Queries) *NonceRepository {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	getByChainAddressStmt, err := db.PrepareContext(ctx, `SELECT ID,VALUE,ADDRESS,VERSION,DELETED,CREATED_AT,LAST_UPDATED FROM nonces WHERE ADDRESS = $1 AND CHAIN = $2 ORDER BY LAST_UPDATED DESC LIMIT 1`)
+	getByChainAddressStmt, err := db.PrepareContext(ctx, `SELECT ID,VALUE,ADDRESS,VERSION,DELETED,CREATED_AT,LAST_UPDATED FROM nonces WHERE ADDRESS = $1 AND CHAIN = any($2) ORDER BY LAST_UPDATED DESC LIMIT 1`)
 	checkNoErr(err)
 
 	createStmt, err := db.PrepareContext(ctx, `INSERT INTO nonces (ID,VALUE,ADDRESS,CHAIN,VERSION,DELETED) VALUES ($1,$2,$3,$4,$5,$6)`)
@@ -34,7 +35,7 @@ func NewNonceRepository(db *sql.DB, queries *db.Queries) *NonceRepository {
 // Get returns a nonce from the DB by its address
 func (n *NonceRepository) Get(pCtx context.Context, pChainAddress persist.ChainAddress) (persist.UserNonce, error) {
 	var nonce persist.UserNonce
-	err := n.getByChainAddressStmt.QueryRowContext(pCtx, pChainAddress.Address(), pChainAddress.Chain()).Scan(&nonce.ID, &nonce.Value, &nonce.Address, &nonce.Version, &nonce.Deleted, &nonce.CreationTime, &nonce.LastUpdated)
+	err := n.getByChainAddressStmt.QueryRowContext(pCtx, pChainAddress.Address(), pChainAddress.Multichains()).Scan(&nonce.ID, &nonce.Value, &nonce.Address, &nonce.Version, &nonce.Deleted, &nonce.CreationTime, &nonce.LastUpdated)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return persist.UserNonce{}, persist.ErrNonceNotFoundForAddress{ChainAddress: pChainAddress}

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -3,11 +3,13 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
@@ -347,17 +349,20 @@ func (u *UserRepository) GetByIDs(pCtx context.Context, pIDs []persist.DBID) ([]
 
 // GetByChainAddress gets the user who owns the wallet with the specified ChainAddress (if any)
 func (u *UserRepository) GetByChainAddress(pCtx context.Context, pChainAddress persist.ChainAddress) (persist.User, error) {
-	var walletID persist.DBID
 
-	err := u.getWalletIDStmt.QueryRowContext(pCtx, pChainAddress.Address(), pChainAddress.Chain()).Scan(&walletID)
+	dbUser, err := u.queries.GetUserByAddress(pCtx, db.GetUserByAddressParams{
+		Address:     pChainAddress.Address(),
+		Multichains: pChainAddress.Multichains(),
+	})
+
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return persist.User{}, persist.ErrWalletNotFound{ChainAddress: pChainAddress}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return persist.User{}, persist.ErrUserNotFound{ChainAddress: pChainAddress}
 		}
 		return persist.User{}, err
 	}
 
-	return u.GetByWalletID(pCtx, walletID)
+	return u.dbUserToPersist(pCtx, dbUser)
 }
 
 // GetByWalletID gets the user with the given wallet in their list of addresses
@@ -599,4 +604,36 @@ func (u *UserRepository) FillWalletDataForUser(pCtx context.Context, user *persi
 	user.Wallets = wallets
 
 	return nil
+}
+
+func (u *UserRepository) dbUserToPersist(ctx context.Context, dbUser db.User) (persist.User, error) {
+	var traits persist.Traits
+	if dbUser.Traits.Status == pgtype.Present {
+		bs := dbUser.Traits.Bytes
+		if err := json.Unmarshal(bs, &traits); err != nil {
+			return persist.User{}, err
+		}
+	}
+	user := &persist.User{
+		Version:            persist.NullInt32(dbUser.Version.Int32),
+		ID:                 dbUser.ID,
+		CreationTime:       dbUser.CreatedAt,
+		Deleted:            persist.NullBool(dbUser.Deleted),
+		LastUpdated:        dbUser.LastUpdated,
+		Username:           persist.NullString(dbUser.Username.String),
+		UsernameIdempotent: persist.NullString(dbUser.UsernameIdempotent.String),
+		Wallets:            dbUser.Wallets,
+		Bio:                persist.NullString(dbUser.Bio.String),
+		Traits:             traits,
+		Universal:          persist.NullBool(dbUser.Universal),
+		PrimaryWalletID:    persist.NullString(dbUser.PrimaryWalletID),
+		EmailVerified:      persist.NullInt64(dbUser.EmailVerified),
+	}
+
+	err := u.FillWalletDataForUser(ctx, user)
+	if err != nil {
+		return persist.User{}, err
+	}
+
+	return *user, nil
 }

--- a/service/persist/wallet.go
+++ b/service/persist/wallet.go
@@ -138,7 +138,7 @@ func (c ChainAddress) String() string {
 }
 
 func (c ChainAddress) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]any{"address": c.address, "chain": c.chain})
+	return json.Marshal(map[string]any{"address": c.address.String(), "chain": int(c.chain)})
 }
 
 func (c *ChainAddress) UnmarshalJSON(data []byte) error {
@@ -154,8 +154,13 @@ func (c *ChainAddress) UnmarshalJSON(data []byte) error {
 	}
 
 	if v["chain"] != nil {
-		c.chain = Chain(v["chain"].(float64))
-		c.chainSet = true
+		if chain, ok := v["chain"].(int); ok {
+			c.chain = Chain(chain)
+			c.chainSet = true
+		} else if chain, ok := v["chain"].(int32); ok {
+			c.chain = Chain(chain)
+			c.chainSet = true
+		}
 	}
 
 	return nil

--- a/service/persist/wallet.go
+++ b/service/persist/wallet.go
@@ -3,6 +3,7 @@ package persist
 import (
 	"context"
 	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -134,6 +135,30 @@ func (c *ChainAddress) GQLSetChainFromResolver(chain Chain) error {
 
 func (c ChainAddress) String() string {
 	return fmt.Sprintf("%d:%s", c.chain, c.address)
+}
+
+func (c ChainAddress) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]any{"address": c.address, "chain": c.chain})
+}
+
+func (c *ChainAddress) UnmarshalJSON(data []byte) error {
+	var v map[string]any
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+
+	if v["address"] != nil {
+		c.address = Address(v["address"].(string))
+		c.addressSet = true
+	}
+
+	if v["chain"] != nil {
+		c.chain = Chain(v["chain"].(float64))
+		c.chainSet = true
+	}
+
+	return nil
 }
 
 var WalletOverrideMap = map[Chain][]Chain{ChainPOAP: EvmChains, ChainOptimism: EvmChains, ChainPolygon: EvmChains, ChainArbitrum: EvmChains, ChainETH: EvmChains, ChainZora: EvmChains, ChainBase: EvmChains}

--- a/service/socialauth/socialauth.go
+++ b/service/socialauth/socialauth.go
@@ -71,9 +71,9 @@ type FarcasterAuthenticator struct {
 
 func (a FarcasterAuthenticator) Authenticate(ctx context.Context) (*SocialAuthResult, error) {
 	api := farcaster.NewNeynarAPI(a.HTTPClient)
-	user, err := a.Queries.GetUserByAddressAndChains(ctx, coredb.GetUserByAddressAndChainsParams{
-		Address: a.Address,
-		Chains:  util.MapWithoutError(persist.EvmChains, func(c persist.Chain) int32 { return int32(c) }),
+	user, err := a.Queries.GetUserByAddress(ctx, coredb.GetUserByAddressParams{
+		Address:     a.Address,
+		Multichains: persist.NewMultichains(persist.ChainETH),
 	})
 	if err != nil {
 		return nil, err
@@ -114,9 +114,9 @@ type LensAuthenticator struct {
 
 func (a LensAuthenticator) Authenticate(ctx context.Context) (*SocialAuthResult, error) {
 	api := lens.NewAPI(a.HTTPClient)
-	user, err := a.Queries.GetUserByAddressAndChains(ctx, coredb.GetUserByAddressAndChainsParams{
-		Address: a.Address,
-		Chains:  util.MapWithoutError(persist.EvmChains, func(c persist.Chain) int32 { return int32(c) }),
+	user, err := a.Queries.GetUserByAddress(ctx, coredb.GetUserByAddressParams{
+		Address:     a.Address,
+		Multichains: persist.NewMultichains(persist.ChainETH),
 	})
 	if err != nil {
 		return nil, err

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -240,3 +240,5 @@ sql:
             go_type: 'github.com/mikeydub/go-gallery/service/persist.Socials'
           - column: '*.*.mentions'
             go_type: 'github.com/mikeydub/go-gallery/service/persist.Mentions'
+          - column: '*.*.multichains'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.Multichains'

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -403,9 +403,9 @@ func processOwnersForAlchemyTokens(mc *multichain.Provider, queries *coredb.Quer
 
 			userID, ok := addressToUsers[persist.NewChainAddress(activity.ToAddress, chain)]
 			if !ok {
-				user, err := queries.GetUserByAddressAndChains(c, coredb.GetUserByAddressAndChainsParams{
-					Address: persist.Address(chain.NormalizeAddress(activity.ToAddress)),
-					Chains:  util.MapWithoutError(persist.EvmChains, func(c persist.Chain) int32 { return int32(c) }),
+				user, err := queries.GetUserByAddress(c, coredb.GetUserByAddressParams{
+					Address:     persist.Address(chain.NormalizeAddress(activity.ToAddress)),
+					Multichains: persist.NewMultichains(chain),
 				})
 				if err != nil {
 					logger.For(c).Warnf("error getting user by address: %s", err)


### PR DESCRIPTION
Changes:

- **Removed** `WalletOverrideMap` on the multichain provider; it is hard coded in the persist package now so that it can be used more universally. It was previously hardcoded in the wire injector and only existed there anyway, so it isn't hurting us to have it hard coded somewhere else
- **Added** `persist.Multichains` type that wraps a `persist.Chai`n and has only one purpose: to be an input to sql queries where its `.Value()` func will automatically return an array of every associated chain (e.g. base -> all other evm chains)

By including this new type in the sqlc.yaml, most cases are covered as far as type safety. A caller for a search by chain address for many queries will require a persist.Multichains input. A few problems arise from this though:

- One current query searches for users by ChainAddresses plural. This query has to be modified to search by tuples of (address, chain) because we don't want to return users where one wallet row in the DB has an address we supplied and another has a chain but that individual chain-address combo is not actually owned by the user. I found a query that accomplishes this but it requires us to manually create the tuples up front to pass in and sqlc could not successfully infer the `persist.Multichains` type. Thankfully this query is only used in one place, but still I do not like this.
- What's stopping someone from writing a query that uses `wallets.address = @address and wallets.chain = @chain` when they should be using `any(@multichains)`. I'm not sure if there really is any solution for this problem because some queries we actually want to search by one chain (like looking up a wallet in the DB) and some queries we want to search by all associated chains (like searching for a user). Now that I think about it, we may even want to start searching for wallets by multiple chains; currently we don't have to because the only place we use wallets functionally is in the `multichain` package and the `multichain` package handles alternative chains already in its own logic, but what if we start using wallets elsewhere in a context where EVM wallets are all considered equal. It feels sticky to have a type that always is used one way in both business logic and search queries but a separate related type actually exists in the DB as a column. Almost makes me think we modify the wallets table to not include a chain column, but to include a `ChainGroup` column of sorts ("EvmChains", "TezChains", etc.)