### PR TITLE
Fix gallery token previews

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -1720,8 +1720,8 @@ select tm.id, tm.created_at, tm.last_updated, tm.version, tm.contract_id__deprec
 from galleries g, collections c, tokens t, token_medias tm, token_definitions td
 where
 	g.id = $1
-	and c.id = any(g.collections[:8])
-	and t.id = any(c.nfts[:8])
+	and c.id = any(g.collections)
+	and t.id = any(c.nfts)
     and t.owner_user_id = g.owner_user_id
     and t.displayable
     and t.token_definition_id = td.id
@@ -1731,8 +1731,10 @@ where
 	and not c.deleted
 	and not t.deleted
 	and not tm.deleted
-	and tm.active
-	and (length(tm.media ->> 'thumbnail_url'::varchar) > 0 or length(tm.media ->> 'media_url'::varchar) > 0)
+	and (
+		tm.media->>'thumbnail_url' is not null
+		or (tm.media->>'media_type' = 'image' and tm.media->>'media_url' is not null)
+	)
 order by array_position(g.collections, c.id) , array_position(c.nfts, t.id)
 limit 4
 `

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1021,8 +1021,8 @@ select tm.*
 from galleries g, collections c, tokens t, token_medias tm, token_definitions td
 where
 	g.id = $1
-	and c.id = any(g.collections[:8])
-	and t.id = any(c.nfts[:8])
+	and c.id = any(g.collections)
+	and t.id = any(c.nfts)
     and t.owner_user_id = g.owner_user_id
     and t.displayable
     and t.token_definition_id = td.id
@@ -1032,8 +1032,10 @@ where
 	and not c.deleted
 	and not t.deleted
 	and not tm.deleted
-	and tm.active
-	and (length(tm.media ->> 'thumbnail_url'::varchar) > 0 or length(tm.media ->> 'media_url'::varchar) > 0)
+	and (
+		tm.media->>'thumbnail_url' is not null
+		or (tm.media->>'media_type' = 'image' and tm.media->>'media_url' is not null)
+	)
 order by array_position(g.collections, c.id) , array_position(c.nfts, t.id)
 limit 4;
 


### PR DESCRIPTION
Fixes gallery token preview. 
Before:
<img width="1226" alt="Screen Shot 2023-11-13 at 1 05 15 PM" src="https://github.com/gallery-so/go-gallery/assets/20363846/67c73951-077a-48f3-9c19-ca20a1367848">
After:
<img width="1222" alt="Screen Shot 2023-11-13 at 1 05 29 PM" src="https://github.com/gallery-so/go-gallery/assets/20363846/1597d764-17c1-4c65-8601-244c50cfb49d">
