### PR TITLE
Fix IPFS fallback previews

### DIFF
--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -2091,7 +2091,7 @@ func pageInfoToModel(ctx context.Context, pageInfo publicapi.PageInfo) *model.Pa
 
 func resolveTokenMedia(ctx context.Context, td db.TokenDefinition, tokenMedia db.TokenMedia, highDef bool) model.MediaSubtype {
 	// Rewrite fallback IPFS and Arweave URLs to HTTP
-	if fallback := strings.ToLower(td.FallbackMedia.ImageURL.String()); strings.HasPrefix(fallback, "ipfs://") {
+	if fallback := td.FallbackMedia.ImageURL.String(); strings.HasPrefix(fallback, "ipfs://") {
 		td.FallbackMedia.ImageURL = persist.NullString(ipfs.DefaultGatewayFrom(fallback))
 	} else if strings.HasPrefix(fallback, "ar://") {
 		td.FallbackMedia.ImageURL = persist.NullString(fmt.Sprintf("https://arweave.net/%s", util.GetURIPath(fallback, false)))


### PR DESCRIPTION
This fixes the broken image that is briefly shown for fallback media using IPFS. Turns out IPFS CIDs are case-sensitive and shouldn't be lower-cased.
| Before | After |
| --- | ----------- |
| <img width="680" alt="Screen Shot 2023-11-13 at 2 42 54 PM" src="https://github.com/gallery-so/go-gallery/assets/20363846/60868bf0-8fb1-4d92-92ad-672d7a6021ff"> |  <img width="680" alt="Screen Shot 2023-11-13 at 2 44 45 PM" src="https://github.com/gallery-so/go-gallery/assets/20363846/4bcddefd-4a25-4b91-a3aa-9cb2bcae02d0"> |

