### PR TITLE
show nested comments as a flat list

### DIFF
--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -49,18 +49,18 @@ type Collection struct {
 }
 
 type Comment struct {
-	ID             persist.DBID `db:"id" json:"id"`
-	Version        int32        `db:"version" json:"version"`
-	FeedEventID    persist.DBID `db:"feed_event_id" json:"feed_event_id"`
-	ActorID        persist.DBID `db:"actor_id" json:"actor_id"`
-	ReplyTo        persist.DBID `db:"reply_to" json:"reply_to"`
-	Comment        string       `db:"comment" json:"comment"`
-	Deleted        bool         `db:"deleted" json:"deleted"`
-	CreatedAt      time.Time    `db:"created_at" json:"created_at"`
-	LastUpdated    time.Time    `db:"last_updated" json:"last_updated"`
-	PostID         persist.DBID `db:"post_id" json:"post_id"`
-	Removed        bool         `db:"removed" json:"removed"`
-	ReplyAncestors []string     `db:"reply_ancestors" json:"reply_ancestors"`
+	ID                persist.DBID `db:"id" json:"id"`
+	Version           int32        `db:"version" json:"version"`
+	FeedEventID       persist.DBID `db:"feed_event_id" json:"feed_event_id"`
+	ActorID           persist.DBID `db:"actor_id" json:"actor_id"`
+	ReplyTo           persist.DBID `db:"reply_to" json:"reply_to"`
+	Comment           string       `db:"comment" json:"comment"`
+	Deleted           bool         `db:"deleted" json:"deleted"`
+	CreatedAt         time.Time    `db:"created_at" json:"created_at"`
+	LastUpdated       time.Time    `db:"last_updated" json:"last_updated"`
+	PostID            persist.DBID `db:"post_id" json:"post_id"`
+	Removed           bool         `db:"removed" json:"removed"`
+	TopLevelCommentID persist.DBID `db:"top_level_comment_id" json:"top_level_comment_id"`
 }
 
 type Contract struct {

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -49,17 +49,18 @@ type Collection struct {
 }
 
 type Comment struct {
-	ID          persist.DBID `db:"id" json:"id"`
-	Version     int32        `db:"version" json:"version"`
-	FeedEventID persist.DBID `db:"feed_event_id" json:"feed_event_id"`
-	ActorID     persist.DBID `db:"actor_id" json:"actor_id"`
-	ReplyTo     persist.DBID `db:"reply_to" json:"reply_to"`
-	Comment     string       `db:"comment" json:"comment"`
-	Deleted     bool         `db:"deleted" json:"deleted"`
-	CreatedAt   time.Time    `db:"created_at" json:"created_at"`
-	LastUpdated time.Time    `db:"last_updated" json:"last_updated"`
-	PostID      persist.DBID `db:"post_id" json:"post_id"`
-	Removed     bool         `db:"removed" json:"removed"`
+	ID             persist.DBID `db:"id" json:"id"`
+	Version        int32        `db:"version" json:"version"`
+	FeedEventID    persist.DBID `db:"feed_event_id" json:"feed_event_id"`
+	ActorID        persist.DBID `db:"actor_id" json:"actor_id"`
+	ReplyTo        persist.DBID `db:"reply_to" json:"reply_to"`
+	Comment        string       `db:"comment" json:"comment"`
+	Deleted        bool         `db:"deleted" json:"deleted"`
+	CreatedAt      time.Time    `db:"created_at" json:"created_at"`
+	LastUpdated    time.Time    `db:"last_updated" json:"last_updated"`
+	PostID         persist.DBID `db:"post_id" json:"post_id"`
+	Removed        bool         `db:"removed" json:"removed"`
+	ReplyAncestors []string     `db:"reply_ancestors" json:"reply_ancestors"`
 }
 
 type Contract struct {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -5508,35 +5508,35 @@ const insertComment = `-- name: InsertComment :one
 INSERT INTO comments 
 (ID, FEED_EVENT_ID, POST_ID, ACTOR_ID, REPLY_TO, TOP_LEVEL_COMMENT_ID, COMMENT) 
 VALUES 
-($1, $4, $5, $2, $6, 
+($1, $2::varchar, $3::varchar, $4, $5::varchar, 
     (CASE 
-        WHEN $6 IS NOT NULL THEN
-            (SELECT COALESCE(c.top_level_comment_id, $6) 
+        WHEN $5::varchar IS NOT NULL THEN
+            (SELECT COALESCE(c.top_level_comment_id, $5::varchar) 
              FROM comments c 
-             WHERE c.id = $6)
+             WHERE c.id = $5::varchar)
         ELSE NULL 
     END), 
-$3) 
+$6::varchar) 
 RETURNING ID
 `
 
 type InsertCommentParams struct {
 	ID        persist.DBID   `db:"id" json:"id"`
-	ActorID   persist.DBID   `db:"actor_id" json:"actor_id"`
-	Comment   string         `db:"comment" json:"comment"`
 	FeedEvent sql.NullString `db:"feed_event" json:"feed_event"`
 	Post      sql.NullString `db:"post" json:"post"`
+	ActorID   persist.DBID   `db:"actor_id" json:"actor_id"`
 	Reply     sql.NullString `db:"reply" json:"reply"`
+	Comment   string         `db:"comment" json:"comment"`
 }
 
 func (q *Queries) InsertComment(ctx context.Context, arg InsertCommentParams) (persist.DBID, error) {
 	row := q.db.QueryRow(ctx, insertComment,
 		arg.ID,
-		arg.ActorID,
-		arg.Comment,
 		arg.FeedEvent,
 		arg.Post,
+		arg.ActorID,
 		arg.Reply,
+		arg.Comment,
 	)
 	var id persist.DBID
 	err := row.Scan(&id)

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -1702,7 +1702,7 @@ func (q *Queries) GetCollectionsByGalleryId(ctx context.Context, id persist.DBID
 }
 
 const getCommentByCommentID = `-- name: GetCommentByCommentID :one
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, reply_ancestors FROM comments WHERE id = $1
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, top_level_comment_id FROM comments WHERE id = $1
 `
 
 func (q *Queries) GetCommentByCommentID(ctx context.Context, id persist.DBID) (Comment, error) {
@@ -1720,13 +1720,13 @@ func (q *Queries) GetCommentByCommentID(ctx context.Context, id persist.DBID) (C
 		&i.LastUpdated,
 		&i.PostID,
 		&i.Removed,
-		&i.ReplyAncestors,
+		&i.TopLevelCommentID,
 	)
 	return i, err
 }
 
 const getCommentsByCommentIDs = `-- name: GetCommentsByCommentIDs :many
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, reply_ancestors from comments WHERE id = ANY($1)
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, top_level_comment_id from comments WHERE id = ANY($1)
 `
 
 func (q *Queries) GetCommentsByCommentIDs(ctx context.Context, commentIds persist.DBIDList) ([]Comment, error) {
@@ -1750,7 +1750,7 @@ func (q *Queries) GetCommentsByCommentIDs(ctx context.Context, commentIds persis
 			&i.LastUpdated,
 			&i.PostID,
 			&i.Removed,
-			&i.ReplyAncestors,
+			&i.TopLevelCommentID,
 		); err != nil {
 			return nil, err
 		}

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -1702,7 +1702,7 @@ func (q *Queries) GetCollectionsByGalleryId(ctx context.Context, id persist.DBID
 }
 
 const getCommentByCommentID = `-- name: GetCommentByCommentID :one
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed FROM comments WHERE id = $1 and deleted = false
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, reply_ancestors FROM comments WHERE id = $1
 `
 
 func (q *Queries) GetCommentByCommentID(ctx context.Context, id persist.DBID) (Comment, error) {
@@ -1720,12 +1720,13 @@ func (q *Queries) GetCommentByCommentID(ctx context.Context, id persist.DBID) (C
 		&i.LastUpdated,
 		&i.PostID,
 		&i.Removed,
+		&i.ReplyAncestors,
 	)
 	return i, err
 }
 
 const getCommentsByCommentIDs = `-- name: GetCommentsByCommentIDs :many
-SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed from comments WHERE id = ANY($1) and deleted = false
+SELECT id, version, feed_event_id, actor_id, reply_to, comment, deleted, created_at, last_updated, post_id, removed, reply_ancestors from comments WHERE id = ANY($1)
 `
 
 func (q *Queries) GetCommentsByCommentIDs(ctx context.Context, commentIds persist.DBIDList) ([]Comment, error) {
@@ -1749,6 +1750,7 @@ func (q *Queries) GetCommentsByCommentIDs(ctx context.Context, commentIds persis
 			&i.LastUpdated,
 			&i.PostID,
 			&i.Removed,
+			&i.ReplyAncestors,
 		); err != nil {
 			return nil, err
 		}

--- a/db/migrations/core/000125_reply_ancestors.up.sql
+++ b/db/migrations/core/000125_reply_ancestors.up.sql
@@ -1,0 +1,3 @@
+alter table comments add column reply_ancestors varchar(255)[];
+
+create index comments_reply_ancestors_idx on comments using gin(reply_ancestors);

--- a/db/migrations/core/000125_reply_ancestors.up.sql
+++ b/db/migrations/core/000125_reply_ancestors.up.sql
@@ -1,3 +1,0 @@
-alter table comments add column reply_ancestors varchar(255)[];
-
-create index comments_reply_ancestors_idx on comments using gin(reply_ancestors);

--- a/db/migrations/core/000125_top_level_comment.up.sql
+++ b/db/migrations/core/000125_top_level_comment.up.sql
@@ -1,3 +1,25 @@
 alter table comments add column top_level_comment_id varchar(255) references comments(id);
 
 create index top_level_comment_id_idx on comments(top_level_comment_id);
+
+WITH RECURSIVE comment_thread AS (
+    SELECT 
+        id, 
+        reply_to, 
+        id as top_level_comment_id
+    FROM comments
+    WHERE reply_to IS NULL
+
+    UNION ALL
+
+    SELECT 
+        c.id, 
+        c.reply_to, 
+        ct.top_level_comment_id
+    FROM comments c
+    INNER JOIN comment_thread ct ON c.reply_to = ct.id
+)
+UPDATE comments
+SET top_level_comment_id = ct.top_level_comment_id
+FROM comment_thread ct
+WHERE comments.id = ct.id AND comments.reply_to IS NOT NULL;

--- a/db/migrations/core/000125_top_level_comment.up.sql
+++ b/db/migrations/core/000125_top_level_comment.up.sql
@@ -1,0 +1,3 @@
+alter table comments add column top_level_comment_id varchar(255) references comments(id);
+
+create index top_level_comment_id_idx on comments(top_level_comment_id);

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -702,16 +702,16 @@ SELECT * FROM admires WHERE token_id = sqlc.arg('token_id') AND (not @only_for_a
 SELECT count(*) FROM admires WHERE token_id = $1 AND deleted = false;
 
 -- name: GetCommentByCommentID :one
-SELECT * FROM comments WHERE id = $1 and deleted = false;
+SELECT * FROM comments WHERE id = $1;
 
 -- name: GetCommentsByCommentIDs :many
-SELECT * from comments WHERE id = ANY(@comment_ids) and deleted = false;
+SELECT * from comments WHERE id = ANY(@comment_ids);
 
 -- name: GetCommentByCommentIDBatch :batchone
-SELECT * FROM comments WHERE id = $1 and deleted = false;
+SELECT * FROM comments WHERE id = $1;
 
 -- name: PaginateCommentsByFeedEventIDBatch :batchmany
-SELECT * FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND reply_to is null AND deleted = false
+SELECT * FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND reply_to is null
     AND (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
     AND (created_at, id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
     ORDER BY CASE WHEN sqlc.arg('paging_forward')::bool THEN (created_at, id) END ASC,
@@ -719,10 +719,10 @@ SELECT * FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND reply
     LIMIT sqlc.arg('limit');
 
 -- name: CountCommentsByFeedEventIDBatch :batchone
-SELECT count(*) FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND reply_to is null AND deleted = false;
+SELECT count(*) FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND reply_to is null;
 
 -- name: PaginateCommentsByPostIDBatch :batchmany
-SELECT * FROM comments WHERE post_id = sqlc.arg('post_id') AND reply_to is null AND deleted = false
+SELECT * FROM comments WHERE post_id = sqlc.arg('post_id') AND reply_to is null
     AND (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
     AND (created_at, id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
     ORDER BY CASE WHEN sqlc.arg('paging_forward')::bool THEN (created_at, id) END ASC,
@@ -730,7 +730,7 @@ SELECT * FROM comments WHERE post_id = sqlc.arg('post_id') AND reply_to is null 
     LIMIT sqlc.arg('limit');
 
 -- name: PaginateRepliesByCommentIDBatch :batchmany
-SELECT * FROM comments WHERE reply_to = sqlc.arg('comment_id') AND deleted = false
+SELECT * FROM comments WHERE sqlc.arg('comment_id') = any(reply_ancestors)
     AND (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
     AND (created_at, id) > (sqlc.arg('cur_after_time'), sqlc.arg('cur_after_id'))
     ORDER BY CASE WHEN sqlc.arg('paging_forward')::bool THEN (created_at, id) END ASC,
@@ -738,10 +738,10 @@ SELECT * FROM comments WHERE reply_to = sqlc.arg('comment_id') AND deleted = fal
     LIMIT sqlc.arg('limit');
 
 -- name: CountCommentsByPostIDBatch :batchone
-SELECT count(*) FROM comments WHERE post_id = sqlc.arg('post_id') AND reply_to is null AND deleted = false;
+SELECT count(*) FROM comments WHERE post_id = sqlc.arg('post_id') AND reply_to is null;
 
 -- name: CountRepliesByCommentIDBatch :batchone
-SELECT count(*) FROM comments WHERE reply_to = sqlc.arg('comment_id') AND deleted = false;
+SELECT count(*) FROM comments WHERE sqlc.arg('comment_id') = any(reply_ancestors);
 
 -- name: GetUserNotifications :many
 SELECT * FROM notifications WHERE owner_id = $1 AND deleted = false

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1710,15 +1710,15 @@ INSERT INTO mentions (ID, COMMENT_ID, USER_ID, CONTRACT_ID, START, LENGTH) VALUE
 INSERT INTO comments 
 (ID, FEED_EVENT_ID, POST_ID, ACTOR_ID, REPLY_TO, TOP_LEVEL_COMMENT_ID, COMMENT) 
 VALUES 
-($1, sqlc.narg('feed_event'), sqlc.narg('post'), $2, sqlc.narg('reply'), 
+(sqlc.arg('id'), sqlc.narg('feed_event')::varchar, sqlc.narg('post')::varchar, sqlc.arg('actor_id'), sqlc.narg('reply')::varchar, 
     (CASE 
-        WHEN sqlc.narg('reply') IS NOT NULL THEN
-            (SELECT COALESCE(c.top_level_comment_id, sqlc.narg('reply')) 
+        WHEN sqlc.narg('reply')::varchar IS NOT NULL THEN
+            (SELECT COALESCE(c.top_level_comment_id, sqlc.narg('reply')::varchar) 
              FROM comments c 
-             WHERE c.id = sqlc.narg('reply'))
+             WHERE c.id = sqlc.narg('reply')::varchar)
         ELSE NULL 
     END), 
-$3) 
+sqlc.arg('comment')::varchar) 
 RETURNING ID;
 
 -- name: RemoveComment :exec

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -1106,7 +1106,7 @@ func (api InteractionAPI) RemoveComment(ctx context.Context, commentID persist.D
 		return "", "", ErrOnlyRemoveOwnComment
 	}
 
-	return comment.FeedEventID, comment.PostID, api.repos.CommentRepository.RemoveComment(ctx, commentID)
+	return comment.FeedEventID, comment.PostID, api.queries.RemoveComment(ctx, commentID)
 }
 
 func (api InteractionAPI) GetMentionsByCommentID(ctx context.Context, commentID persist.DBID) ([]db.Mention, error) {

--- a/service/persist/postgres/comment.go
+++ b/service/persist/postgres/comment.go
@@ -67,6 +67,9 @@ func (a *CommentRepository) CreateComment(ctx context.Context, feedEventID, post
 		Reply:     replyToString,
 		Comment:   comment,
 	})
+	if err != nil {
+		return "", nil, err
+	}
 
 	ms := make([]db.Mention, len(mentions))
 

--- a/service/persist/postgres/comment.go
+++ b/service/persist/postgres/comment.go
@@ -3,57 +3,24 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"time"
 
+	"github.com/jackc/pgx/v4/pgxpool"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 
-	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
 // CommentRepository represents an comment repository in the postgres database
 type CommentRepository struct {
-	db                *sql.DB
-	queries           *db.Queries
-	createStmt        *sql.Stmt
-	createMentionStmt *sql.Stmt
-	deleteStmt        *sql.Stmt
-	topAncestorStmt   *sql.Stmt
+	pgx     *pgxpool.Pool
+	queries *db.Queries
 }
 
 // NewCommentRepository creates a new postgres repository for interacting with comments
-func NewCommentRepository(db *sql.DB, queries *db.Queries) *CommentRepository {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	createStmt, err := db.PrepareContext(ctx, `INSERT INTO comments (ID, FEED_EVENT_ID, POST_ID, ACTOR_ID, REPLY_TO, TOP_LEVEL_COMMENT_ID, COMMENT) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING ID;`)
-	checkNoErr(err)
-
-	createMentionStmt, err := db.PrepareContext(ctx, `INSERT INTO mentions (ID, COMMENT_ID, USER_ID, CONTRACT_ID, START, LENGTH) VALUES ($1, $2, $3, $4, $5, $6) RETURNING ID;`)
-	checkNoErr(err)
-
-	deleteStmt, err := db.PrepareContext(ctx, `UPDATE comments SET REMOVED = TRUE, COMMENT = 'comment removed' WHERE ID = $1;`)
-	checkNoErr(err)
-
-	topAncestorStmt, err := db.PrepareContext(ctx, `WITH RECURSIVE comment_thread AS (
-    SELECT *
-    FROM comments
-    WHERE comments.id = $1
-    UNION ALL
-    SELECT c.* 
-    FROM comments c
-    INNER JOIN comment_thread ct ON c.id = ct.reply_to
-)
-SELECT id FROM comment_thread where reply_to is null limit 1;`)
-	checkNoErr(err)
-
+func NewCommentRepository(queries *db.Queries, pgx *pgxpool.Pool) *CommentRepository {
 	return &CommentRepository{
-		db:                db,
-		queries:           queries,
-		createStmt:        createStmt,
-		createMentionStmt: createMentionStmt,
-		deleteStmt:        deleteStmt,
-		topAncestorStmt:   topAncestorStmt,
+		queries: queries,
+		pgx:     pgx,
 	}
 }
 
@@ -75,28 +42,34 @@ func (a *CommentRepository) CreateComment(ctx context.Context, feedEventID, post
 		}
 	}
 
-	tx, err := a.db.BeginTx(ctx, nil)
-	if err != nil {
-		return "", nil, err
-	}
-	defer tx.Rollback()
-
-	var topLevelComment *persist.DBID
+	var replyToString sql.NullString
 	if replyToID != nil {
-		tx.StmtContext(ctx, a.topAncestorStmt).QueryRowContext(ctx, replyToID).Scan(&topLevelComment)
-		if err != nil {
-			logger.For(ctx).Errorf("error getting top level comment: %v", err)
+		replyToString = sql.NullString{
+			String: replyToID.String(),
+			Valid:  true,
 		}
 	}
 
-	var resultID persist.DBID
-	err = tx.StmtContext(ctx, a.createStmt).QueryRowContext(ctx, persist.GenerateID(), feedEventString, postString, actorID, replyToID, topLevelComment, comment).Scan(&resultID)
+	qtx, err := a.pgx.Begin(ctx)
 	if err != nil {
 		return "", nil, err
 	}
 
+	defer qtx.Rollback(ctx)
+
+	qs := a.queries.WithTx(qtx)
+
+	resultID, err := qs.InsertComment(ctx, db.InsertCommentParams{
+		ID:        persist.GenerateID(),
+		FeedEvent: feedEventString,
+		Post:      postString,
+		ActorID:   actorID,
+		Reply:     replyToString,
+		Comment:   comment,
+	})
+
 	ms := make([]db.Mention, len(mentions))
-	cm := tx.StmtContext(ctx, a.createMentionStmt)
+
 	for i, m := range mentions {
 		var userID, contractID sql.NullString
 		if m.UserID != "" {
@@ -110,8 +83,14 @@ func (a *CommentRepository) CreateComment(ctx context.Context, feedEventID, post
 				Valid:  true,
 			}
 		}
-		var mid persist.DBID
-		err = cm.QueryRowContext(ctx, persist.GenerateID(), resultID, userID, contractID, m.Start, m.Length).Scan(&mid)
+		mid, err := qs.InsertMention(ctx, db.InsertMentionParams{
+			ID:        persist.GenerateID(),
+			CommentID: resultID,
+			Start:     m.Start,
+			Length:    m.Length,
+			User:      userID,
+			Contract:  contractID,
+		})
 		if err != nil {
 			return "", nil, err
 		}
@@ -119,15 +98,10 @@ func (a *CommentRepository) CreateComment(ctx context.Context, feedEventID, post
 		ms[i] = m
 	}
 
-	err = tx.Commit()
+	err = qtx.Commit(ctx)
 	if err != nil {
 		return "", nil, err
 	}
 
 	return resultID, ms, nil
-}
-
-func (a *CommentRepository) RemoveComment(ctx context.Context, commentID persist.DBID) error {
-	_, err := a.deleteStmt.ExecContext(ctx, commentID)
-	return err
 }

--- a/service/persist/postgres/postgres.go
+++ b/service/persist/postgres/postgres.go
@@ -327,7 +327,7 @@ func NewRepositories(pq *sql.DB, pgx *pgxpool.Pool) *Repositories {
 		EarlyAccessRepository: NewEarlyAccessRepository(pq, queries),
 		WalletRepository:      NewWalletRepository(pq, queries),
 		AdmireRepository:      NewAdmireRepository(queries),
-		CommentRepository:     NewCommentRepository(pq, queries),
+		CommentRepository:     NewCommentRepository(queries, pgx),
 		EventRepository:       &EventRepository{queries},
 	}
 }

--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -266,7 +266,7 @@ func (p *Personalization) update(ctx context.Context) {
 
 	if p.pM == nil {
 		logger.For(ctx).Infof("no data loaded, reading from cache")
-		// p.readCache(ctx)
+		p.readCache(ctx)
 		return
 	}
 

--- a/service/recommend/userpref/personalize.go
+++ b/service/recommend/userpref/personalize.go
@@ -266,7 +266,7 @@ func (p *Personalization) update(ctx context.Context) {
 
 	if p.pM == nil {
 		logger.For(ctx).Infof("no data loaded, reading from cache")
-		p.readCache(ctx)
+		// p.readCache(ctx)
 		return
 	}
 


### PR DESCRIPTION
Changes:

- **Added** a new column to the `comments` table called `reply_ancestors` that is an array of all of the reply ancestors (including the most recently replied to comment in `reply_to`) so that when we ask for the replies to a comment we can return any comment where the ancestors contains this comment we are querying for. 

![CleanShot 2023-11-13 at 17 47 30@2x (1)](https://github.com/gallery-so/go-gallery/assets/70491084/3c298421-04d8-4089-8019-ba6f3ec4efc8)

I experimented with a few paths before arriving here:

- My first instinct was to just have the get replies query traverse the reply tree until it reaches the comment we are querying for. SQLC hated this approach and no matter how much experimentation I did with the query and chatGPT and copilot I could not get a recursive reply pagination query to work so I went looking for other answers.
- My second instinct was to just have a new column that stores the "top level comment" ID. This mostly works for the use case we are looking for given that we only really care about showing a flat list of comments under the top level comment (no matter who is replying to who and how deeply nested, it will show flat ordered by comment time). The problem with this is it kind of separates top level comments into their own class of comments and "replies" would have to function differently for them than any nested reply. If I ask for `top_level_comment.replies` we simply get all comments where the `top_level_comment_id = top_level_comment.id`. What about if I want the replies to a reply in the future? Well asking for any comments where `top_level_comment_id = nested_reply.id` will return nothing and if we ask for  `top_level_comment_id = nested_reply.top_level_comment_id` it will return comments that aren't replying to this comment. 
- So then I'm thinking, well do we even need nested replies if we are going to always just show a flat list? Why don't we just drop the idea of a `reply_to` and just have there be a top level comment ID stored or just not allow a reply to a reply? Well despite the comments being ordered by date, there has to be some way for a user to see visually that a comment further in the chain is replying to them. Some way or another we need to store what specific comment is being replied to, or at least who is being replied to for the user to then infer which comment.

That landed me with two final directions:

1. The frontend stops replying to nested replies and instead does what instagram does and whenever a nested comment is being replied to it just mentions the user being replied to. We could then match this on the backend by adding a constraint to ensure no replies are replied to and they all are replying to the top level comment only. e.g. TL comment: I love this post, reply to TL: agreed, reply to reply: @replier I disagree
2. We store an ancestry of replies on the comment so that we can lookup the comments that contain the queried comment in their ancestry. This works for any level of nesting and will always return only the comments that are below in the reply tree.

Although I feel that solution 1 is better, solution 2 leaves us with the option to show nested comments reddit style later on and also means the frontend can have the "reply" button always function the same for top level comments and nested comments, they don't need to worry about "do we mention here or do we reply here?". What do we think?