### PR TITLE
Benny/email lock and templates

### DIFF
--- a/emails/emails.go
+++ b/emails/emails.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
+	"github.com/mikeydub/go-gallery/service/redis"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/mikeydub/go-gallery/util"
@@ -71,7 +72,9 @@ func coreInitServer() *gin.Engine {
 		}
 	}
 
-	go autoSendNotificationEmails(queries, sendgridClient, pub)
+	lock := redis.NewLockClient(redis.NewCache(redis.EmailThrottleCache))
+
+	go autoSendNotificationEmails(queries, sendgridClient, pub, lock)
 
 	return handlersInitServer(router, loaders, queries, sendgridClient)
 }

--- a/emails/send.go
+++ b/emails/send.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bsm/redislock"
 	"github.com/mikeydub/go-gallery/service/auth"
+	"github.com/mikeydub/go-gallery/service/notifications"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/gin-gonic/gin"
@@ -105,17 +106,10 @@ func sendVerificationEmail(dataloaders *dataloader.Loaders, queries *coredb.Quer
 	}
 }
 
-type notificationEmailDynamicTemplateData struct {
-	Actor          string       `json:"actor"`
-	Action         string       `json:"action"`
-	CollectionName string       `json:"collectionName"`
-	CollectionID   persist.DBID `json:"collectionId"`
-	PreviewText    string       `json:"previewText"`
-}
 type notificationsEmailDynamicTemplateData struct {
-	Notifications    []notificationEmailDynamicTemplateData `json:"notifications"`
-	Username         string                                 `json:"username"`
-	UnsubscribeToken string                                 `json:"unsubscribeToken"`
+	Notifications    []notifications.UserFacingNotificationData `json:"notifications"`
+	Username         string                                     `json:"username"`
+	UnsubscribeToken string                                     `json:"unsubscribeToken"`
 }
 
 func adminSendNotificationEmail(queries *coredb.Queries, s *sendgrid.Client) gin.HandlerFunc {
@@ -205,17 +199,18 @@ func sendNotificationEmailToUser(c context.Context, u coredb.PiiUserView, emailR
 	}
 
 	data := notificationsEmailDynamicTemplateData{
-		Notifications:    make([]notificationEmailDynamicTemplateData, 0, resultLimit),
+		Notifications:    make([]notifications.UserFacingNotificationData, 0, resultLimit),
 		Username:         u.Username.String,
 		UnsubscribeToken: j,
 	}
-	notifTemplates := make(chan notificationEmailDynamicTemplateData)
+	notifTemplates := make(chan notifications.UserFacingNotificationData)
 	errChan := make(chan error)
 
 	for _, n := range notifs {
 		notif := n
 		go func() {
-			notifTemplate, err := notifToTemplateData(c, queries, notif)
+			// notifTemplate, err := notifToTemplateData(c, queries, notif)
+			notifTemplate, err := notifications.NotificationToUserFacingData(c, queries, notif)
 			if err != nil {
 				errChan <- err
 				return
@@ -275,142 +270,6 @@ outer:
 	logger.For(c).Infof("would have sent email to %s (username: %s): %s", u.ID, u.Username.String, string(asJSON))
 
 	return &rest.Response{StatusCode: 200, Body: "not sending real emails", Headers: map[string][]string{}}, nil
-}
-
-func notifToTemplateData(ctx context.Context, queries *coredb.Queries, n coredb.Notification) (notificationEmailDynamicTemplateData, error) {
-
-	switch n.Action {
-	case persist.ActionAdmiredFeedEvent:
-		feedEvent, err := queries.GetFeedEventByID(ctx, n.FeedEventID)
-		if err != nil {
-			return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get feed event for admire %s: %w", n.FeedEventID, err)
-		}
-		collection, _ := queries.GetCollectionById(ctx, feedEvent.Data.CollectionID)
-		data := notificationEmailDynamicTemplateData{}
-		if collection.ID != "" && collection.Name.String != "" {
-			data.CollectionID = collection.ID
-			data.CollectionName = collection.Name.String
-			data.Action = "admired your additions to"
-		} else {
-			data.Action = "admired your gallery update"
-		}
-		if len(n.Data.AdmirerIDs) > 1 {
-			data.Actor = fmt.Sprintf("%d collectors", len(n.Data.AdmirerIDs))
-		} else {
-			actorUser, err := queries.GetUserById(ctx, n.Data.AdmirerIDs[0])
-			if err != nil {
-				return notificationEmailDynamicTemplateData{}, err
-			}
-			data.Actor = actorUser.Username.String
-		}
-		return data, nil
-	case persist.ActionUserFollowedUsers:
-		if len(n.Data.FollowerIDs) > 1 {
-			return notificationEmailDynamicTemplateData{
-				Actor:  fmt.Sprintf("%d users", len(n.Data.FollowerIDs)),
-				Action: "followed you",
-			}, nil
-		}
-		if len(n.Data.FollowerIDs) == 1 {
-			userActor, err := queries.GetUserById(ctx, n.Data.FollowerIDs[0])
-			if err != nil {
-				return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get user for follower %s: %w", n.Data.FollowerIDs[0], err)
-			}
-			action := "followed you"
-			if n.Data.FollowedBack {
-				action = "followed you back"
-			}
-			return notificationEmailDynamicTemplateData{
-				Actor:  userActor.Username.String,
-				Action: action,
-			}, nil
-		}
-		return notificationEmailDynamicTemplateData{}, fmt.Errorf("no follower ids")
-	case persist.ActionCommentedOnFeedEvent:
-		comment, err := queries.GetCommentByCommentID(ctx, n.CommentID)
-		if err != nil {
-			return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get comment for comment %s: %w", n.CommentID, err)
-		}
-		userActor, err := queries.GetUserById(ctx, comment.ActorID)
-		if err != nil {
-			return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get user for comment actor %s: %w", comment.ActorID, err)
-		}
-		feedEvent, err := queries.GetFeedEventByID(ctx, n.FeedEventID)
-		if err != nil {
-			return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get feed event for comment %s: %w", n.FeedEventID, err)
-		}
-		collection, _ := queries.GetCollectionById(ctx, feedEvent.Data.CollectionID)
-		if collection.ID != "" {
-			return notificationEmailDynamicTemplateData{
-				Actor:          userActor.Username.String,
-				Action:         "commented on your additions to",
-				CollectionName: collection.Name.String,
-				CollectionID:   collection.ID,
-				PreviewText:    util.TruncateWithEllipsis(comment.Comment, 20),
-			}, nil
-		}
-		return notificationEmailDynamicTemplateData{
-			Actor:       userActor.Username.String,
-			Action:      "commented on your gallery update",
-			PreviewText: util.TruncateWithEllipsis(comment.Comment, 20),
-		}, nil
-	case persist.ActionViewedGallery:
-		if len(n.Data.AuthedViewerIDs)+len(n.Data.UnauthedViewerIDs) > 1 {
-			return notificationEmailDynamicTemplateData{
-				Actor:  fmt.Sprintf("%d collectors", len(n.Data.AuthedViewerIDs)+len(n.Data.UnauthedViewerIDs)),
-				Action: "viewed your gallery",
-			}, nil
-		}
-		if len(n.Data.AuthedViewerIDs) == 1 {
-			userActor, err := queries.GetUserById(ctx, n.Data.AuthedViewerIDs[0])
-			if err != nil {
-				return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get user for viewer %s: %w", n.Data.AuthedViewerIDs[0], err)
-			}
-			return notificationEmailDynamicTemplateData{
-				Actor:  userActor.Username.String,
-				Action: "viewed your gallery",
-			}, nil
-		}
-		if len(n.Data.UnauthedViewerIDs) == 1 {
-			return notificationEmailDynamicTemplateData{
-				Actor:  "Someone",
-				Action: "viewed your gallery",
-			}, nil
-		}
-
-		return notificationEmailDynamicTemplateData{}, fmt.Errorf("no viewer ids")
-
-	case persist.ActionAdmiredPost:
-		data := notificationEmailDynamicTemplateData{}
-		if len(n.Data.AdmirerIDs) > 1 {
-			data.Actor = fmt.Sprintf("%d collectors", len(n.Data.AdmirerIDs))
-		} else {
-			actorUser, err := queries.GetUserById(ctx, n.Data.AdmirerIDs[0])
-			if err != nil {
-				return notificationEmailDynamicTemplateData{}, err
-			}
-			data.Actor = actorUser.Username.String
-		}
-		data.Action = "admired your post"
-		return data, nil
-
-	case persist.ActionCommentedOnPost:
-		comment, err := queries.GetCommentByCommentID(ctx, n.CommentID)
-		if err != nil {
-			return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get comment for comment %s: %w", n.CommentID, err)
-		}
-		userActor, err := queries.GetUserById(ctx, comment.ActorID)
-		if err != nil {
-			return notificationEmailDynamicTemplateData{}, fmt.Errorf("failed to get user for comment actor %s: %w", comment.ActorID, err)
-		}
-		return notificationEmailDynamicTemplateData{
-			Actor:       userActor.Username.String,
-			Action:      "commented on your post",
-			PreviewText: util.TruncateWithEllipsis(comment.Comment, 20),
-		}, nil
-	default:
-		return notificationEmailDynamicTemplateData{}, fmt.Errorf("unknown action %s", n.Action)
-	}
 }
 
 func runForUsersWithNotificationsOnForEmailType(ctx context.Context, emailType persist.EmailType, queries *coredb.Queries, fn func(u coredb.PiiUserView) error) error {

--- a/emails/send.go
+++ b/emails/send.go
@@ -144,7 +144,8 @@ func autoSendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, psu
 	return sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		l, err := r.Obtain(ctx, "send-notification-emails", time.Minute*5, nil)
 		if err != nil {
-			return // don't ack message
+			msg.Ack()
+			return
 		}
 		defer l.Release(ctx)
 		err = sendNotificationEmailsToAllUsers(ctx, queries, s, env.GetString("ENV") == "production")
@@ -154,6 +155,7 @@ func autoSendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, psu
 			return
 		}
 		msg.Ack()
+
 	})
 }
 

