### PR TITLE
Add fxhash specific gateway

### DIFF
--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:NJTs2w==,iv:L3pzvKag0Vr5XUq0HpIZR0oWDDeI1Zs3vgMLJOIib/o=,tag:USUpC7AmGXjqMvACopv3Dg==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:a1vWew==,iv:SDUlYFsEZFcN3HU+zBkVoXa+HP9K6d7TqQCqeaW6wOI=,tag:HRXn1jSa+sILtq/qoIcJkg==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:ZL2SfsMdMDJkgwHdfGVLCnTaRVlwJeCC9oH1qhlS5lM=,iv:7kwdA18x0IvcbKKjXJJ+s/zqKNQA85/Y7yguLQZlm0w=,tag:LpNBMF6OVotf77oeM/sk5g==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:rj8U63dquwJBWqzqcEZFhuHRk6Zdb/dBu/QiX0046dI=,iv:YXGkf0LShCCe4rVKmPbEvj3BKIzMZifdxWJ1wdaCBUk=,tag:loeie4GylDttpj/+KbD+MA==,type:str]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:bL4KfxRX7j9/+tez25NfWrk+OBsS0dpqtx0zccyqiBk=,iv:8vNwDPwoBs82KxiJI9xDe42FbegK6xXqi+7XcR+M33Y=,tag:JvPH45ipwRDGzs8M7ceMvw==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -62,8 +62,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-02T17:12:08Z"
-    mac: ENC[AES256_GCM,data:7pHStlwj7rmAgObg7tYJs52moJQeEm+c8I+L9tYJAtZ8xtsQ5i/zdMTrt8tG1obzO2v5BbXUrLhzLpjydGtMnfJG4tKN6CT+qkbdQohA0HUn7ZkG2k+yqMR7h270Ongic6rjX2N90qe0+X3ezegJbjqp1DiG+HI18zxMv+JJHLo=,iv:S2h6XtxmBuSR611NDfX2Xh186o3tFzqVMGKYjdFrlFU=,tag:3noMSOeB8ejn108wPFSEbA==,type:str]
+    lastmodified: "2023-11-07T20:46:34Z"
+    mac: ENC[AES256_GCM,data:WV1tNiZx0VI2HgpM7dBEL2eElMFifnIfvzWCQEA4G0haxxYsRcP/8zU+ksbpkDHoMifyH2d8IBqgfzbhiealwTVROY7ZKjUg1CnbYKADC8VuqwmI4+SSODMyec6bzo5DqK/lKUE9msiZ053CZaoGqI72xFL4P2uuAtYRqsoyJkE=,iv:XgXr22KnLfz0UQOjAchvuAmVw5pe6IueUn4dZw80i+s=,tag:oEttdLUT7VgvAAbNO83kPw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:a1vWew==,iv:SDUlYFsEZFcN3HU+zBkVoXa+HP9K6d7TqQCqeaW6wOI=,tag:HRXn1jSa+sILtq/qoIcJkg==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:NJTs2w==,iv:L3pzvKag0Vr5XUq0HpIZR0oWDDeI1Zs3vgMLJOIib/o=,tag:USUpC7AmGXjqMvACopv3Dg==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:rj8U63dquwJBWqzqcEZFhuHRk6Zdb/dBu/QiX0046dI=,iv:YXGkf0LShCCe4rVKmPbEvj3BKIzMZifdxWJ1wdaCBUk=,tag:loeie4GylDttpj/+KbD+MA==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:ZL2SfsMdMDJkgwHdfGVLCnTaRVlwJeCC9oH1qhlS5lM=,iv:7kwdA18x0IvcbKKjXJJ+s/zqKNQA85/Y7yguLQZlm0w=,tag:LpNBMF6OVotf77oeM/sk5g==,type:str]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:bL4KfxRX7j9/+tez25NfWrk+OBsS0dpqtx0zccyqiBk=,iv:8vNwDPwoBs82KxiJI9xDe42FbegK6xXqi+7XcR+M33Y=,tag:JvPH45ipwRDGzs8M7ceMvw==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -62,8 +62,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-11-07T20:46:34Z"
-    mac: ENC[AES256_GCM,data:WV1tNiZx0VI2HgpM7dBEL2eElMFifnIfvzWCQEA4G0haxxYsRcP/8zU+ksbpkDHoMifyH2d8IBqgfzbhiealwTVROY7ZKjUg1CnbYKADC8VuqwmI4+SSODMyec6bzo5DqK/lKUE9msiZ053CZaoGqI72xFL4P2uuAtYRqsoyJkE=,iv:XgXr22KnLfz0UQOjAchvuAmVw5pe6IueUn4dZw80i+s=,tag:oEttdLUT7VgvAAbNO83kPw==,type:str]
+    lastmodified: "2023-12-02T17:12:08Z"
+    mac: ENC[AES256_GCM,data:7pHStlwj7rmAgObg7tYJs52moJQeEm+c8I+L9tYJAtZ8xtsQ5i/zdMTrt8tG1obzO2v5BbXUrLhzLpjydGtMnfJG4tKN6CT+qkbdQohA0HUn7ZkG2k+yqMR7h270Ongic6rjX2N90qe0+X3ezegJbjqp1DiG+HI18zxMv+JJHLo=,iv:S2h6XtxmBuSR611NDfX2Xh186o3tFzqVMGKYjdFrlFU=,tag:3noMSOeB8ejn108wPFSEbA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/rpc/ipfs/ipfs.go
+++ b/service/rpc/ipfs/ipfs.go
@@ -209,12 +209,12 @@ func pathURL(host, uri string) string {
 	return fmt.Sprintf("%s/ipfs/%s", host, uri)
 }
 
-// standardizeQueryParams converts a URI with optional query params from the format <cid>?key=val&key=val to the format <cid>/?key=val&key=val
-// Most gateways will redirect the former to the latter, but some gayeways like fxhash.xyz don't.
-// https://docs.ipfs.tech/concepts/ipfs-gateway/#path
+// standardizeQueryParams converts a URI with optional params from the format <cid>?key=val&key=val to the format <cid>/?key=val&key=val
+// Most gateways will redirect the former to the latter, but some gateways don't. https://docs.ipfs.tech/concepts/ipfs-gateway/#path
 func standardizeQueryParams(uri string) string {
 	paramIdx := strings.Index(uri, "?")
-	if paramIdx == -1 {
+	isClean := strings.Index(uri, "/?") != -1
+	if paramIdx != -1 && !isClean {
 		uri = uri[:paramIdx] + "/?" + uri[paramIdx+1:]
 	}
 	return uri

--- a/service/rpc/ipfs/ipfs.go
+++ b/service/rpc/ipfs/ipfs.go
@@ -109,6 +109,9 @@ var (
 	nodeCloudFlare = func(h *http.Client, s *shell.Shell) HTTPReader {
 		return HTTPReader{Host: "https://cloudflare-ipfs.com", Client: h}
 	}
+	nodeFxHash = func(h *http.Client, s *shell.Shell) HTTPReader {
+		return HTTPReader{Host: "https://gateway.fxhash.xyz", Client: h}
+	}
 )
 
 func GetResponse(ctx context.Context, path string) (io.ReadCloser, error) {
@@ -170,21 +173,22 @@ func defaultHTTPClient() *http.Client {
 	}
 }
 
+// BestGatewayNodeFrom rewrites an IPFS URL to a gateway URL using the appropriate gateway
+func BestGatewayNodeFrom(ipfsURL string, isFxHash bool) string {
+	if isFxHash {
+		return PathGatewayFrom(nodeFxHash(nil, nil).Host, ipfsURL)
+	}
+	return DefaultGatewayFrom(ipfsURL)
+}
+
 // DefaultGatewayFrom rewrites an IPFS URL to a gateway URL using the default gateway
 func DefaultGatewayFrom(ipfsURL string) string {
-	// Rewrite Gallery Infura URLs temporarily to ipfs.io while our gateway is down
-	return PathGatewayFrom("https://ipfs.io", ipfsURL, false)
+	return PathGatewayFrom(nodeIpfsIO(nil, nil).Host, ipfsURL)
 }
 
 // PathGatewayFrom is a helper function that rewrites an IPFS URI to an IPFS gateway URL
-// If withOutQueryParams is true, the query parameters will be removed from the gateway URL
-func PathGatewayFrom(gatewayHost, ipfsURL string, withOutQueryParams bool) string {
-	return PathGatewayFor(gatewayHost, util.GetURIPath(ipfsURL, withOutQueryParams))
-}
-
-// PathGatewayFor returns the path gateway URL for a CID
-func PathGatewayFor(gatewayHost, cid string) string {
-	return pathURL(gatewayHost, cid)
+func PathGatewayFrom(gatewayHost, ipfsURL string) string {
+	return pathURL(gatewayHost, util.GetURIPath(ipfsURL, false))
 }
 
 // authTransport decorates each request with a basic auth header.
@@ -200,8 +204,20 @@ func (t authTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 // pathURL returns the gateway URL in path resolution sytle
-func pathURL(host, path string) string {
-	return fmt.Sprintf("%s/ipfs/%s", host, path)
+func pathURL(host, uri string) string {
+	uri = standardizeQueryParams(uri)
+	return fmt.Sprintf("%s/ipfs/%s", host, uri)
+}
+
+// standardizeQueryParams converts a URI with optional query params from the format <cid>?key=val&key=val to the format <cid>/?key=val&key=val
+// Most gateways will redirect the former to the latter, but some gayeways like fxhash.xyz don't.
+// https://docs.ipfs.tech/concepts/ipfs-gateway/#path
+func standardizeQueryParams(uri string) string {
+	paramIdx := strings.Index(uri, "?")
+	if paramIdx == -1 {
+		uri = uri[:paramIdx] + "/?" + uri[paramIdx+1:]
+	}
+	return uri
 }
 
 func isInfura(gateway string) bool {

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -424,7 +424,7 @@ func getHTMLDimensions(ctx context.Context, url string) (persist.Dimensions, err
 func remapPaths(mediaURL string) string {
 	switch persist.TokenURI(mediaURL).Type() {
 	case persist.URITypeIPFS, persist.URITypeIPFSAPI:
-		return ipfs.PathGatewayFrom(env.GetString("IPFS_URL"), mediaURL, false)
+		return ipfs.PathGatewayFrom(env.GetString("IPFS_URL"), mediaURL)
 	case persist.URITypeArweave:
 		path := util.GetURIPath(mediaURL, false)
 		return fmt.Sprintf("https://arweave.net/%s", path)


### PR DESCRIPTION
Fxhash has a gateway that caches their content locally, so we can use that to retrieve fxhash-specific assets faster.