### PR TITLE
Fix ordering of push tokens

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -3019,7 +3019,12 @@ func (q *Queries) GetPushTokenByPushToken(ctx context.Context, pushToken string)
 }
 
 const getPushTokensByIDs = `-- name: GetPushTokensByIDs :many
-select t.id, t.user_id, t.push_token, t.created_at, t.deleted from unnest($1::text[]) ids join push_notification_tokens t on t.id = ids and t.deleted = false
+with keys as (
+    select unnest ($1::text[]) as id
+         , generate_subscripts($1::text[], 1) as index
+)
+select t.id, t.user_id, t.push_token, t.created_at, t.deleted from keys k join push_notification_tokens t on t.id = k.id and t.deleted = false
+    order by k.index
 `
 
 func (q *Queries) GetPushTokensByIDs(ctx context.Context, ids []string) ([]PushNotificationToken, error) {

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1374,7 +1374,12 @@ update push_notification_tokens set deleted = true where id = any(@ids) and dele
 select * from push_notification_tokens where user_id = @user_id and deleted = false;
 
 -- name: GetPushTokensByIDs :many
-select t.* from unnest(@ids::text[]) ids join push_notification_tokens t on t.id = ids and t.deleted = false;
+with keys as (
+    select unnest (@ids::text[]) as id
+         , generate_subscripts(@ids::text[], 1) as index
+)
+select t.* from keys k join push_notification_tokens t on t.id = k.id and t.deleted = false
+    order by k.index;
 
 -- name: CreatePushTickets :exec
 insert into push_notification_tickets (id, push_token_id, ticket_id, created_at, check_after, num_check_attempts, status, deleted) values


### PR DESCRIPTION
When I originally wrote this query, I thought joining on an unnested set of keys would return results in the same order as the keys. As it turns out, that's not true! This PR updates the query to explicitly order the results, which is what the backend expects when it receives them.