--- a/emails/t__unit_test.go
+++ b/emails/t__unit_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/service/notifications"
 )
 
 func TestNotificationTemplating_Success(t *testing.T) {
@@ -17,20 +18,20 @@ func TestNotificationTemplating_Success(t *testing.T) {
 	q := coredb.New(pgx)
 
 	t.Run("creates a template for admire notifications", func(t *testing.T) {
-		data, err := notifToTemplateData(ctx, q, admireNotif)
+		data, err := notifications.NotificationToUserFacingData(ctx, q, admireNotif)
 		a.NoError(err)
 		a.Equal(testUser2.Username.String, data.Actor)
 		a.Equal(data.CollectionID, testGallery.Collections[0])
 	})
 
 	t.Run("creates a template for follow notifications", func(t *testing.T) {
-		data, err := notifToTemplateData(ctx, q, followNotif)
+		data, err := notifications.NotificationToUserFacingData(ctx, q, followNotif)
 		a.NoError(err)
 		a.Equal(testUser2.Username.String, data.Actor)
 	})
 
 	t.Run("creates a template for comment notifications", func(t *testing.T) {
-		data, err := notifToTemplateData(ctx, q, commentNotif)
+		data, err := notifications.NotificationToUserFacingData(ctx, q, commentNotif)
 		a.NoError(err)
 		a.Equal(testUser2.Username.String, data.Actor)
 		a.Equal(data.CollectionID, testGallery.Collections[0])
@@ -38,7 +39,7 @@ func TestNotificationTemplating_Success(t *testing.T) {
 	})
 
 	t.Run("creates a template for view notifications", func(t *testing.T) {
-		data, err := notifToTemplateData(ctx, q, viewNotif)
+		data, err := notifications.NotificationToUserFacingData(ctx, q, viewNotif)
 		a.NoError(err)
 		a.Equal(testUser2.Username.String, data.Actor)
 	})

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bsm/redislock"
 	"github.com/gin-gonic/gin"
 	"github.com/googleapis/gax-go/v2/apierror"
+	"github.com/mikeydub/go-gallery/db/gen/coredb"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -527,6 +528,11 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 		},
 	}
 
+	userFacing, err := NotificationToUserFacingData(ctx, queries, notif)
+	if err != nil {
+		return task.PushNotificationMessage{}, err
+	}
+
 	if notif.Action == persist.ActionAdmiredFeedEvent || notif.Action == persist.ActionAdmiredPost {
 		admirer, err := queries.GetUserById(ctx, notif.Data.AdmirerIDs[0])
 		if err != nil {
@@ -537,16 +543,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		if !admirer.Username.Valid {
-			return task.PushNotificationMessage{}, fmt.Errorf("user with ID=%s has no username", admirer.ID)
-		}
-
-		ac := "activity"
-		if notif.Action == persist.ActionAdmiredPost {
-			ac = "post"
-		}
-
-		message.Body = fmt.Sprintf("%s admired your %s", admirer.Username.String, ac)
+		message.Body = userFacing.String()
 		return message, nil
 	}
 
@@ -565,16 +562,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		if !commenter.Username.Valid {
-			return task.PushNotificationMessage{}, fmt.Errorf("user with ID=%s has no username", commenter.ID)
-		}
-
-		ac := "activity"
-		if notif.Action == persist.ActionCommentedOnPost {
-			ac = "post"
-		}
-
-		message.Body = fmt.Sprintf("%s commented on your %s", commenter.Username.String, ac)
+		message.Body = userFacing.String()
 		return message, nil
 	}
 
@@ -588,47 +576,15 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		if !follower.Username.Valid {
-			return task.PushNotificationMessage{}, fmt.Errorf("user with ID=%s has no username", follower.ID)
-		}
-
-		var body string
-		if notif.Data.FollowedBack {
-			body = fmt.Sprintf("%s followed you back", follower.Username.String)
-		} else {
-			body = fmt.Sprintf("%s followed you", follower.Username.String)
-		}
-
-		message.Body = body
+		message.Body = userFacing.String()
 		return message, nil
 	}
 	if notif.Action == persist.ActionNewTokensReceived {
 
-		tm, err := queries.GetTokenMediaByTokenId(ctx, notif.Data.NewTokenID)
-		if err != nil {
-			return task.PushNotificationMessage{}, err
-		}
-		name := tm.Name
-		if name == "" {
-			to, err := queries.GetTokenById(ctx, notif.Data.NewTokenID)
-			if err != nil {
-				return task.PushNotificationMessage{}, err
-			}
-			name = to.Name.String
-		}
-
-		name = util.TruncateWithEllipsis(name, 20)
-
 		if err := limiter.tryTokens(ctx, notif.OwnerID, notif.Data.NewTokenID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
-		amount := notif.Data.NewTokenQuantity
-		i := amount.BigInt().Uint64()
-		if i > 1 {
-			message.Body = fmt.Sprintf("You received %d new %s tokens", i, name)
-		} else {
-			message.Body = fmt.Sprintf("You received a new %s token", name)
-		}
+		message.Body = userFacing.String()
 		return message, nil
 	}
 
@@ -648,11 +604,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		if !commenter.Username.Valid {
-			return task.PushNotificationMessage{}, fmt.Errorf("user with ID=%s has no username", commenter.ID)
-		}
-
-		message.Body = fmt.Sprintf("%s replied to your comment", commenter.Username.String)
+		message.Body = userFacing.String()
 		return message, nil
 
 	}
