### PR TITLE
Add reservoir to polygon

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -6,7 +6,6 @@ package server
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"net/http"
 
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
@@ -409,13 +408,13 @@ func newMultichainSet(
 	baseProviders baseProviderList,
 	polygonProviders polygonProviderList,
 	arbitrumProviders arbitrumProviderList,
-) map[persist.Chain]]any {
+) map[persist.Chain][]any {
 	// dedupe providers based on provider ID
 	dedupe := func(providers []any) []any {
 		seen := map[string]bool{}
 		deduped := []any{}
 		for _, p := range providers {
-			if id := p.(multichain.Configurer).GetBlockhainInfo().ProviderID; !seen[id] {
+			if id := p.(multichain.Configurer).GetBlockchainInfo().ProviderID; !seen[id] {
 				seen[id] = true
 				deduped = append(deduped, p)
 			}

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -10,7 +10,6 @@ import (
 	"cloud.google.com/go/cloudtasks/apiv2"
 	"context"
 	"database/sql"
-	"fmt"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/google/wire"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -400,14 +399,13 @@ func newMultichainSet(
 		seen := map[string]bool{}
 		deduped := []any{}
 		for _, p := range providers {
-			if addr := fmt.Sprintf("%p", p); !seen[addr] {
-				seen[addr] = true
+			if id := p.(multichain.Configurer).GetBlockchainInfo().ProviderID; !seen[id] {
+				seen[id] = true
 				deduped = append(deduped, p)
 			}
 		}
 		return deduped
 	}
-
 	chainToProviders := map[persist.Chain][]any{}
 	chainToProviders[persist.ChainETH] = dedupe(ethProviders)
 	chainToProviders[persist.ChainOptimism] = dedupe(optimismProviders)

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -203,25 +203,18 @@ func baseProvidersConfig(baseProvider *reservoir.Provider) baseProviderList {
 func polygonProviderSet(client *http.Client) polygonProviderList {
 	cache := newTokenProcessingCache()
 	serverPolygonProvider := newPolygonProvider(client, cache)
-	ethclientClient := rpc.NewEthClient()
-	chain := _wireChainValue4
-	provider := opensea.NewProvider(ethclientClient, client, chain)
-	serverPolygonProviderList := polygonProvidersConfig(serverPolygonProvider, provider)
+	serverPolygonProviderList := polygonProvidersConfig(serverPolygonProvider)
 	return serverPolygonProviderList
 }
 
-var (
-	_wireChainValue4 = persist.ChainPolygon
-)
-
 // polygonProvidersConfig is a wire injector that binds multichain interfaces to their concrete Polygon implementations
-func polygonProvidersConfig(polygonProvider2 *polygonProvider, openseaProvider *opensea.Provider) polygonProviderList {
-	serverPolygonProviderList := polygonRequirements(polygonProvider2, polygonProvider2, polygonProvider2, openseaProvider)
+func polygonProvidersConfig(polygonProvider2 *polygonProvider) polygonProviderList {
+	serverPolygonProviderList := polygonRequirements(polygonProvider2, polygonProvider2, polygonProvider2)
 	return serverPolygonProviderList
 }
 
 func ethFallbackProvider(httpClient *http.Client, r *redis.Cache) multichain.SyncFailureFallbackProvider {
-	chain := _wireChainValue5
+	chain := _wireChainValue4
 	provider := alchemy.NewProvider(chain, httpClient, r)
 	infuraProvider := infura.NewProvider(httpClient)
 	syncFailureFallbackProvider := multichain.SyncFailureFallbackProvider{
@@ -232,7 +225,7 @@ func ethFallbackProvider(httpClient *http.Client, r *redis.Cache) multichain.Syn
 }
 
 var (
-	_wireChainValue5 = persist.ChainETH
+	_wireChainValue4 = persist.ChainETH
 )
 
 func tezosFallbackProvider(httpClient *http.Client, tzktProvider *tezos.Provider, objktProvider *tezos.TezosObjktProvider) multichain.SyncWithContractEvalFallbackProvider {
@@ -386,10 +379,9 @@ func baseRequirements(
 func polygonRequirements(
 	tof multichain.TokensOwnerFetcher,
 	tiof multichain.TokensIncrementalOwnerFetcher,
-	toc multichain.TokensContractFetcher, opensea2 multichain.OpenSeaChildContractFetcher,
-
+	toc multichain.TokensContractFetcher,
 ) polygonProviderList {
-	return polygonProviderList{tof, tiof, toc, opensea2}
+	return polygonProviderList{tof, tiof, toc}
 }
 
 // newMultichain is a wire provider that creates a multichain provider

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -10,11 +10,9 @@ import (
 	"cloud.google.com/go/cloudtasks/apiv2"
 	"context"
 	"database/sql"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/google/wire"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
-	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/multichain/alchemy"
 	"github.com/mikeydub/go-gallery/service/multichain/eth"
@@ -30,6 +28,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/mikeydub/go-gallery/service/tokenmanage"
+	"github.com/mikeydub/go-gallery/util"
 	"net/http"
 )
 
@@ -45,14 +44,15 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 	cache := newCommunitiesCache()
 	client := task.NewClient(ctx)
 	httpClient := _wireClientValue
-	serverEthProviderList := ethProviderSet(serverEnvInit, client, httpClient)
-	serverOptimismProviderList := optimismProviderSet(httpClient)
+	serverTokenMetadataCache := newTokenMetadataCache()
+	serverEthProviderList := ethProviderSet(serverEnvInit, client, httpClient, serverTokenMetadataCache)
+	serverOptimismProviderList := optimismProviderSet(httpClient, serverTokenMetadataCache)
 	serverTezosProviderList := tezosProviderSet(serverEnvInit, httpClient)
 	serverPoapProviderList := poapProviderSet(serverEnvInit, httpClient)
 	serverZoraProviderList := zoraProviderSet(serverEnvInit, httpClient)
 	serverBaseProviderList := baseProviderSet(httpClient)
-	serverPolygonProviderList := polygonProviderSet(httpClient)
-	serverArbitrumProviderList := arbitrumProviderSet(httpClient)
+	serverPolygonProviderList := polygonProviderSet(httpClient, serverTokenMetadataCache)
+	serverArbitrumProviderList := arbitrumProviderSet(httpClient, serverTokenMetadataCache)
 	v := newMultichainSet(serverEthProviderList, serverOptimismProviderList, serverTezosProviderList, serverPoapProviderList, serverZoraProviderList, serverBaseProviderList, serverPolygonProviderList, serverArbitrumProviderList)
 	v2 := defaultWalletOverrides()
 	manager := tokenmanage.New(ctx, client)
@@ -76,15 +76,13 @@ var (
 )
 
 // ethProviderSet is a wire injector that creates the set of Ethereum providers
-func ethProviderSet(serverEnvInit envInit, client *cloudtasks.Client, httpClient *http.Client) ethProviderList {
+func ethProviderSet(serverEnvInit envInit, client *cloudtasks.Client, httpClient *http.Client, serverTokenMetadataCache *tokenMetadataCache) ethProviderList {
 	ethclientClient := rpc.NewEthClient()
-	provider := newIndexerProvider(serverEnvInit, httpClient, ethclientClient, client)
+	provider := eth.NewProvider(httpClient, ethclientClient, client)
 	chain := _wireChainValue
 	openseaProvider := opensea.NewProvider(ethclientClient, httpClient, chain)
-	cache := newTokenProcessingCache()
-	syncFailureFallbackProvider := ethFallbackProvider(httpClient, cache)
-	alchemyProvider := alchemy.NewProvider(chain, httpClient, cache)
-	serverEthProviderList := ethProvidersConfig(provider, openseaProvider, syncFailureFallbackProvider, alchemyProvider)
+	syncFailureFallbackProvider := ethFallbackProvider(httpClient, serverTokenMetadataCache)
+	serverEthProviderList := ethProvidersConfig(provider, openseaProvider, syncFailureFallbackProvider)
 	return serverEthProviderList
 }
 
@@ -93,16 +91,15 @@ var (
 )
 
 // ethProvidersConfig is a wire injector that binds multichain interfaces to their concrete Ethereum implementations
-func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.Provider, fallbackProvider multichain.SyncFailureFallbackProvider, alchemyProvider *alchemy.Provider) ethProviderList {
-	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, alchemyProvider, fallbackProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider, openseaProvider)
+// func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.Provider, fallbackProvider multichain.SyncFailureFallbackProvider, alchemyProvider *alchemy.Provider) ethProviderList {
+func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.Provider, fallbackProvider multichain.SyncFailureFallbackProvider) ethProviderList {
+	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, fallbackProvider, fallbackProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider, openseaProvider)
 	return serverEthProviderList
 }
 
 // tezosProviderSet is a wire injector that creates the set of Tezos providers
 func tezosProviderSet(serverEnvInit envInit, client *http.Client) tezosProviderList {
-	provider := newTzktProvider(serverEnvInit, client)
-	tezosObjktProvider := newObjktProvider(serverEnvInit)
-	syncWithContractEvalFallbackProvider := tezosFallbackProvider(client, provider, tezosObjktProvider)
+	syncWithContractEvalFallbackProvider := tezosFallbackProvider(serverEnvInit, client)
 	serverTezosProviderList := tezosProvidersConfig(syncWithContractEvalFallbackProvider)
 	return serverTezosProviderList
 }
@@ -114,13 +111,12 @@ func tezosProvidersConfig(tezosProvider multichain.SyncWithContractEvalFallbackP
 }
 
 // optimismProviderSet is a wire injector that creates the set of Optimism providers
-func optimismProviderSet(client *http.Client) optimismProviderList {
-	cache := newTokenProcessingCache()
-	serverOptimismProvider := newOptimismProvider(client, cache)
-	ethclientClient := rpc.NewEthClient()
+func optimismProviderSet(client *http.Client, serverTokenMetadataCache *tokenMetadataCache) optimismProviderList {
 	chain := _wirePersistChainValue
-	provider := opensea.NewProvider(ethclientClient, client, chain)
-	serverOptimismProviderList := optimismProvidersConfig(serverOptimismProvider, provider)
+	provider := newAlchemyProvider(client, chain, serverTokenMetadataCache)
+	ethclientClient := rpc.NewEthClient()
+	openseaProvider := opensea.NewProvider(ethclientClient, client, chain)
+	serverOptimismProviderList := optimismProvidersConfig(provider, openseaProvider)
 	return serverOptimismProviderList
 }
 
@@ -129,19 +125,18 @@ var (
 )
 
 // optimismProvidersConfig is a wire injector that binds multichain interfaces to their concrete Optimism implementations
-func optimismProvidersConfig(optimismProvider2 *optimismProvider, openseaProvier *opensea.Provider) optimismProviderList {
-	serverOptimismProviderList := optimismRequirements(optimismProvider2, optimismProvider2, optimismProvider2, optimismProvider2, openseaProvier)
+func optimismProvidersConfig(alchemyProvider *alchemy.Provider, openseaProvider *opensea.Provider) optimismProviderList {
+	serverOptimismProviderList := optimismRequirements(alchemyProvider, alchemyProvider, alchemyProvider, alchemyProvider, openseaProvider)
 	return serverOptimismProviderList
 }
 
 // arbitrumProviderSet is a wire injector that creates the set of Arbitrum providers
-func arbitrumProviderSet(client *http.Client) arbitrumProviderList {
-	cache := newTokenProcessingCache()
-	serverArbitrumProvider := newArbitrumProvider(client, cache)
-	ethclientClient := rpc.NewEthClient()
+func arbitrumProviderSet(client *http.Client, serverTokenMetadataCache *tokenMetadataCache) arbitrumProviderList {
 	chain := _wireChainValue2
-	provider := opensea.NewProvider(ethclientClient, client, chain)
-	serverArbitrumProviderList := arbitrumProvidersConfig(serverArbitrumProvider, provider)
+	provider := newAlchemyProvider(client, chain, serverTokenMetadataCache)
+	ethclientClient := rpc.NewEthClient()
+	openseaProvider := opensea.NewProvider(ethclientClient, client, chain)
+	serverArbitrumProviderList := arbitrumProvidersConfig(provider, openseaProvider)
 	return serverArbitrumProviderList
 }
 
@@ -150,14 +145,14 @@ var (
 )
 
 // arbitrumProvidersConfig is a wire injector that binds multichain interfaces to their concrete Arbitrum implementations
-func arbitrumProvidersConfig(arbitrumProvider2 *arbitrumProvider, openseaProvider *opensea.Provider) arbitrumProviderList {
-	serverArbitrumProviderList := arbitrumRequirements(arbitrumProvider2, arbitrumProvider2, arbitrumProvider2, arbitrumProvider2, openseaProvider, arbitrumProvider2)
+func arbitrumProvidersConfig(alchemyProvider *alchemy.Provider, openseaProvider *opensea.Provider) arbitrumProviderList {
+	serverArbitrumProviderList := arbitrumRequirements(alchemyProvider, alchemyProvider, alchemyProvider, alchemyProvider, openseaProvider, alchemyProvider)
 	return serverArbitrumProviderList
 }
 
 // poapProviderSet is a wire injector that creates the set of POAP providers
 func poapProviderSet(serverEnvInit envInit, client *http.Client) poapProviderList {
-	provider := newPoapProvider(serverEnvInit, client)
+	provider := poap.NewProvider(client)
 	serverPoapProviderList := poapProvidersConfig(provider)
 	return serverPoapProviderList
 }
@@ -170,7 +165,7 @@ func poapProvidersConfig(poapProvider *poap.Provider) poapProviderList {
 
 // zoraProviderSet is a wire injector that creates the set of zora providers
 func zoraProviderSet(serverEnvInit envInit, client *http.Client) zoraProviderList {
-	provider := newZoraProvider(serverEnvInit, client)
+	provider := zora.NewProvider(client)
 	serverZoraProviderList := zoraProvidersConfig(provider)
 	return serverZoraProviderList
 }
@@ -199,22 +194,27 @@ func baseProvidersConfig(baseProvider *reservoir.Provider) baseProviderList {
 }
 
 // polygonProviderSet is a wire injector that creates the set of polygon providers
-func polygonProviderSet(client *http.Client) polygonProviderList {
-	cache := newTokenProcessingCache()
-	serverPolygonProvider := newPolygonProvider(client, cache)
-	serverPolygonProviderList := polygonProvidersConfig(serverPolygonProvider)
+func polygonProviderSet(client *http.Client, serverTokenMetadataCache *tokenMetadataCache) polygonProviderList {
+	chain := _wireChainValue4
+	provider := newAlchemyProvider(client, chain, serverTokenMetadataCache)
+	reservoirProvider := reservoir.NewProvider(chain, client)
+	serverPolygonProviderList := polygonProvidersConfig(provider, reservoirProvider)
 	return serverPolygonProviderList
 }
+
+var (
+	_wireChainValue4 = persist.ChainPolygon
+)
 
 // polygonProvidersConfig is a wire injector that binds multichain interfaces to their concrete Polygon implementations
-func polygonProvidersConfig(polygonProvider2 *polygonProvider) polygonProviderList {
-	serverPolygonProviderList := polygonRequirements(polygonProvider2, polygonProvider2, polygonProvider2)
+func polygonProvidersConfig(alchemyProvider *alchemy.Provider, reservoirProvider *reservoir.Provider) polygonProviderList {
+	serverPolygonProviderList := polygonRequirements(alchemyProvider, alchemyProvider, alchemyProvider, reservoirProvider)
 	return serverPolygonProviderList
 }
 
-func ethFallbackProvider(httpClient *http.Client, r *redis.Cache) multichain.SyncFailureFallbackProvider {
-	chain := _wireChainValue4
-	provider := alchemy.NewProvider(chain, httpClient, r)
+func ethFallbackProvider(httpClient *http.Client, cache *tokenMetadataCache) multichain.SyncFailureFallbackProvider {
+	chain := _wireChainValue5
+	provider := newAlchemyProvider(httpClient, chain, cache)
 	infuraProvider := infura.NewProvider(httpClient)
 	syncFailureFallbackProvider := multichain.SyncFailureFallbackProvider{
 		Primary:  provider,
@@ -224,14 +224,16 @@ func ethFallbackProvider(httpClient *http.Client, r *redis.Cache) multichain.Syn
 }
 
 var (
-	_wireChainValue4 = persist.ChainETH
+	_wireChainValue5 = persist.ChainETH
 )
 
-func tezosFallbackProvider(httpClient *http.Client, tzktProvider *tezos.Provider, objktProvider *tezos.TezosObjktProvider) multichain.SyncWithContractEvalFallbackProvider {
+func tezosFallbackProvider(e envInit, httpClient *http.Client) multichain.SyncWithContractEvalFallbackProvider {
+	provider := tezos.NewProvider(httpClient)
+	tezosObjktProvider := tezos.NewObjktProvider()
 	v := tezosTokenEvalFunc()
 	syncWithContractEvalFallbackProvider := multichain.SyncWithContractEvalFallbackProvider{
-		Primary:  tzktProvider,
-		Fallback: objktProvider,
+		Primary:  provider,
+		Fallback: tezosObjktProvider,
 		Eval:     v,
 	}
 	return syncWithContractEvalFallbackProvider
@@ -260,11 +262,7 @@ type polygonProviderList []any
 
 type arbitrumProviderList []any
 
-type optimismProvider struct{ *alchemy.Provider }
-
-type polygonProvider struct{ *alchemy.Provider }
-
-type arbitrumProvider struct{ *alchemy.Provider }
+type tokenMetadataCache redis.Cache
 
 // dbConnSet is a wire provider set for initializing a postgres connection
 var dbConnSet = wire.NewSet(
@@ -379,8 +377,22 @@ func polygonRequirements(
 	tof multichain.TokensOwnerFetcher,
 	tiof multichain.TokensIncrementalOwnerFetcher,
 	toc multichain.TokensContractFetcher,
+	tmf multichain.TokenMetadataFetcher,
 ) polygonProviderList {
-	return polygonProviderList{tof, tiof, toc}
+	return polygonProviderList{tof, tiof, toc, tmf}
+}
+
+// dedupe removes duplicate providers based on provider ID
+func dedupe(providers []any) []any {
+	seen := map[string]bool{}
+	deduped := []any{}
+	for _, p := range providers {
+		if id := p.(multichain.Configurer).GetBlockchainInfo().ProviderID; !seen[id] {
+			seen[id] = true
+			deduped = append(deduped, p)
+		}
+	}
+	return deduped
 }
 
 // newMultichain is a wire provider that creates a multichain provider
@@ -394,18 +406,6 @@ func newMultichainSet(
 	polygonProviders polygonProviderList,
 	arbitrumProviders arbitrumProviderList,
 ) map[persist.Chain][]any {
-
-	dedupe := func(providers []any) []any {
-		seen := map[string]bool{}
-		deduped := []any{}
-		for _, p := range providers {
-			if id := p.(multichain.Configurer).GetBlockchainInfo().ProviderID; !seen[id] {
-				seen[id] = true
-				deduped = append(deduped, p)
-			}
-		}
-		return deduped
-	}
 	chainToProviders := map[persist.Chain][]any{}
 	chainToProviders[persist.ChainETH] = dedupe(ethProviders)
 	chainToProviders[persist.ChainOptimism] = dedupe(optimismProviders)
@@ -423,50 +423,24 @@ func defaultWalletOverrides() multichain.WalletOverrideMap {
 	return multichain.WalletOverrideMap{persist.ChainPOAP: persist.EvmChains, persist.ChainOptimism: persist.EvmChains, persist.ChainPolygon: persist.EvmChains, persist.ChainArbitrum: persist.EvmChains, persist.ChainETH: persist.EvmChains, persist.ChainZora: persist.EvmChains, persist.ChainBase: persist.EvmChains}
 }
 
-func newIndexerProvider(e envInit, httpClient *http.Client, ethClient *ethclient.Client, taskClient *cloudtasks.Client) *eth.Provider {
-	return eth.NewProvider(env.GetString("INDEXER_HOST"), httpClient, ethClient, taskClient)
-}
-
-func newTzktProvider(e envInit, httpClient *http.Client) *tezos.Provider {
-	return tezos.NewProvider(env.GetString("TEZOS_API_URL"), httpClient)
-}
-
-func newObjktProvider(e envInit) *tezos.TezosObjktProvider {
-	return tezos.NewObjktProvider(env.GetString("IPFS_URL"))
-}
-
 func tezosTokenEvalFunc() func(context.Context, multichain.ChainAgnosticToken) bool {
 	return func(ctx context.Context, token multichain.ChainAgnosticToken) bool {
 		return tezos.IsSigned(ctx, token) && tezos.ContainsTezosKeywords(ctx, token)
 	}
 }
 
-func newPoapProvider(e envInit, c *http.Client) *poap.Provider {
-	return poap.NewProvider(c, env.GetString("POAP_API_KEY"), env.GetString("POAP_AUTH_TOKEN"))
-}
-
-func newZoraProvider(e envInit, c *http.Client) *zora.Provider {
-	return zora.NewProvider(c)
-}
-
-func newOptimismProvider(c *http.Client, r *redis.Cache) *optimismProvider {
-	return &optimismProvider{alchemy.NewProvider(persist.ChainOptimism, c, r)}
-}
-
-func newPolygonProvider(c *http.Client, r *redis.Cache) *polygonProvider {
-	return &polygonProvider{alchemy.NewProvider(persist.ChainPolygon, c, r)}
-}
-
-func newArbitrumProvider(c *http.Client, r *redis.Cache) *arbitrumProvider {
-	return &arbitrumProvider{alchemy.NewProvider(persist.ChainArbitrum, c, r)}
+func newAlchemyProvider(httpClient *http.Client, chain persist.Chain, cache *tokenMetadataCache) *alchemy.Provider {
+	c := redis.Cache(*cache)
+	return alchemy.NewProvider(chain, httpClient, util.ToPointer(c))
 }
 
 func newCommunitiesCache() *redis.Cache {
 	return redis.NewCache(redis.CommunitiesCache)
 }
 
-func newTokenProcessingCache() *redis.Cache {
-	return redis.NewCache(redis.TokenProcessingMetadataCache)
+func newTokenMetadataCache() *tokenMetadataCache {
+	cache := redis.NewCache(redis.TokenProcessingMetadataCache)
+	return util.ToPointer(tokenMetadataCache(*cache))
 }
 
 func newManagedTokens(ctx context.Context, tm *tokenmanage.Manager) multichain.SubmitUserTokensF {

--- a/service/multichain/eth/eth.go
+++ b/service/multichain/eth/eth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/mikeydub/go-gallery/contracts"
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/indexer"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -37,9 +38,9 @@ type Provider struct {
 }
 
 // NewProvider creates a new ethereum Provider
-func NewProvider(indexerBaseURL string, httpClient *http.Client, ec *ethclient.Client, tc *cloudtasks.Client) *Provider {
+func NewProvider(httpClient *http.Client, ec *ethclient.Client, tc *cloudtasks.Client) *Provider {
 	return &Provider{
-		indexerBaseURL: indexerBaseURL,
+		indexerBaseURL: env.GetString("INDEXER_HOST"),
 		httpClient:     httpClient,
 		ethClient:      ec,
 		taskClient:     tc,

--- a/service/multichain/poap/poap.go
+++ b/service/multichain/poap/poap.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net/http"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
@@ -135,11 +136,11 @@ type Provider struct {
 }
 
 // NewProvider creates a new Tezos Provider
-func NewProvider(httpClient *http.Client, apiKey string, authToken string) *Provider {
+func NewProvider(httpClient *http.Client) *Provider {
 	return &Provider{
 		apiURL:     "https://api.poap.tech",
-		apiKey:     apiKey,
-		authToken:  authToken,
+		apiKey:     env.GetString("POAP_API_KEY"),
+		authToken:  env.GetString("POAP_AUTH_TOKEN"),
 		httpClient: httpClient,
 	}
 }

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -93,10 +94,10 @@ type TezosObjktProvider struct {
 	ipfsGatewayURL string
 }
 
-func NewObjktProvider(ipfsGatewayURL string) *TezosObjktProvider {
+func NewObjktProvider() *TezosObjktProvider {
 	return &TezosObjktProvider{
 		gql:            graphql.NewClient(objktEndpoint, http.DefaultClient),
-		ipfsGatewayURL: ipfsGatewayURL,
+		ipfsGatewayURL: env.GetString("IPFS_URL"),
 	}
 }
 

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -14,13 +14,15 @@ import (
 	"blockwatch.cc/tzgo/tezos"
 	"github.com/gammazero/workerpool"
 	"github.com/machinebox/graphql"
+	"golang.org/x/crypto/blake2b"
+
+	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
-	"golang.org/x/crypto/blake2b"
 )
 
 const (
@@ -122,9 +124,9 @@ type Provider struct {
 }
 
 // NewProvider creates a new Tezos Provider
-func NewProvider(tezosAPIUrl string, httpClient *http.Client) *Provider {
+func NewProvider(httpClient *http.Client) *Provider {
 	return &Provider{
-		apiURL:     tezosAPIUrl,
+		apiURL:     env.GetString("TEZOS_API_URL"),
 		httpClient: httpClient,
 		graphQL:    graphql.NewClient(tezDomainsApiURL, graphql.WithHTTPClient(httpClient)),
 	}


### PR DESCRIPTION
**Changes**
* Replaces Opensea as a provider with Reservoir for Polygon
* Refactors `inject.go`:
    * Providers now share the same client instance of the token metadata cache instead of keeping separate clients
    * Removes throwaway inject functions
    * Cleans up each chain's provider sets so it's easier to see which providers are used per chain
    * Moves provider de-duplication logic to multichain initialization
* Minor refactor in `pipeline.go` to remove the need of a channel when processing media