### PR TITLE
fix wallet override group check

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -1834,7 +1834,7 @@ func (p *Provider) matchingWallets(wallets []persist.Wallet, chains []persist.Ch
 		for _, wallet := range wallets {
 			if wallet.Chain == chain {
 				matches[chain] = append(matches[chain], wallet.Address)
-			} else if overrides := wallet.Chain.L1ChainGroup(); util.Contains(overrides, wallet.Chain) {
+			} else if overrides := chain.L1ChainGroup(); util.Contains(overrides, wallet.Chain) {
 				matches[chain] = append(matches[chain], wallet.Address)
 			}
 		}

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -461,6 +461,7 @@ func (d *Provider) tokensToChainAgnostic(ctx context.Context, tokens []zoraToken
 const ipfsFallbackURLFormat = "https://ipfs.decentralized-content.com/ipfs/%s"
 
 func (*Provider) tokenToAgnostic(ctx context.Context, token zoraToken) (multichain.ChainAgnosticToken, error) {
+
 	var tokenType persist.TokenType
 	standard := util.FirstNonEmptyString(token.TokenStandard, token.Mintable.Collection.TokenStandard, token.Collection.TokenStandard)
 	switch standard {
@@ -471,6 +472,11 @@ func (*Provider) tokenToAgnostic(ctx context.Context, token zoraToken) (multicha
 	default:
 		return multichain.ChainAgnosticToken{}, fmt.Errorf("unknown token standard %s", token.TokenStandard)
 	}
+
+	if token.Metadata == nil {
+		token.Metadata = map[string]any{}
+	}
+
 	metadataName, _ := token.Metadata["name"].(string)
 	metadataDescription, _ := token.Metadata["description"].(string)
 
@@ -527,10 +533,11 @@ func (d *Provider) contractToChainAgnostic(ctx context.Context, token zoraToken)
 
 	return multichain.ChainAgnosticContract{
 		Descriptors: multichain.ChainAgnosticContractDescriptors{
-			Symbol:         token.Mintable.Collection.Symbol,
-			Name:           token.Mintable.Collection.Name,
-			Description:    token.Mintable.Collection.Description,
-			CreatorAddress: persist.Address(strings.ToLower(token.Mintable.CreatorAddress)),
+			Symbol:          token.Mintable.Collection.Symbol,
+			Name:            token.Mintable.Collection.Name,
+			Description:     token.Mintable.Collection.Description,
+			CreatorAddress:  persist.Address(strings.ToLower(token.Mintable.CreatorAddress)),
+			ProfileImageURL: token.Mintable.Collection.Image,
 		},
 		Address: persist.Address(strings.ToLower(token.CollectionAddress)),
 	}


### PR DESCRIPTION
Changes:

- **Changed** wallet search in multichain to use the correct chain L1Group so that addresses like tezos addresses aren't used for providers they should not be used for