### PR TITLE
better rasterizing and log fallback failures

### DIFF
--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -8,7 +8,7 @@ POSTGRES_PASSWORD: ENC[AES256_GCM,data:rj8U63dquwJBWqzqcEZFhuHRk6Zdb/dBu/QiX0046
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:bL4KfxRX7j9/+tez25NfWrk+OBsS0dpqtx0zccyqiBk=,iv:8vNwDPwoBs82KxiJI9xDe42FbegK6xXqi+7XcR+M33Y=,tag:JvPH45ipwRDGzs8M7ceMvw==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
-TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:ojH31zMn5Kart+JgWscxY5M8+FJq,iv:Zz00FJ0pjgxJeSXhYLW8dmOihL6bP9qRuu7xKe2dZ/8=,tag:ncy42h7nPWDCA0cxzuC6AA==,type:str]
+TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:254mQ1xI3t6JUzPthzps9jZbwVBGZ0zGnHJpRqG5QCo=,iv:Jr8gE0ke5fX6XEyT226Y7wJko/x2Ng4t5jq0Hd7A6l8=,tag:w3aG95+2MXhg+nXvANNr5Q==,type:str]
 #ENC[AES256_GCM,data:zwgPg5o8EPv7KbOu5EqFHugDrfOLowyKmaUEK8pP+aGvGbk4gkNJlA53e5aMbVYvGf4ZiVjCaP5xhKn2S+4sn3tIqfh8maOT0A==,iv:CDILhjibyqjLV2a8CX7CR/S6yv4Ged0RNxqPVOIfZX8=,tag:jrHScI7Ia64NEPRWi8reqg==,type:comment]
 INDEXER_HOST: ENC[AES256_GCM,data:AMSoNna+FClTDLT2p+9jVnH2qH9M,iv:vywl4L+b3B1WSIIYPwKzRMSRn67boCM531P5dLKw1Ls=,tag:y4erUfhOns07F4RqDLafGQ==,type:str]
 #ENC[AES256_GCM,data:kxDk5XyPsjJvjeJCrLoxZ8W52B7Wk4NgVQ9aJfOM3MBvOkumXBstjLTrZZCd/zbg3PwVRLeF/ZYISA==,iv:Ik9VWuJvIgVobthlV1mKTfCBqwqCVDi4UOIJ/4cDNz0=,tag:Xe49oB+2mypS+DbEGh9ErQ==,type:comment]
@@ -62,8 +62,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-10-31T21:41:28Z"
-    mac: ENC[AES256_GCM,data:CLNOQktR1Pn0qRNDz5xgDdarQAbbhdy853A/ruFjcMr/EtYlB/LD9mxu3+qQPSG0o5JcEj5yIUfeFdwLQG3Ff+fxXrl2tG8407wYCZUQQCSuZVH5M7wcaC3x0kWyAS5wCv6EkndrXWt/627V8/mWq19WFax/1WFgMmrQh7C99cE=,iv:GGUEbw9a+QX0nTz41qR3C7jZnAfXB4YdxutEGS0jq+o=,tag:RIa1RLciIySEdWtDZHe40w==,type:str]
+    lastmodified: "2023-11-07T20:46:34Z"
+    mac: ENC[AES256_GCM,data:WV1tNiZx0VI2HgpM7dBEL2eElMFifnIfvzWCQEA4G0haxxYsRcP/8zU+ksbpkDHoMifyH2d8IBqgfzbhiealwTVROY7ZKjUg1CnbYKADC8VuqwmI4+SSODMyec6bzo5DqK/lKUE9msiZ053CZaoGqI72xFL4P2uuAtYRqsoyJkE=,iv:XgXr22KnLfz0UQOjAchvuAmVw5pe6IueUn4dZw80i+s=,tag:oEttdLUT7VgvAAbNO83kPw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -488,6 +488,8 @@ func (*Provider) tokenToAgnostic(ctx context.Context, token zoraToken) (multicha
 		q.Set("url", u)
 		fallbackFormat.RawQuery = q.Encode()
 		token.Media.ImagePreview.EncodedPreview = fallbackFormat.String()
+	} else if strings.HasPrefix(token.Media.ImagePreview.Raw, "https://") {
+		token.Media.ImagePreview.EncodedPreview = token.Media.ImagePreview.Raw
 	}
 
 	realMedia, ok := util.FindFirst(token.Media.ImageCarousel, func(media zoraMedia) bool {


### PR DESCRIPTION
Changes:

- **Added** a log to check for fallback 200's
- **Added** a fixed dimension to the SVG rasterizer to ensure that large SVGs are scaled down and we take more uniformly sized PNG thumbnails (svgs with 3000x3000 for example were timing out because the PNG was too big, given that SVGs are scalable we might as well scale it down)
- **Changed** SVG dimension searching to check in a few more spots