### PR TITLE
mention typo

### DIFF
--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -166,6 +166,9 @@ func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, ment
 	}
 
 	dbMentions, err := insertMentionsForPost(ctx, mentions, postID, q)
+	if err != nil {
+		return "", err
+	}
 	if len(dbMentions) > 0 {
 		for _, mention := range dbMentions {
 			switch {

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -1122,7 +1122,7 @@ func mentionInputsToMentions(ctx context.Context, ms []*model.MentionInput, quer
 			if c, err := queries.GetContractByID(ctx, *m.CommunityID); c.ID == "" || err != nil {
 				return nil, fmt.Errorf("could retrieve community: %s (%s)", *m.CommunityID, err)
 			}
-			mention.CommentID = *m.CommunityID
+			mention.ContractID = *m.CommunityID
 		}
 		if m.UserID != nil {
 			if u, err := queries.GetUserById(ctx, *m.UserID); u.ID == "" || err != nil {


### PR DESCRIPTION
Put `CommentID` where `ContractID` was expected.