### PR TITLE
comment total on feed entities

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -184,6 +184,28 @@ func (q *Queries) ClearNotificationsForUser(ctx context.Context, ownerID persist
 	return items, nil
 }
 
+const countCommentsAndRepliesByFeedEventID = `-- name: CountCommentsAndRepliesByFeedEventID :one
+SELECT count(*) FROM comments WHERE feed_event_id = $1 AND deleted = false
+`
+
+func (q *Queries) CountCommentsAndRepliesByFeedEventID(ctx context.Context, feedEventID persist.DBID) (int64, error) {
+	row := q.db.QueryRow(ctx, countCommentsAndRepliesByFeedEventID, feedEventID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countCommentsAndRepliesByPostID = `-- name: CountCommentsAndRepliesByPostID :one
+SELECT count(*) FROM comments WHERE post_id = $1 is null AND deleted = false
+`
+
+func (q *Queries) CountCommentsAndRepliesByPostID(ctx context.Context, postID persist.DBID) (int64, error) {
+	row := q.db.QueryRow(ctx, countCommentsAndRepliesByPostID, postID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countFollowersByUserID = `-- name: CountFollowersByUserID :one
 SELECT count(*) FROM follows WHERE followee = $1 AND deleted = false
 `

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -734,6 +734,9 @@ SELECT * FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND reply
 -- name: CountCommentsByFeedEventIDBatch :batchone
 SELECT count(*) FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND reply_to is null AND deleted = false;
 
+-- name: CountCommentsAndRepliesByFeedEventID :one
+SELECT count(*) FROM comments WHERE feed_event_id = sqlc.arg('feed_event_id') AND deleted = false;
+
 -- name: PaginateCommentsByPostIDBatch :batchmany
 SELECT * FROM comments WHERE post_id = sqlc.arg('post_id') AND reply_to is null AND deleted = false
     AND (created_at, id) < (sqlc.arg('cur_before_time'), sqlc.arg('cur_before_id'))
@@ -761,6 +764,10 @@ SELECT * FROM comments WHERE
 
 -- name: CountCommentsByPostIDBatch :batchone
 SELECT count(*) FROM comments WHERE post_id = sqlc.arg('post_id') AND reply_to is null AND deleted = false;
+
+-- name: CountCommentsAndRepliesByPostID :one
+SELECT count(*) FROM comments WHERE post_id = sqlc.arg('post_id') is null AND deleted = false;
+
 
 -- name: CountRepliesByCommentIDBatch :batchone
 SELECT count(*) FROM comments WHERE 

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1392,6 +1392,7 @@ type FeedEvent struct {
 	EventData             FeedEventData                `json:"eventData"`
 	Admires               *FeedEventAdmiresConnection  `json:"admires"`
 	Comments              *FeedEventCommentsConnection `json:"comments"`
+	TotalComments         *int                         `json:"totalComments"`
 	Caption               *string                      `json:"caption"`
 	Interactions          *InteractionsConnection      `json:"interactions"`
 	ViewerAdmire          *Admire                      `json:"viewerAdmire"`
@@ -1832,17 +1833,18 @@ func (PDFMedia) IsMedia()        {}
 
 type Post struct {
 	HelperPostData
-	Dbid         persist.DBID            `json:"dbid"`
-	Author       *GalleryUser            `json:"author"`
-	CreationTime *time.Time              `json:"creationTime"`
-	Tokens       []*Token                `json:"tokens"`
-	Caption      *string                 `json:"caption"`
-	Mentions     []*Mention              `json:"mentions"`
-	Admires      *PostAdmiresConnection  `json:"admires"`
-	Comments     *PostCommentsConnection `json:"comments"`
-	Interactions *InteractionsConnection `json:"interactions"`
-	ViewerAdmire *Admire                 `json:"viewerAdmire"`
-	IsFirstPost  bool                    `json:"isFirstPost"`
+	Dbid          persist.DBID            `json:"dbid"`
+	Author        *GalleryUser            `json:"author"`
+	CreationTime  *time.Time              `json:"creationTime"`
+	Tokens        []*Token                `json:"tokens"`
+	Caption       *string                 `json:"caption"`
+	Mentions      []*Mention              `json:"mentions"`
+	Admires       *PostAdmiresConnection  `json:"admires"`
+	Comments      *PostCommentsConnection `json:"comments"`
+	TotalComments *int                    `json:"totalComments"`
+	Interactions  *InteractionsConnection `json:"interactions"`
+	ViewerAdmire  *Admire                 `json:"viewerAdmire"`
+	IsFirstPost   bool                    `json:"isFirstPost"`
 }
 
 func (Post) IsAdmireSource()     {}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -482,6 +482,11 @@ func (r *feedEventResolver) Comments(ctx context.Context, obj *model.FeedEvent, 
 	}, nil
 }
 
+// TotalComments is the resolver for the totalComments field.
+func (r *feedEventResolver) TotalComments(ctx context.Context, obj *model.FeedEvent) (*int, error) {
+	return publicapi.For(ctx).Interaction.GetTotalCommentsByFeedEventID(ctx, obj.Dbid)
+}
+
 // Interactions is the resolver for the interactions field.
 func (r *feedEventResolver) Interactions(ctx context.Context, obj *model.FeedEvent, before *string, after *string, first *int, last *int) (*model.InteractionsConnection, error) {
 	interactions, pageInfo, err := publicapi.For(ctx).Interaction.PaginateInteractionsByFeedEventID(ctx, obj.Dbid, before, after, first, last)
@@ -2229,6 +2234,11 @@ func (r *postResolver) Comments(ctx context.Context, obj *model.Post, before *st
 		Edges:    edges,
 		PageInfo: pageInfoToModel(ctx, pageInfo),
 	}, nil
+}
+
+// TotalComments is the resolver for the totalComments field.
+func (r *postResolver) TotalComments(ctx context.Context, obj *model.Post) (*int, error) {
+	return publicapi.For(ctx).Interaction.GetTotalCommentsByPostID(ctx, obj.Dbid)
 }
 
 // Interactions is the resolver for the interactions field.

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1020,6 +1020,9 @@ type FeedEvent implements Node @key(fields: "dbid") {
     @goField(forceResolver: true)
   comments(before: String, after: String, first: Int, last: Int): FeedEventCommentsConnection
     @goField(forceResolver: true)
+
+  totalComments: Int @goField(forceResolver: true)
+
   caption: String
 
   interactions(before: String, after: String, first: Int, last: Int): InteractionsConnection
@@ -1048,6 +1051,8 @@ type Post implements Node @key(fields: "dbid") @goEmbedHelper {
     @goField(forceResolver: true)
   comments(before: String, after: String, first: Int, last: Int): PostCommentsConnection
     @goField(forceResolver: true)
+
+  totalComments: Int @goField(forceResolver: true)
 
   interactions(before: String, after: String, first: Int, last: Int): InteractionsConnection
     @goField(forceResolver: true)

--- a/publicapi/interaction.go
+++ b/publicapi/interaction.go
@@ -549,6 +549,38 @@ func (api InteractionAPI) PaginateRepliesByCommentID(ctx context.Context, commen
 	return comments, pageInfo, err
 }
 
+func (api InteractionAPI) GetTotalCommentsByPostID(ctx context.Context, postID persist.DBID) (*int, error) {
+	// Validate
+	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
+		"postID": validate.WithTag(postID, "required"),
+	}); err != nil {
+		return nil, err
+	}
+
+	count, err := api.queries.CountCommentsAndRepliesByPostID(ctx, postID)
+	if err != nil {
+		return nil, err
+	}
+
+	return util.ToPointer(int(count)), nil
+}
+
+func (api InteractionAPI) GetTotalCommentsByFeedEventID(ctx context.Context, feedEventID persist.DBID) (*int, error) {
+	// Validate
+	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
+		"feedEventID": validate.WithTag(feedEventID, "required"),
+	}); err != nil {
+		return nil, err
+	}
+
+	count, err := api.queries.CountCommentsAndRepliesByFeedEventID(ctx, feedEventID)
+	if err != nil {
+		return nil, err
+	}
+
+	return util.ToPointer(int(count)), nil
+}
+
 func (api InteractionAPI) PaginateAdmiresByPostID(ctx context.Context, postID persist.DBID, before *string, after *string,
 	first *int, last *int) ([]db.Admire, PageInfo, error) {
 	// Validate


### PR DESCRIPTION
Changes:

- **Added** `totalComments` to the `Post` and `FeedEvent` types. This represents total comments and their replies count, different than what the `comments.pageTotal.total` would return (that is just top level comments).

I considered adding it to the `CommentsConnection` type but it just didn't end up feeling right that a type that was meant to represent a page in pagination would uniquely have this extraneous field that didn't have to do with pagination. It also would require the frontend to dig into at least 1 comment which is fair but seems safer to have the field just exist on the type with the comments and replies