### PR TITLE
notification handling for posting first post [GAL-4716]

### DIFF
--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -820,6 +820,10 @@ INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id,
 -- name: CreateUserPostedYourWorkNotification :one
 INSERT INTO notifications (id, owner_id, action, data, event_ids, post_id, contract_id) VALUES ($1, $2, $3, $4, $5, sqlc.narg('post'), $6) RETURNING *;
 
+-- name: CreateUserPostedFirstPostNotifications :many
+INSERT INTO notifications (id, owner_id, action, data, event_ids, post_id) select $1, follows.follower, $2, $3, $4, sqlc.narg('post') from follows where follows.followee = @actor_id RETURNING *;
+
+
 -- name: CreateSimpleNotification :one
 INSERT INTO notifications (id, owner_id, action, data, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING *;
 

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -89,6 +89,7 @@ type ResolverRoot interface {
 	SomeonePostedYourWorkNotification() SomeonePostedYourWorkNotificationResolver
 	SomeoneRepliedToYourCommentNotification() SomeoneRepliedToYourCommentNotificationResolver
 	SomeoneViewedYourGalleryNotification() SomeoneViewedYourGalleryNotificationResolver
+	SomeoneYouFollowPostedTheirFirstPostNotification() SomeoneYouFollowPostedTheirFirstPostNotificationResolver
 	Subscription() SubscriptionResolver
 	Token() TokenResolver
 	TokenDefinition() TokenDefinitionResolver
@@ -1302,6 +1303,15 @@ type ComplexityRoot struct {
 		UserViewers        func(childComplexity int, before *string, after *string, first *int, last *int) int
 	}
 
+	SomeoneYouFollowPostedTheirFirstPostNotification struct {
+		CreationTime func(childComplexity int) int
+		Dbid         func(childComplexity int) int
+		ID           func(childComplexity int) int
+		Post         func(childComplexity int) int
+		Seen         func(childComplexity int) int
+		UpdatedTime  func(childComplexity int) int
+	}
+
 	Subscription struct {
 		NewNotification     func(childComplexity int) int
 		NotificationUpdated func(childComplexity int) int
@@ -2000,6 +2010,9 @@ type SomeoneViewedYourGalleryNotificationResolver interface {
 	UserViewers(ctx context.Context, obj *model.SomeoneViewedYourGalleryNotification, before *string, after *string, first *int, last *int) (*model.GroupNotificationUsersConnection, error)
 
 	Gallery(ctx context.Context, obj *model.SomeoneViewedYourGalleryNotification) (*model.Gallery, error)
+}
+type SomeoneYouFollowPostedTheirFirstPostNotificationResolver interface {
+	Post(ctx context.Context, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (*model.Post, error)
 }
 type SubscriptionResolver interface {
 	NewNotification(ctx context.Context) (<-chan model.Notification, error)
@@ -7417,6 +7430,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.SomeoneViewedYourGalleryNotification.UserViewers(childComplexity, args["before"].(*string), args["after"].(*string), args["first"].(*int), args["last"].(*int)), true
 
+	case "SomeoneYouFollowPostedTheirFirstPostNotification.creationTime":
+		if e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.CreationTime == nil {
+			break
+		}
+
+		return e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.CreationTime(childComplexity), true
+
+	case "SomeoneYouFollowPostedTheirFirstPostNotification.dbid":
+		if e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.Dbid == nil {
+			break
+		}
+
+		return e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.Dbid(childComplexity), true
+
+	case "SomeoneYouFollowPostedTheirFirstPostNotification.id":
+		if e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.ID == nil {
+			break
+		}
+
+		return e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.ID(childComplexity), true
+
+	case "SomeoneYouFollowPostedTheirFirstPostNotification.post":
+		if e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.Post == nil {
+			break
+		}
+
+		return e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.Post(childComplexity), true
+
+	case "SomeoneYouFollowPostedTheirFirstPostNotification.seen":
+		if e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.Seen == nil {
+			break
+		}
+
+		return e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.Seen(childComplexity), true
+
+	case "SomeoneYouFollowPostedTheirFirstPostNotification.updatedTime":
+		if e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.UpdatedTime == nil {
+			break
+		}
+
+		return e.complexity.SomeoneYouFollowPostedTheirFirstPostNotification.UpdatedTime(childComplexity), true
+
 	case "Subscription.newNotification":
 		if e.complexity.Subscription.NewNotification == nil {
 			break
@@ -10439,7 +10494,11 @@ type SyncCreatedTokensForExistingContractPayload {
   viewer: Viewer
 }
 
-union RefreshTokenPayloadOrError = RefreshTokenPayload | ErrInvalidInput | ErrSyncFailed | ErrTokenNotFound
+union RefreshTokenPayloadOrError =
+    RefreshTokenPayload
+  | ErrInvalidInput
+  | ErrSyncFailed
+  | ErrTokenNotFound
 
 type RefreshTokenPayload {
   token: Token
@@ -10958,6 +11017,17 @@ type SomeonePostedYourWorkNotification implements Notification & Node @goEmbedHe
 
   post: Post @goField(forceResolver: true)
   community: Community @goField(forceResolver: true)
+}
+
+type SomeoneYouFollowPostedTheirFirstPostNotification implements Notification & Node
+  @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  post: Post @goField(forceResolver: true)
 }
 
 type ClearAllNotificationsPayload {
@@ -50625,6 +50695,282 @@ func (ec *executionContext) fieldContext_SomeoneViewedYourGalleryNotification_ga
 	return fc, nil
 }
 
+func (ec *executionContext) _SomeoneYouFollowPostedTheirFirstPostNotification_id(ctx context.Context, field graphql.CollectedField, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.GqlID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGqlID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SomeoneYouFollowPostedTheirFirstPostNotification",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SomeoneYouFollowPostedTheirFirstPostNotification_dbid(ctx context.Context, field graphql.CollectedField, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_dbid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Dbid, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(persist.DBID)
+	fc.Result = res
+	return ec.marshalNDBID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_dbid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SomeoneYouFollowPostedTheirFirstPostNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DBID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SomeoneYouFollowPostedTheirFirstPostNotification_seen(ctx context.Context, field graphql.CollectedField, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_seen(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Seen, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_seen(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SomeoneYouFollowPostedTheirFirstPostNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SomeoneYouFollowPostedTheirFirstPostNotification_creationTime(ctx context.Context, field graphql.CollectedField, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_creationTime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreationTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_creationTime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SomeoneYouFollowPostedTheirFirstPostNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SomeoneYouFollowPostedTheirFirstPostNotification_updatedTime(ctx context.Context, field graphql.CollectedField, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_updatedTime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_updatedTime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SomeoneYouFollowPostedTheirFirstPostNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SomeoneYouFollowPostedTheirFirstPostNotification_post(ctx context.Context, field graphql.CollectedField, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_post(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.SomeoneYouFollowPostedTheirFirstPostNotification().Post(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.Post)
+	fc.Result = res
+	return ec.marshalOPost2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPost(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SomeoneYouFollowPostedTheirFirstPostNotification_post(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SomeoneYouFollowPostedTheirFirstPostNotification",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Post_id(ctx, field)
+			case "dbid":
+				return ec.fieldContext_Post_dbid(ctx, field)
+			case "author":
+				return ec.fieldContext_Post_author(ctx, field)
+			case "creationTime":
+				return ec.fieldContext_Post_creationTime(ctx, field)
+			case "tokens":
+				return ec.fieldContext_Post_tokens(ctx, field)
+			case "caption":
+				return ec.fieldContext_Post_caption(ctx, field)
+			case "mentions":
+				return ec.fieldContext_Post_mentions(ctx, field)
+			case "admires":
+				return ec.fieldContext_Post_admires(ctx, field)
+			case "comments":
+				return ec.fieldContext_Post_comments(ctx, field)
+			case "interactions":
+				return ec.fieldContext_Post_interactions(ctx, field)
+			case "viewerAdmire":
+				return ec.fieldContext_Post_viewerAdmire(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Subscription_newNotification(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
 	fc, err := ec.fieldContext_Subscription_newNotification(ctx, field)
 	if err != nil {
@@ -66432,6 +66778,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._SomeonePostedYourWorkNotification(ctx, sel, obj)
+	case model.SomeoneYouFollowPostedTheirFirstPostNotification:
+		return ec._SomeoneYouFollowPostedTheirFirstPostNotification(ctx, sel, &obj)
+	case *model.SomeoneYouFollowPostedTheirFirstPostNotification:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._SomeoneYouFollowPostedTheirFirstPostNotification(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -66537,6 +66890,13 @@ func (ec *executionContext) _Notification(ctx context.Context, sel ast.Selection
 			return graphql.Null
 		}
 		return ec._SomeonePostedYourWorkNotification(ctx, sel, obj)
+	case model.SomeoneYouFollowPostedTheirFirstPostNotification:
+		return ec._SomeoneYouFollowPostedTheirFirstPostNotification(ctx, sel, &obj)
+	case *model.SomeoneYouFollowPostedTheirFirstPostNotification:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._SomeoneYouFollowPostedTheirFirstPostNotification(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -77549,6 +77909,70 @@ func (ec *executionContext) _SomeoneViewedYourGalleryNotification(ctx context.Co
 					}
 				}()
 				res = ec._SomeoneViewedYourGalleryNotification_gallery(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var someoneYouFollowPostedTheirFirstPostNotificationImplementors = []string{"SomeoneYouFollowPostedTheirFirstPostNotification", "Notification", "Node"}
+
+func (ec *executionContext) _SomeoneYouFollowPostedTheirFirstPostNotification(ctx context.Context, sel ast.SelectionSet, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, someoneYouFollowPostedTheirFirstPostNotificationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SomeoneYouFollowPostedTheirFirstPostNotification")
+		case "id":
+
+			out.Values[i] = ec._SomeoneYouFollowPostedTheirFirstPostNotification_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "dbid":
+
+			out.Values[i] = ec._SomeoneYouFollowPostedTheirFirstPostNotification_dbid(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "seen":
+
+			out.Values[i] = ec._SomeoneYouFollowPostedTheirFirstPostNotification_seen(ctx, field, obj)
+
+		case "creationTime":
+
+			out.Values[i] = ec._SomeoneYouFollowPostedTheirFirstPostNotification_creationTime(ctx, field, obj)
+
+		case "updatedTime":
+
+			out.Values[i] = ec._SomeoneYouFollowPostedTheirFirstPostNotification_updatedTime(ctx, field, obj)
+
+		case "post":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._SomeoneYouFollowPostedTheirFirstPostNotification_post(ctx, field, obj)
 				return res
 			}
 

--- a/graphql/model/gqlidgen_gen.go
+++ b/graphql/model/gqlidgen_gen.go
@@ -128,6 +128,10 @@ func (r *SomeoneViewedYourGalleryNotification) ID() GqlID {
 	return GqlID(fmt.Sprintf("SomeoneViewedYourGalleryNotification:%s", r.Dbid))
 }
 
+func (r *SomeoneYouFollowPostedTheirFirstPostNotification) ID() GqlID {
+	return GqlID(fmt.Sprintf("SomeoneYouFollowPostedTheirFirstPostNotification:%s", r.Dbid))
+}
+
 func (r *Token) ID() GqlID {
 	return GqlID(fmt.Sprintf("Token:%s", r.Dbid))
 }
@@ -154,37 +158,38 @@ func (r *Wallet) ID() GqlID {
 }
 
 type NodeFetcher struct {
-	OnAdmire                                      func(ctx context.Context, dbid persist.DBID) (*Admire, error)
-	OnCollection                                  func(ctx context.Context, dbid persist.DBID) (*Collection, error)
-	OnCollectionToken                             func(ctx context.Context, tokenId string, collectionId string) (*CollectionToken, error)
-	OnComment                                     func(ctx context.Context, dbid persist.DBID) (*Comment, error)
-	OnCommunity                                   func(ctx context.Context, dbid persist.DBID) (*Community, error)
-	OnContract                                    func(ctx context.Context, dbid persist.DBID) (*Contract, error)
-	OnDeletedNode                                 func(ctx context.Context, dbid persist.DBID) (*DeletedNode, error)
-	OnFeedEvent                                   func(ctx context.Context, dbid persist.DBID) (*FeedEvent, error)
-	OnGallery                                     func(ctx context.Context, dbid persist.DBID) (*Gallery, error)
-	OnGalleryUser                                 func(ctx context.Context, dbid persist.DBID) (*GalleryUser, error)
-	OnMembershipTier                              func(ctx context.Context, dbid persist.DBID) (*MembershipTier, error)
-	OnMerchToken                                  func(ctx context.Context, tokenId string) (*MerchToken, error)
-	OnNewTokensNotification                       func(ctx context.Context, dbid persist.DBID) (*NewTokensNotification, error)
-	OnPost                                        func(ctx context.Context, dbid persist.DBID) (*Post, error)
-	OnSocialConnection                            func(ctx context.Context, socialId string, socialType persist.SocialProvider) (*SocialConnection, error)
-	OnSomeoneAdmiredYourFeedEventNotification     func(ctx context.Context, dbid persist.DBID) (*SomeoneAdmiredYourFeedEventNotification, error)
-	OnSomeoneAdmiredYourPostNotification          func(ctx context.Context, dbid persist.DBID) (*SomeoneAdmiredYourPostNotification, error)
-	OnSomeoneAdmiredYourTokenNotification         func(ctx context.Context, dbid persist.DBID) (*SomeoneAdmiredYourTokenNotification, error)
-	OnSomeoneCommentedOnYourFeedEventNotification func(ctx context.Context, dbid persist.DBID) (*SomeoneCommentedOnYourFeedEventNotification, error)
-	OnSomeoneCommentedOnYourPostNotification      func(ctx context.Context, dbid persist.DBID) (*SomeoneCommentedOnYourPostNotification, error)
-	OnSomeoneFollowedYouBackNotification          func(ctx context.Context, dbid persist.DBID) (*SomeoneFollowedYouBackNotification, error)
-	OnSomeoneFollowedYouNotification              func(ctx context.Context, dbid persist.DBID) (*SomeoneFollowedYouNotification, error)
-	OnSomeoneMentionedYouNotification             func(ctx context.Context, dbid persist.DBID) (*SomeoneMentionedYouNotification, error)
-	OnSomeoneMentionedYourCommunityNotification   func(ctx context.Context, dbid persist.DBID) (*SomeoneMentionedYourCommunityNotification, error)
-	OnSomeonePostedYourWorkNotification           func(ctx context.Context, dbid persist.DBID) (*SomeonePostedYourWorkNotification, error)
-	OnSomeoneRepliedToYourCommentNotification     func(ctx context.Context, dbid persist.DBID) (*SomeoneRepliedToYourCommentNotification, error)
-	OnSomeoneViewedYourGalleryNotification        func(ctx context.Context, dbid persist.DBID) (*SomeoneViewedYourGalleryNotification, error)
-	OnToken                                       func(ctx context.Context, dbid persist.DBID) (*Token, error)
-	OnTokenDefinition                             func(ctx context.Context, dbid persist.DBID) (*TokenDefinition, error)
-	OnViewer                                      func(ctx context.Context, userId string) (*Viewer, error)
-	OnWallet                                      func(ctx context.Context, dbid persist.DBID) (*Wallet, error)
+	OnAdmire                                           func(ctx context.Context, dbid persist.DBID) (*Admire, error)
+	OnCollection                                       func(ctx context.Context, dbid persist.DBID) (*Collection, error)
+	OnCollectionToken                                  func(ctx context.Context, tokenId string, collectionId string) (*CollectionToken, error)
+	OnComment                                          func(ctx context.Context, dbid persist.DBID) (*Comment, error)
+	OnCommunity                                        func(ctx context.Context, dbid persist.DBID) (*Community, error)
+	OnContract                                         func(ctx context.Context, dbid persist.DBID) (*Contract, error)
+	OnDeletedNode                                      func(ctx context.Context, dbid persist.DBID) (*DeletedNode, error)
+	OnFeedEvent                                        func(ctx context.Context, dbid persist.DBID) (*FeedEvent, error)
+	OnGallery                                          func(ctx context.Context, dbid persist.DBID) (*Gallery, error)
+	OnGalleryUser                                      func(ctx context.Context, dbid persist.DBID) (*GalleryUser, error)
+	OnMembershipTier                                   func(ctx context.Context, dbid persist.DBID) (*MembershipTier, error)
+	OnMerchToken                                       func(ctx context.Context, tokenId string) (*MerchToken, error)
+	OnNewTokensNotification                            func(ctx context.Context, dbid persist.DBID) (*NewTokensNotification, error)
+	OnPost                                             func(ctx context.Context, dbid persist.DBID) (*Post, error)
+	OnSocialConnection                                 func(ctx context.Context, socialId string, socialType persist.SocialProvider) (*SocialConnection, error)
+	OnSomeoneAdmiredYourFeedEventNotification          func(ctx context.Context, dbid persist.DBID) (*SomeoneAdmiredYourFeedEventNotification, error)
+	OnSomeoneAdmiredYourPostNotification               func(ctx context.Context, dbid persist.DBID) (*SomeoneAdmiredYourPostNotification, error)
+	OnSomeoneAdmiredYourTokenNotification              func(ctx context.Context, dbid persist.DBID) (*SomeoneAdmiredYourTokenNotification, error)
+	OnSomeoneCommentedOnYourFeedEventNotification      func(ctx context.Context, dbid persist.DBID) (*SomeoneCommentedOnYourFeedEventNotification, error)
+	OnSomeoneCommentedOnYourPostNotification           func(ctx context.Context, dbid persist.DBID) (*SomeoneCommentedOnYourPostNotification, error)
+	OnSomeoneFollowedYouBackNotification               func(ctx context.Context, dbid persist.DBID) (*SomeoneFollowedYouBackNotification, error)
+	OnSomeoneFollowedYouNotification                   func(ctx context.Context, dbid persist.DBID) (*SomeoneFollowedYouNotification, error)
+	OnSomeoneMentionedYouNotification                  func(ctx context.Context, dbid persist.DBID) (*SomeoneMentionedYouNotification, error)
+	OnSomeoneMentionedYourCommunityNotification        func(ctx context.Context, dbid persist.DBID) (*SomeoneMentionedYourCommunityNotification, error)
+	OnSomeonePostedYourWorkNotification                func(ctx context.Context, dbid persist.DBID) (*SomeonePostedYourWorkNotification, error)
+	OnSomeoneRepliedToYourCommentNotification          func(ctx context.Context, dbid persist.DBID) (*SomeoneRepliedToYourCommentNotification, error)
+	OnSomeoneViewedYourGalleryNotification             func(ctx context.Context, dbid persist.DBID) (*SomeoneViewedYourGalleryNotification, error)
+	OnSomeoneYouFollowPostedTheirFirstPostNotification func(ctx context.Context, dbid persist.DBID) (*SomeoneYouFollowPostedTheirFirstPostNotification, error)
+	OnToken                                            func(ctx context.Context, dbid persist.DBID) (*Token, error)
+	OnTokenDefinition                                  func(ctx context.Context, dbid persist.DBID) (*TokenDefinition, error)
+	OnViewer                                           func(ctx context.Context, userId string) (*Viewer, error)
+	OnWallet                                           func(ctx context.Context, dbid persist.DBID) (*Wallet, error)
 }
 
 func (n *NodeFetcher) GetNodeByGqlID(ctx context.Context, id GqlID) (Node, error) {
@@ -332,6 +337,11 @@ func (n *NodeFetcher) GetNodeByGqlID(ctx context.Context, id GqlID) (Node, error
 			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'SomeoneViewedYourGalleryNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
 		}
 		return n.OnSomeoneViewedYourGalleryNotification(ctx, persist.DBID(ids[0]))
+	case "SomeoneYouFollowPostedTheirFirstPostNotification":
+		if len(ids) != 1 {
+			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'SomeoneYouFollowPostedTheirFirstPostNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
+		}
+		return n.OnSomeoneYouFollowPostedTheirFirstPostNotification(ctx, persist.DBID(ids[0]))
 	case "Token":
 		if len(ids) != 1 {
 			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'Token' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
@@ -413,6 +423,8 @@ func (n *NodeFetcher) ValidateHandlers() {
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneRepliedToYourCommentNotification")
 	case n.OnSomeoneViewedYourGalleryNotification == nil:
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneViewedYourGalleryNotification")
+	case n.OnSomeoneYouFollowPostedTheirFirstPostNotification == nil:
+		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnSomeoneYouFollowPostedTheirFirstPostNotification")
 	case n.OnToken == nil:
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnToken")
 	case n.OnTokenDefinition == nil:

--- a/graphql/model/models.go
+++ b/graphql/model/models.go
@@ -87,6 +87,7 @@ type HelperSomeoneViewedYourGalleryNotificationData struct {
 	GalleryID        persist.DBID
 	NotificationData persist.NotificationData
 }
+
 type HelperSomeoneFollowedYouBackNotificationData struct {
 	OwnerID          persist.DBID
 	NotificationData persist.NotificationData
@@ -147,6 +148,10 @@ type HelperSomeoneMentionedYourCommunityNotificationData struct {
 type HelperSomeonePostedYourWorkNotificationData struct {
 	ContractID persist.DBID
 	PostID     persist.DBID
+}
+
+type HelperSomeoneYouFollowPostedTheirFirstPostNotificationData struct {
+	PostID persist.DBID
 }
 
 type HelperNotificationsConnectionData struct {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -2235,6 +2235,18 @@ func (SomeoneViewedYourGalleryNotification) IsNotification()        {}
 func (SomeoneViewedYourGalleryNotification) IsNode()                {}
 func (SomeoneViewedYourGalleryNotification) IsGroupedNotification() {}
 
+type SomeoneYouFollowPostedTheirFirstPostNotification struct {
+	HelperSomeoneYouFollowPostedTheirFirstPostNotificationData
+	Dbid         persist.DBID `json:"dbid"`
+	Seen         *bool        `json:"seen"`
+	CreationTime *time.Time   `json:"creationTime"`
+	UpdatedTime  *time.Time   `json:"updatedTime"`
+	Post         *Post        `json:"post"`
+}
+
+func (SomeoneYouFollowPostedTheirFirstPostNotification) IsNotification() {}
+func (SomeoneYouFollowPostedTheirFirstPostNotification) IsNode()         {}
+
 type SyncCreatedTokensForExistingContractInput struct {
 	ContractID persist.DBID `json:"contractId"`
 }

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2768,6 +2768,11 @@ func (r *someoneViewedYourGalleryNotificationResolver) Gallery(ctx context.Conte
 	return resolveGalleryByGalleryID(ctx, obj.GalleryID)
 }
 
+// Post is the resolver for the post field.
+func (r *someoneYouFollowPostedTheirFirstPostNotificationResolver) Post(ctx context.Context, obj *model.SomeoneYouFollowPostedTheirFirstPostNotification) (*model.Post, error) {
+	return resolvePostByPostID(ctx, obj.PostID)
+}
+
 // NewNotification is the resolver for the newNotification field.
 func (r *subscriptionResolver) NewNotification(ctx context.Context) (<-chan model.Notification, error) {
 	return resolveNewNotificationSubscription(ctx), nil
@@ -2776,35 +2781,6 @@ func (r *subscriptionResolver) NewNotification(ctx context.Context) (<-chan mode
 // NotificationUpdated is the resolver for the notificationUpdated field.
 func (r *subscriptionResolver) NotificationUpdated(ctx context.Context) (<-chan model.Notification, error) {
 	return resolveUpdatedNotificationSubscription(ctx), nil
-}
-
-// Media is the resolver for the media field.
-func (r *tokenResolver) Media(ctx context.Context, obj *model.Token) (model.MediaSubtype, error) {
-	var highDef bool
-	if obj.CollectionID != nil {
-		settings, err := resolveTokenSettingsByIDs(ctx, obj.Dbid, *obj.CollectionID)
-		if err != nil {
-			return nil, err
-		}
-		highDef = *settings.HighDefinition
-	}
-
-	// The definition is likely already cached by the root dataloader that queries for the definition alongside the token instance
-	td, err := publicapi.For(ctx).Token.GetTokenDefinitionByID(ctx, obj.HelperTokenData.Token.TokenDefinitionID)
-	if err != nil {
-		return nil, err
-	}
-
-	var media coredb.TokenMedia
-
-	if td.TokenMediaID != "" {
-		media, err = publicapi.For(ctx).Token.GetMediaByMediaID(ctx, td.TokenMediaID)
-		if util.ErrorAs[persist.ErrMediaNotFound](err) {
-			err = nil
-		}
-	}
-
-	return resolveTokenMedia(ctx, td, media, highDef), err
 }
 
 // Owner is the resolver for the owner field.
@@ -2830,40 +2806,6 @@ func (r *tokenResolver) OwnedByWallets(ctx context.Context, obj *model.Token) ([
 // Definition is the resolver for the definition field.
 func (r *tokenResolver) Definition(ctx context.Context, obj *model.Token) (*model.TokenDefinition, error) {
 	return resolveTokenDefinitionByID(ctx, obj.HelperTokenData.Token.TokenDefinitionID)
-}
-
-// TokenMetadata is the resolver for the tokenMetadata field.
-func (r *tokenResolver) TokenMetadata(ctx context.Context, obj *model.Token) (*string, error) {
-	tokenMedia, err := publicapi.For(ctx).Token.GetTokenDefinitionByID(ctx, obj.HelperTokenData.Token.TokenDefinitionID)
-	if err != nil {
-		return nil, err
-	}
-	mar, err := json.Marshal(tokenMedia.Metadata)
-	if err != nil {
-		return nil, err
-	}
-
-	return util.ToPointer(string(mar)), nil
-}
-
-// Contract is the resolver for the contract field.
-func (r *tokenResolver) Contract(ctx context.Context, obj *model.Token) (*model.Contract, error) {
-	return resolveContractByContractID(ctx, obj.HelperTokenData.Token.ContractID)
-}
-
-// Community is the resolver for the community field.
-func (r *tokenResolver) Community(ctx context.Context, obj *model.Token) (*model.Community, error) {
-	return resolveCommunityByID(ctx, obj.HelperTokenData.Token.ContractID)
-}
-
-// IsSpamByProvider is the resolver for the isSpamByProvider field.
-func (r *tokenResolver) IsSpamByProvider(ctx context.Context, obj *model.Token) (*bool, error) {
-	c, err := resolveContractByContractID(ctx, obj.HelperTokenData.Token.ContractID)
-	if err != nil {
-		return nil, err
-	}
-	isSpam := (c.IsSpam != nil && *c.IsSpam) || (obj.IsSpamByProvider != nil && *obj.IsSpamByProvider)
-	return &isSpam, nil
 }
 
 // Admires is the resolver for the admires field.
@@ -2906,6 +2848,35 @@ func (r *tokenResolver) ViewerAdmire(ctx context.Context, obj *model.Token) (*mo
 	}
 
 	return admireToModel(ctx, *admire), nil
+}
+
+// Media is the resolver for the media field.
+func (r *tokenResolver) Media(ctx context.Context, obj *model.Token) (model.MediaSubtype, error) {
+	var highDef bool
+	if obj.CollectionID != nil {
+		settings, err := resolveTokenSettingsByIDs(ctx, obj.Dbid, *obj.CollectionID)
+		if err != nil {
+			return nil, err
+		}
+		highDef = *settings.HighDefinition
+	}
+
+	// The definition is likely already cached by the root dataloader that queries for the definition alongside the token instance
+	td, err := publicapi.For(ctx).Token.GetTokenDefinitionByID(ctx, obj.HelperTokenData.Token.TokenDefinitionID)
+	if err != nil {
+		return nil, err
+	}
+
+	var media coredb.TokenMedia
+
+	if td.TokenMediaID != "" {
+		media, err = publicapi.For(ctx).Token.GetMediaByMediaID(ctx, td.TokenMediaID)
+		if util.ErrorAs[persist.ErrMediaNotFound](err) {
+			err = nil
+		}
+	}
+
+	return resolveTokenMedia(ctx, td, media, highDef), err
 }
 
 // TokenType is the resolver for the tokenType field.
@@ -2953,6 +2924,30 @@ func (r *tokenResolver) TokenID(ctx context.Context, obj *model.Token) (*string,
 	return td.TokenID, nil
 }
 
+// TokenMetadata is the resolver for the tokenMetadata field.
+func (r *tokenResolver) TokenMetadata(ctx context.Context, obj *model.Token) (*string, error) {
+	tokenMedia, err := publicapi.For(ctx).Token.GetTokenDefinitionByID(ctx, obj.HelperTokenData.Token.TokenDefinitionID)
+	if err != nil {
+		return nil, err
+	}
+	mar, err := json.Marshal(tokenMedia.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return util.ToPointer(string(mar)), nil
+}
+
+// Contract is the resolver for the contract field.
+func (r *tokenResolver) Contract(ctx context.Context, obj *model.Token) (*model.Contract, error) {
+	return resolveContractByContractID(ctx, obj.HelperTokenData.Token.ContractID)
+}
+
+// Community is the resolver for the community field.
+func (r *tokenResolver) Community(ctx context.Context, obj *model.Token) (*model.Community, error) {
+	return resolveCommunityByID(ctx, obj.HelperTokenData.Token.ContractID)
+}
+
 // ExternalURL is the resolver for the externalUrl field.
 func (r *tokenResolver) ExternalURL(ctx context.Context, obj *model.Token) (*string, error) {
 	td, err := resolveTokenDefinitionByID(ctx, obj.HelperTokenData.Token.TokenDefinitionID)
@@ -2960,6 +2955,16 @@ func (r *tokenResolver) ExternalURL(ctx context.Context, obj *model.Token) (*str
 		return nil, err
 	}
 	return td.ExternalURL, nil
+}
+
+// IsSpamByProvider is the resolver for the isSpamByProvider field.
+func (r *tokenResolver) IsSpamByProvider(ctx context.Context, obj *model.Token) (*bool, error) {
+	c, err := resolveContractByContractID(ctx, obj.HelperTokenData.Token.ContractID)
+	if err != nil {
+		return nil, err
+	}
+	isSpam := (c.IsSpam != nil && *c.IsSpam) || (obj.IsSpamByProvider != nil && *obj.IsSpamByProvider)
+	return &isSpam, nil
 }
 
 // Media is the resolver for the media field.
@@ -3370,6 +3375,11 @@ func (r *Resolver) SomeoneViewedYourGalleryNotification() generated.SomeoneViewe
 	return &someoneViewedYourGalleryNotificationResolver{r}
 }
 
+// SomeoneYouFollowPostedTheirFirstPostNotification returns generated.SomeoneYouFollowPostedTheirFirstPostNotificationResolver implementation.
+func (r *Resolver) SomeoneYouFollowPostedTheirFirstPostNotification() generated.SomeoneYouFollowPostedTheirFirstPostNotificationResolver {
+	return &someoneYouFollowPostedTheirFirstPostNotificationResolver{r}
+}
+
 // Subscription returns generated.SubscriptionResolver implementation.
 func (r *Resolver) Subscription() generated.SubscriptionResolver { return &subscriptionResolver{r} }
 
@@ -3473,6 +3483,7 @@ type someoneMentionedYourCommunityNotificationResolver struct{ *Resolver }
 type someonePostedYourWorkNotificationResolver struct{ *Resolver }
 type someoneRepliedToYourCommentNotificationResolver struct{ *Resolver }
 type someoneViewedYourGalleryNotificationResolver struct{ *Resolver }
+type someoneYouFollowPostedTheirFirstPostNotificationResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type tokenResolver struct{ *Resolver }
 type tokenDefinitionResolver struct{ *Resolver }

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -62,19 +62,20 @@ var nodeFetcher = model.NodeFetcher{
 	OnCommunity: func(ctx context.Context, dbid persist.DBID) (*model.Community, error) {
 		return resolveCommunityByID(ctx, dbid)
 	},
-	OnSomeoneAdmiredYourFeedEventNotification:     fetchNotificationByID[model.SomeoneAdmiredYourFeedEventNotification],
-	OnSomeoneCommentedOnYourFeedEventNotification: fetchNotificationByID[model.SomeoneCommentedOnYourFeedEventNotification],
-	OnSomeoneAdmiredYourPostNotification:          fetchNotificationByID[model.SomeoneAdmiredYourPostNotification],
-	OnSomeoneCommentedOnYourPostNotification:      fetchNotificationByID[model.SomeoneCommentedOnYourPostNotification],
-	OnSomeoneFollowedYouBackNotification:          fetchNotificationByID[model.SomeoneFollowedYouBackNotification],
-	OnSomeoneFollowedYouNotification:              fetchNotificationByID[model.SomeoneFollowedYouNotification],
-	OnSomeoneViewedYourGalleryNotification:        fetchNotificationByID[model.SomeoneViewedYourGalleryNotification],
-	OnNewTokensNotification:                       fetchNotificationByID[model.NewTokensNotification],
-	OnSomeoneMentionedYouNotification:             fetchNotificationByID[model.SomeoneMentionedYouNotification],
-	OnSomeoneMentionedYourCommunityNotification:   fetchNotificationByID[model.SomeoneMentionedYourCommunityNotification],
-	OnSomeoneRepliedToYourCommentNotification:     fetchNotificationByID[model.SomeoneRepliedToYourCommentNotification],
-	OnSomeoneAdmiredYourTokenNotification:         fetchNotificationByID[model.SomeoneAdmiredYourTokenNotification],
-	OnSomeonePostedYourWorkNotification:           fetchNotificationByID[model.SomeonePostedYourWorkNotification],
+	OnSomeoneAdmiredYourFeedEventNotification:          fetchNotificationByID[model.SomeoneAdmiredYourFeedEventNotification],
+	OnSomeoneCommentedOnYourFeedEventNotification:      fetchNotificationByID[model.SomeoneCommentedOnYourFeedEventNotification],
+	OnSomeoneAdmiredYourPostNotification:               fetchNotificationByID[model.SomeoneAdmiredYourPostNotification],
+	OnSomeoneCommentedOnYourPostNotification:           fetchNotificationByID[model.SomeoneCommentedOnYourPostNotification],
+	OnSomeoneFollowedYouBackNotification:               fetchNotificationByID[model.SomeoneFollowedYouBackNotification],
+	OnSomeoneFollowedYouNotification:                   fetchNotificationByID[model.SomeoneFollowedYouNotification],
+	OnSomeoneViewedYourGalleryNotification:             fetchNotificationByID[model.SomeoneViewedYourGalleryNotification],
+	OnNewTokensNotification:                            fetchNotificationByID[model.NewTokensNotification],
+	OnSomeoneMentionedYouNotification:                  fetchNotificationByID[model.SomeoneMentionedYouNotification],
+	OnSomeoneMentionedYourCommunityNotification:        fetchNotificationByID[model.SomeoneMentionedYourCommunityNotification],
+	OnSomeoneRepliedToYourCommentNotification:          fetchNotificationByID[model.SomeoneRepliedToYourCommentNotification],
+	OnSomeoneAdmiredYourTokenNotification:              fetchNotificationByID[model.SomeoneAdmiredYourTokenNotification],
+	OnSomeonePostedYourWorkNotification:                fetchNotificationByID[model.SomeonePostedYourWorkNotification],
+	OnSomeoneYouFollowPostedTheirFirstPostNotification: fetchNotificationByID[model.SomeoneYouFollowPostedTheirFirstPostNotification],
 }
 
 // T any is a notification type, will panic if it is not a notification type
@@ -1033,6 +1034,17 @@ func notificationToModel(notif db.Notification) (model.Notification, error) {
 			CreationTime: &notif.CreatedAt,
 			UpdatedTime:  &notif.LastUpdated,
 			Community:    nil, // handled by dedicated resolver
+			Post:         nil, // handled by dedicated resolver
+		}, nil
+	case persist.ActionUserPostedFirstPost:
+		return model.SomeoneYouFollowPostedTheirFirstPostNotification{
+			HelperSomeoneYouFollowPostedTheirFirstPostNotificationData: model.HelperSomeoneYouFollowPostedTheirFirstPostNotificationData{
+				PostID: notif.PostID,
+			},
+			Dbid:         notif.ID,
+			Seen:         &notif.Seen,
+			CreationTime: &notif.CreatedAt,
+			UpdatedTime:  &notif.LastUpdated,
 			Post:         nil, // handled by dedicated resolver
 		}, nil
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2168,6 +2168,17 @@ type SomeonePostedYourWorkNotification implements Notification & Node @goEmbedHe
   community: Community @goField(forceResolver: true)
 }
 
+type SomeoneYouFollowPostedTheirFirstPostNotification implements Notification & Node
+  @goEmbedHelper {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  post: Post @goField(forceResolver: true)
+}
+
 type ClearAllNotificationsPayload {
   notifications: [Notification]
 }

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mikeydub/go-gallery/event"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/redis"
+	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/validate"
 
 	gcptasks "cloud.google.com/go/cloudtasks/apiv2"
@@ -224,6 +225,7 @@ func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, ment
 			ContractID:     creator.ContractID,
 		})
 		if err != nil {
+			sentryutil.ReportError(ctx, fmt.Errorf("error dispatching event: %w", err))
 			logger.For(ctx).Errorf("error dispatching event: %v", err)
 		}
 	}
@@ -237,6 +239,7 @@ func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, ment
 		PostID:         postID,
 	})
 	if err != nil {
+		sentryutil.ReportError(ctx, fmt.Errorf("error dispatching event: %w", err))
 		logger.For(ctx).Errorf("error dispatching event: %v", err)
 	}
 
@@ -255,6 +258,7 @@ func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, ment
 			PostID:         postID,
 		})
 		if err != nil {
+			sentryutil.ReportError(ctx, fmt.Errorf("error dispatching event: %w", err))
 			logger.For(ctx).Errorf("error dispatching event: %v", err)
 		}
 	}
@@ -323,6 +327,7 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 				ContractID:     creator.ContractID,
 			})
 			if err != nil {
+				sentryutil.ReportError(ctx, fmt.Errorf("error dispatching event: %w", err))
 				logger.For(ctx).Errorf("error dispatching event: %v", err)
 			}
 		}
@@ -377,6 +382,7 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 			ContractID:     creator.ContractID,
 		})
 		if err != nil {
+			sentryutil.ReportError(ctx, fmt.Errorf("error dispatching event: %w", err))
 			logger.For(ctx).Errorf("error dispatching event: %v", err)
 		}
 	}
@@ -390,6 +396,7 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 		PostID:         postID,
 	})
 	if err != nil {
+		sentryutil.ReportError(ctx, fmt.Errorf("error dispatching event: %w", err))
 		logger.For(ctx).Errorf("error dispatching event: %v", err)
 	}
 	count, err := api.queries.CountPostsByUserID(ctx, user.ID)
@@ -407,6 +414,7 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 			PostID:         postID,
 		})
 		if err != nil {
+			sentryutil.ReportError(ctx, fmt.Errorf("error dispatching event: %w", err))
 			logger.For(ctx).Errorf("error dispatching event: %v", err)
 		}
 	}

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -811,7 +811,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 				Action:         "commented on your additions to",
 				CollectionName: collection.Name.String,
 				CollectionID:   collection.ID,
-				PreviewText:    util.TruncateWithEllipsis(comment.Comment, 20),
+				PreviewText:    util.TruncateWithEllipsis(comment.Comment, 40),
 			}, nil
 
 		} else if n.Action == persist.ActionCommentedOnFeedEvent {
@@ -821,7 +821,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 		return UserFacingNotificationData{
 			Actor:       userActor.Username.String,
 			Action:      action,
-			PreviewText: util.TruncateWithEllipsis(comment.Comment, 20),
+			PreviewText: util.TruncateWithEllipsis(comment.Comment, 40),
 		}, nil
 	case persist.ActionViewedGallery:
 		if len(n.Data.AuthedViewerIDs)+len(n.Data.UnauthedViewerIDs) > 1 {
@@ -865,7 +865,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 				return UserFacingNotificationData{}, err
 			}
 
-			preview = util.TruncateWithEllipsis(comment.Comment, 20)
+			preview = util.TruncateWithEllipsis(comment.Comment, 40)
 
 			actor, err = queries.GetUserById(ctx, comment.ActorID)
 			if err != nil {
@@ -880,7 +880,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 				return UserFacingNotificationData{}, err
 			}
 
-			preview = util.TruncateWithEllipsis(post.Caption.String, 20)
+			preview = util.TruncateWithEllipsis(post.Caption.String, 40)
 
 			actor, err = queries.GetUserById(ctx, post.ActorID)
 			if err != nil {
@@ -931,7 +931,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 		return UserFacingNotificationData{
 			Actor:       commenter.Username.String,
 			Action:      "replied to your comment",
-			PreviewText: util.TruncateWithEllipsis(comment.Comment, 20),
+			PreviewText: util.TruncateWithEllipsis(comment.Comment, 40),
 		}, nil
 	case persist.ActionNewTokensReceived:
 		data := UserFacingNotificationData{}
@@ -941,7 +941,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 			return UserFacingNotificationData{}, err
 		}
 
-		name := util.TruncateWithEllipsis(td.Name.String, 20)
+		name := util.TruncateWithEllipsis(td.Name.String, 40)
 
 		amount := n.Data.NewTokenQuantity
 		i := amount.BigInt().Uint64()
@@ -975,7 +975,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 			Action:         "posted your work",
 			CollectionName: contract.Name.String,
 			CollectionID:   contract.ID,
-			PreviewText:    util.TruncateWithEllipsis(post.Caption.String, 20),
+			PreviewText:    util.TruncateWithEllipsis(post.Caption.String, 40),
 		}, nil
 
 	case persist.ActionUserPostedFirstPost:
@@ -993,7 +993,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 		return UserFacingNotificationData{
 			Actor:       actor.Username.String,
 			Action:      "posted their first post",
-			PreviewText: util.TruncateWithEllipsis(post.Caption.String, 20),
+			PreviewText: util.TruncateWithEllipsis(post.Caption.String, 40),
 		}, nil
 	default:
 		return UserFacingNotificationData{}, fmt.Errorf("unknown action %s", n.Action)

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -80,8 +80,8 @@ func (p *pushLimiter) tryComment(ctx context.Context, sendingUserID persist.DBID
 	}
 }
 
-func (p *pushLimiter) tryMention(ctx context.Context, sendingUserID persist.DBID, receivingUserID persist.DBID, feedEventID persist.DBID) error {
-	key := fmt.Sprintf("%s:%s:%s", sendingUserID.String(), receivingUserID.String(), feedEventID.String())
+func (p *pushLimiter) tryMention(ctx context.Context, sendingUserID persist.DBID, receivingUserID persist.DBID, postID persist.DBID) error {
+	key := fmt.Sprintf("%s:%s:%s", sendingUserID.String(), receivingUserID.String(), postID.String())
 	if p.isActionAllowed(ctx, p.mentions, key) {
 		return nil
 	}
@@ -90,7 +90,7 @@ func (p *pushLimiter) tryMention(ctx context.Context, sendingUserID persist.DBID
 		limiterName: p.mentions.Name(),
 		senderID:    sendingUserID,
 		receiverID:  receivingUserID,
-		feedEventID: feedEventID,
+		feedEventID: postID,
 	}
 }
 
@@ -647,7 +647,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		if err = limiter.tryMention(ctx, commenter.ID, notif.OwnerID, notif.FeedEventID); err != nil {
+		if err = limiter.tryMention(ctx, commenter.ID, notif.OwnerID, notif.PostID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
 
@@ -688,7 +688,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, fmt.Errorf("no comment or post id provided for mention notification")
 		}
 
-		if err := limiter.tryMention(ctx, actor.ID, notif.OwnerID, notif.FeedEventID); err != nil {
+		if err := limiter.tryMention(ctx, actor.ID, notif.OwnerID, notif.PostID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
 
@@ -707,7 +707,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
-		if err := limiter.tryMention(ctx, actor.ID, notif.OwnerID, notif.FeedEventID); err != nil {
+		if err := limiter.tryMention(ctx, actor.ID, notif.OwnerID, notif.PostID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
 

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -22,6 +22,7 @@ const (
 	ActionUserFollowedUsers               Action = "UserFollowedUsers"
 	ActionUserPosted                      Action = "UserPosted"
 	ActionUserPostedYourWork              Action = "UserPostedYourWork"
+	ActionUserPostedFirstPost             Action = "UserPostedFirstPost"
 	ActionCollectorsNoteAddedToToken      Action = "CollectorsNoteAddedToToken"
 	ActionCollectionCreated               Action = "CollectionCreated"
 	ActionCollectorsNoteAddedToCollection Action = "CollectorsNoteAddedToCollection"


### PR DESCRIPTION
Changes:

- **Added** a new action `UserPostedFirstPost`
- **Added** a new type of event notification handler for "follower" events that don't have a single owner and are going to be associated with the followers of the event actor
- **Added** a new type of notification handler for "follower" notifications that will fan out notifications to the followers of the determined actor based on the notification type (e.g. a user posted first notification will fan out to the followers of the poster user)
- **Added** new GQL type `SomeoneYouFollowPostedTheirFirstPostNotification` to the schema

How it works:

1. A user posts, we check if this is their first post (posts.count == 1). If it is, we send a single event saying this user posted their first work
2. A new event handler picks up that event and creates a notification that says, "here is all the data needed for this notification, but we don't have an owner just yet because this notification is meant to be sent out to many owners, the followers of the event actor"
3. A new notification handler picks up that notification and uses it to insert batch many notifications after determining who the "actor" of the notification is. In the case of the first post, this will be the user who posted.
4. The new notifications are sent as they are usually to the push notification task queue