### PR TITLE
generate many ids for user post first post

### DIFF
--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -820,9 +820,11 @@ INSERT INTO notifications (id, owner_id, action, data, event_ids, feed_event_id,
 -- name: CreateUserPostedYourWorkNotification :one
 INSERT INTO notifications (id, owner_id, action, data, event_ids, post_id, contract_id) VALUES ($1, $2, $3, $4, $5, sqlc.narg('post'), $6) RETURNING *;
 
--- name: CreateUserPostedFirstPostNotifications :many
-INSERT INTO notifications (id, owner_id, action, data, event_ids, post_id) select $1, follows.follower, $2, $3, $4, sqlc.narg('post') from follows where follows.followee = @actor_id RETURNING *;
+-- name: CountFollowersByUserID :one
+SELECT count(*) FROM follows WHERE followee = $1 AND deleted = false;
 
+-- name: CreateUserPostedFirstPostNotifications :many
+INSERT INTO notifications (id, owner_id, action, data, event_ids, post_id) select unnest(sqlc.arg('ids')::varchar[]), follows.follower, $1, $2, $3, sqlc.narg('post') from follows where follows.followee = @actor_id RETURNING *;
 
 -- name: CreateSimpleNotification :one
 INSERT INTO notifications (id, owner_id, action, data, event_ids) VALUES ($1, $2, $3, $4, $5) RETURNING *;

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -1321,8 +1321,17 @@ func addFollowerNotifications(ctx context.Context, notif db.Notification, querie
 		if err != nil {
 			return nil, err
 		}
+
+		followerCount, err := queries.CountFollowersByUserID(ctx, post.ActorID)
+		if err != nil {
+			return nil, err
+		}
+
+		ids := util.MapWithoutError(make([]any, followerCount), func(i any) string {
+			return persist.GenerateID().String()
+		})
 		return queries.CreateUserPostedFirstPostNotifications(ctx, db.CreateUserPostedFirstPostNotificationsParams{
-			ID:       persist.GenerateID(),
+			Ids:      ids,
 			Action:   notif.Action,
 			Data:     notif.Data,
 			EventIds: notif.EventIds,


### PR DESCRIPTION
Changes:

1. **Changed** insert of user posted first notification to take in an array of IDs generated up front