### PR TITLE
Add return to ActionUserPostedYourWork

### DIFF
--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -703,6 +703,7 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 		message.Body = fmt.Sprintf("%s posted your work: %s", actor.Username.String, contract.Name.String)
+		return message, nil
 	}
 
 	return task.PushNotificationMessage{}, fmt.Errorf("unsupported notification action: %s", notif.Action)


### PR DESCRIPTION
Noticed when I mentioned Figure31 that this sentry error popped up: https://usegallery.sentry.io/issues/4612178636/?referrer=slack&notification_uuid=68366714-4e34-4a68-80df-c9d14a7e1041&alert_rule_id=13000544&alert_type=issue

The notification was sent, but it fell through and hit the error because it was missing a `return`.