### PR TITLE
Move to OS V2

### DIFF
--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -498,10 +498,6 @@ func tokensToConnection(ctx context.Context, tokens []db.Token, pageInfo publica
 	}
 }
 
-func refreshTokensInContractAsync(ctx context.Context, contractID persist.DBID, forceRefresh bool) error {
-	return publicapi.For(ctx).Contract.RefreshOwnersAsync(ctx, contractID, forceRefresh)
-}
-
 func resolveTokenOwnerByTokenID(ctx context.Context, tokenID persist.DBID) (*model.GalleryUser, error) {
 	token, err := publicapi.For(ctx).Token.GetTokenById(ctx, tokenID)
 

--- a/indexer/metadatas.go
+++ b/indexer/metadatas.go
@@ -413,19 +413,16 @@ func ens(ctx context.Context, turi persist.TokenURI, addr persist.EthereumAddres
 
 	result := domain.LabelName + ".eth"
 
-	assets, err := opensea.FetchAssetsForTokenIdentifiers(ctx, addr, opensea.TokenID(tid.Base10String()))
+	assets, err := opensea.FetchAssetsForTokenIdentifiers(ctx, persist.ChainETH, persist.Address(addr), tid)
 	if err != nil {
 		return persist.TokenURI(result), nil, err
 	}
-	withImage, ok := util.FindFirst(assets, func(asset opensea.Asset) bool {
-		return asset.ImageURL != "" || asset.ImagePreviewURL != "" || asset.ImageOriginalURL != "" || asset.ImageThumbnailURL != ""
-	})
-
+	withImage, ok := util.FindFirst(assets, func(asset opensea.Asset) bool { return asset.ImageURL != "" })
 	if ok {
 		return persist.TokenURI(withImage.ImageURL), persist.TokenMetadata{
 			"name":          fmt.Sprintf("ENS: %s", result),
 			"description":   "ENS names are used to resolve domain names to Ethereum addresses.",
-			"image":         util.FirstNonEmptyString(withImage.ImageURL, withImage.ImagePreviewURL, withImage.ImageOriginalURL, withImage.ImageThumbnailURL),
+			"image":         withImage.ImageURL,
 			"profile_image": fmt.Sprintf("https://metadata.ens.domains/mainnet/avatar/%s", result),
 		}, nil
 	}

--- a/publicapi/contract.go
+++ b/publicapi/contract.go
@@ -171,22 +171,6 @@ func (api ContractAPI) RefreshContract(ctx context.Context, contractID persist.D
 	}
 
 	return nil
-
-}
-
-func (api ContractAPI) RefreshOwnersAsync(ctx context.Context, contractID persist.DBID, forceRefresh bool) error {
-	// Validate
-	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractID": validate.WithTag(contractID, "required"),
-	}); err != nil {
-		return err
-	}
-
-	in := task.TokenProcessingContractTokensMessage{
-		ContractID:   contractID,
-		ForceRefresh: forceRefresh,
-	}
-	return api.taskClient.CreateTaskForContractOwnerProcessing(ctx, in)
 }
 
 func (api ContractAPI) GetCommunityOwnersByContractAddress(ctx context.Context, contractAddress persist.ChainAddress, before, after *string, first, last *int, onlyGalleryUsers bool) ([]db.User, PageInfo, error) {

--- a/publicapi/token.go
+++ b/publicapi/token.go
@@ -433,21 +433,6 @@ func (api TokenAPI) RefreshToken(ctx context.Context, tokenDBID persist.DBID) er
 	return nil
 }
 
-func (api TokenAPI) RefreshTokensInCollection(ctx context.Context, ci persist.ContractIdentifiers) error {
-	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
-		"contractIdentifiers": validate.WithTag(ci, "required"),
-	}); err != nil {
-		return err
-	}
-
-	err := api.multichainProvider.RefreshTokensForContract(ctx, ci)
-	if err != nil {
-		return ErrTokenRefreshFailed{Message: err.Error()}
-	}
-
-	return nil
-}
-
 func (api TokenAPI) RefreshCollection(ctx context.Context, collectionDBID persist.DBID) error {
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
 		"collectionID": validate.WithTag(collectionDBID, "required"),

--- a/server/inject.go
+++ b/server/inject.go
@@ -125,7 +125,6 @@ func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.
 		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.ContractsOwnerFetcher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(indexerProvider)),
-		wire.Bind(new(multichain.OpenSeaChildContractFetcher), util.ToPointer(openseaProvider)),
 		ethRequirements,
 	)
 	return nil
@@ -143,9 +142,8 @@ func ethRequirements(
 	tmf multichain.TokenMetadataFetcher,
 	tcof multichain.ContractsOwnerFetcher,
 	tdf multichain.TokenDescriptorsFetcher,
-	osccf multichain.OpenSeaChildContractFetcher,
 ) ethProviderList {
-	return ethProviderList{nr, v, tof, toc, tiof, cf, cr, tmf, tcof, tdf, osccf}
+	return ethProviderList{nr, v, tof, toc, tiof, cf, cr, tmf, tcof, tdf}
 }
 
 // tezosProviderSet is a wire injector that creates the set of Tezos providers
@@ -185,7 +183,6 @@ func tezosRequirements(
 // optimismProviderSet is a wire injector that creates the set of Optimism providers
 func optimismProviderSet(*http.Client, *tokenMetadataCache) optimismProviderList {
 	wire.Build(
-		rpc.NewEthClient,
 		optimismProvidersConfig,
 		wire.Value(persist.ChainOptimism),
 		// Add providers for Optimism here
@@ -202,7 +199,6 @@ func optimismProvidersConfig(alchemyProvider *alchemy.Provider, openseaProvider 
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(alchemyProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(alchemyProvider)),
 		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(alchemyProvider)),
-		wire.Bind(new(multichain.OpenSeaChildContractFetcher), util.ToPointer(openseaProvider)),
 		optimismRequirements,
 	)
 	return nil
@@ -214,15 +210,13 @@ func optimismRequirements(
 	tiof multichain.TokensIncrementalOwnerFetcher,
 	toc multichain.TokensContractFetcher,
 	tmf multichain.TokenMetadataFetcher,
-	opensea multichain.OpenSeaChildContractFetcher,
 ) optimismProviderList {
-	return optimismProviderList{tof, toc, tiof, tmf, opensea}
+	return optimismProviderList{tof, toc, tiof, tmf}
 }
 
 // arbitrumProviderSet is a wire injector that creates the set of Arbitrum providers
 func arbitrumProviderSet(*http.Client, *tokenMetadataCache) arbitrumProviderList {
 	wire.Build(
-		rpc.NewEthClient,
 		arbitrumProvidersConfig,
 		wire.Value(persist.ChainArbitrum),
 		// Add providers for Optimism here
@@ -239,7 +233,6 @@ func arbitrumProvidersConfig(alchemyProvider *alchemy.Provider, openseaProvider 
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(alchemyProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(alchemyProvider)),
 		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(alchemyProvider)),
-		wire.Bind(new(multichain.OpenSeaChildContractFetcher), util.ToPointer(openseaProvider)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(alchemyProvider)),
 		arbitrumRequirements,
 	)
@@ -252,10 +245,9 @@ func arbitrumRequirements(
 	tiof multichain.TokensIncrementalOwnerFetcher,
 	toc multichain.TokensContractFetcher,
 	tmf multichain.TokenMetadataFetcher,
-	opensea multichain.OpenSeaChildContractFetcher,
 	tdf multichain.TokenDescriptorsFetcher,
 ) arbitrumProviderList {
-	return arbitrumProviderList{tof, toc, tiof, tmf, opensea, tdf}
+	return arbitrumProviderList{tof, toc, tiof, tmf, tdf}
 }
 
 // poapProviderSet is a wire injector that creates the set of POAP providers

--- a/server/server.go
+++ b/server/server.go
@@ -57,9 +57,10 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	recommender := recommend.NewRecommender(c.Queries)
-	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	router := CoreInit(ctx, c, provider, recommender, p)
+	// XXX recommender := recommend.NewRecommender(c.Queries)
+	// XXX p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	// XXX router := CoreInit(ctx, c, provider, recommender, p)
+	router := CoreInit(ctx, c, provider, nil, nil)
 	http.Handle("/", router)
 }
 
@@ -128,8 +129,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	socialCache := redis.NewCache(redis.SocialCache)
 	authRefreshCache := redis.NewCache(redis.AuthTokenForceRefreshCache)
 
-	recommender.Loop(ctx, time.NewTicker(time.Hour))
-	p.Loop(ctx, time.NewTicker(time.Minute*15))
+	// XXX recommender.Loop(ctx, time.NewTicker(time.Hour))
+	// XXX p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, c.MagicLinkClient, recommender, p)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -57,10 +57,9 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	// XXX recommender := recommend.NewRecommender(c.Queries)
-	// XXX p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	// XXX router := CoreInit(ctx, c, provider, recommender, p)
-	router := CoreInit(ctx, c, provider, nil, nil)
+	recommender := recommend.NewRecommender(c.Queries)
+	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	router := CoreInit(ctx, c, provider, recommender, p)
 	http.Handle("/", router)
 }
 
@@ -129,8 +128,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	socialCache := redis.NewCache(redis.SocialCache)
 	authRefreshCache := redis.NewCache(redis.AuthTokenForceRefreshCache)
 
-	// XXX recommender.Loop(ctx, time.NewTicker(time.Hour))
-	// XXX p.Loop(ctx, time.NewTicker(time.Minute*15))
+	recommender.Loop(ctx, time.NewTicker(time.Hour))
+	p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, c.MagicLinkClient, recommender, p)
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -77,7 +77,7 @@ func ethProviderSet(serverEnvInit envInit, client *task.Client, httpClient *http
 	ethclientClient := rpc.NewEthClient()
 	provider := eth.NewProvider(httpClient, ethclientClient, client)
 	chain := _wireChainValue
-	openseaProvider := opensea.NewProvider(ethclientClient, httpClient, chain)
+	openseaProvider := opensea.NewProvider(httpClient, chain)
 	syncFailureFallbackProvider := ethFallbackProvider(httpClient, serverTokenMetadataCache)
 	serverEthProviderList := ethProvidersConfig(provider, openseaProvider, syncFailureFallbackProvider)
 	return serverEthProviderList
@@ -89,7 +89,7 @@ var (
 
 // ethProvidersConfig is a wire injector that binds multichain interfaces to their concrete Ethereum implementations
 func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.Provider, fallbackProvider multichain.SyncFailureFallbackProvider) ethProviderList {
-	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, fallbackProvider, fallbackProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider, openseaProvider)
+	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, fallbackProvider, fallbackProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider)
 	return serverEthProviderList
 }
 
