### PR TITLE
Fix token admire notifications

### DIFF
--- a/db/gen/coredb/admire.sql.go
+++ b/db/gen/coredb/admire.sql.go
@@ -15,7 +15,7 @@ import (
 const createAdmire = `-- name: CreateAdmire :one
 INSERT INTO admires (id, feed_event_id, post_id, token_id, actor_id)
 VALUES ($1, $3, $4, $5, $2)
-ON CONFLICT (actor_id, token_id) WHERE deleted = false DO NOTHING
+ON CONFLICT (actor_id, token_id) WHERE deleted = false DO UPDATE SET last_updated = now()
 RETURNING id
 `
 

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -334,7 +334,7 @@ func (q *Queries) CountUserUnseenNotifications(ctx context.Context, ownerID pers
 }
 
 const createAdmireEvent = `-- name: CreateAdmireEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $10, $11, $6, $7, $8, $9) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id, mention_id
+INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, token_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $10, $11, $12, $6, $7, $8, $9) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id, mention_id
 `
 
 type CreateAdmireEventParams struct {
@@ -349,6 +349,7 @@ type CreateAdmireEventParams struct {
 	Caption        sql.NullString       `db:"caption" json:"caption"`
 	FeedEvent      sql.NullString       `db:"feed_event" json:"feed_event"`
 	Post           sql.NullString       `db:"post" json:"post"`
+	Token          sql.NullString       `db:"token" json:"token"`
 }
 
 func (q *Queries) CreateAdmireEvent(ctx context.Context, arg CreateAdmireEventParams) (Event, error) {
@@ -364,6 +365,7 @@ func (q *Queries) CreateAdmireEvent(ctx context.Context, arg CreateAdmireEventPa
 		arg.Caption,
 		arg.FeedEvent,
 		arg.Post,
+		arg.Token,
 	)
 	var i Event
 	err := row.Scan(

--- a/db/queries/core/admire.sql
+++ b/db/queries/core/admire.sql
@@ -1,7 +1,7 @@
 -- name: CreateAdmire :one
 INSERT INTO admires (id, feed_event_id, post_id, token_id, actor_id)
 VALUES ($1, sqlc.narg('feed_event'), sqlc.narg('post'), sqlc.narg('token'), $2)
-ON CONFLICT (actor_id, token_id) WHERE deleted = false DO NOTHING
+ON CONFLICT (actor_id, token_id) WHERE deleted = false DO UPDATE SET last_updated = now()
 RETURNING id;
 
 -- name: DeleteAdmireByID :exec

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -426,7 +426,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, contract_id, subject
 INSERT INTO events (id, actor_id, action, resource_type_id, user_id, subject_id, post_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;
 
 -- name: CreateAdmireEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), $6, $7, $8, $9) RETURNING *;
+INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, token_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), sqlc.narg('token'), $6, $7, $8, $9) RETURNING *;
 
 -- name: CreateCommentEvent :one
 INSERT INTO events (id, actor_id, action, resource_type_id, comment_id, feed_event_id, post_id, mention_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), sqlc.narg('mention'), $6, $7, $8, $9) RETURNING *;

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -568,15 +568,14 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 			return task.PushNotificationMessage{}, err
 		}
 
+		if admirer.Username.String == "" {
+			return task.PushNotificationMessage{}, fmt.Errorf("user with ID=%s has no username", admirer.ID)
+		}
+
 		if err = limiter.tryAdmireToken(ctx, admirer.ID, notif.OwnerID, notif.TokenID); err != nil {
 			return task.PushNotificationMessage{}, err
 		}
 
-		if !admirer.Username.Valid {
-			return task.PushNotificationMessage{}, fmt.Errorf("user with ID=%s has no username", admirer.ID)
-		}
-
-		message.Body = fmt.Sprintf("%s admired your token", admirer.Username.String)
 		return message, nil
 	}
 
