### PR TITLE
Re-add missing contract creators error

### DIFF
--- a/graphql/dataloader/notfound.go
+++ b/graphql/dataloader/notfound.go
@@ -126,7 +126,7 @@ func (*GetWalletByIDBatch) getNotFoundError(key persist.DBID) error {
 }
 
 func (*GetContractCreatorsByIds) getNotFoundError(key string) error {
-	return pgx.ErrNoRows
+	return persist.ErrContractCreatorNotFound{ContractID: persist.DBID(key)}
 }
 
 func (*GetContractsByIDs) getNotFoundError(key string) error {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -255,6 +255,9 @@ func (r *commentOnPostPayloadResolver) ReplyToComment(ctx context.Context, obj *
 func (r *communityResolver) Creator(ctx context.Context, obj *model.Community) (model.GalleryUserOrAddress, error) {
 	creator, err := publicapi.For(ctx).Contract.GetContractCreatorByContractID(ctx, obj.Dbid)
 	if err != nil {
+		if util.ErrorAs[persist.ErrContractCreatorNotFound](err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -256,6 +256,8 @@ func (r *communityResolver) Creator(ctx context.Context, obj *model.Community) (
 	creator, err := publicapi.For(ctx).Contract.GetContractCreatorByContractID(ctx, obj.Dbid)
 	if err != nil {
 		if util.ErrorAs[persist.ErrContractCreatorNotFound](err) {
+			// It's normal not to find a creator for a community -- we may not have an address available.
+			// If that happens, just return nil to the frontend to signify that there is no creator.
 			return nil, nil
 		}
 		return nil, err

--- a/service/persist/token_gallery.go
+++ b/service/persist/token_gallery.go
@@ -95,3 +95,11 @@ func NewContractIdentifiers(pContractAddress Address, pChain Chain) ContractIden
 		Chain:           pChain,
 	}
 }
+
+type ErrContractCreatorNotFound struct {
+	ContractID DBID
+}
+
+func (e ErrContractCreatorNotFound) Error() string {
+	return fmt.Sprintf("ContractCreator not found for contractID %s", e.ContractID)
+}


### PR DESCRIPTION
I fixed a previous error re: contract creators, but forgot to update `notfound.go` with an appropriate alternative to `pgx.ErrNoRows`. This PR returns the correct error, and uses that error to return `nil` to the frontend if a contract creator isn't found (instead of throwing an unsupported error type).

We could return the `ErrContractCreatorNotFound` directly to the frontend, but historically haven't done that for backwards compatibility reasons, and I don't think it's worth doing at this point!