### PR TITLE
Tokenprocessing pipeline updates

### DIFF
--- a/service/persist/token_processing_jobs.go
+++ b/service/persist/token_processing_jobs.go
@@ -98,52 +98,58 @@ func (p PipelineStepStatus) MarshalJSON() ([]byte, error) {
 }
 
 type PipelineMetadata struct {
-	MetadataRetrieval                        PipelineStepStatus `json:"metadata_retrieval,omitempty"`
-	TokenInfoRetrieval                       PipelineStepStatus `json:"token_info_retrieval,omitempty"`
-	MediaURLsRetrieval                       PipelineStepStatus `json:"media_urls_retrieval,omitempty"`
-	AnimationContentHeaderValueRetrieval     PipelineStepStatus `json:"animation_content_header_value_retrieval,omitempty"`
-	AnimationReaderRetrieval                 PipelineStepStatus `json:"animation_reader_retrieval,omitempty"`
-	AnimationOpenseaFallback                 PipelineStepStatus `json:"animation_opensea_fallback,omitempty"`
-	AnimationDetermineMediaTypeWithReader    PipelineStepStatus `json:"animation_determine_media_type_with_reader,omitempty"`
-	AnimationAnimationGzip                   PipelineStepStatus `json:"animation_animation_gzip,omitempty"`
-	AnimationSVGRasterize                    PipelineStepStatus `json:"animation_svg_rasterize,omitempty"`
-	AnimationStoreGCP                        PipelineStepStatus `json:"animation_store_gcp,omitempty"`
-	AnimationThumbnailGCP                    PipelineStepStatus `json:"animation_thumbnail_gcp,omitempty"`
-	AnimationLiveRenderGCP                   PipelineStepStatus `json:"animation_live_render_gcp,omitempty"`
-	ImageContentHeaderValueRetrieval         PipelineStepStatus `json:"image_content_header_value_retrieval,omitempty"`
-	ImageReaderRetrieval                     PipelineStepStatus `json:"image_reader_retrieval,omitempty"`
-	ImageOpenseaFallback                     PipelineStepStatus `json:"image_opensea_fallback,omitempty"`
-	ImageDetermineMediaTypeWithReader        PipelineStepStatus `json:"image_determine_media_type_with_reader,omitempty"`
-	ImageAnimationGzip                       PipelineStepStatus `json:"image_animation_gzip,omitempty"`
-	ImageSVGRasterize                        PipelineStepStatus `json:"image_svg_rasterize,omitempty"`
-	ImageStoreGCP                            PipelineStepStatus `json:"image_store_gcp,omitempty"`
-	ImageThumbnailGCP                        PipelineStepStatus `json:"image_thumbnail_gcp,omitempty"`
-	ImageLiveRenderGCP                       PipelineStepStatus `json:"image_live_render_gcp,omitempty"`
-	AlternateContentHeaderValueRetrieval     PipelineStepStatus `json:"alternate_content_header_value_retrieval,omitempty"`
-	AlternateReaderRetrieval                 PipelineStepStatus `json:"alternate_reader_retrieval,omitempty"`
-	AlternateOpenseaFallback                 PipelineStepStatus `json:"alternate_opensea_fallback,omitempty"`
-	AlternateDetermineMediaTypeWithReader    PipelineStepStatus `json:"alternate_determine_media_type_with_reader,omitempty"`
-	AlternateAnimationGzip                   PipelineStepStatus `json:"alternate_animation_gzip,omitempty"`
-	AlternateSVGRasterize                    PipelineStepStatus `json:"alternate_svg_rasterize,omitempty"`
-	AlternateStoreGCP                        PipelineStepStatus `json:"alternate_store_gcp,omitempty"`
-	AlternateThumbnailGCP                    PipelineStepStatus `json:"alternate_thumbnail_gcp,omitempty"`
-	AlternateLiveRenderGCP                   PipelineStepStatus `json:"alternate_live_render_gcp,omitempty"`
-	ProfileImageContentHeaderValueRetrieval  PipelineStepStatus `json:"pfp_content_header_value_retrieval,omitempty"`
-	ProfileImageReaderRetrieval              PipelineStepStatus `json:"pfp_reader_retrieval,omitempty"`
-	ProfileImageOpenseaFallback              PipelineStepStatus `json:"pfp_opensea_fallback,omitempty"`
-	ProfileImageDetermineMediaTypeWithReader PipelineStepStatus `json:"pfp_determine_media_type_with_reader,omitempty"`
-	ProfileImageAnimationGzip                PipelineStepStatus `json:"pfp_animation_gzip,omitempty"`
-	ProfileImageSVGRasterize                 PipelineStepStatus `json:"pfp_svg_rasterize,omitempty"`
-	ProfileImageStoreGCP                     PipelineStepStatus `json:"pfp_store_gcp,omitempty"`
-	ProfileImageThumbnailGCP                 PipelineStepStatus `json:"pfp_thumbnail_gcp,omitempty"`
-	ProfileImageLiveRenderGCP                PipelineStepStatus `json:"pfp_live_render_gcp,omitempty"`
-	NothingCachedWithErrors                  PipelineStepStatus `json:"nothing_cached_errors,omitempty"`
-	NothingCachedWithoutErrors               PipelineStepStatus `json:"nothing_cached_no_errors,omitempty"`
-	CreateMedia                              PipelineStepStatus `json:"create_media,omitempty"`
-	CreateMediaFromCachedObjects             PipelineStepStatus `json:"create_media_from_cached_objects,omitempty"`
-	CreateRawMedia                           PipelineStepStatus `json:"create_raw_media,omitempty"`
-	SetUnknownMediaType                      PipelineStepStatus `json:"set_default_media_type,omitempty"`
-	MediaResultComparison                    PipelineStepStatus `json:"media_result_comparison,omitempty"`
+	MetadataRetrieval                              PipelineStepStatus `json:"metadata_retrieval,omitempty"`
+	TokenInfoRetrieval                             PipelineStepStatus `json:"token_info_retrieval,omitempty"`
+	MediaURLsRetrieval                             PipelineStepStatus `json:"media_urls_retrieval,omitempty"`
+	AnimationContentHeaderValueRetrieval           PipelineStepStatus `json:"animation_content_header_value_retrieval,omitempty"`
+	AnimationReaderRetrieval                       PipelineStepStatus `json:"animation_reader_retrieval,omitempty"`
+	AnimationOpenseaFallback                       PipelineStepStatus `json:"animation_opensea_fallback,omitempty"`
+	AnimationDetermineMediaTypeWithReader          PipelineStepStatus `json:"animation_determine_media_type_with_reader,omitempty"`
+	AnimationAnimationGzip                         PipelineStepStatus `json:"animation_animation_gzip,omitempty"`
+	AnimationSVGRasterize                          PipelineStepStatus `json:"animation_svg_rasterize,omitempty"`
+	AnimationStoreGCP                              PipelineStepStatus `json:"animation_store_gcp,omitempty"`
+	AnimationThumbnailGCP                          PipelineStepStatus `json:"animation_thumbnail_gcp,omitempty"`
+	AnimationLiveRenderGCP                         PipelineStepStatus `json:"animation_live_render_gcp,omitempty"`
+	ImageContentHeaderValueRetrieval               PipelineStepStatus `json:"image_content_header_value_retrieval,omitempty"`
+	ImageReaderRetrieval                           PipelineStepStatus `json:"image_reader_retrieval,omitempty"`
+	ImageOpenseaFallback                           PipelineStepStatus `json:"image_opensea_fallback,omitempty"`
+	ImageDetermineMediaTypeWithReader              PipelineStepStatus `json:"image_determine_media_type_with_reader,omitempty"`
+	ImageAnimationGzip                             PipelineStepStatus `json:"image_animation_gzip,omitempty"`
+	ImageSVGRasterize                              PipelineStepStatus `json:"image_svg_rasterize,omitempty"`
+	ImageStoreGCP                                  PipelineStepStatus `json:"image_store_gcp,omitempty"`
+	ImageThumbnailGCP                              PipelineStepStatus `json:"image_thumbnail_gcp,omitempty"`
+	ImageLiveRenderGCP                             PipelineStepStatus `json:"image_live_render_gcp,omitempty"`
+	AlternateAnimationContentHeaderValueRetrieval  PipelineStepStatus `json:"alternate_animation_content_header_value_retrieval,omitempty"`
+	AlternateAnimationReaderRetrieval              PipelineStepStatus `json:"alternate_animation_reader_retrieval,omitempty"`
+	AlternateAnimationDetermineMediaTypeWithReader PipelineStepStatus `json:"alternate_animation_determine_media_type_with_reader,omitempty"`
+	AlternateAnimationAnimationGzip                PipelineStepStatus `json:"alternate_animation_animation_gzip,omitempty"`
+	AlternateAnimationSVGRasterize                 PipelineStepStatus `json:"alternate_animation_svg_rasterize,omitempty"`
+	AlternateAnimationStoreGCP                     PipelineStepStatus `json:"alternate_animation_store_gcp,omitempty"`
+	AlternateAnimationThumbnailGCP                 PipelineStepStatus `json:"alternate_animation_thumbnail_gcp,omitempty"`
+	AlternateAnimationLiveRenderGCP                PipelineStepStatus `json:"alternate_animation_live_render_gcp,omitempty"`
+	AlternateImageContentHeaderValueRetrieval      PipelineStepStatus `json:"alternate_image_content_header_value_retrieval,omitempty"`
+	AlternateImageReaderRetrieval                  PipelineStepStatus `json:"alternate_image_reader_retrieval,omitempty"`
+	AlternateImageDetermineMediaTypeWithReader     PipelineStepStatus `json:"alternate_image_determine_media_type_with_reader,omitempty"`
+	AlternateImageAnimationGzip                    PipelineStepStatus `json:"alternate_image_animation_gzip,omitempty"`
+	AlternateImageSVGRasterize                     PipelineStepStatus `json:"alternate_image_svg_rasterize,omitempty"`
+	AlternateImageStoreGCP                         PipelineStepStatus `json:"alternate_image_store_gcp,omitempty"`
+	AlternateImageThumbnailGCP                     PipelineStepStatus `json:"alternate_image_thumbnail_gcp,omitempty"`
+	AlternateImageLiveRenderGCP                    PipelineStepStatus `json:"alternate_image_live_render_gcp,omitempty"`
+	ProfileImageContentHeaderValueRetrieval        PipelineStepStatus `json:"pfp_content_header_value_retrieval,omitempty"`
+	ProfileImageReaderRetrieval                    PipelineStepStatus `json:"pfp_reader_retrieval,omitempty"`
+	ProfileImageOpenseaFallback                    PipelineStepStatus `json:"pfp_opensea_fallback,omitempty"`
+	ProfileImageDetermineMediaTypeWithReader       PipelineStepStatus `json:"pfp_determine_media_type_with_reader,omitempty"`
+	ProfileImageAnimationGzip                      PipelineStepStatus `json:"pfp_animation_gzip,omitempty"`
+	ProfileImageSVGRasterize                       PipelineStepStatus `json:"pfp_svg_rasterize,omitempty"`
+	ProfileImageStoreGCP                           PipelineStepStatus `json:"pfp_store_gcp,omitempty"`
+	ProfileImageThumbnailGCP                       PipelineStepStatus `json:"pfp_thumbnail_gcp,omitempty"`
+	ProfileImageLiveRenderGCP                      PipelineStepStatus `json:"pfp_live_render_gcp,omitempty"`
+	NothingCachedWithErrors                        PipelineStepStatus `json:"nothing_cached_errors,omitempty"`
+	NothingCachedWithoutErrors                     PipelineStepStatus `json:"nothing_cached_no_errors,omitempty"`
+	CreateMedia                                    PipelineStepStatus `json:"create_media,omitempty"`
+	CreateMediaFromCachedObjects                   PipelineStepStatus `json:"create_media_from_cached_objects,omitempty"`
+	CreateRawMedia                                 PipelineStepStatus `json:"create_raw_media,omitempty"`
+	MediaResultComparison                          PipelineStepStatus `json:"media_result_comparison,omitempty"`
 }
 
 func (p PipelineMetadata) Value() (driver.Value, error) {
@@ -192,7 +198,7 @@ func TrackStepStatus(ctx context.Context, status *PipelineStepStatus, name strin
 	return func() {
 		defer tracing.FinishSpan(span)
 		if *status == PipelineStepStatusError {
-			logger.For(ctx).Infof("failed [%s] (took: %s)", name, time.Since(startTime))
+			logger.For(ctx).Errorf("failed [%s] (took: %s)", name, time.Since(startTime))
 			return
 		}
 		*status = PipelineStepStatusSuccess

--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -27,19 +27,19 @@ var contractSpecificRetries = map[persist.ContractIdentifiers]int{prohibitionCon
 
 func handlersInitServer(ctx context.Context, router *gin.Engine, tp *tokenProcessor, mc *multichain.Provider, repos *postgres.Repositories, throttler *throttle.Locker, taskClient *cloudtasks.Client) *gin.Engine {
 	// Retry tokens that failed during syncs, but don't retry tokens that failed during manual refreshes
-	refreshManager := tokenmanage.New(ctx, taskClient)
-	syncManager := tokenmanage.NewWithRetries(ctx, taskClient, syncMaxRetries)
+	noRetryManager := tokenmanage.New(ctx, taskClient)
+	retryManager := tokenmanage.NewWithRetries(ctx, taskClient, syncMaxRetries)
 
 	mediaGroup := router.Group("/media")
 	mediaGroup.POST("/process", func(c *gin.Context) {
 		if hub := sentryutil.SentryHubFromContext(c); hub != nil {
 			hub.Scope().AddEventProcessor(sentryutil.SpanFilterEventProcessor(c, 1000, 1*time.Millisecond, 8, true))
 		}
-		processBatch(tp, mc.Queries, syncManager)(c)
+		processBatch(tp, mc.Queries, retryManager)(c)
 	})
-	mediaGroup.POST("/process/token", processMediaForTokenIdentifiers(tp, mc.Queries, refreshManager))
-	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, syncManager))
-	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, syncManager, mc, repos.UserRepository))
+	mediaGroup.POST("/process/token", processMediaForTokenIdentifiers(tp, mc.Queries, noRetryManager))
+	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, retryManager))
+	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, retryManager, mc, repos.UserRepository))
 	ownersGroup := router.Group("/owners")
 	ownersGroup.POST("/process/contract", processOwnersForContractTokens(mc, throttler))
 	ownersGroup.POST("/process/user", processOwnersForUserTokens(mc, mc.Queries))

