### PR TITLE
Add mint link to posts

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -2430,7 +2430,7 @@ func (b *GetOwnersByContractIdBatchPaginateBatchResults) Close() error {
 }
 
 const getPostByIdBatch = `-- name: GetPostByIdBatch :batchone
-SELECT id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted, is_first_post FROM posts WHERE id = $1 AND deleted = false
+SELECT id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted, is_first_post, user_mint_url FROM posts WHERE id = $1 AND deleted = false
 `
 
 type GetPostByIdBatchBatchResults struct {
@@ -2473,6 +2473,7 @@ func (b *GetPostByIdBatchBatchResults) QueryRow(f func(int, Post, error)) {
 			&i.LastUpdated,
 			&i.Deleted,
 			&i.IsFirstPost,
+			&i.UserMintUrl,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -4852,7 +4853,7 @@ func (b *PaginateInteractionsByPostIDBatchBatchResults) Close() error {
 }
 
 const paginatePostsByContractID = `-- name: PaginatePostsByContractID :batchmany
-SELECT posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post
+SELECT posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post, posts.user_mint_url
 FROM posts
 WHERE $1 = ANY(posts.contract_ids)
 AND posts.deleted = false
@@ -4927,6 +4928,7 @@ func (b *PaginatePostsByContractIDBatchResults) Query(f func(int, []Post, error)
 					&i.LastUpdated,
 					&i.Deleted,
 					&i.IsFirstPost,
+					&i.UserMintUrl,
 				); err != nil {
 					return err
 				}

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -404,6 +404,7 @@ type Post struct {
 	LastUpdated time.Time        `db:"last_updated" json:"last_updated"`
 	Deleted     bool             `db:"deleted" json:"deleted"`
 	IsFirstPost bool             `db:"is_first_post" json:"is_first_post"`
+	UserMintUrl sql.NullString   `db:"user_mint_url" json:"user_mint_url"`
 }
 
 type ProfileImage struct {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -3046,7 +3046,7 @@ func (q *Queries) GetNotificationsByOwnerIDForActionAfter(ctx context.Context, a
 }
 
 const getPostByID = `-- name: GetPostByID :one
-SELECT id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted, is_first_post FROM posts WHERE id = $1 AND deleted = false
+SELECT id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted, is_first_post, user_mint_url FROM posts WHERE id = $1 AND deleted = false
 `
 
 func (q *Queries) GetPostByID(ctx context.Context, id persist.DBID) (Post, error) {
@@ -3063,12 +3063,13 @@ func (q *Queries) GetPostByID(ctx context.Context, id persist.DBID) (Post, error
 		&i.LastUpdated,
 		&i.Deleted,
 		&i.IsFirstPost,
+		&i.UserMintUrl,
 	)
 	return i, err
 }
 
 const getPostsByIds = `-- name: GetPostsByIds :many
-select posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post
+select posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post, posts.user_mint_url
 from posts
 join unnest($1::varchar(255)[]) with ordinality t(id, pos) using(id)
 where not posts.deleted
@@ -3095,6 +3096,7 @@ func (q *Queries) GetPostsByIds(ctx context.Context, postIds []string) ([]Post, 
 			&i.LastUpdated,
 			&i.Deleted,
 			&i.IsFirstPost,
+			&i.UserMintUrl,
 		); err != nil {
 			return nil, err
 		}
@@ -5825,8 +5827,8 @@ func (q *Queries) InsertMention(ctx context.Context, arg InsertMentionParams) (p
 }
 
 const insertPost = `-- name: InsertPost :one
-insert into posts(id, token_ids, contract_ids, actor_id, caption, is_first_post, created_at)
-values ($1, $2, $3, $4, $5, not exists(select 1 from posts where posts.created_at < now() and posts.actor_id = $4::varchar limit 1), now())
+insert into posts(id, token_ids, contract_ids, actor_id, caption, user_mint_url, is_first_post, created_at)
+values ($1, $2, $3, $4, $5, $6, not exists(select 1 from posts where posts.created_at < now() and posts.actor_id = $4::varchar limit 1), now())
 on conflict (actor_id, is_first_post) where is_first_post do update set is_first_post = false
 returning id
 `
@@ -5837,6 +5839,7 @@ type InsertPostParams struct {
 	ContractIds persist.DBIDList `db:"contract_ids" json:"contract_ids"`
 	ActorID     persist.DBID     `db:"actor_id" json:"actor_id"`
 	Caption     sql.NullString   `db:"caption" json:"caption"`
+	UserMintUrl sql.NullString   `db:"user_mint_url" json:"user_mint_url"`
 }
 
 func (q *Queries) InsertPost(ctx context.Context, arg InsertPostParams) (persist.DBID, error) {
@@ -5846,6 +5849,7 @@ func (q *Queries) InsertPost(ctx context.Context, arg InsertPostParams) (persist
 		arg.ContractIds,
 		arg.ActorID,
 		arg.Caption,
+		arg.UserMintUrl,
 	)
 	var id persist.DBID
 	err := row.Scan(&id)
@@ -6367,7 +6371,7 @@ with valid_post_ids as (
     WHERE $7 = ANY(posts.contract_ids)
       AND posts.deleted = false
 )
-SELECT posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post from posts
+SELECT posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post, posts.user_mint_url from posts
     join valid_post_ids on posts.id = valid_post_ids.id
 WHERE (posts.created_at, posts.id) < ($1, $2)
   AND (posts.created_at, posts.id) > ($3, $4)
@@ -6417,6 +6421,7 @@ func (q *Queries) PaginatePostsByContractIDAndProjectID(ctx context.Context, arg
 			&i.LastUpdated,
 			&i.Deleted,
 			&i.IsFirstPost,
+			&i.UserMintUrl,
 		); err != nil {
 			return nil, err
 		}
@@ -6429,7 +6434,7 @@ func (q *Queries) PaginatePostsByContractIDAndProjectID(ctx context.Context, arg
 }
 
 const paginatePostsByUserID = `-- name: PaginatePostsByUserID :many
-select id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted, is_first_post
+select id, version, token_ids, contract_ids, actor_id, caption, created_at, last_updated, deleted, is_first_post, user_mint_url
 from posts
 where actor_id = $1
         and (created_at, id) < ($2, $3)
@@ -6479,6 +6484,7 @@ func (q *Queries) PaginatePostsByUserID(ctx context.Context, arg PaginatePostsBy
 			&i.LastUpdated,
 			&i.Deleted,
 			&i.IsFirstPost,
+			&i.UserMintUrl,
 		); err != nil {
 			return nil, err
 		}

--- a/db/gen/coredb/recommend.sql.go
+++ b/db/gen/coredb/recommend.sql.go
@@ -95,7 +95,7 @@ with refreshed as (
 )
 select
   feed_entity_scores.id, feed_entity_scores.created_at, feed_entity_scores.actor_id, feed_entity_scores.action, feed_entity_scores.contract_ids, feed_entity_scores.interactions, feed_entity_scores.feed_entity_type, feed_entity_scores.last_updated,
-  posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post,
+  posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post, posts.user_mint_url,
   coalesce(posts.actor_id = (select id from gallery_user), false)::bool is_gallery_post
 from feed_entity_scores
 join posts on feed_entity_scores.id = posts.id
@@ -106,7 +106,7 @@ where feed_entity_scores.created_at > $1::timestamptz
 union
 select
   feed_entity_scores.id, feed_entity_scores.created_at, feed_entity_scores.actor_id, feed_entity_scores.action, feed_entity_scores.contract_ids, feed_entity_scores.interactions, feed_entity_scores.feed_entity_type, feed_entity_scores.last_updated,
-  posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post,
+  posts.id, posts.version, posts.token_ids, posts.contract_ids, posts.actor_id, posts.caption, posts.created_at, posts.last_updated, posts.deleted, posts.is_first_post, posts.user_mint_url,
   coalesce(posts.actor_id = (select id from gallery_user), false)::bool is_gallery_post
 from feed_entity_score_view feed_entity_scores
 join posts on feed_entity_scores.id = posts.id
@@ -155,6 +155,7 @@ func (q *Queries) GetFeedEntityScores(ctx context.Context, arg GetFeedEntityScor
 			&i.Post.LastUpdated,
 			&i.Post.Deleted,
 			&i.Post.IsFirstPost,
+			&i.Post.UserMintUrl,
 			&i.IsGalleryPost,
 		); err != nil {
 			return nil, err

--- a/db/migrations/core/000131_add_post_mint_url.up.sql
+++ b/db/migrations/core/000131_add_post_mint_url.up.sql
@@ -1,0 +1,1 @@
+alter table posts add column if not exists user_mint_url varchar;

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -949,8 +949,8 @@ SELECT * FROM admires WHERE actor_id = $1 AND token_id = $2 AND deleted = false;
 SELECT * FROM admires WHERE actor_id = $1 AND comment_id = $2 AND deleted = false;
 
 -- name: InsertPost :one
-insert into posts(id, token_ids, contract_ids, actor_id, caption, is_first_post, created_at)
-values ($1, $2, $3, $4, $5, not exists(select 1 from posts where posts.created_at < now() and posts.actor_id = $4::varchar limit 1), now())
+insert into posts(id, token_ids, contract_ids, actor_id, caption, user_mint_url, is_first_post, created_at)
+values ($1, $2, $3, $4, $5, $6, not exists(select 1 from posts where posts.created_at < now() and posts.actor_id = $4::varchar limit 1), now())
 on conflict (actor_id, is_first_post) where is_first_post do update set is_first_post = false
 returning id;
 

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -989,18 +989,19 @@ type ComplexityRoot struct {
 	}
 
 	Post struct {
-		Admires      func(childComplexity int, before *string, after *string, first *int, last *int) int
-		Author       func(childComplexity int) int
-		Caption      func(childComplexity int) int
-		Comments     func(childComplexity int, before *string, after *string, first *int, last *int) int
-		CreationTime func(childComplexity int) int
-		Dbid         func(childComplexity int) int
-		ID           func(childComplexity int) int
-		Interactions func(childComplexity int, before *string, after *string, first *int, last *int) int
-		IsFirstPost  func(childComplexity int) int
-		Mentions     func(childComplexity int) int
-		Tokens       func(childComplexity int) int
-		ViewerAdmire func(childComplexity int) int
+		Admires          func(childComplexity int, before *string, after *string, first *int, last *int) int
+		Author           func(childComplexity int) int
+		Caption          func(childComplexity int) int
+		Comments         func(childComplexity int, before *string, after *string, first *int, last *int) int
+		CreationTime     func(childComplexity int) int
+		Dbid             func(childComplexity int) int
+		ID               func(childComplexity int) int
+		Interactions     func(childComplexity int, before *string, after *string, first *int, last *int) int
+		IsFirstPost      func(childComplexity int) int
+		Mentions         func(childComplexity int) int
+		Tokens           func(childComplexity int) int
+		UserAddedMintURL func(childComplexity int) int
+		ViewerAdmire     func(childComplexity int) int
 	}
 
 	PostAdmireEdge struct {
@@ -6134,6 +6135,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Post.Tokens(childComplexity), true
 
+	case "Post.userAddedMintURL":
+		if e.complexity.Post.UserAddedMintURL == nil {
+			break
+		}
+
+		return e.complexity.Post.UserAddedMintURL(childComplexity), true
+
 	case "Post.viewerAdmire":
 		if e.complexity.Post.ViewerAdmire == nil {
 			break
@@ -10224,6 +10232,7 @@ type Post implements Node @key(fields: "dbid") @goEmbedHelper {
 
   viewerAdmire: Admire @goField(forceResolver: true)
   isFirstPost: Boolean!
+  userAddedMintURL: String
 }
 
 type UserCreatedFeedEventData implements FeedEventData {
@@ -11855,6 +11864,7 @@ input PostTokensInput {
   tokenIds: [DBID!]
   caption: String
   mentions: [MentionInput!]
+  mintURL: String
 }
 
 type PostTokensPayload {
@@ -11866,6 +11876,7 @@ union PostTokensPayloadOrError = PostTokensPayload | ErrInvalidInput | ErrNotAut
 input ReferralPostTokenInput {
   token: ChainAddressTokenInput!
   caption: String
+  mintURL: String
 }
 
 type ReferralPostTokenPayload {
@@ -16692,6 +16703,8 @@ func (ec *executionContext) fieldContext_AdmirePostPayload_post(ctx context.Cont
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -21651,6 +21664,8 @@ func (ec *executionContext) fieldContext_CommentOnPostPayload_post(ctx context.C
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -24885,6 +24900,8 @@ func (ec *executionContext) fieldContext_Entity_findPostByDbid(ctx context.Conte
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -42254,6 +42271,47 @@ func (ec *executionContext) fieldContext_Post_isFirstPost(ctx context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _Post_userAddedMintURL(ctx context.Context, field graphql.CollectedField, obj *model.Post) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Post_userAddedMintURL(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UserAddedMintURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Post_userAddedMintURL(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Post",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PostAdmireEdge_node(ctx context.Context, field graphql.CollectedField, obj *model.PostAdmireEdge) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PostAdmireEdge_node(ctx, field)
 	if err != nil {
@@ -43021,6 +43079,8 @@ func (ec *executionContext) fieldContext_PostTokensPayload_post(ctx context.Cont
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -45822,6 +45882,8 @@ func (ec *executionContext) fieldContext_ReferralPostTokenPayload_post(ctx conte
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -46348,6 +46410,8 @@ func (ec *executionContext) fieldContext_RemoveAdmirePayload_post(ctx context.Co
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -46539,6 +46603,8 @@ func (ec *executionContext) fieldContext_RemoveCommentPayload_post(ctx context.C
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -49070,6 +49136,8 @@ func (ec *executionContext) fieldContext_SomeoneAdmiredYourPostNotification_post
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -50229,6 +50297,8 @@ func (ec *executionContext) fieldContext_SomeoneCommentedOnYourPostNotification_
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -51714,6 +51784,8 @@ func (ec *executionContext) fieldContext_SomeonePostedYourWorkNotification_post(
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -52836,6 +52908,8 @@ func (ec *executionContext) fieldContext_SomeoneYouFollowPostedTheirFirstPostNot
 				return ec.fieldContext_Post_viewerAdmire(ctx, field)
 			case "isFirstPost":
 				return ec.fieldContext_Post_isFirstPost(ctx, field)
+			case "userAddedMintURL":
+				return ec.fieldContext_Post_userAddedMintURL(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Post", field.Name)
 		},
@@ -65580,7 +65654,7 @@ func (ec *executionContext) unmarshalInputPostTokensInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"tokenIds", "caption", "mentions"}
+	fieldsInOrder := [...]string{"tokenIds", "caption", "mentions", "mintURL"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -65614,6 +65688,15 @@ func (ec *executionContext) unmarshalInputPostTokensInput(ctx context.Context, o
 				return it, err
 			}
 			it.Mentions = data
+		case "mintURL":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mintURL"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MintURL = data
 		}
 	}
 
@@ -65788,7 +65871,7 @@ func (ec *executionContext) unmarshalInputReferralPostTokenInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"token", "caption"}
+	fieldsInOrder := [...]string{"token", "caption", "mintURL"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -65813,6 +65896,15 @@ func (ec *executionContext) unmarshalInputReferralPostTokenInput(ctx context.Con
 				return it, err
 			}
 			it.Caption = data
+		case "mintURL":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("mintURL"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MintURL = data
 		}
 	}
 
@@ -77663,6 +77755,10 @@ func (ec *executionContext) _Post(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "userAddedMintURL":
+
+			out.Values[i] = ec._Post_userAddedMintURL(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/generated_test.go
+++ b/graphql/generated_test.go
@@ -373,6 +373,7 @@ type PostTokensInput struct {
 	TokenIds []persist.DBID `json:"tokenIds"`
 	Caption  *string        `json:"caption"`
 	Mentions []MentionInput `json:"mentions"`
+	MintURL  *string        `json:"mintURL"`
 }
 
 // GetTokenIds returns PostTokensInput.TokenIds, and is useful for accessing the field via an interface.
@@ -383,6 +384,9 @@ func (v *PostTokensInput) GetCaption() *string { return v.Caption }
 
 // GetMentions returns PostTokensInput.Mentions, and is useful for accessing the field via an interface.
 func (v *PostTokensInput) GetMentions() []MentionInput { return v.Mentions }
+
+// GetMintURL returns PostTokensInput.MintURL, and is useful for accessing the field via an interface.
+func (v *PostTokensInput) GetMintURL() *string { return v.MintURL }
 
 type PublishGalleryInput struct {
 	GalleryId persist.DBID `json:"galleryId"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1832,17 +1832,18 @@ func (PDFMedia) IsMedia()        {}
 
 type Post struct {
 	HelperPostData
-	Dbid         persist.DBID            `json:"dbid"`
-	Author       *GalleryUser            `json:"author"`
-	CreationTime *time.Time              `json:"creationTime"`
-	Tokens       []*Token                `json:"tokens"`
-	Caption      *string                 `json:"caption"`
-	Mentions     []*Mention              `json:"mentions"`
-	Admires      *PostAdmiresConnection  `json:"admires"`
-	Comments     *PostCommentsConnection `json:"comments"`
-	Interactions *InteractionsConnection `json:"interactions"`
-	ViewerAdmire *Admire                 `json:"viewerAdmire"`
-	IsFirstPost  bool                    `json:"isFirstPost"`
+	Dbid             persist.DBID            `json:"dbid"`
+	Author           *GalleryUser            `json:"author"`
+	CreationTime     *time.Time              `json:"creationTime"`
+	Tokens           []*Token                `json:"tokens"`
+	Caption          *string                 `json:"caption"`
+	Mentions         []*Mention              `json:"mentions"`
+	Admires          *PostAdmiresConnection  `json:"admires"`
+	Comments         *PostCommentsConnection `json:"comments"`
+	Interactions     *InteractionsConnection `json:"interactions"`
+	ViewerAdmire     *Admire                 `json:"viewerAdmire"`
+	IsFirstPost      bool                    `json:"isFirstPost"`
+	UserAddedMintURL *string                 `json:"userAddedMintURL"`
 }
 
 func (Post) IsAdmireSource()     {}
@@ -1896,6 +1897,7 @@ type PostTokensInput struct {
 	TokenIds []persist.DBID  `json:"tokenIds"`
 	Caption  *string         `json:"caption"`
 	Mentions []*MentionInput `json:"mentions"`
+	MintURL  *string         `json:"mintURL"`
 }
 
 type PostTokensPayload struct {
@@ -1969,6 +1971,7 @@ func (ReferralPostPreflightPayload) IsReferralPostPreflightPayloadOrError() {}
 type ReferralPostTokenInput struct {
 	Token   *ChainAddressTokenInput `json:"token"`
 	Caption *string                 `json:"caption"`
+	MintURL *string                 `json:"mintURL"`
 }
 
 type ReferralPostTokenPayload struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -1578,7 +1578,7 @@ func (r *mutationResolver) CommentOnPost(ctx context.Context, postID persist.DBI
 
 // PostTokens is the resolver for the postTokens field.
 func (r *mutationResolver) PostTokens(ctx context.Context, input model.PostTokensInput) (model.PostTokensPayloadOrError, error) {
-	id, err := publicapi.For(ctx).Feed.PostTokens(ctx, input.TokenIds, input.Mentions, input.Caption)
+	id, err := publicapi.For(ctx).Feed.PostTokens(ctx, input.TokenIds, input.Mentions, input.Caption, input.MintURL)
 	if err != nil {
 		return nil, err
 	}
@@ -1602,7 +1602,7 @@ func (r *mutationResolver) ReferralPostToken(ctx context.Context, input model.Re
 		ContractAddress: input.Token.ChainAddress.Address(),
 		TokenID:         input.Token.TokenID,
 	}
-	id, err := publicapi.For(ctx).Feed.ReferralPostToken(ctx, token, input.Caption)
+	id, err := publicapi.For(ctx).Feed.ReferralPostToken(ctx, token, input.Caption, input.MintURL)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1696,15 +1696,16 @@ func postToModel(post *db.Post) *model.Post {
 			TokenIDs: post.TokenIds,
 			AuthorID: post.ActorID,
 		},
-		Dbid:         post.ID,
-		Tokens:       nil, // handled by dedicated resolver
-		CreationTime: &post.CreatedAt,
-		Caption:      captionVal,
-		Admires:      nil, // handled by dedicated resolver
-		Comments:     nil, // handled by dedicated resolver
-		Interactions: nil, // handled by dedicated resolver
-		ViewerAdmire: nil, // handled by dedicated resolver
-		IsFirstPost:  post.IsFirstPost,
+		Dbid:             post.ID,
+		Tokens:           nil, // handled by dedicated resolver
+		CreationTime:     &post.CreatedAt,
+		Caption:          captionVal,
+		Admires:          nil, // handled by dedicated resolver
+		Comments:         nil, // handled by dedicated resolver
+		Interactions:     nil, // handled by dedicated resolver
+		ViewerAdmire:     nil, // handled by dedicated resolver
+		IsFirstPost:      post.IsFirstPost,
+		UserAddedMintURL: &post.UserMintUrl.String,
 	}
 }
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1054,6 +1054,7 @@ type Post implements Node @key(fields: "dbid") @goEmbedHelper {
 
   viewerAdmire: Admire @goField(forceResolver: true)
   isFirstPost: Boolean!
+  userAddedMintURL: String
 }
 
 type UserCreatedFeedEventData implements FeedEventData {
@@ -2685,6 +2686,7 @@ input PostTokensInput {
   tokenIds: [DBID!]
   caption: String
   mentions: [MentionInput!]
+  mintURL: String
 }
 
 type PostTokensPayload {
@@ -2696,6 +2698,7 @@ union PostTokensPayloadOrError = PostTokensPayload | ErrInvalidInput | ErrNotAut
 input ReferralPostTokenInput {
   token: ChainAddressTokenInput!
   caption: String
+  mintURL: String
 }
 
 type ReferralPostTokenPayload {

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -128,26 +128,19 @@ func (api FeedAPI) GetPostById(ctx context.Context, postID persist.DBID) (*db.Po
 	return &post, nil
 }
 
-func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, mentions []*model.MentionInput, caption *string) (persist.DBID, error) {
+func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, mentions []*model.MentionInput, caption, mintURL *string) (persist.DBID, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
 		"tokenIDs": validate.WithTag(tokenIDs, "required"),
 		// caption can be null but less than 600 chars
 		"caption": validate.WithTag(caption, "max=600"),
+		"mintURL": validate.WithTag(mintURL, "omitempty,http"),
 	}); err != nil {
 		return "", err
 	}
 	actorID, err := getAuthenticatedUserID(ctx)
 	if err != nil {
 		return "", err
-	}
-
-	var c sql.NullString
-	if caption != nil {
-		c = sql.NullString{
-			String: *caption,
-			Valid:  true,
-		}
 	}
 
 	contracts, err := api.queries.GetContractsByTokenIDs(ctx, tokenIDs)
@@ -172,7 +165,8 @@ func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, ment
 		TokenIds:    tokenIDs,
 		ContractIds: contractIDs,
 		ActorID:     actorID,
-		Caption:     c,
+		Caption:     util.ToSQLNullString(caption),
+		UserMintUrl: util.ToSQLNullString(mintURL),
 	})
 	if err != nil {
 		return "", err
@@ -278,12 +272,13 @@ func (api FeedAPI) PostTokens(ctx context.Context, tokenIDs []persist.DBID, ment
 	return postID, nil
 }
 
-func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentifiers, caption *string) (persist.DBID, error) {
+func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentifiers, caption, mintURL *string) (persist.DBID, error) {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
 		"token": validate.WithTag(t, "required"),
 		// caption can be null but less than 600 chars
 		"caption": validate.WithTag(caption, "max=600"),
+		"mintURL": validate.WithTag(mintURL, "omitempty,http"),
 	}); err != nil {
 		return "", err
 	}
@@ -296,15 +291,6 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 	user, err := api.repos.UserRepository.GetByID(ctx, userID)
 	if err != nil {
 		return "", err
-	}
-
-	var c sql.NullString
-
-	if caption != nil {
-		c = sql.NullString{
-			String: *caption,
-			Valid:  true,
-		}
 	}
 
 	r, err := api.loaders.GetTokenByUserTokenIdentifiersBatch.Load(db.GetTokenByUserTokenIdentifiersBatchParams{
@@ -321,7 +307,8 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 			TokenIds:    []persist.DBID{r.Token.ID},
 			ContractIds: []persist.DBID{r.Contract.ID},
 			ActorID:     user.ID,
-			Caption:     c,
+			Caption:     util.ToSQLNullString(caption),
+			UserMintUrl: util.ToSQLNullString(mintURL),
 		})
 		if err != nil {
 			return postID, err
@@ -376,7 +363,8 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 		TokenIds:    []persist.DBID{synced.Instance.ID},
 		ContractIds: []persist.DBID{synced.Contract.ID},
 		ActorID:     user.ID,
-		Caption:     c,
+		Caption:     util.ToSQLNullString(caption),
+		UserMintUrl: util.ToSQLNullString(mintURL),
 	})
 	if err != nil {
 		return postID, err

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:NJTs2w==,iv:L3pzvKag0Vr5XUq0HpIZR0oWDDeI1Zs3vgMLJOIib/o=,tag:USUpC7AmGXjqMvACopv3Dg==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:a1vWew==,iv:SDUlYFsEZFcN3HU+zBkVoXa+HP9K6d7TqQCqeaW6wOI=,tag:HRXn1jSa+sILtq/qoIcJkg==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:ZL2SfsMdMDJkgwHdfGVLCnTaRVlwJeCC9oH1qhlS5lM=,iv:7kwdA18x0IvcbKKjXJJ+s/zqKNQA85/Y7yguLQZlm0w=,tag:LpNBMF6OVotf77oeM/sk5g==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:rj8U63dquwJBWqzqcEZFhuHRk6Zdb/dBu/QiX0046dI=,iv:YXGkf0LShCCe4rVKmPbEvj3BKIzMZifdxWJ1wdaCBUk=,tag:loeie4GylDttpj/+KbD+MA==,type:str]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:bL4KfxRX7j9/+tez25NfWrk+OBsS0dpqtx0zccyqiBk=,iv:8vNwDPwoBs82KxiJI9xDe42FbegK6xXqi+7XcR+M33Y=,tag:JvPH45ipwRDGzs8M7ceMvw==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -62,8 +62,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-02T17:12:08Z"
-    mac: ENC[AES256_GCM,data:7pHStlwj7rmAgObg7tYJs52moJQeEm+c8I+L9tYJAtZ8xtsQ5i/zdMTrt8tG1obzO2v5BbXUrLhzLpjydGtMnfJG4tKN6CT+qkbdQohA0HUn7ZkG2k+yqMR7h270Ongic6rjX2N90qe0+X3ezegJbjqp1DiG+HI18zxMv+JJHLo=,iv:S2h6XtxmBuSR611NDfX2Xh186o3tFzqVMGKYjdFrlFU=,tag:3noMSOeB8ejn108wPFSEbA==,type:str]
+    lastmodified: "2023-11-07T20:46:34Z"
+    mac: ENC[AES256_GCM,data:WV1tNiZx0VI2HgpM7dBEL2eElMFifnIfvzWCQEA4G0haxxYsRcP/8zU+ksbpkDHoMifyH2d8IBqgfzbhiealwTVROY7ZKjUg1CnbYKADC8VuqwmI4+SSODMyec6bzo5DqK/lKUE9msiZ053CZaoGqI72xFL4P2uuAtYRqsoyJkE=,iv:XgXr22KnLfz0UQOjAchvuAmVw5pe6IueUn4dZw80i+s=,tag:oEttdLUT7VgvAAbNO83kPw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:a1vWew==,iv:SDUlYFsEZFcN3HU+zBkVoXa+HP9K6d7TqQCqeaW6wOI=,tag:HRXn1jSa+sILtq/qoIcJkg==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:NJTs2w==,iv:L3pzvKag0Vr5XUq0HpIZR0oWDDeI1Zs3vgMLJOIib/o=,tag:USUpC7AmGXjqMvACopv3Dg==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:rj8U63dquwJBWqzqcEZFhuHRk6Zdb/dBu/QiX0046dI=,iv:YXGkf0LShCCe4rVKmPbEvj3BKIzMZifdxWJ1wdaCBUk=,tag:loeie4GylDttpj/+KbD+MA==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:ZL2SfsMdMDJkgwHdfGVLCnTaRVlwJeCC9oH1qhlS5lM=,iv:7kwdA18x0IvcbKKjXJJ+s/zqKNQA85/Y7yguLQZlm0w=,tag:LpNBMF6OVotf77oeM/sk5g==,type:str]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:bL4KfxRX7j9/+tez25NfWrk+OBsS0dpqtx0zccyqiBk=,iv:8vNwDPwoBs82KxiJI9xDe42FbegK6xXqi+7XcR+M33Y=,tag:JvPH45ipwRDGzs8M7ceMvw==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -62,8 +62,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-11-07T20:46:34Z"
-    mac: ENC[AES256_GCM,data:WV1tNiZx0VI2HgpM7dBEL2eElMFifnIfvzWCQEA4G0haxxYsRcP/8zU+ksbpkDHoMifyH2d8IBqgfzbhiealwTVROY7ZKjUg1CnbYKADC8VuqwmI4+SSODMyec6bzo5DqK/lKUE9msiZ053CZaoGqI72xFL4P2uuAtYRqsoyJkE=,iv:XgXr22KnLfz0UQOjAchvuAmVw5pe6IueUn4dZw80i+s=,tag:oEttdLUT7VgvAAbNO83kPw==,type:str]
+    lastmodified: "2023-12-02T17:12:08Z"
+    mac: ENC[AES256_GCM,data:7pHStlwj7rmAgObg7tYJs52moJQeEm+c8I+L9tYJAtZ8xtsQ5i/zdMTrt8tG1obzO2v5BbXUrLhzLpjydGtMnfJG4tKN6CT+qkbdQohA0HUn7ZkG2k+yqMR7h270Ongic6rjX2N90qe0+X3ezegJbjqp1DiG+HI18zxMv+JJHLo=,iv:S2h6XtxmBuSR611NDfX2Xh186o3tFzqVMGKYjdFrlFU=,tag:3noMSOeB8ejn108wPFSEbA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -655,6 +655,13 @@ func ToNullString(s string, emptyIsNull bool) sql.NullString {
 	return sql.NullString{String: s, Valid: true}
 }
 
+func ToSQLNullString(s *string) sql.NullString {
+	if s == nil {
+		return sql.NullString{}
+	}
+	return ToNullString(*s, true)
+}
+
 func ToNullInt32(i *int) sql.NullInt32 {
 	if i == nil {
 		return sql.NullInt32{Int32: 0, Valid: false}


### PR DESCRIPTION
Schema changes:

Adds `userAddedMintURL` to the `Post` type and `mintURL` as an input to the post creation mutations. Note: the backend only checks if the URL is valid, it doesn't check if the URL is from an allow-listed domain. cc @Robinnnnn 

```graphql
type Post {
  ...
  userAddedMintURL: String
}

input ReferralPostTokenInput {
  token: ChainAddressTokenInput!
  caption: String
  mintURL: String  # new field
}

input PostTokensInput {
  tokenIds: [DBID!]
  caption: String
  mentions: [MentionInput!]
  mintURL: String. # new field
}

type Contract {
  mintURL: String  # should be used if `post.userAddedMintURL` does not exist
}
```

