### PR TITLE
Use retries by default for all Postgres clients

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/mikeydub/go-gallery/util/retry"
 	"net/http"
 	"os"
 	"time"
@@ -84,9 +83,8 @@ func (c *Clients) Close() {
 }
 
 func ClientInit(ctx context.Context) *Clients {
-	retries := retry.Retry{Base: 2, Cap: 4, Tries: 3}
-	pq := postgres.MustCreateClient(postgres.WithRetries(retries))
-	pgx := postgres.NewPgxClient(postgres.WithRetries(retries))
+	pq := postgres.MustCreateClient()
+	pgx := postgres.NewPgxClient()
 	return &Clients{
 		Repos:           postgres.NewRepositories(pq, pgx),
 		Queries:         db.New(pgx),

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -101,7 +101,9 @@ func RetryFunc(ctx context.Context, f func(ctx context.Context) error, shouldRet
 			return err
 		}
 
-		r.Sleep(i)
+		if i != r.Tries-1 {
+			r.Sleep(i)
+		}
 	}
 	return ErrOutOfRetries{Err: err, Retry: r}
 }


### PR DESCRIPTION
After adding retries for Postgres clients created by the main backend server, I saw tests continuing to fail (without retries!) for clients created by other services (e.g. `pushnotifications`). In general, it seems to me that we want to retry connections before giving up, so this PR makes it the default behavior whenever we create a Postgres client, and adds a `WithNoRetries` option to disable the behavior.