--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -7,6 +7,7 @@ import (
 	cloudtasks "cloud.google.com/go/cloudtasks/apiv2"
 	"github.com/gin-gonic/gin"
 
+	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -17,9 +18,12 @@ import (
 
 const defaultSyncMaxRetries = 4
 
-var contractSpecificRetries = map[persist.ContractIdentifiers]int{
-	persist.NewContractIdentifiers("0x47a91457a3a1f700097199fd63c039c4784384ab", persist.ChainArbitrum): 24, // Prohibition
-}
+var (
+	prohibitionContract = persist.NewContractIdentifiers("0x47a91457a3a1f700097199fd63c039c4784384ab", persist.ChainArbitrum)
+	ensContract         = persist.NewContractIdentifiers(eth.EnsAddress, persist.ChainETH)
+)
+
+var contractSpecificRetries = map[persist.ContractIdentifiers]int{prohibitionContract: 24}
 
 func handlersInitServer(ctx context.Context, router *gin.Engine, tp *tokenProcessor, mc *multichain.Provider, repos *postgres.Repositories, throttler *throttle.Locker, taskClient *cloudtasks.Client) *gin.Engine {
 	// Retry tokens that failed during syncs, but don't retry tokens that failed during manual refreshes

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -134,6 +134,9 @@ func createUncachedMedia(ctx context.Context, job *tokenProcessingJob, url strin
 }
 
 func mustCreateMediaFromErr(ctx context.Context, err error, job *tokenProcessingJob) persist.Media {
+	if bErr, ok := err.(ErrBadToken); ok {
+		return mustCreateMediaFromErr(ctx, bErr.Unwrap(), job)
+	}
 	if util.ErrorAs[errInvalidMedia](err) {
 		invalidErr := err.(errInvalidMedia)
 		return persist.Media{MediaType: persist.MediaTypeInvalid, MediaURL: persist.NullString(invalidErr.URL)}

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -870,7 +870,7 @@ func readerFromURL(ctx context.Context, mediaURL string, mediaType persist.Media
 	switch caught := err.(type) {
 	case util.ErrHTTP:
 		// We might want to support redirects later
-		if caught.Status < 200 || caught.Status < 299 {
+		if caught.Status < 200 || caught.Status > 299 {
 			return reader, mediaType, errInvalidMedia{URL: mediaURL, err: err}
 		}
 	case *net.DNSError, *url.Error:

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -185,7 +185,7 @@ func wrapWithBadTokenErr(err error) error {
 	return err
 }
 
-func cacheResultsToErr(animResult cacheResult, imgResult cacheResult, imageRequired bool) error {
+func createErrFromResults(animResult cacheResult, imgResult cacheResult, imageRequired bool) error {
 	if imageRequired && !imgResult.IsSuccess() {
 		return ErrImageResultRequired{Err: wrapWithBadTokenErr(imgResult.err)}
 	}
@@ -406,7 +406,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, p
 	imgResult, pfpResult, animResult := tpj.cacheMediaFromOriginalURLs(ctx, imgURL, pfpURL, animURL)
 
 	if (!imgRequired && animResult.IsSuccess()) || imgResult.IsSuccess() {
-		err = cacheResultsToErr(animResult, imgResult, imgRequired)
+		err = createErrFromResults(animResult, imgResult, imgRequired)
 		return createMediaFromResults(ctx, tpj, animResult, imgResult, pfpResult), err
 	}
 
@@ -424,7 +424,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, p
 
 	// Now check if we got any result from OpenSea
 	if animResult.IsSuccess() || imgResult.IsSuccess() {
-		err = cacheResultsToErr(animResult, imgResult, imgRequired)
+		err = createErrFromResults(animResult, imgResult, imgRequired)
 		return createMediaFromResults(ctx, tpj, animResult, imgResult, pfpResult), err
 	}
 
@@ -432,7 +432,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, p
 	defer traceCallback()
 
 	// At this point we don't have a way to make media so we return an error
-	err = cacheResultsToErr(animResult, imgResult, imgRequired)
+	err = createErrFromResults(animResult, imgResult, imgRequired)
 	return mustCreateMediaFromErr(ctx, err, tpj), err
 }
 

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -19,7 +19,6 @@ import (
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/event"
-	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -716,7 +715,10 @@ func processPostPreflight(tp *tokenProcessor, tm *tokenmanage.Manager, mc *multi
 				return
 			}
 
-			_, err = runManagedPipeline(c, tp, tm, td, persist.ProcessingCausePostPreflight, 0, addIsSpamJobOption(contract))
+			_, err = runManagedPipeline(c, tp, tm, td, persist.ProcessingCausePostPreflight, 0,
+				addIsSpamJobOption(contract),
+				PipelineOpts.WithRequireImage(), // Require an image if available
+			)
 			if err != nil {
 				// Only log the error, because tokenmanage will handle reprocessing
 				logger.For(c).Errorf("error in preflight: error processing token: %s", err)
@@ -754,6 +756,7 @@ func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage
 		"tokenID_base10":      td.TokenID.Base10String(),
 		"contractAddress":     td.ContractAddress,
 		"chain":               td.Chain,
+		"cause":               cause,
 	})
 	tID := persist.NewTokenIdentifiers(td.ContractAddress, td.TokenID, td.Chain)
 	cID := persist.NewContractIdentifiers(td.ContractAddress, td.Chain)
@@ -780,7 +783,8 @@ func addContextRunOptions(cause persist.ProcessingCause) (opts []PipelineOption)
 
 // addContractRunOptions adds pipeline options for specific contracts
 func addContractRunOptions(contract persist.ContractIdentifiers) (opts []PipelineOption) {
-	if contract.Chain == persist.ChainETH && contract.ContractAddress == eth.EnsAddress {
+	// Process PFPs from ENS tokens
+	if contract == ensContract {
 		opts = append(opts, PipelineOpts.WithProfileImageKey("profile_image"))
 	}
 	return opts

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -783,7 +783,6 @@ func addContextRunOptions(cause persist.ProcessingCause) (opts []PipelineOption)
 
 // addContractRunOptions adds pipeline options for specific contracts
 func addContractRunOptions(contract persist.ContractIdentifiers) (opts []PipelineOption) {
-	// Process PFPs from ENS tokens
 	if contract == ensContract {
 		opts = append(opts, PipelineOpts.WithProfileImageKey("profile_image"))
 	}


### PR DESCRIPTION
### What's new?
* Added a new job option `requireImage` which requires an image to be processed if an image keyword is in the metadata. `requireImage` is enabled for jobs started by the `processPostPreflight` endpoint to help ensure that preview images are available for posts.
* Refactored how the Opensea fallback is used. Before, when processing an animation, if the pipeline failed to download content from the animation URL, OS was used to download any asset type (even a non-animation asset). The same was true for images. Now, we try to fetch specific assets from OS. The fallback is now only used at the top-level of the pipeline and only if the pipeline requirements aren't met yet (e.g. if the job has `requireImage` enabled and an image wasn't cached yet)
* Non `2xx` HTTP codes are now categorized as `errInvalidMedia` instead of `errNoDataFromReader`. `errNoDataFromReader` errors are now wrapped as `ErrBadToken` so those errors are excluded from error reporting and altering.
* Fixes bug where higher priority object types weren't used in the final media result