@@ -110,8 +110,7 @@ func tezosProvidersConfig(tezosProvider multichain.SyncWithContractEvalFallbackP
 func optimismProviderSet(client *http.Client, serverTokenMetadataCache *tokenMetadataCache) optimismProviderList {
 	chain := _wirePersistChainValue
 	provider := newAlchemyProvider(client, chain, serverTokenMetadataCache)
-	ethclientClient := rpc.NewEthClient()
-	openseaProvider := opensea.NewProvider(ethclientClient, client, chain)
+	openseaProvider := opensea.NewProvider(client, chain)
 	serverOptimismProviderList := optimismProvidersConfig(provider, openseaProvider)
 	return serverOptimismProviderList
 }
@@ -122,7 +121,7 @@ var (
 
 // optimismProvidersConfig is a wire injector that binds multichain interfaces to their concrete Optimism implementations
 func optimismProvidersConfig(alchemyProvider *alchemy.Provider, openseaProvider *opensea.Provider) optimismProviderList {
-	serverOptimismProviderList := optimismRequirements(alchemyProvider, alchemyProvider, alchemyProvider, alchemyProvider, openseaProvider)
+	serverOptimismProviderList := optimismRequirements(alchemyProvider, alchemyProvider, alchemyProvider, alchemyProvider)
 	return serverOptimismProviderList
 }
 
@@ -130,8 +129,7 @@ func optimismProvidersConfig(alchemyProvider *alchemy.Provider, openseaProvider 
 func arbitrumProviderSet(client *http.Client, serverTokenMetadataCache *tokenMetadataCache) arbitrumProviderList {
 	chain := _wireChainValue2
 	provider := newAlchemyProvider(client, chain, serverTokenMetadataCache)
-	ethclientClient := rpc.NewEthClient()
-	openseaProvider := opensea.NewProvider(ethclientClient, client, chain)
+	openseaProvider := opensea.NewProvider(client, chain)
 	serverArbitrumProviderList := arbitrumProvidersConfig(provider, openseaProvider)
 	return serverArbitrumProviderList
 }
@@ -142,7 +140,7 @@ var (
 
 // arbitrumProvidersConfig is a wire injector that binds multichain interfaces to their concrete Arbitrum implementations
 func arbitrumProvidersConfig(alchemyProvider *alchemy.Provider, openseaProvider *opensea.Provider) arbitrumProviderList {
-	serverArbitrumProviderList := arbitrumRequirements(alchemyProvider, alchemyProvider, alchemyProvider, alchemyProvider, openseaProvider, alchemyProvider)
+	serverArbitrumProviderList := arbitrumRequirements(alchemyProvider, alchemyProvider, alchemyProvider, alchemyProvider, alchemyProvider)
 	return serverArbitrumProviderList
 }
 
@@ -298,9 +296,8 @@ func ethRequirements(
 	tmf multichain.TokenMetadataFetcher,
 	tcof multichain.ContractsOwnerFetcher,
 	tdf multichain.TokenDescriptorsFetcher,
-	osccf multichain.OpenSeaChildContractFetcher,
 ) ethProviderList {
-	return ethProviderList{nr, v, tof, toc, tiof, cf, cr, tmf, tcof, tdf, osccf}
+	return ethProviderList{nr, v, tof, toc, tiof, cf, cr, tmf, tcof, tdf}
 }
 
 // tezosRequirements is the set of provider interfaces required for Tezos
@@ -319,10 +316,9 @@ func optimismRequirements(
 	tof multichain.TokensOwnerFetcher,
 	tiof multichain.TokensIncrementalOwnerFetcher,
 	toc multichain.TokensContractFetcher,
-	tmf multichain.TokenMetadataFetcher, opensea2 multichain.OpenSeaChildContractFetcher,
-
+	tmf multichain.TokenMetadataFetcher,
 ) optimismProviderList {
-	return optimismProviderList{tof, toc, tiof, tmf, opensea2}
+	return optimismProviderList{tof, toc, tiof, tmf}
 }
 
 // arbitrumRequirements is the set of provider interfaces required for Arbitrum
@@ -330,11 +326,10 @@ func arbitrumRequirements(
 	tof multichain.TokensOwnerFetcher,
 	tiof multichain.TokensIncrementalOwnerFetcher,
 	toc multichain.TokensContractFetcher,
-	tmf multichain.TokenMetadataFetcher, opensea2 multichain.OpenSeaChildContractFetcher,
-
+	tmf multichain.TokenMetadataFetcher,
 	tdf multichain.TokenDescriptorsFetcher,
 ) arbitrumProviderList {
-	return arbitrumProviderList{tof, toc, tiof, tmf, opensea2, tdf}
+	return arbitrumProviderList{tof, toc, tiof, tmf, tdf}
 }
 
 // poapRequirements is the set of provider interfaces required for POAP

--- a/service/membership/membership.go
+++ b/service/membership/membership.go
@@ -3,10 +3,8 @@ package membership
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -16,9 +14,7 @@ import (
 	"github.com/everFinance/goar"
 	"github.com/gammazero/workerpool"
 	shell "github.com/ipfs/go-ipfs-api"
-	"github.com/mikeydub/go-gallery/service/multichain/opensea"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/util"
 )
 
 // MembershipTierIDs is a list of all membership tiers
@@ -81,62 +77,6 @@ func UpdateMembershipTier(pTokenID persist.TokenID, membershipRepository *postgr
 		return persist.MembershipTier{}, fmt.Errorf("no owners found for token: %s", pTokenID)
 	}
 	return processOwners(ctx, pTokenID, md, owners, ethClient, userRepository, galleryRepository, membershipRepository, walletRepository)
-}
-
-// OpenseaFetchMembershipCards recursively fetches all membership cards for a token ID
-func OpenseaFetchMembershipCards(contractAddress persist.EthereumAddress, tokenID persist.TokenID, pOffset int, pRetry int) ([]opensea.Event, error) {
-
-	client := &http.Client{
-		Timeout: time.Minute,
-	}
-
-	result := []opensea.Event{}
-
-	urlStr := fmt.Sprintf("https://api.opensea.io/api/v1/events?asset_contract_address=%s&token_id=%s&only_opensea=false&offset=%d&limit=50", contractAddress, tokenID.Base10String(), pOffset)
-
-	req, err := http.NewRequest("GET", urlStr, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("X-API-KEY", env.GetString("OPENSEA_API_KEY"))
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		if resp.StatusCode == 429 {
-			if pRetry > 3 {
-				return nil, fmt.Errorf("timed out fetching membership cards %d at url: %s", tokenID.ToInt(), urlStr)
-			}
-
-			logger.For(nil).Warnf("Opensea API rate limit exceeded, retrying in 5 seconds")
-			time.Sleep(time.Second * 2 * time.Duration(pRetry+1))
-			return OpenseaFetchMembershipCards(contractAddress, tokenID, pOffset, pRetry+1)
-		}
-		return nil, fmt.Errorf("unexpected status code: %d - url: %s", resp.StatusCode, urlStr)
-	}
-
-	response := &opensea.Events{}
-	err = util.UnmarshallBody(response, resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	err = resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	result = append(result, response.Events...)
-	if len(response.Events) == 50 {
-		next, err := OpenseaFetchMembershipCards(contractAddress, tokenID, pOffset+50, pRetry)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, next...)
-	}
-
-	return result, nil
 }
 
 func filterTokenHolders(holdersChannel chan persist.TokenHolder, numHolders int, tokenID persist.TokenID) []persist.TokenHolder {

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gammazero/workerpool"
 	"github.com/sirupsen/logrus"
 	"github.com/sourcegraph/conc"
 	"github.com/sourcegraph/conc/pool"
@@ -34,10 +33,6 @@ import (
 func init() {
 	env.RegisterValidation("TOKEN_PROCESSING_URL", "required")
 }
-
-const staleCommunityTime = time.Minute * 30
-
-const maxCommunitySize = 10_000
 
 var contractNameBlacklist = map[string]bool{
 	"unidentified contract": true,
@@ -827,45 +822,6 @@ outer:
 	return err
 }
 
-type ProviderChildContractResult struct {
-	Priority int
-	Chain    persist.Chain
-	Edges    []ParentToChildEdge
-}
-
-type ParentToChildEdge struct {
-	Parent   ChainAgnosticContract // Providers may optionally provide the parent if its convenient to do so
-	Children []ChildContract
-}
-
-type ChildContract struct {
-	ChildID        string // Uniquely identifies a child contract within a parent contract
-	Name           string
-	Description    string
-	OwnerAddress   persist.Address
-	CreatorAddress persist.Address
-	Tokens         []ChainAgnosticToken
-}
-
-// combinedProviderChildContractResults is a helper for combining results from multiple providers
-type combinedProviderChildContractResults []ProviderChildContractResult
-
-func (c combinedProviderChildContractResults) ParentContracts() []db.Contract {
-	combined := make([]chainContracts, 0)
-	for _, result := range c {
-		contracts := make([]ChainAgnosticContract, 0)
-		for _, edge := range result.Edges {
-			contracts = append(contracts, edge.Parent)
-		}
-		combined = append(combined, chainContracts{
-			priority:  result.Priority,
-			chain:     result.Chain,
-			contracts: contracts,
-		})
-	}
-	return chainContractsToUpsertableContracts(combined, nil)
-}
-
 func (p *Provider) processTokenCommunities(ctx context.Context, contracts []db.Contract, tokens []op.TokenFullDetails) error {
 	knownProviders, err := p.Queries.GetCommunityContractProviders(ctx, util.MapWithoutError(contracts, func(c db.Contract) persist.DBID { return c.ID }))
 	if err != nil {
@@ -1022,21 +978,6 @@ func (p *Provider) processTokensForUser(ctx context.Context, user persist.User, 
 	}
 
 	return currentUserTokens[user.ID], newUserTokens[user.ID], nil
-}
-
-func (p *Provider) processTokensForOwnersOfContract(ctx context.Context, contract db.Contract, users map[persist.DBID]persist.User,
-	chainTokensForUsers map[persist.DBID][]chainTokens, upsertParams op.TokenUpsertParams) (map[persist.DBID][]op.TokenFullDetails, map[persist.DBID][]op.TokenFullDetails, error) {
-	existingTokens, err := op.TokensFullDetailsByContractID(ctx, p.Queries, contract.ID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	existingTokensForUsers := make(map[persist.DBID][]op.TokenFullDetails)
-	for _, t := range existingTokens {
-		existingTokensForUsers[t.Instance.OwnerUserID] = append(existingTokensForUsers[t.Instance.OwnerUserID], t)
-	}
-
-	return p.processTokensForUsers(ctx, users, chainTokensForUsers, existingTokensForUsers, []db.Contract{contract}, upsertParams)
 }
 
 func (p *Provider) processTokenMedia(ctx context.Context, tokenID persist.TokenID, contractAddress persist.Address, chain persist.Chain) error {
@@ -1387,81 +1328,6 @@ func (p *Provider) RefreshContract(ctx context.Context, ci persist.ContractIdent
 	return err
 }
 
-// RefreshTokensForContract refreshes all tokens in a given contract
-func (p *Provider) RefreshTokensForContract(ctx context.Context, ci persist.ContractIdentifiers) error {
-	contractRefreshers := matchingProvidersForChain[TokensContractFetcher](p.Chains, ci.Chain)
-
-	tokensFromProviders := []chainTokens{}
-	contractsFromProviders := []chainContracts{}
-	tokensReceive := make(chan chainTokens)
-	contractsReceive := make(chan chainContracts)
-	errChan := make(chan errWithPriority)
-	done := make(chan struct{})
-	wg := &sync.WaitGroup{}
-	for i, fetcher := range contractRefreshers {
-		wg.Add(1)
-		go func(priority int, p TokensContractFetcher) {
-			defer wg.Done()
-			tokens, contract, err := p.GetTokensByContractAddress(ctx, ci.ContractAddress, maxCommunitySize, 0)
-			if err != nil {
-				errChan <- errWithPriority{priority: priority, err: err}
-				return
-			}
-			tokensReceive <- chainTokens{chain: ci.Chain, tokens: tokens, priority: priority}
-			contractsReceive <- chainContracts{chain: ci.Chain, contracts: []ChainAgnosticContract{contract}, priority: priority}
-		}(i, fetcher)
-	}
-	go func() {
-		defer close(done)
-		wg.Wait()
-	}()
-
-outer:
-	for {
-		select {
-		case err := <-errChan:
-			logger.For(ctx).Errorf("error fetching tokens for contract %s-%d: %s", ci.ContractAddress, ci.Chain, err)
-			if err.priority == 0 {
-				return err
-			}
-		case tokens := <-tokensReceive:
-			tokensFromProviders = append(tokensFromProviders, tokens)
-		case contract := <-contractsReceive:
-			contractsFromProviders = append(contractsFromProviders, contract)
-		case <-done:
-			logger.For(ctx).Debug("done refreshing tokens for collection")
-			break outer
-		}
-	}
-
-	logger.For(ctx).Debug("creating users")
-
-	chainTokensForUsers, users, err := p.createUsersForTokens(ctx, tokensFromProviders, ci.Chain)
-	if err != nil {
-		return err
-	}
-
-	logger.For(ctx).Debug("creating contracts")
-
-	_, persistedContracts, err := p.processContracts(ctx, contractsFromProviders, nil, false)
-	if err != nil {
-		return err
-	}
-
-	// We should receive exactly one contract from processContracts
-	if len(persistedContracts) != 1 {
-		return fmt.Errorf("expected one contract to be returned from processContracts, got %d", len(persistedContracts))
-	}
-
-	_, _, err = p.processTokensForOwnersOfContract(ctx, persistedContracts[0], users, chainTokensForUsers, op.TokenUpsertParams{
-		SetCreatorFields: false,
-		SetHolderFields:  true,
-		OptionalDelete:   nil,
-	})
-
-	return err
-}
-
 type ContractOwnerResult struct {
 	Priority  int
 	Contracts []ChainAgnosticContract
@@ -1525,212 +1391,6 @@ func (p *Provider) SyncContractsOwnedByUser(ctx context.Context, userID persist.
 	}
 
 	return nil
-}
-
-type tokenForUser struct {
-	userID   persist.DBID
-	token    ChainAgnosticToken
-	chain    persist.Chain
-	priority int
-}
-
-// this function returns a map of user IDs to their new tokens as well as a map of user IDs to the users themselves
-func (p *Provider) createUsersForTokens(ctx context.Context, tokens []chainTokens, chain persist.Chain) (map[persist.DBID][]chainTokens, map[persist.DBID]persist.User, error) {
-	users := map[persist.DBID]persist.User{}
-	userTokens := map[persist.DBID]map[int]chainTokens{}
-	seenTokens := map[persist.TokenUniqueIdentifiers]bool{}
-
-	userChan := make(chan persist.User)
-	tokensForUserChan := make(chan tokenForUser)
-	errChan := make(chan error)
-	done := make(chan struct{})
-	wp := workerpool.New(100)
-
-	mu := &sync.Mutex{}
-
-	ownerAddresses := make([]string, 0, len(tokens))
-
-	for _, chainToken := range tokens {
-		for _, token := range chainToken.tokens {
-			ownerAddresses = append(ownerAddresses, token.OwnerAddress.String())
-		}
-	}
-
-	// get all current users
-
-	allCurrentUsers, err := p.Queries.GetUsersByChainAddresses(ctx, db.GetUsersByChainAddressesParams{
-		Addresses: ownerAddresses,
-		L1Chain:   chain.L1Chain(),
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// figure out which users are not in the database
-
-	addressesToUsers := map[string]persist.User{}
-
-	for _, user := range allCurrentUsers {
-		traits := persist.Traits{}
-		err = user.Traits.AssignTo(&traits)
-		if err != nil {
-			return nil, nil, err
-		}
-		addressesToUsers[string(user.Address)] = persist.User{
-			Version:            persist.NullInt32(user.Version.Int32),
-			ID:                 user.ID,
-			CreationTime:       user.CreatedAt,
-			Deleted:            persist.NullBool(user.Deleted),
-			LastUpdated:        user.LastUpdated,
-			Username:           persist.NullString(user.Username.String),
-			UsernameIdempotent: persist.NullString(user.UsernameIdempotent.String),
-			Wallets:            user.Wallets,
-			Bio:                persist.NullString(user.Bio.String),
-			Traits:             traits,
-			Universal:          persist.NullBool(user.Universal),
-		}
-	}
-
-	logger.For(ctx).Debugf("found %d users", len(addressesToUsers))
-
-	// create users for those that are not in the database
-
-	for _, chainToken := range tokens {
-		resolvers := matchingProvidersForChain[NameResolver](p.Chains, chainToken.chain)
-
-		for _, agnosticToken := range chainToken.tokens {
-			if agnosticToken.OwnerAddress == "" {
-				continue
-			}
-			tid := persist.TokenUniqueIdentifiers{Chain: chainToken.chain, ContractAddress: agnosticToken.ContractAddress, TokenID: agnosticToken.TokenID, OwnerAddress: agnosticToken.OwnerAddress}
-			if seenTokens[tid] {
-				continue
-			}
-			seenTokens[tid] = true
-			ct := chainToken
-			t := agnosticToken
-			wp.Submit(func() {
-				user, ok := addressesToUsers[string(t.OwnerAddress)]
-				if !ok {
-					username := t.OwnerAddress.String()
-					for _, resolver := range resolvers {
-						doBreak := func() bool {
-							displayCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-							defer cancel()
-							display := resolver.GetDisplayNameByAddress(displayCtx, t.OwnerAddress)
-
-							// if display is an empty address, this will return empty
-							displayCopy := strings.TrimLeft(display, "0x")
-							displayCopy = strings.TrimRight(displayCopy, "0")
-							if displayCopy != "" {
-								username = display
-								return true
-							}
-							return false
-						}()
-						if doBreak {
-							break
-						}
-					}
-					func() {
-						mu.Lock()
-						defer mu.Unlock()
-						userID, err := p.Repos.UserRepository.Create(ctx, persist.CreateUserInput{
-							Username:     username,
-							ChainAddress: persist.NewChainAddress(t.OwnerAddress, ct.chain),
-							Universal:    true,
-						}, nil)
-						if err != nil {
-							if _, ok := err.(persist.ErrUsernameNotAvailable); ok {
-								logger.For(ctx).Infof("username %s not available", username)
-								user, err = p.Repos.UserRepository.GetByUsername(ctx, username)
-								if err != nil {
-									errChan <- err
-									return
-								}
-							} else if _, ok := err.(persist.ErrAddressOwnedByUser); ok {
-								logger.For(ctx).Infof("address %s already owned by user", t.OwnerAddress)
-								user, err = p.Repos.UserRepository.GetByChainAddress(ctx, persist.NewL1ChainAddress(t.OwnerAddress, ct.chain))
-								if err != nil {
-									errChan <- err
-									return
-								}
-							} else if _, ok := err.(persist.ErrWalletCreateFailed); ok {
-								logger.For(ctx).Infof("wallet creation failed for address %s", t.OwnerAddress)
-								user, err = p.Repos.UserRepository.GetByChainAddress(ctx, persist.NewL1ChainAddress(t.OwnerAddress, ct.chain))
-								if err != nil {
-									errChan <- err
-									return
-								}
-							} else {
-								errChan <- err
-								return
-							}
-						} else {
-							user, err = p.Repos.UserRepository.GetByID(ctx, userID)
-							if err != nil {
-								errChan <- err
-								return
-							}
-						}
-					}()
-				}
-
-				err = p.Repos.UserRepository.FillWalletDataForUser(ctx, &user)
-				if err != nil {
-					errChan <- err
-					return
-				}
-				userChan <- user
-				tokensForUserChan <- tokenForUser{
-					userID:   user.ID,
-					token:    t,
-					chain:    ct.chain,
-					priority: ct.priority,
-				}
-			})
-		}
-	}
-
-	go func() {
-		defer close(done)
-		wp.StopWait()
-	}()
-
-outer:
-	for {
-		select {
-		case user := <-userChan:
-			logger.For(ctx).Debugf("got user %s", user.Username)
-			users[user.ID] = user
-			if userTokens[user.ID] == nil {
-				userTokens[user.ID] = map[int]chainTokens{}
-			}
-		case token := <-tokensForUserChan:
-			chainTokensForUser := userTokens[token.userID]
-			tokensInChainTokens, ok := chainTokensForUser[token.priority]
-			if !ok {
-				tokensInChainTokens = chainTokens{chain: token.chain, tokens: []ChainAgnosticToken{}, priority: token.priority}
-			}
-			tokensInChainTokens.tokens = append(tokensInChainTokens.tokens, token.token)
-			chainTokensForUser[token.priority] = tokensInChainTokens
-			userTokens[token.userID] = chainTokensForUser
-		case err := <-errChan:
-			return nil, nil, err
-		case <-done:
-			break outer
-		}
-	}
-
-	chainTokensForUser := map[persist.DBID][]chainTokens{}
-	for userID, chainTokens := range userTokens {
-		for _, chainToken := range chainTokens {
-			chainTokensForUser[userID] = append(chainTokensForUser[userID], chainToken)
-		}
-	}
-
-	logger.For(ctx).Infof("created %d users for tokens", len(users))
-	return chainTokensForUser, users, nil
 }
 
 // matchingWallets returns wallet addresses that belong to any of the passed chains
@@ -2176,38 +1836,6 @@ func mergeContractMetadata(lower contractMetadata, higher contractMetadata) cont
 	}
 
 	return lower
-}
-
-func tokenHoldersToTokenHolders(ctx context.Context, owners []persist.TokenHolder, userRepo *postgres.UserRepository) ([]TokenHolder, error) {
-	seenUsers := make(map[persist.DBID]persist.TokenHolder)
-	allUserIDs := make([]persist.DBID, 0, len(owners))
-	for _, owner := range owners {
-		if _, ok := seenUsers[owner.UserID]; !ok {
-			allUserIDs = append(allUserIDs, owner.UserID)
-			seenUsers[owner.UserID] = owner
-		}
-	}
-	allUsers, err := userRepo.GetByIDs(ctx, allUserIDs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get users for token holders: %s", err)
-	}
-	res := make([]TokenHolder, 0, len(seenUsers))
-	for _, user := range allUsers {
-		owner := seenUsers[user.ID]
-		username := user.Username.String()
-		previews := make([]string, 0, len(owner.PreviewTokens))
-		for _, p := range owner.PreviewTokens {
-			previews = append(previews, p.String())
-		}
-		res = append(res, TokenHolder{
-			UserID:        owner.UserID,
-			DisplayName:   username,
-			WalletIDs:     owner.WalletIDs,
-			PreviewTokens: previews,
-		})
-	}
-
-	return res, nil
 }
 
 func (t ChainAgnosticIdentifiers) String() string {

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -4,142 +4,111 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"math/big"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
-	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/mikeydub/go-gallery/contracts"
 	"github.com/mikeydub/go-gallery/env"
-	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
-	"github.com/sirupsen/logrus"
 	"github.com/sourcegraph/conc/pool"
 )
-
-var client = http.DefaultClient
-
-var ErrAPIKeyExpired = errors.New("opensea api key expired")
 
 func init() {
 	env.RegisterValidation("OPENSEA_API_KEY", "required")
 }
 
-var baseURL, _ = url.Parse("https://api.opensea.io/api/v1")
+var ErrAPIKeyExpired = errors.New("opensea api key expired")
 
-var eip1271MagicValue = [4]byte{0x16, 0x26, 0xBA, 0x7E}
+var (
+	baseURL, _                        = url.Parse("https://api.opensea.io/api/v2")
+	getContractEndpointTemplate       = fmt.Sprintf("%s/%s", baseURL.String(), "chain/%s/contract/%s")
+	getCollectionEndpointTemplate     = fmt.Sprintf("%s/%s", baseURL.String(), "collections/%s")
+	getNftEndpointTemplate            = fmt.Sprintf("%s/%s", baseURL.String(), "chain/%s/contract/%s/nfts/%s")
+	getNftsByWalletEndpointTemplate   = fmt.Sprintf("%s/%s", baseURL.String(), "chain/%s/account/%s/nfts")
+	getNftsByContractEndpointTemplate = fmt.Sprintf("%s/%s", baseURL.String(), "chain/%s/contract/%s/nfts")
+)
 
-var sharedStoreFrontAddresses = []persist.EthereumAddress{
-	"0x09200b963c52d3297a93af71f919e7829c53cf9a",
-	"0x37530eef6290a0be43d481e8feb5597c3a05f03e",
-	"0x495f947276749ce646f68ac8c248420045cb7b5e",
-	"0x4bea754665a141bf4837e743f8ca08507e8afb01",
-	"0x5e30b1d6f920364c847512e2528efdadf72a97a9",
-	"0x80fa4ab88378853d97e30a9f002b084b1a4efd00",
-	"0x8798093380deea4af4007b8e874643c61ea2dae8",
-	"0xfda7a5ecd561af6a17506a686ad0a648857dcc14",
+func getContractEndpoint(chain persist.Chain, address persist.Address) (*url.URL, error) {
+	s := fmt.Sprintf(getContractEndpointTemplate, mustChainIdentifierFrom(chain), address)
+	return url.Parse(s)
+}
+
+func getCollectionEndpoint(slug string) (*url.URL, error) {
+	s := fmt.Sprintf(getCollectionEndpointTemplate, slug)
+	return url.Parse(s)
+}
+
+func getNftEndpoint(chain persist.Chain, address persist.Address, tokenID persist.TokenID) (*url.URL, error) {
+	s := fmt.Sprintf(getNftEndpointTemplate, mustChainIdentifierFrom(chain), address, tokenID.Base10String())
+	return url.Parse(s)
+}
+
+func getNftsByWalletEndpoint(chain persist.Chain, address persist.Address) (*url.URL, error) {
+	s := fmt.Sprintf(getNftsByWalletEndpointTemplate, mustChainIdentifierFrom(persist.ChainETH), address)
+	return url.Parse(s)
+}
+
+func getNftsByContractEndpoint(chain persist.Chain, address persist.Address) (*url.URL, error) {
+	s := fmt.Sprintf(getNftsByContractEndpointTemplate, mustChainIdentifierFrom(chain), address)
+	return url.Parse(s)
 }
 
 type Provider struct {
 	httpClient *http.Client
-	ethClient  *ethclient.Client
 	chain      persist.Chain
 }
 
-// TokenID represents a token ID from Opensea. It is separate from persist.TokenID because opensea returns token IDs in base 10 format instead of what we want, base 16
-type TokenID string
+// TokenIdentifer represents a token identifer from Opensea. It is separate from persist.TokenID because opensea returns token IDs in base 10 format instead of what we want, base 16
+type TokenIdentifer string
 
-// Assets is a list of NFTs from OpenSea
-type Assets struct {
-	Next   string  `json:"next"`
-	Assets []Asset `json:"assets"`
+// TokenID coverts an OpenSea token identifier to a persist.TokenID and panics if it fails
+func (t TokenIdentifer) MustTokenID() persist.TokenID {
+	asBig, ok := new(big.Int).SetString(string(t), 10)
+	if !ok {
+		panic("failed to convert opensea token id to big int")
+	}
+	return persist.TokenID(asBig.Text(16))
 }
 
 // Asset is an NFT from OpenSea
 type Asset struct {
-	Version int64 `json:"version"` // schema version for this model
-	ID      int   `json:"id"`
-
-	Name        string `json:"name"`
-	Description string `json:"description"`
-
-	ExternalURL      string     `json:"external_link"`
-	TokenMetadataURL string     `json:"token_metadata"`
-	Creator          Account    `json:"creator"`
-	Owner            Account    `json:"owner"`
-	Contract         Contract   `json:"asset_contract"`
-	Collection       Collection `json:"collection"`
-
-	// OPEN_SEA_TOKEN_ID
-	// https://api.opensea.io/api/v1/asset/0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270/26000331
-	// (/asset/:contract_address/:token_id)
-	TokenID TokenID `json:"token_id"`
-
-	// IMAGES - OPENSEA
-	ImageURL             string `json:"image_url"`
-	ImageThumbnailURL    string `json:"image_thumbnail_url"`
-	ImagePreviewURL      string `json:"image_preview_url"`
-	ImageOriginalURL     string `json:"image_original_url"`
-	AnimationURL         string `json:"animation_url"`
-	AnimationOriginalURL string `json:"animation_original_url"`
-
-	Orders []Order `json:"orders"`
-
-	AcquisitionDateStr string `json:"acquisition_date"`
-}
-
-// Events is a list of events from OpenSea
-type Events struct {
-	Events []Event `json:"asset_events"`
-}
-
-// Event is an event from OpenSea
-type Event struct {
-	Asset       Asset   `json:"asset"`
-	FromAccount Account `json:"from_account"`
-	ToAccount   Account `json:"to_account"`
-	CreatedDate string  `json:"created_date"`
-}
-
-// Account is a user account from OpenSea
-type Account struct {
-	User    User                    `json:"user"`
-	Address persist.EthereumAddress `json:"address"`
-}
-
-// User is a user from OpenSea
-type User struct {
-	Username string `json:"username"`
-}
-
-// Order is an order from OpenSea representing an NFT's maker and buyer
-type Order struct {
-	Maker Account `json:"maker"`
-	Taker Account `json:"taker"`
+	Identifier    TokenIdentifer `json:"identifier"`
+	Collection    string         `json:"collection"`
+	Contract      string         `json:"contract"`
+	TokenStandard string         `json:"token_standard"`
+	Name          string         `json:"name"`
+	Description   string         `json:"description"`
+	ImageURL      string         `json:"image_url"`
+	MetadataURL   string         `json:"metadata_url"`
+	OpenSeaURL    string         `json:"opensea_url"`
+	IsDisabled    bool           `json:"is_disabled"`
+	IsNSFW        bool           `json:"is_nsfw"`
 }
 
 // Collection is a collection from OpenSea
 type Collection struct {
-	Name                  string                  `json:"name"`
-	Description           string                  `json:"description"`
-	PayoutAddress         persist.EthereumAddress `json:"payout_address"`
-	PrimaryAssetContracts []Contract              `json:"primary_asset_contracts"`
-	Slug                  string                  `json:"slug"`
-	ImageURL              string                  `json:"image_url"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Owner       string `json:"owner"`
+	ImageURL    string `json:"image_url"`
 }
+
+// Contract represents an NFT contract from Opensea
+type Contract struct {
+	Address         persist.Address `json:"address"`
+	ChainIdentifier ChainIdentifier `json:"chain_identifier"`
+	Collection      string          `json:"collection"`
+	Name            string          `json:"name"`
+	Supply          int             `json:"supply"`
+}
+
 type ChainIdentifier string
 
 const (
@@ -168,34 +137,22 @@ func (c ChainIdentifier) Chain() persist.Chain {
 	}
 }
 
-// Contract represents an NFT contract from Opensea
-type Contract struct {
-	Collection      Collection              `json:"collection"`
-	Address         persist.EthereumAddress `json:"address"`
-	Symbol          string                  `json:"symbol"`
-	Name            string                  `json:"name"`
-	SchemaName      string                  `json:"schema_name"`
-	ChainIdentifier ChainIdentifier         `json:"chain_identifier"`
+var chainToChainIndentifier = map[persist.Chain]ChainIdentifier{
+	persist.ChainETH: ChainIdentifierEthereum,
 }
 
-type assetsReceieved struct {
-	assets []Asset
-	err    error
-}
-
-// ErrNoAssetsForWallets is returned when opensea returns an empty array of assets for a wallet address
-type ErrNoAssetsForWallets struct {
-	Wallets []persist.EthereumAddress
-}
-
-// NewProvider creates a new provider for opensea
-func NewProvider(ethClient *ethclient.Client, httpClient *http.Client, chain persist.Chain) *Provider {
-	client = httpClient
-	return &Provider{
-		httpClient: httpClient,
-		ethClient:  ethClient,
-		chain:      chain,
+func mustChainIdentifierFrom(c persist.Chain) ChainIdentifier {
+	id, ok := chainToChainIndentifier[c]
+	if !ok {
+		panic(fmt.Sprintf("unknown chain identifier: %s", c))
 	}
+	return id
+}
+
+// NewProvider creates a new provider for OpenSea
+func NewProvider(httpClient *http.Client, chain persist.Chain) *Provider {
+	mustChainIdentifierFrom(chain) // validate that the chain is supported
+	return &Provider{httpClient: httpClient, chain: chain}
 }
 
 // GetBlockchainInfo returns Ethereum blockchain info
@@ -208,39 +165,36 @@ func (p *Provider) GetBlockchainInfo() multichain.BlockchainInfo {
 }
 
 // GetTokensByWalletAddress returns a list of tokens for a wallet address
-func (p *Provider) GetTokensByWalletAddress(ctx context.Context, address persist.Address) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
-	assetsChan := make(chan assetsReceieved)
+func (p *Provider) GetTokensByWalletAddress(ctx context.Context, walletAddress persist.Address) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+	outCh := make(chan assetsReceived)
 	go func() {
-		defer close(assetsChan)
-		streamAssetsForWallet(ctx, persist.EthereumAddress(address), assetsChan)
+		defer close(outCh)
+		streamAssetsForWallet(ctx, p.httpClient, p.chain, walletAddress, outCh)
 	}()
-
-	return assetsToTokens(ctx, address, assetsChan, p.ethClient, p.chain)
+	return assetsToTokens(ctx, walletAddress, outCh)
 }
 
 // GetTokensIncrementallyByWalletAddress returns a list of tokens for a wallet address
-func (p *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, address persist.Address) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
-	rec := make(chan multichain.ChainAgnosticTokensAndContracts)
-	errChan := make(chan error)
-
-	assetsChan := make(chan assetsReceieved)
+func (p *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, walletAddress persist.Address) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
+	recCh := make(chan multichain.ChainAgnosticTokensAndContracts)
+	errCh := make(chan error)
+	outCh := make(chan assetsReceived)
 	go func() {
-		defer close(assetsChan)
-		streamAssetsForWallet(ctx, persist.EthereumAddress(address), assetsChan)
+		defer close(outCh)
+		streamAssetsForWallet(ctx, p.httpClient, p.chain, walletAddress, outCh)
 	}()
-
-	go streamAssetsToTokens(ctx, address, assetsChan, p.ethClient, p.chain, rec, errChan)
-	return rec, errChan
+	go streamAssetsToTokens(ctx, walletAddress, outCh, recCh, errCh)
+	return recCh, errCh
 }
 
 // GetTokensByContractAddress returns a list of tokens for a contract address
-func (p *Provider) GetTokensByContractAddress(ctx context.Context, address persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	assetsChan := make(chan assetsReceieved)
+func (p *Provider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	outCh := make(chan assetsReceived)
 	go func() {
-		defer close(assetsChan)
-		streamAssetsForContract(ctx, persist.EthereumAddress(address), assetsChan)
+		defer close(outCh)
+		streamAssetsForContract(ctx, p.httpClient, p.chain, contractAddress, outCh)
 	}()
-	tokens, contracts, err := assetsToTokens(ctx, "", assetsChan, p.ethClient, p.chain)
+	tokens, contracts, err := assetsToTokens(ctx, "", outCh)
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
@@ -252,13 +206,13 @@ func (p *Provider) GetTokensByContractAddress(ctx context.Context, address persi
 }
 
 // GetTokensByContractAddressAndOwner returns a list of tokens for a contract address and owner
-func (p *Provider) GetTokensByContractAddressAndOwner(ctx context.Context, owner, address persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	assetsChan := make(chan assetsReceieved)
+func (p *Provider) GetTokensByContractAddressAndOwner(ctx context.Context, walletAddress, contractAddress persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	outCh := make(chan assetsReceived)
 	go func() {
-		defer close(assetsChan)
-		streamAssetsForContractAddressAndOwner(ctx, persist.EthereumAddress(owner), persist.EthereumAddress(address), assetsChan)
+		defer close(outCh)
+		streamAssetsForContractAddressAndOwner(ctx, p.httpClient, p.chain, walletAddress, contractAddress, outCh)
 	}()
-	tokens, contracts, err := assetsToTokens(ctx, owner, assetsChan, p.ethClient, p.chain)
+	tokens, contracts, err := assetsToTokens(ctx, walletAddress, outCh)
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
@@ -271,12 +225,12 @@ func (p *Provider) GetTokensByContractAddressAndOwner(ctx context.Context, owner
 
 // GetTokensByTokenIdentifiers returns a list of tokens for a list of token identifiers
 func (p *Provider) GetTokensByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	assetsChan := make(chan assetsReceieved)
+	outCh := make(chan assetsReceived)
 	go func() {
-		defer close(assetsChan)
-		streamAssetsForTokenIdentifiers(ctx, persist.EthereumAddress(ti.ContractAddress), TokenID(ti.TokenID.Base10String()), assetsChan)
+		defer close(outCh)
+		streamAssetsForToken(ctx, p.httpClient, p.GetBlockchainInfo().Chain, ti.ContractAddress, ti.TokenID, outCh)
 	}()
-	tokens, contracts, err := assetsToTokens(ctx, "", assetsChan, p.ethClient, p.chain)
+	tokens, contracts, err := assetsToTokens(ctx, "", outCh)
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
@@ -287,13 +241,13 @@ func (p *Provider) GetTokensByTokenIdentifiers(ctx context.Context, ti multichai
 	return tokens, contract, nil
 }
 
-func (p *Provider) GetTokenByTokenIdentifiersAndOwner(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, ownerAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	assetsChan := make(chan assetsReceieved)
+func (p *Provider) GetTokenByTokenIdentifiersAndOwner(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, walletAddress persist.Address) (multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	outCh := make(chan assetsReceived)
 	go func() {
-		defer close(assetsChan)
-		streamAssetsForTokenIdentifiersAndOwner(ctx, persist.EthereumAddress(ownerAddress), persist.EthereumAddress(ti.ContractAddress), TokenID(ti.TokenID.Base10String()), assetsChan)
+		defer close(outCh)
+		streamAssetsForTokenIdentifiersAndOwner(ctx, p.httpClient, p.chain, walletAddress, ti.ContractAddress, ti.TokenID, outCh)
 	}()
-	tokens, contracts, err := assetsToTokens(ctx, ownerAddress, assetsChan, p.ethClient, p.chain)
+	tokens, contracts, err := assetsToTokens(ctx, walletAddress, outCh)
 	if err != nil {
 		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, err
 	}
@@ -322,12 +276,29 @@ func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti mu
 }
 
 // GetContractByAddress returns a contract for a contract address
-func (p *Provider) GetContractByAddress(ctx context.Context, contract persist.Address) (multichain.ChainAgnosticContract, error) {
-	c, err := FetchContractByAddress(ctx, persist.EthereumAddress(contract))
+func (p *Provider) GetContractByAddress(ctx context.Context, contractAddress persist.Address) (multichain.ChainAgnosticContract, error) {
+	contract, err := fetchContractByAddress(ctx, p.httpClient, p.chain, contractAddress)
 	if err != nil {
 		return multichain.ChainAgnosticContract{}, err
 	}
-	return contractToContract(ctx, c, p.ethClient)
+
+	collection, err := fetchCollectionBySlug(ctx, p.httpClient, p.chain, contract.Collection)
+	if err != nil {
+		return multichain.ChainAgnosticContract{}, err
+	}
+
+	desc := multichain.ChainAgnosticContractDescriptors{
+		Symbol:       "TODO",
+		Name:         contract.Name,
+		Description:  collection.Description,
+		OwnerAddress: persist.Address(collection.Owner),
+	}
+
+	return multichain.ChainAgnosticContract{
+		Address:     persist.Address(contract.Address.String()),
+		Descriptors: desc,
+		IsSpam:      util.ToPointer(contractNameIsSpam(contract.Name)),
+	}, nil
 }
 
 func (d *Provider) GetOwnedTokensByContract(context.Context, persist.Address, persist.Address, int, int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
@@ -338,365 +309,180 @@ func (d *Provider) GetDisplayNameByAddress(ctx context.Context, addr persist.Add
 	return addr.String()
 }
 
-func (p *Provider) IsOpenSea() {}
-
-// GetChildContractsCreatedOnSharedContract returns a tokens created by the address under the Shared Storefront contract
-func (p *Provider) GetChildContractsCreatedOnSharedContract(ctx context.Context, creatorAddress persist.Address) ([]multichain.ParentToChildEdge, error) {
-	assetsChan := make(chan assetsReceieved)
-	go func() {
-		defer close(assetsChan)
-		streamAssetsForSharedContract(ctx, persist.EthereumAddress(creatorAddress), assetsChan)
-	}()
-	return assetsByChildContract(ctx, assetsChan, p.ethClient, creatorAddress)
-}
-
-// VerifySignature will verify a signature using all available methods (eth_sign and personal_sign)
-func (p *Provider) VerifySignature(pCtx context.Context,
-	pAddressStr persist.PubKey, pWalletType persist.WalletType, pNonce string, pSignatureStr string) (bool, error) {
-
-	nonce := auth.NewNoncePrepend + pNonce
-	// personal_sign
-	validBool, err := verifySignature(pSignatureStr,
-		nonce,
-		pAddressStr.String(), pWalletType,
-		true, p.ethClient)
-
-	if !validBool || err != nil {
-		// eth_sign
-		validBool, err = verifySignature(pSignatureStr,
-			nonce,
-			pAddressStr.String(), pWalletType,
-			false, p.ethClient)
-		if err != nil || !validBool {
-			nonce = auth.NoncePrepend + pNonce
-			validBool, err = verifySignature(pSignatureStr,
-				nonce,
-				pAddressStr.String(), pWalletType,
-				true, p.ethClient)
-			if err != nil || !validBool {
-				validBool, err = verifySignature(pSignatureStr,
-					nonce,
-					pAddressStr.String(), pWalletType,
-					false, p.ethClient)
-			}
-		}
-	}
-
-	if err != nil {
-		return false, err
-	}
-
-	return validBool, nil
-}
-
-func verifySignature(pSignatureStr string,
-	pData string,
-	pAddress string, pWalletType persist.WalletType,
-	pUseDataHeaderBool bool, ec *ethclient.Client) (bool, error) {
-
-	// eth_sign:
-	// - https://goethereumbook.org/signature-verify/
-	// - http://man.hubwiz.com/docset/Ethereum.docset/Contents/Resources/Documents/eth_sign.html
-	// - sign(keccak256("\x19Ethereum Signed Message:\n" + len(message) + message)))
-
-	var data string
-	if pUseDataHeaderBool {
-		data = fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", len(pData), pData)
-	} else {
-		data = pData
-	}
-
-	switch pWalletType {
-	case persist.WalletTypeEOA:
-		dataHash := crypto.Keccak256Hash([]byte(data))
-
-		sig, err := hexutil.Decode(pSignatureStr)
-		if err != nil {
-			return false, err
-		}
-		// Ledger-produced signatures have v = 0 or 1
-		if sig[64] == 0 || sig[64] == 1 {
-			sig[64] += 27
-		}
-		v := sig[64]
-		if v != 27 && v != 28 {
-			return false, errors.New("invalid signature (V is not 27 or 28)")
-		}
-		sig[64] -= 27
-
-		sigPublicKeyECDSA, err := crypto.SigToPub(dataHash.Bytes(), sig)
-		if err != nil {
-			return false, err
-		}
-
-		pubkeyAddressHexStr := crypto.PubkeyToAddress(*sigPublicKeyECDSA).Hex()
-		log.Println("pubkeyAddressHexStr:", pubkeyAddressHexStr)
-		log.Println("pAddress:", pAddress)
-		if !strings.EqualFold(pubkeyAddressHexStr, pAddress) {
-			return false, auth.ErrAddressSignatureMismatch
-		}
-
-		publicKeyBytes := crypto.CompressPubkey(sigPublicKeyECDSA)
-
-		signatureNoRecoverID := sig[:len(sig)-1]
-
-		return crypto.VerifySignature(publicKeyBytes, dataHash.Bytes(), signatureNoRecoverID), nil
-	case persist.WalletTypeGnosis:
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		sigValidator, err := contracts.NewISignatureValidator(common.HexToAddress(pAddress), ec)
-		if err != nil {
-			return false, err
-		}
-
-		hashedData := crypto.Keccak256([]byte(data))
-		var input [32]byte
-		copy(input[:], hashedData)
-
-		result, err := sigValidator.IsValidSignature(&bind.CallOpts{Context: ctx}, input, []byte{})
-		if err != nil {
-			logrus.WithError(err).Error("IsValidSignature")
-			return false, nil
-		}
-
-		return result == eip1271MagicValue, nil
-	default:
-		return false, errors.New("wallet type not supported")
-	}
-}
-
-func FetchAssetsForWallet(ctx context.Context, address persist.EthereumAddress) ([]Asset, error) {
-	outCh := make(chan assetsReceieved)
+func FetchAssetsForTokenIdentifiers(ctx context.Context, chain persist.Chain, contractAddress persist.Address, tokenID persist.TokenID) ([]Asset, error) {
+	outCh := make(chan assetsReceived)
 
 	go func() {
 		defer close(outCh)
-		streamAssetsForWallet(ctx, address, outCh)
+		streamAssetsForToken(ctx, http.DefaultClient, chain, contractAddress, tokenID, outCh)
 	}()
 
 	assets := make([]Asset, 0)
 	for a := range outCh {
-		if a.err != nil {
-			return nil, a.err
+		if a.Err != nil {
+			return nil, a.Err
 		}
-		assets = append(assets, a.assets...)
+		assets = append(assets, a.Assets...)
 	}
 
 	return assets, nil
 }
 
-func FetchAssetsForTokenIdentifiers(ctx context.Context, contractAddress persist.EthereumAddress, tokenID TokenID) ([]Asset, error) {
-	outCh := make(chan assetsReceieved)
-
-	go func() {
-		defer close(outCh)
-		streamAssetsForToken(ctx, contractAddress, tokenID, outCh)
-	}()
-
-	assets := make([]Asset, 0)
-	for a := range outCh {
-		if a.err != nil {
-			return nil, a.err
-		}
-		assets = append(assets, a.assets...)
+func fetchContractByAddress(ctx context.Context, client *http.Client, chain persist.Chain, contractAddress persist.Address) (Contract, error) {
+	endpoint, err := getContractEndpoint(chain, contractAddress)
+	if err != nil {
+		return Contract{}, err
 	}
 
-	return assets, nil
-}
-
-// FetchContractByAddress fetches a contract by address
-func FetchContractByAddress(pCtx context.Context, pContract persist.EthereumAddress) (Contract, error) {
-	url := baseURL.JoinPath("asset_contract", pContract.String())
-
-	req := authRequest(pCtx, url.String())
-
-	resp, err := retry.RetryRequest(http.DefaultClient, req)
+	resp, err := retry.RetryRequest(client, authRequest(ctx, endpoint))
 	if err != nil {
-		return Contract{}, fmt.Errorf("err retrying: %w", err)
+		return Contract{}, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return Contract{}, fmt.Errorf("error status: %s %w", resp.Status, util.BodyAsError(resp))
+		return Contract{}, util.ErrHTTP{
+			URL:    endpoint.String(),
+			Status: resp.StatusCode,
+			Err:    util.BodyAsError(resp),
+		}
 	}
 
 	contract := Contract{}
 	err = util.UnmarshallBody(&contract, resp.Body)
 	if err != nil {
-		return Contract{}, fmt.Errorf("err unmarshalling: %w", err)
+		return Contract{}, err
 	}
 
 	return contract, nil
 }
 
-func streamAssetsForToken(ctx context.Context, address persist.EthereumAddress, tokenID TokenID, out chan assetsReceieved) {
-	url := baseURL.JoinPath("assets")
-	setPagingParams(url)
-	setContractAddress(url, address)
-	setTokenID(url, tokenID)
-	paginateAssets(ctx, authRequest(ctx, url.String()), out)
-}
-
-func streamAssetsForWallet(ctx context.Context, address persist.EthereumAddress, out chan assetsReceieved) {
-	url := baseURL.JoinPath("assets")
-	setPagingParams(url)
-	setOwner(url, address)
-	paginateAssets(ctx, authRequest(ctx, url.String()), out)
-}
-
-func streamAssetsForContract(ctx context.Context, address persist.EthereumAddress, out chan assetsReceieved) {
-	url := baseURL.JoinPath("assets")
-	setPagingParams(url)
-	setContractAddress(url, address)
-	paginateAssets(ctx, authRequest(ctx, url.String()), out)
-}
-
-func streamAssetsForContractAddressAndOwner(ctx context.Context, ownerAddress, contractAddress persist.EthereumAddress, out chan assetsReceieved) {
-	url := baseURL.JoinPath("assets")
-	setPagingParams(url)
-	setOwner(url, ownerAddress)
-	setContractAddress(url, contractAddress)
-	paginateAssets(ctx, authRequest(ctx, url.String()), out)
-}
-
-func streamAssetsForTokenIdentifiers(ctx context.Context, contractAddress persist.EthereumAddress, tokenID TokenID, out chan assetsReceieved) {
-	url := baseURL.JoinPath("assets")
-	setPagingParams(url)
-	setContractAddress(url, contractAddress)
-	setTokenID(url, tokenID)
-	paginateAssets(ctx, authRequest(ctx, url.String()), out)
-}
-
-func streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, ownerAddress, contractAddress persist.EthereumAddress, tokenID TokenID, out chan assetsReceieved) {
-	url := baseURL.JoinPath("assets")
-	setPagingParams(url)
-	setContractAddress(url, contractAddress)
-	setTokenID(url, tokenID)
-	if ownerAddress != "" {
-		setOwner(url, ownerAddress)
-	}
-	paginateAssets(ctx, authRequest(ctx, url.String()), out)
-}
-
-func streamAssetsForSharedContract(ctx context.Context, editorAddress persist.EthereumAddress, out chan assetsReceieved) {
-	url := baseURL.JoinPath("assets")
-	setPagingParams(url)
-	setCollectionEditor(url, editorAddress)
-	for _, address := range sharedStoreFrontAddresses {
-		addContractAddresses(url, address)
-	}
-	paginateAssets(ctx, authRequest(ctx, url.String()), out)
-}
-
-// assetsByChildContract converts a channel of assets to a slice of sub-contract groups
-func assetsByChildContract(ctx context.Context, assetsChan <-chan assetsReceieved, ethClient *ethclient.Client, creatorAddress persist.Address) ([]multichain.ParentToChildEdge, error) {
-	block, err := ethClient.BlockNumber(ctx)
+func fetchCollectionBySlug(ctx context.Context, client *http.Client, chain persist.Chain, slug string) (Collection, error) {
+	endpoint, err := getCollectionEndpoint(slug)
 	if err != nil {
-		return nil, err
+		return Collection{}, err
 	}
 
-	childIdx := make(map[string]int)
-	parents := make(map[persist.EthereumAddress]multichain.ParentToChildEdge)
+	resp, err := retry.RetryRequest(client, authRequest(ctx, endpoint))
+	if err != nil {
+		return Collection{}, err
+	}
+	defer resp.Body.Close()
 
-	for page := range assetsChan {
-
-		if page.err != nil {
-			return nil, err
-		}
-
-		for _, asset := range page.assets {
-			// We override the owner of the token with the creator of the token
-			token, err := assetToToken(asset, persist.BlockNumber(block), creatorAddress)
-
-			var unknownSchemaErr unknownContractSchemaError
-			if errors.As(err, &unknownSchemaErr) {
-				continue
-			}
-			if err != nil {
-				return nil, err
-			}
-
-			parentAddress := asset.Contract.Address
-
-			// Found a new parent
-			if _, seen := parents[parentAddress]; !seen {
-				parents[parentAddress] = multichain.ParentToChildEdge{
-					Parent:   contractFromAsset(asset, persist.BlockNumber(block)),
-					Children: make([]multichain.ChildContract, 0),
-				}
-			}
-
-			childID := asset.Collection.Slug
-
-			// Found a new child
-			if _, seen := childIdx[childID]; !seen {
-				parent := parents[parentAddress]
-				parent.Children = append(parent.Children, multichain.ChildContract{
-					ChildID:        childID,
-					Name:           asset.Collection.Name,
-					Description:    asset.Collection.Description,
-					OwnerAddress:   creatorAddress,
-					CreatorAddress: creatorAddress,
-					Tokens:         make([]multichain.ChainAgnosticToken, 0),
-				})
-				parents[parentAddress] = parent
-				childIdx[childID] = len(parent.Children) - 1
-			}
-
-			// Add the token
-			idx := childIdx[childID]
-			parents[parentAddress].Children[idx].Tokens = append(parents[parentAddress].Children[idx].Tokens, token)
+	if resp.StatusCode != http.StatusOK {
+		return Collection{}, util.ErrHTTP{
+			URL:    endpoint.String(),
+			Status: resp.StatusCode,
+			Err:    util.BodyAsError(resp),
 		}
 	}
 
-	edges := make([]multichain.ParentToChildEdge, 0)
-	for _, edge := range parents {
-		edges = append(edges, edge)
+	collection := Collection{}
+	err = util.UnmarshallBody(&collection, resp.Body)
+	if err != nil {
+		return Collection{}, err
 	}
 
-	return edges, nil
+	return collection, nil
 }
 
-type unknownContractSchemaError struct {
-	schema string
+func streamAssetsForToken(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
+	endpoint, err := getNftEndpoint(chain, address, tokenID)
+	if err != nil {
+		outCh <- assetsReceived{Err: err}
+		return
+	}
+	paginateAssets(ctx, client, authRequest(ctx, endpoint), outCh)
 }
 
-func (e unknownContractSchemaError) Error() string {
-	return fmt.Sprintf("unknown token type: %s", e.schema)
+func streamAssetsForWallet(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, outCh chan assetsReceived) {
+	endpoint, err := getNftsByWalletEndpoint(chain, address)
+	if err != nil {
+		outCh <- assetsReceived{Err: err}
+		return
+	}
+	setPagingParams(endpoint)
+	paginateAssets(ctx, client, authRequest(ctx, endpoint), outCh)
+}
+
+func streamAssetsForContract(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, outCh chan assetsReceived) {
+	endpoint, err := getNftsByContractEndpoint(chain, address)
+	if err != nil {
+		outCh <- assetsReceived{Err: err}
+		return
+	}
+	setPagingParams(endpoint)
+	paginateAssets(ctx, client, authRequest(ctx, endpoint), outCh)
+}
+
+func streamAssetsForContractAddressAndOwner(ctx context.Context, client *http.Client, chain persist.Chain, ownerAddress, contractAddress persist.Address, outCh chan assetsReceived) {
+	contract, err := fetchContractByAddress(ctx, client, chain, contractAddress)
+	if err != nil {
+		outCh <- assetsReceived{Err: err}
+		return
+	}
+	endpoint, err := getNftsByWalletEndpoint(chain, ownerAddress)
+	if err != nil {
+		outCh <- assetsReceived{Err: err}
+		return
+	}
+	setCollection(endpoint, contract.Collection)
+	setPagingParams(endpoint)
+	paginateAssets(ctx, client, authRequest(ctx, endpoint), outCh)
+}
+
+func streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, client *http.Client, chain persist.Chain, ownerAddress, contractAddress persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
+	contract, err := fetchContractByAddress(ctx, client, chain, contractAddress)
+	if err != nil {
+		outCh <- assetsReceived{Err: err}
+		return
+	}
+	endpoint, err := getNftsByWalletEndpoint(chain, ownerAddress)
+	if err != nil {
+		outCh <- assetsReceived{Err: err}
+		return
+	}
+	// OS doesn't let you filter for a specific token ID, so we have to filter it ourselves
+	setCollection(endpoint, contract.Collection)
+	setPagingParams(endpoint)
+	paginateAssetsFilter(ctx, client, authRequest(ctx, endpoint), outCh, func(a Asset) bool {
+		return a.Contract != contractAddress.String() && a.Identifier.MustTokenID() != tokenID
+	})
+}
+
+type unknownTokenStandard struct {
+	TokenStandard string
+}
+
+func (e unknownTokenStandard) Error() string {
+	return fmt.Sprintf("unknown token standard: %s", e.TokenStandard)
 }
 
 func tokenTypeFromAsset(asset Asset) (persist.TokenType, error) {
-	switch asset.Contract.SchemaName {
-	case "ERC721", "CRYPTOPUNKS":
+	switch asset.TokenStandard {
+	case "erc721", "cryptopunks":
 		return persist.TokenTypeERC721, nil
-	case "ERC1155":
+	case "erc1155":
 		return persist.TokenTypeERC1155, nil
 	default:
-		return "", unknownContractSchemaError{asset.Contract.SchemaName}
+		return "", unknownTokenStandard{asset.TokenStandard}
 	}
 }
 
-func assetToToken(asset Asset, block persist.BlockNumber, tokenOwner persist.Address) (multichain.ChainAgnosticToken, error) {
+func assetToToken(asset Asset, tokenOwner persist.Address, externalURL string) (multichain.ChainAgnosticToken, error) {
 	tokenType, err := tokenTypeFromAsset(asset)
 	if err != nil {
 		return multichain.ChainAgnosticToken{}, err
 	}
-
 	return multichain.ChainAgnosticToken{
-		TokenType: tokenType,
-		Descriptors: multichain.ChainAgnosticTokenDescriptors{
-			Name:        asset.Name,
-			Description: asset.Description,
-		},
-		TokenURI:     persist.TokenURI(asset.TokenMetadataURL),
-		TokenID:      persist.TokenID(asset.TokenID.ToBase16()),
-		OwnerAddress: tokenOwner,
-		FallbackMedia: persist.FallbackMedia{
-			ImageURL: persist.NullString(firstNonEmptyString(asset.ImagePreviewURL, asset.ImageThumbnailURL, asset.ImageURL)),
-		},
-		ContractAddress: persist.Address(asset.Contract.Address.String()),
-		ExternalURL:     asset.ExternalURL,
-		BlockNumber:     block,
+		TokenType:       tokenType,
+		Descriptors:     multichain.ChainAgnosticTokenDescriptors{Name: asset.Name, Description: asset.Description},
+		TokenURI:        persist.TokenURI(asset.MetadataURL),
+		TokenID:         asset.Identifier.MustTokenID(),
+		OwnerAddress:    tokenOwner,
+		FallbackMedia:   persist.FallbackMedia{ImageURL: persist.NullString(asset.ImageURL)},
+		ContractAddress: persist.Address(asset.Contract),
+		ExternalURL:     externalURL,
 		TokenMetadata:   metadataFromAsset(asset),
 		Quantity:        "1",
 	}, nil
@@ -704,21 +490,19 @@ func assetToToken(asset Asset, block persist.BlockNumber, tokenOwner persist.Add
 
 func metadataFromAsset(asset Asset) persist.TokenMetadata {
 	m := persist.TokenMetadata{
-		"name":          asset.Name,
-		"description":   asset.Description,
-		"image_url":     asset.ImageOriginalURL,
-		"animation_url": asset.AnimationOriginalURL,
+		"name":        asset.Name,
+		"description": asset.Description,
+		"image_url":   asset.ImageURL,
 	}
 	// ENS
-	if asset.Contract.Address == eth.EnsAddress {
+	if persist.Address(asset.Contract) == eth.EnsAddress {
 		m["profile_image"] = fmt.Sprintf("https://metadata.ens.domains/mainnet/avatar/%s", asset.Name)
 	}
 	return m
 }
 
-func contractFromAsset(asset Asset, block persist.BlockNumber) multichain.ChainAgnosticContract {
+func contractFromAddress(contractAddress persist.Address) multichain.ChainAgnosticContract {
 	isSpam := contractNameIsSpam(asset.Contract.Name)
-
 	return multichain.ChainAgnosticContract{
 		Address: persist.Address(asset.Contract.Address.String()),
 		Descriptors: multichain.ChainAgnosticContractDescriptors{
@@ -728,19 +512,14 @@ func contractFromAsset(asset Asset, block persist.BlockNumber) multichain.ChainA
 			Description:     asset.Collection.Description,
 			ProfileImageURL: asset.Collection.ImageURL,
 		},
-		IsSpam:      &isSpam,
-		LatestBlock: block,
+		IsSpam: &isSpam,
 	}
 }
 
-func assetsToTokens(ctx context.Context, ownerAddress persist.Address, assetsChan <-chan assetsReceieved, ethClient *ethclient.Client, chain persist.Chain) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
-	block, err := ethClient.BlockNumber(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	resultTokens := make([]multichain.ChainAgnosticToken, 0, len(assetsChan))
+func assetsToTokens(ctx context.Context, ownerAddress persist.Address, outCh <-chan assetsReceived) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
+	resultTokens := make([]multichain.ChainAgnosticToken, 0, len(outCh))
 	seenContracts := &sync.Map{}
-	resultContracts := make([]multichain.ChainAgnosticContract, 0, len(assetsChan))
+	resultContracts := make([]multichain.ChainAgnosticContract, 0, len(outCh))
 	tokensChan := make(chan multichain.ChainAgnosticToken)
 	contractsChan := make(chan multichain.ChainAgnosticContract)
 	errChan := make(chan error)
@@ -748,19 +527,16 @@ func assetsToTokens(ctx context.Context, ownerAddress persist.Address, assetsCha
 
 	go func() {
 		defer close(tokensChan)
-		for a := range assetsChan {
+		for a := range outCh {
 			assetsReceived := a
-			if assetsReceived.err != nil {
-				errChan <- assetsReceived.err
+			if assetsReceived.Err != nil {
+				errChan <- assetsReceived.Err
 				return
 			}
-			for _, n := range assetsReceived.assets {
+			for _, n := range assetsReceived.Assets {
 				nft := n
-				if nft.Contract.ChainIdentifier.Chain() != chain {
-					continue
-				}
 				wp.Go(func(ctx context.Context) error {
-					return streamTokenAndContract(ctx, ownerAddress, nft, persist.BlockNumber(block), tokensChan, contractsChan, seenContracts)
+					return streamTokenAndContract(ctx, ownerAddress, nft, tokensChan, contractsChan, seenContracts)
 				})
 			}
 		}
@@ -792,23 +568,18 @@ func assetsToTokens(ctx context.Context, ownerAddress persist.Address, assetsCha
 	}
 }
 
-func streamAssetsToTokens(ctx context.Context, ownerAddress persist.Address, assetsChan <-chan assetsReceieved, ethClient *ethclient.Client, chain persist.Chain, rec chan<- multichain.ChainAgnosticTokensAndContracts, errChan chan<- error) {
-	block, err := ethClient.BlockNumber(ctx)
-	if err != nil {
-		errChan <- err
-		return
-	}
-
+func streamAssetsToTokens(ctx context.Context, ownerAddress persist.Address, outCh <-chan assetsReceived, rec chan<- multichain.ChainAgnosticTokensAndContracts, errChan chan<- error) {
 	seenContracts := &sync.Map{}
-
-	for a := range assetsChan {
+	for a := range outCh {
 		assetsReceived := a
-		if assetsReceived.err != nil {
-			errChan <- assetsReceived.err
+
+		if assetsReceived.Err != nil {
+			errChan <- assetsReceived.Err
 			return
 		}
-		innerTokens := make([]multichain.ChainAgnosticToken, 0, len(assetsReceived.assets))
-		innerContracts := make([]multichain.ChainAgnosticContract, 0, len(assetsReceived.assets))
+
+		innerTokens := make([]multichain.ChainAgnosticToken, 0, len(assetsReceived.Assets))
+		innerContracts := make([]multichain.ChainAgnosticContract, 0, len(assetsReceived.Assets))
 		innerTokenReceived := make(chan multichain.ChainAgnosticToken)
 		innerContractReceived := make(chan multichain.ChainAgnosticContract)
 		innerErrChan := make(chan error)
@@ -817,21 +588,18 @@ func streamAssetsToTokens(ctx context.Context, ownerAddress persist.Address, ass
 			wp := pool.New().WithMaxGoroutines(10).WithContext(ctx)
 			defer close(innerTokenReceived)
 			defer close(innerContractReceived)
-			for _, n := range assetsReceived.assets {
+			for _, n := range assetsReceived.Assets {
 				nft := n
-				if nft.Contract.ChainIdentifier.Chain() != chain {
-					continue
-				}
 				wp.Go(func(ctx context.Context) error {
-					return streamTokenAndContract(ctx, ownerAddress, nft, persist.BlockNumber(block), innerTokenReceived, innerContractReceived, seenContracts)
+					return streamTokenAndContract(ctx, ownerAddress, nft, innerTokenReceived, innerContractReceived, seenContracts)
 				})
 			}
 			err := wp.Wait()
 			if err != nil {
 				innerErrChan <- err
 			}
-
 		}()
+
 	outer:
 		for {
 			select {
@@ -865,28 +633,25 @@ func streamAssetsToTokens(ctx context.Context, ownerAddress persist.Address, ass
 	}
 }
 
-func streamTokenAndContract(ctx context.Context, ownerAddress persist.Address, nft Asset, block persist.BlockNumber, innerTokenReceived chan<- multichain.ChainAgnosticToken, innerContractReceived chan<- multichain.ChainAgnosticContract, seenContracts *sync.Map) error {
-	contract, ok := seenContracts.LoadOrStore(nft.Contract.Address.String(), contractFromAsset(nft, persist.BlockNumber(block)))
+func streamTokenAndContract(ctx context.Context, ownerAddress persist.Address, asset Asset, innerTokenReceived chan<- multichain.ChainAgnosticToken, innerContractReceived chan<- multichain.ChainAgnosticContract, seenContracts *sync.Map) error {
+	contract, ok := seenContracts.LoadOrStore(asset.Contract, contractFromAddress(asset.Contract))
 	if !ok {
 		innerContractReceived <- contract.(multichain.ChainAgnosticContract)
 	} else {
 		innerContractReceived <- multichain.ChainAgnosticContract{}
 	}
+
 	tokenOwner := ownerAddress
 	if tokenOwner == "" {
-		tokenOwner = persist.Address(nft.Owner.Address)
+		tokenOwner = persist.Address(asset.Owner.Address)
 	}
 
-	token, err := assetToToken(nft, block, tokenOwner)
-
-	var unknownSchemaErr unknownContractSchemaError
-
-	if errors.As(err, &unknownSchemaErr) {
-		logger.For(ctx).Error(err)
-		return nil
-	}
-
+	token, err := assetToToken(asset, tokenOwner)
 	if err != nil {
+		if util.ErrorIs[unknownTokenStandard](err) {
+			logger.For(ctx).Error(err)
+			return nil
+		}
 		return err
 	}
 
@@ -894,55 +659,9 @@ func streamTokenAndContract(ctx context.Context, ownerAddress persist.Address, n
 	return nil
 }
 
-func contractToContract(ctx context.Context, openseaContract Contract, ethClient *ethclient.Client) (multichain.ChainAgnosticContract, error) {
-	block, err := ethClient.BlockNumber(ctx)
-	if err != nil {
-		return multichain.ChainAgnosticContract{}, err
-	}
-	isSpam := contractNameIsSpam(openseaContract.Name)
-
-	return multichain.ChainAgnosticContract{
-		Address: persist.Address(openseaContract.Address.String()),
-		Descriptors: multichain.ChainAgnosticContractDescriptors{
-			Symbol:       openseaContract.Symbol,
-			Name:         openseaContract.Collection.Name,
-			OwnerAddress: persist.Address(openseaContract.Collection.PayoutAddress),
-		},
-
-		IsSpam:      &isSpam,
-		LatestBlock: persist.BlockNumber(block),
-	}, nil
-}
-
-func (e ErrNoAssetsForWallets) Error() string {
-	return fmt.Sprintf("no assets found for wallet: %v", e.Wallets)
-}
-
-func (t TokenID) String() string {
-	return string(t)
-}
-
-// ToBase16 coverts a base 10 tokenID to base 16
-func (t TokenID) ToBase16() string {
-	asBig, ok := new(big.Int).SetString(string(t), 10)
-	if !ok {
-		panic("failed to convert opensea token id to big int")
-	}
-	return asBig.Text(16)
-}
-
-func firstNonEmptyString(strs ...string) string {
-	for _, str := range strs {
-		if str != "" {
-			return str
-		}
-	}
-	return ""
-}
-
 // authRequest returns a http.Request with authorization headers
-func authRequest(ctx context.Context, url string) *http.Request {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func authRequest(ctx context.Context, url *url.URL) *http.Request {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -950,80 +669,79 @@ func authRequest(ctx context.Context, url string) *http.Request {
 	return req
 }
 
-func paginateAssets(ctx context.Context, req *http.Request, outCh chan assetsReceieved) {
+type assetPage struct {
+	Next string  `json:"next"`
+	NFTs []Asset `json:"nfts"`
+}
+
+type assetsReceived struct {
+	Assets []Asset
+	Err    error
+}
+
+func paginateAssets(ctx context.Context, client *http.Client, req *http.Request, outCh chan assetsReceived) {
+	paginateAssetsFilter(ctx, client, req, outCh, nil)
+}
+
+// paginatesAssetsFilter fetches assets from OpenSea and sends them to outCh. An optional keepAssetFilter can be provided to filter out an asset
+// after it is fetched if keepAssetFilter evaluates to false. This is useful for filtering out assets that can't be filtered natively by the API.
+func paginateAssetsFilter(ctx context.Context, client *http.Client, req *http.Request, outCh chan assetsReceived, keepAssetFilter func(a Asset) bool) {
 	for {
 		resp, err := retry.RetryRequest(client, req)
 		if err != nil {
-			outCh <- assetsReceieved{err: err}
+			outCh <- assetsReceived{Err: err}
 			return
 		}
 
 		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusUnauthorized {
-			outCh <- assetsReceieved{err: ErrAPIKeyExpired}
+			outCh <- assetsReceived{Err: ErrAPIKeyExpired}
 			return
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			outCh <- assetsReceieved{err: util.BodyAsError(resp)}
+			outCh <- assetsReceived{Err: util.BodyAsError(resp)}
 			return
 		}
 
-		assets := Assets{}
-		if err := util.UnmarshallBody(&assets, resp.Body); err != nil {
-			outCh <- assetsReceieved{err: err}
+		page := assetPage{}
+		if err := util.UnmarshallBody(&page, resp.Body); err != nil {
+			outCh <- assetsReceived{Err: err}
 			return
 		}
 
-		logger.For(ctx).Infof("received %d assets from opensea query %s", len(assets.Assets), req.URL.RawQuery)
+		logger.For(ctx).Infof("received %d assets from opensea query %s", len(page.NFTs), req.URL.RawQuery)
 
-		outCh <- assetsReceieved{assets: assets.Assets}
+		if keepAssetFilter == nil {
+			outCh <- assetsReceived{Assets: page.NFTs}
+		} else {
+			outCh <- assetsReceived{Assets: util.Filter(page.NFTs, keepAssetFilter, true)}
+		}
 
-		if assets.Next == "" {
+		if page.Next == "" {
 			return
 		}
 
-		query := req.URL.Query()
-		query.Set("cursor", assets.Next)
-		req.URL.RawQuery = query.Encode()
+		setNext(req.URL, page.Next)
 	}
+}
+
+func setNext(url *url.URL, next string) {
+	query := url.Query()
+	query.Set("next", next)
+	url.RawQuery = query.Encode()
 }
 
 func setPagingParams(url *url.URL) {
 	query := url.Query()
-	query.Set("order_direction", "desc")
 	query.Set("limit", "200")
 	url.RawQuery = query.Encode()
 }
 
-func setOwner(url *url.URL, address persist.EthereumAddress) {
+func setCollection(url *url.URL, slug string) {
 	query := url.Query()
-	query.Set("owner", address.String())
-	url.RawQuery = query.Encode()
-}
-
-func setContractAddress(url *url.URL, address persist.EthereumAddress) {
-	query := url.Query()
-	query.Set("asset_contract_address", address.String())
-	url.RawQuery = query.Encode()
-}
-
-func addContractAddresses(url *url.URL, address persist.EthereumAddress) {
-	query := url.Query()
-	query.Add("asset_contract_addresses", address.String())
-	url.RawQuery = query.Encode()
-}
-
-func setCollectionEditor(url *url.URL, address persist.EthereumAddress) {
-	query := url.Query()
-	query.Add("collection_editor", address.String())
-	url.RawQuery = query.Encode()
-}
-
-func setTokenID(url *url.URL, tokenID TokenID) {
-	query := url.Query()
-	query.Add("token_ids", string(tokenID))
+	query.Set("collection", slug)
 	url.RawQuery = query.Encode()
 }
 

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -38,6 +38,7 @@ type Asset struct {
 	Name          string         `json:"name"`
 	Description   string         `json:"description"`
 	ImageURL      string         `json:"image_url"`
+	AnimationURL  string         `json:"animation_url"`
 	MetadataURL   string         `json:"metadata_url"`
 	Owners        []Owner        `json:"owners"`
 }
@@ -617,9 +618,10 @@ func assetToToken(asset Asset, collection Collection, tokenType persist.TokenTyp
 
 func metadataFromAsset(asset Asset) persist.TokenMetadata {
 	m := persist.TokenMetadata{
-		"name":        asset.Name,
-		"description": asset.Description,
-		"image_url":   asset.ImageURL,
+		"name":          asset.Name,
+		"description":   asset.Description,
+		"image_url":     asset.ImageURL,
+		"animation_url": asset.AnimationURL,
 	}
 	// ENS
 	if persist.Address(asset.Contract) == eth.EnsAddress {

--- a/service/multichain/tezos/objkt.go
+++ b/service/multichain/tezos/objkt.go
@@ -130,18 +130,6 @@ tokens by creator
   }
 */
 
-type objktTokenCreator struct {
-	Token token
-}
-
-type tokensByCreatorQuery struct {
-	TokenCreator []objktTokenCreator `graphql:"token_creator(where: {creator_address: {_eq: $creatorAddress}, token: {fa_contract: {_nin: $contracts}}}, order_by: {token_pk: desc_nulls_last}, limit: $limit, offset: $offset)"`
-}
-
-type faByCreatorQuery struct {
-	Fa []contract `graphql:"fa(where: {creator: {address: {_eq: $creatorAddress}}})"`
-}
-
 // Objkt's API has pretty strict usage limits (120 requests/minute, and 500 results per page)
 // so its best used as a fallback.
 type TezosObjktProvider struct {

--- a/service/rpc/ipfs/ipfs.go
+++ b/service/rpc/ipfs/ipfs.go
@@ -213,7 +213,7 @@ func pathURL(host, uri string) string {
 // Most gateways will redirect the former to the latter, but some gateways don't. https://docs.ipfs.tech/concepts/ipfs-gateway/#path
 func standardizeQueryParams(uri string) string {
 	paramIdx := strings.Index(uri, "?")
-	isClean := strings.Index(uri, "/?") != -1
+	isClean := strings.Contains(uri, "/?")
 	if paramIdx != -1 && !isClean {
 		uri = uri[:paramIdx] + "/?" + uri[paramIdx+1:]
 	}

--- a/service/task/task.go
+++ b/service/task/task.go
@@ -168,15 +168,6 @@ func (c *Client) CreateTaskForTokenProcessing(ctx context.Context, message Token
 	return c.submitTask(ctx, queue, url, withDeadline(time.Minute*30), withJSON(message), withTrace(span))
 }
 
-func (c *Client) CreateTaskForContractOwnerProcessing(ctx context.Context, message TokenProcessingContractTokensMessage) error {
-	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForContractOwnerProcessing")
-	defer tracing.FinishSpan(span)
-	tracing.AddEventDataToSpan(span, map[string]any{"Contract ID": message.ContractID})
-	queue := env.GetString("TOKEN_PROCESSING_QUEUE")
-	url := fmt.Sprintf("%s/owners/process/contract", env.GetString("TOKEN_PROCESSING_URL"))
-	return c.submitTask(ctx, queue, url, withJSON(message), withTrace(span))
-}
-
 func (c *Client) CreateTaskForUserTokenProcessing(ctx context.Context, message TokenProcessingUserTokensMessage) error {
 	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForUserTokenProcessing")
 	defer tracing.FinishSpan(span)

--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -41,7 +41,6 @@ func handlersInitServer(ctx context.Context, router *gin.Engine, tp *tokenProces
 	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, retryManager))
 	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, retryManager, mc, repos.UserRepository))
 	ownersGroup := router.Group("/owners")
-	ownersGroup.POST("/process/contract", processOwnersForContractTokens(mc, throttler))
 	ownersGroup.POST("/process/user", processOwnersForUserTokens(mc, mc.Queries))
 	ownersGroup.POST("/process/alchemy", processOwnersForAlchemyTokens(mc, mc.Queries))
 	ownersGroup.POST("/process/wallet-removal", processWalletRemoval(mc.Queries))

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -319,7 +319,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromOriginalURLs(ctx context.Context, i
 
 func (tpj *tokenProcessingJob) cacheMediaFromOpenSeaAssetURLs(ctx context.Context) (imgResult, animResult cacheResult) {
 	tID := persist.NewTokenIdentifiers(tpj.token.ContractAddress, tpj.token.TokenID, tpj.token.Chain)
-	assets, err := opensea.FetchAssetsForTokenIdentifiers(ctx, persist.EthereumAddress(tID.ContractAddress), opensea.TokenID(tID.TokenID.Base10String()))
+	assets, err := opensea.FetchAssetsForTokenIdentifiers(ctx, tpj.token.Chain, tID.ContractAddress, tID.TokenID)
 	if err != nil || len(assets) == 0 {
 		result := cacheResult{err: errNoDataFromOpensea{err}}
 		return result, result
@@ -345,17 +345,12 @@ func (tpj *tokenProcessingJob) cacheMediaFromOpenSeaAssetURLs(ctx context.Contex
 		LiveRenderGCP:                &tpj.pipelineMetadata.AlternateAnimationLiveRenderGCP,
 	}
 	for _, asset := range assets {
-		animURL := media.AnimationURL(util.FirstNonEmptyString(
-			asset.AnimationURL,
-			asset.AnimationOriginalURL,
-		))
-		imgURL := media.ImageURL(util.FirstNonEmptyString(
-			asset.ImageURL,
-			asset.ImagePreviewURL,
-			asset.ImageOriginalURL,
-			asset.ImageThumbnailURL,
-		))
-		imgResult, _, animResult = tpj.cacheMediaSources(ctx, imgURL, "", animURL, imgRunMetadata, nil, animRunMetadata)
+		// Double check how OS gets their animation media from
+		// XXX animURL := media.AnimationURL(util.FirstNonEmptyString(
+		// XXX 	asset.AnimationURL,
+		// XXX 	asset.AnimationOriginalURL,
+		// XXX ))
+		imgResult, _, animResult = tpj.cacheMediaSources(ctx, media.ImageURL(asset.ImageURL), "", "", imgRunMetadata, nil, animRunMetadata)
 		if animResult.IsSuccess() || imgResult.IsSuccess() {
 			return imgResult, animResult
 		}

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -345,12 +345,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromOpenSeaAssetURLs(ctx context.Contex
 		LiveRenderGCP:                &tpj.pipelineMetadata.AlternateAnimationLiveRenderGCP,
 	}
 	for _, asset := range assets {
-		// Double check how OS gets their animation media from
-		// XXX animURL := media.AnimationURL(util.FirstNonEmptyString(
-		// XXX 	asset.AnimationURL,
-		// XXX 	asset.AnimationOriginalURL,
-		// XXX ))
-		imgResult, _, animResult = tpj.cacheMediaSources(ctx, media.ImageURL(asset.ImageURL), "", "", imgRunMetadata, nil, animRunMetadata)
+		imgResult, _, animResult = tpj.cacheMediaSources(ctx, media.ImageURL(asset.ImageURL), "", media.AnimationURL(asset.AnimationURL), imgRunMetadata, nil, animRunMetadata)
 		if animResult.IsSuccess() || imgResult.IsSuccess() {
 			return imgResult, animResult
 		}

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/task"
-	"github.com/mikeydub/go-gallery/service/throttle"
 	"github.com/mikeydub/go-gallery/service/tokenmanage"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
@@ -161,42 +160,6 @@ func processMediaForTokenManaged(tp *tokenProcessor, queries *coredb.Queries, tm
 		runManagedPipeline(c, tp, tm, td, persist.ProcessingCauseSyncRetry, input.Attempts, addIsSpamJobOption(contract))
 
 		// We always return a 200 because retries are managed by the token manager and we don't want the queue retrying the current message.
-		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
-	}
-}
-
-func processOwnersForContractTokens(mc *multichain.Provider, throttler *throttle.Locker) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		var input task.TokenProcessingContractTokensMessage
-		if err := c.ShouldBindJSON(&input); err != nil {
-			util.ErrResponse(c, http.StatusOK, err)
-			return
-		}
-
-		contract, err := mc.Queries.GetContractByID(c, input.ContractID)
-		if err != nil {
-			util.ErrResponse(c, http.StatusInternalServerError, err)
-			return
-		}
-
-		lockID := fmt.Sprintf("%s-%d", contract.Address, contract.Chain)
-
-		if !input.ForceRefresh {
-			if err := throttler.Lock(c, lockID); err != nil {
-				util.ErrResponse(c, http.StatusOK, err)
-				return
-			}
-		}
-
-		// do not unlock, let expiry handle the unlock
-		logger.For(c).Infof("Processing: %s - Processing Collection Refresh", lockID)
-		cID := persist.NewContractIdentifiers(contract.Address, contract.Chain)
-		if err := mc.RefreshTokensForContract(c, cID); err != nil {
-			util.ErrResponse(c, http.StatusInternalServerError, err)
-			return
-		}
-		logger.For(c).Infof("Processing: %s - Finished Processing Collection Refresh", lockID)
-
 		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
 	}
 }


### PR DESCRIPTION
#### Changes
* Updates OpenSea provider to v2 API
* Deprecates refresh tokens in contract operations - universal users are no longer created
* Removes the `ChildContractFetcher` interface and references to it
* Deletes a bunch of dead code - Fetching membership cards via OS

TODOs
* Deploy tokenprocessing, backend, indexer, and indexer-api after merge