### PR TITLE
no error out for comment feed event

### DIFF
--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -790,10 +790,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 		if err != nil {
 			return UserFacingNotificationData{}, fmt.Errorf("failed to get user for comment actor %s: %w", comment.ActorID, err)
 		}
-		feedEvent, err := queries.GetFeedEventByID(ctx, n.FeedEventID)
-		if err != nil {
-			return UserFacingNotificationData{}, fmt.Errorf("failed to get feed event for comment %s: %w", n.FeedEventID, err)
-		}
+		feedEvent, _ := queries.GetFeedEventByID(ctx, n.FeedEventID)
 		action := "commented on your post"
 		if n.Action == persist.ActionCommentedOnFeedEvent && feedEvent.Data.CollectionID != "" {
 			collection, err := queries.GetCollectionById(ctx, feedEvent.Data.CollectionID)


### PR DESCRIPTION
Changes:

- **Removed** error check for comment notification text generation for feed events given they might not exist for a post event