### PR TITLE
Pipeline bug fixes

### DIFF
--- a/util/helpers.go
+++ b/util/helpers.go
@@ -748,7 +748,9 @@ func (f FileHeaderReader) Headers() ([]byte, error) {
 	}
 
 	byt, err := f.Peek(512)
-	if err != nil && err != io.EOF {
+
+	// Use what bytes were read as the header
+	if err != nil && err != io.EOF && err != bufio.ErrBufferFull {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes
* Don't save metadata if the job errored fetching new metadata
* Don't fail on `bufio.ErrBufferFull` if file size is less than 512 bytes