@@ -660,19 +612,14 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 	if notif.Action == persist.ActionMentionUser || notif.Action == persist.ActionMentionCommunity {
 
 		var actor db.User
-		var mentionedIn string
-		var preview string
+
 		switch {
 		case notif.CommentID != "":
-
-			mentionedIn = "comment"
 
 			comment, err := queries.GetCommentByCommentID(ctx, notif.CommentID)
 			if err != nil {
 				return task.PushNotificationMessage{}, err
 			}
-
-			preview = util.TruncateWithEllipsis(comment.Comment, 20)
 
 			actor, err = queries.GetUserById(ctx, comment.ActorID)
 			if err != nil {
@@ -680,14 +627,11 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			}
 
 		case notif.PostID != "":
-			mentionedIn = "post"
 
 			post, err := queries.GetPostByID(ctx, notif.PostID)
 			if err != nil {
 				return task.PushNotificationMessage{}, err
 			}
-
-			preview = util.TruncateWithEllipsis(post.Caption.String, 20)
 
 			actor, err = queries.GetUserById(ctx, post.ActorID)
 			if err != nil {
@@ -697,33 +641,268 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 		default:
 			return task.PushNotificationMessage{}, fmt.Errorf("no comment or post id provided for mention notification")
 		}
-		if mentionedIn == "" || preview == "" {
-			return task.PushNotificationMessage{}, fmt.Errorf("no push data found for mention notification")
-		}
 
 		if err := limiter.tryMention(ctx, actor.ID, notif.OwnerID, notif.FeedEventID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
 
-		if !actor.Username.Valid {
-			return task.PushNotificationMessage{}, fmt.Errorf("user with ID=%s has no username", actor.ID)
-		}
+		message.Body = userFacing.String()
 
-		if notif.Action == persist.ActionMentionCommunity {
-			contract, err := queries.GetContractByID(ctx, notif.ContractID)
-			if err != nil {
-				return task.PushNotificationMessage{}, err
-			}
-
-			message.Body = fmt.Sprintf("%s mentioned @%s in a %s: %s", actor.Username.String, contract.Name.String, mentionedIn, preview)
-		} else {
-			message.Body = fmt.Sprintf("%s mentioned you in a %s: %s", actor.Username.String, mentionedIn, preview)
-		}
 		return message, nil
 
 	}
 
 	return task.PushNotificationMessage{}, fmt.Errorf("unsupported notification action: %s", notif.Action)
+}
+
+type UserFacingNotificationData struct {
+	Actor          string       `json:"actor"`
+	Action         string       `json:"action"`
+	CollectionName string       `json:"collectionName"`
+	CollectionID   persist.DBID `json:"collectionId"`
+	PreviewText    string       `json:"previewText"`
+}
+
+func (u UserFacingNotificationData) String() string {
+	cur := fmt.Sprintf("%s %s", u.Actor, u.Action)
+	if u.CollectionName != "" {
+		cur = fmt.Sprintf("%s %s", cur, u.CollectionName)
+	}
+	if u.PreviewText != "" {
+		cur = fmt.Sprintf("%s: %s", cur, u.PreviewText)
+	}
+	return cur
+}
+
+func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, n coredb.Notification) (UserFacingNotificationData, error) {
+
+	switch n.Action {
+	case persist.ActionAdmiredFeedEvent, persist.ActionAdmiredPost:
+		feedEvent, err := queries.GetFeedEventByID(ctx, n.FeedEventID)
+		if err != nil {
+			return UserFacingNotificationData{}, fmt.Errorf("failed to get feed event for admire %s: %w", n.FeedEventID, err)
+		}
+		collection, _ := queries.GetCollectionById(ctx, feedEvent.Data.CollectionID)
+		data := UserFacingNotificationData{}
+		if n.Action == persist.ActionAdmiredFeedEvent && collection.ID != "" && collection.Name.String != "" {
+			data.CollectionID = collection.ID
+			data.CollectionName = collection.Name.String
+			data.Action = "admired your additions to"
+		} else if n.Action == persist.ActionAdmiredFeedEvent {
+			data.Action = "admired your gallery update"
+		} else {
+			data.Action = "admired your post"
+		}
+		if len(n.Data.AdmirerIDs) > 1 {
+			data.Actor = fmt.Sprintf("%d collectors", len(n.Data.AdmirerIDs))
+		} else {
+			actorUser, err := queries.GetUserById(ctx, n.Data.AdmirerIDs[0])
+			if err != nil {
+				return UserFacingNotificationData{}, err
+			}
+			data.Actor = actorUser.Username.String
+		}
+		return data, nil
+	case persist.ActionUserFollowedUsers:
+		if len(n.Data.FollowerIDs) > 1 {
+			return UserFacingNotificationData{
+				Actor:  fmt.Sprintf("%d users", len(n.Data.FollowerIDs)),
+				Action: "followed you",
+			}, nil
+		}
+		if len(n.Data.FollowerIDs) == 1 {
+			userActor, err := queries.GetUserById(ctx, n.Data.FollowerIDs[0])
+			if err != nil {
+				return UserFacingNotificationData{}, fmt.Errorf("failed to get user for follower %s: %w", n.Data.FollowerIDs[0], err)
+			}
+			action := "followed you"
+			if n.Data.FollowedBack {
+				action = "followed you back"
+			}
+			return UserFacingNotificationData{
+				Actor:  userActor.Username.String,
+				Action: action,
+			}, nil
+		}
+		return UserFacingNotificationData{}, fmt.Errorf("no follower ids")
+	case persist.ActionCommentedOnFeedEvent, persist.ActionCommentedOnPost:
+		comment, err := queries.GetCommentByCommentID(ctx, n.CommentID)
+		if err != nil {
+			return UserFacingNotificationData{}, fmt.Errorf("failed to get comment for comment %s: %w", n.CommentID, err)
+		}
+		userActor, err := queries.GetUserById(ctx, comment.ActorID)
+		if err != nil {
+			return UserFacingNotificationData{}, fmt.Errorf("failed to get user for comment actor %s: %w", comment.ActorID, err)
+		}
+		feedEvent, err := queries.GetFeedEventByID(ctx, n.FeedEventID)
+		if err != nil {
+			return UserFacingNotificationData{}, fmt.Errorf("failed to get feed event for comment %s: %w", n.FeedEventID, err)
+		}
+		action := "commented on your post"
+		if n.Action == persist.ActionCommentedOnFeedEvent && feedEvent.Data.CollectionID != "" {
+			collection, err := queries.GetCollectionById(ctx, feedEvent.Data.CollectionID)
+			if err != nil {
+				return UserFacingNotificationData{}, fmt.Errorf("failed to get collection for comment %s: %w", feedEvent.Data.CollectionID, err)
+			}
+
+			return UserFacingNotificationData{
+				Actor:          userActor.Username.String,
+				Action:         "commented on your additions to",
+				CollectionName: collection.Name.String,
+				CollectionID:   collection.ID,
+				PreviewText:    util.TruncateWithEllipsis(comment.Comment, 20),
+			}, nil
+
+		} else if n.Action == persist.ActionCommentedOnFeedEvent {
+			action = "commented on your gallery update"
+		}
+
+		return UserFacingNotificationData{
+			Actor:       userActor.Username.String,
+			Action:      action,
+			PreviewText: util.TruncateWithEllipsis(comment.Comment, 20),
+		}, nil
+	case persist.ActionViewedGallery:
+		if len(n.Data.AuthedViewerIDs)+len(n.Data.UnauthedViewerIDs) > 1 {
+			return UserFacingNotificationData{
+				Actor:  fmt.Sprintf("%d collectors", len(n.Data.AuthedViewerIDs)+len(n.Data.UnauthedViewerIDs)),
+				Action: "viewed your gallery",
+			}, nil
+		}
+		if len(n.Data.AuthedViewerIDs) == 1 {
+			userActor, err := queries.GetUserById(ctx, n.Data.AuthedViewerIDs[0])
+			if err != nil {
+				return UserFacingNotificationData{}, fmt.Errorf("failed to get user for viewer %s: %w", n.Data.AuthedViewerIDs[0], err)
+			}
+			return UserFacingNotificationData{
+				Actor:  userActor.Username.String,
+				Action: "viewed your gallery",
+			}, nil
+		}
+		if len(n.Data.UnauthedViewerIDs) == 1 {
+			return UserFacingNotificationData{
+				Actor:  "Someone",
+				Action: "viewed your gallery",
+			}, nil
+		}
+
+		return UserFacingNotificationData{}, fmt.Errorf("no viewer ids")
+
+	case persist.ActionMentionUser, persist.ActionMentionCommunity:
+
+		data := UserFacingNotificationData{}
+		var actor db.User
+		var mentionedIn string
+		var preview string
+		switch {
+		case n.CommentID != "":
+
+			mentionedIn = "comment"
+
+			comment, err := queries.GetCommentByCommentID(ctx, n.CommentID)
+			if err != nil {
+				return UserFacingNotificationData{}, err
+			}
+
+			preview = util.TruncateWithEllipsis(comment.Comment, 20)
+
+			actor, err = queries.GetUserById(ctx, comment.ActorID)
+			if err != nil {
+				return UserFacingNotificationData{}, err
+			}
+
+		case n.PostID != "":
+			mentionedIn = "post"
+
+			post, err := queries.GetPostByID(ctx, n.PostID)
+			if err != nil {
+				return UserFacingNotificationData{}, err
+			}
+
+			preview = util.TruncateWithEllipsis(post.Caption.String, 20)
+
+			actor, err = queries.GetUserById(ctx, post.ActorID)
+			if err != nil {
+				return UserFacingNotificationData{}, err
+			}
+
+		default:
+			return UserFacingNotificationData{}, fmt.Errorf("no comment or post id provided for mention notification")
+		}
+		if mentionedIn == "" || preview == "" {
+			return UserFacingNotificationData{}, fmt.Errorf("no push data found for mention notification")
+		}
+
+		if !actor.Username.Valid {
+			return UserFacingNotificationData{}, fmt.Errorf("user with ID=%s has no username", actor.ID)
+		}
+
+		data.Actor = actor.Username.String
+		data.PreviewText = preview
+
+		if n.Action == persist.ActionMentionCommunity {
+			contract, err := queries.GetContractByID(ctx, n.ContractID)
+			if err != nil {
+				return UserFacingNotificationData{}, err
+			}
+
+			data.Action = fmt.Sprintf("mentioned your community @%s in a comment", contract.Name.String)
+		} else {
+			data.Action = "mentioned you in a comment"
+		}
+		return data, nil
+	case persist.ActionReplyToComment:
+
+		comment, err := queries.GetCommentByCommentID(ctx, n.CommentID)
+		if err != nil {
+			return UserFacingNotificationData{}, err
+		}
+
+		commenter, err := queries.GetUserById(ctx, comment.ActorID)
+		if err != nil {
+			return UserFacingNotificationData{}, err
+		}
+
+		if !commenter.Username.Valid {
+			return UserFacingNotificationData{}, fmt.Errorf("user with ID=%s has no username", commenter.ID)
+		}
+
+		return UserFacingNotificationData{
+			Actor:       commenter.Username.String,
+			Action:      "replied to your comment",
+			PreviewText: util.TruncateWithEllipsis(comment.Comment, 20),
+		}, nil
+	case persist.ActionNewTokensReceived:
+		data := UserFacingNotificationData{}
+		tm, err := queries.GetTokenMediaByTokenId(ctx, n.Data.NewTokenID)
+		if err != nil {
+			return UserFacingNotificationData{}, err
+		}
+		name := tm.Name
+		if name == "" {
+			to, err := queries.GetTokenById(ctx, n.Data.NewTokenID)
+			if err != nil {
+				return UserFacingNotificationData{}, err
+			}
+			name = to.Name.String
+		}
+
+		name = util.TruncateWithEllipsis(name, 20)
+
+		amount := n.Data.NewTokenQuantity
+		i := amount.BigInt().Uint64()
+		if i > 1 {
+			data.Actor = "you"
+			data.Action = fmt.Sprintf("received %d new %s tokens", i, name)
+		} else {
+			data.Actor = "you"
+			data.Action = fmt.Sprintf("received a new %s token", name)
+		}
+
+		return data, nil
+	default:
+		return UserFacingNotificationData{}, fmt.Errorf("unknown action %s", n.Action)
+	}
 }
 
 func actionSupportsPushNotifications(action persist.Action) bool {

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -533,6 +533,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 		return task.PushNotificationMessage{}, err
 	}
 