@@ -731,8 +730,7 @@ func (u UserFacingNotificationData) String() string {
 func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, n coredb.Notification) (UserFacingNotificationData, error) {
 
 	switch n.Action {
-	case persist.ActionAdmiredFeedEvent, persist.ActionAdmiredPost:
-
+	case persist.ActionAdmiredFeedEvent, persist.ActionAdmiredPost, persist.ActionAdmiredToken:
 		data := UserFacingNotificationData{}
 		if n.Action == persist.ActionAdmiredFeedEvent {
 			feedEvent, err := queries.GetFeedEventByID(ctx, n.FeedEventID)
@@ -747,6 +745,8 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 			} else {
 				data.Action = "admired your gallery update"
 			}
+		} else if n.Action == persist.ActionAdmiredToken {
+			data.Action = "admired your token"
 		} else {
 			data.Action = "admired your post"
 		}

--- a/service/persist/postgres/admire.go
+++ b/service/persist/postgres/admire.go
@@ -6,6 +6,7 @@ import (
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/util"
 )
 
 // AdmireRepository represents an admire repository in the postgres database
@@ -52,26 +53,11 @@ func (a *AdmireRepository) CreateAdmire(ctx context.Context, feedEventID, postID
 }
 
 func (a *AdmireRepository) CreateTokenAdmire(ctx context.Context, tokenID, actorID persist.DBID) (persist.DBID, error) {
-	var tokenString sql.NullString
-	if tokenID != "" {
-		tokenString = sql.NullString{
-			String: tokenID.String(),
-			Valid:  true,
-		}
-	}
-
-	admireID, err := a.queries.CreateAdmire(ctx, db.CreateAdmireParams{
-		ID:        persist.GenerateID(),
-		Token:     tokenString,
-		ActorID:   actorID,
+	return a.queries.CreateAdmire(ctx, db.CreateAdmireParams{
+		ID:      persist.GenerateID(),
+		Token:   util.ToNullString(tokenID.String(), true),
+		ActorID: actorID,
 	})
-
-	if err != nil {
-		return "", err
-	}
-
-	return admireID, nil
-
 }
 
 func (a *AdmireRepository) RemoveAdmire(ctx context.Context, admireID persist.DBID) error {

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"time"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
@@ -94,26 +93,19 @@ func (r *EventRepository) AddCollectionEvent(ctx context.Context, event db.Event
 }
 
 func (r *EventRepository) AddAdmireEvent(ctx context.Context, event db.Event) (*db.Event, error) {
-	var feedEventID sql.NullString
-	var postID sql.NullString
-	if event.FeedEventID != "" {
-		feedEventID = sql.NullString{String: string(event.FeedEventID), Valid: true}
-	}
-	if event.PostID != "" {
-		postID = sql.NullString{String: string(event.PostID), Valid: true}
-	}
 	event, err := r.Queries.CreateAdmireEvent(ctx, db.CreateAdmireEventParams{
 		ID:             persist.GenerateID(),
 		ActorID:        event.ActorID,
 		Action:         event.Action,
 		ResourceTypeID: event.ResourceTypeID,
 		AdmireID:       event.AdmireID,
-		FeedEvent:      feedEventID,
-		Post:           postID,
+		FeedEvent:      util.ToNullString(event.FeedEventID.String(), true),
+		Post:           util.ToNullString(event.PostID.String(), true),
 		SubjectID:      event.SubjectID,
 		Data:           event.Data,
 		GroupID:        event.GroupID,
 		Caption:        event.Caption,
+		Token:          util.ToNullString(event.TokenID.String(), true),
 	})
 	return &event, err
 }

--- a/service/sentry/sentry.go
+++ b/service/sentry/sentry.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/mikeydub/go-gallery/service/logger"
-	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/sirupsen/logrus"
 
 	"github.com/getsentry/sentry-go"
@@ -19,7 +18,6 @@ import (
 
 const (
 	errorContextName  = "error context"
-	eventContextName  = "event context"
 	loggerContextName = "logger context"
 )
 
@@ -124,16 +122,6 @@ func SetErrorContext(scope *sentry.Scope, mapped bool, mappedTo string) {
 	}
 
 	scope.SetContext(errorContextName, errCtx)
-}
-
-func SetEventContext(scope *sentry.Scope, actorID, subjectID persist.DBID, action persist.Action) {
-	eventCtx := sentry.Context{
-		"ActorID":   actorID,
-		"SubjectID": subjectID,
-		"Action":    action,
-	}
-
-	scope.SetContext(eventContextName, eventCtx)
 }
 
 // NewSentryHubGinContext returns a new Gin context with a cloned hub of the original context's hub.


### PR DESCRIPTION
Was able to get `SomeoneAdmiredYourTokenNotification` working! Tested with the query:
```graphql
query {
  viewer {
    ...on Error {
      message
      __typename
    }
    ...on Viewer {
      notifications(last:4) {
        edges {
          node {
            id
            __typename
            creationTime
            ...on SomeoneAdmiredYourTokenNotification {
              id
              dbid
              token {
                dbid
                name
                tokenId
                description
                media {
                  __typename
                  ...on Media {
                    mediaURL
                    mediaType
                  }
                }
              }
              admirers(first: 4) {
                edges {
                  node {
                    username
                  }
                }
              }
            }
          }
        }
      }
    }
  }
}
```
The frontend doesn't support displaying this notification type yet, but should be ready to integrate now.