### PR TITLE
ENS pfp svg workaround

### DIFF
--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -2169,7 +2169,19 @@ func ensProfileImageToModel(ctx context.Context, userID, walletID persist.DBID, 
 
 	var pfp *model.HTTPSProfileImage = nil
 
-	if url != "" {
+	if strings.HasPrefix(url, "data:image/svg") {
+		previewURL := util.ToPointer(url)
+		pfp = &model.HTTPSProfileImage{
+			PreviewURLs: &model.PreviewURLSet{
+				Raw:       &url,
+				Thumbnail: previewURL,
+				Small:     previewURL,
+				Medium:    previewURL,
+				Large:     previewURL,
+				SrcSet:    previewURL,
+			},
+		}
+	} else {
 		pfp = &model.HTTPSProfileImage{PreviewURLs: previewURLs(ctx, url, nil)}
 	}
 


### PR DESCRIPTION
There is a small bug in the pipeline where ENS profile images that are SVGs are saved as a thumbnail object instead of a PFP object. The bug also results in thumbnails of ENS tokens with SVG pfps to show the profile image as the thumbnail instead of the typical ENS i.e. "vitalik.eth" thumbnail.

The workaround is to serve the SVG from its data URL instead of a rasterized image that we would've saved from the pipeline.