+	message.Body = userFacing.String()
 	if notif.Action == persist.ActionAdmiredFeedEvent || notif.Action == persist.ActionAdmiredPost {
 		admirer, err := queries.GetUserById(ctx, notif.Data.AdmirerIDs[0])
 		if err != nil {
@@ -543,7 +544,6 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		message.Body = userFacing.String()
 		return message, nil
 	}
 
@@ -562,7 +562,6 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		message.Body = userFacing.String()
 		return message, nil
 	}
 
@@ -576,7 +575,6 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		message.Body = userFacing.String()
 		return message, nil
 	}
 	if notif.Action == persist.ActionNewTokensReceived {
@@ -584,7 +582,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 		if err := limiter.tryTokens(ctx, notif.OwnerID, notif.Data.NewTokenID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
-		message.Body = userFacing.String()
+
 		return message, nil
 	}
 
@@ -604,7 +602,6 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		message.Body = userFacing.String()
 		return message, nil
 
 	}
@@ -645,8 +642,6 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 		if err := limiter.tryMention(ctx, actor.ID, notif.OwnerID, notif.FeedEventID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
-
-		message.Body = userFacing.String()
 
 		return message, nil
 


### PR DESCRIPTION
Changes:

- **Added** a redis lock to the notification email subscription receiver so that only one service handles the pubsub and sends notification emails
- **Added** new email notification types to the notification template data creator and shared logic with push notifications