### PR TITLE
don't wait for lock, just end

### DIFF
--- a/emails/emails.go
+++ b/emails/emails.go
@@ -72,9 +72,7 @@ func coreInitServer() *gin.Engine {
 		}
 	}
 
-	lock := redis.NewLockClient(redis.NewCache(redis.EmailThrottleCache))
-
-	go autoSendNotificationEmails(queries, sendgridClient, pub, lock)
+	go autoSendNotificationEmails(queries, sendgridClient, pub, redis.NewCache(redis.EmailThrottleCache))
 
 	return handlersInitServer(router, loaders, queries, sendgridClient)
 }

--- a/emails/send.go
+++ b/emails/send.go
@@ -8,9 +8,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/bsm/redislock"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/notifications"
+	"github.com/mikeydub/go-gallery/service/redis"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/gin-gonic/gin"
@@ -137,25 +137,24 @@ func adminSendNotificationEmail(queries *coredb.Queries, s *sendgrid.Client) gin
 	}
 }
 
-func autoSendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, psub *pubsub.Client, r *redislock.Client) error {
+func autoSendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, psub *pubsub.Client, r *redis.Cache) error {
 	ctx := context.Background()
 	sub := psub.Subscription(env.GetString("PUBSUB_NOTIFICATIONS_EMAILS_SUBSCRIPTION"))
 
 	return sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
-		l, err := r.Obtain(ctx, "send-notification-emails", time.Minute*5, nil)
-		if err != nil {
+		l, _ := r.Get(ctx, "send-notification-emails")
+		if l != nil && len(l) > 0 {
 			msg.Ack()
 			return
 		}
-		defer l.Release(ctx)
-		err = sendNotificationEmailsToAllUsers(ctx, queries, s, env.GetString("ENV") == "production")
+		r.Set(ctx, "send-notification-emails", []byte("sending"), 1*time.Hour)
+		err := sendNotificationEmailsToAllUsers(ctx, queries, s, env.GetString("ENV") == "production")
 		if err != nil {
 			logger.For(ctx).Errorf("error sending notification emails: %s", err)
-			msg.Nack()
+			msg.Ack()
 			return
 		}
 		msg.Ack()
-
 	})
 }
 


### PR DESCRIPTION
Changes:

- **Changed** email send logic to not wait for lock, instead instantly ack the message
- **Changed** error handling for email send to not `Nack()` on failure, still `Ack()`. Better to log error and know for next week that some emails may not have gone out then try to resend all of them on a redelivery.

This will help to ensure no-reduplicates, and will also ensure that on any failures, we do not attempt to retry sending messages.