### PR TITLE
introduce announcement notification type

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -659,6 +659,22 @@ type ComplexityRoot struct {
 		TokenPreviews func(childComplexity int) int
 	}
 
+	GalleryAnnouncementNotification struct {
+		CreationTime         func(childComplexity int) int
+		CtaLink              func(childComplexity int) int
+		CtaText              func(childComplexity int) int
+		Dbid                 func(childComplexity int) int
+		Description          func(childComplexity int) int
+		ID                   func(childComplexity int) int
+		ImageURL             func(childComplexity int) int
+		InternalID           func(childComplexity int) int
+		Platform             func(childComplexity int) int
+		PushNotificationText func(childComplexity int) int
+		Seen                 func(childComplexity int) int
+		Title                func(childComplexity int) int
+		UpdatedTime          func(childComplexity int) int
+	}
+
 	GalleryInfoUpdatedFeedEventData struct {
 		Action         func(childComplexity int) int
 		EventTime      func(childComplexity int) int
@@ -4087,6 +4103,97 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Gallery.TokenPreviews(childComplexity), true
+
+	case "GalleryAnnouncementNotification.creationTime":
+		if e.complexity.GalleryAnnouncementNotification.CreationTime == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.CreationTime(childComplexity), true
+
+	case "GalleryAnnouncementNotification.ctaLink":
+		if e.complexity.GalleryAnnouncementNotification.CtaLink == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.CtaLink(childComplexity), true
+
+	case "GalleryAnnouncementNotification.ctaText":
+		if e.complexity.GalleryAnnouncementNotification.CtaText == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.CtaText(childComplexity), true
+
+	case "GalleryAnnouncementNotification.dbid":
+		if e.complexity.GalleryAnnouncementNotification.Dbid == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.Dbid(childComplexity), true
+
+	case "GalleryAnnouncementNotification.description":
+		if e.complexity.GalleryAnnouncementNotification.Description == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.Description(childComplexity), true
+
+	case "GalleryAnnouncementNotification.id":
+		if e.complexity.GalleryAnnouncementNotification.ID == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.ID(childComplexity), true
+
+	case "GalleryAnnouncementNotification.imageUrl":
+		if e.complexity.GalleryAnnouncementNotification.ImageURL == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.ImageURL(childComplexity), true
+
+	case "GalleryAnnouncementNotification.internalId":
+		if e.complexity.GalleryAnnouncementNotification.InternalID == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.InternalID(childComplexity), true
+
+	case "GalleryAnnouncementNotification.platform":
+		if e.complexity.GalleryAnnouncementNotification.Platform == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.Platform(childComplexity), true
+
+	case "GalleryAnnouncementNotification.pushNotificationText":
+		if e.complexity.GalleryAnnouncementNotification.PushNotificationText == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.PushNotificationText(childComplexity), true
+
+	case "GalleryAnnouncementNotification.seen":
+		if e.complexity.GalleryAnnouncementNotification.Seen == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.Seen(childComplexity), true
+
+	case "GalleryAnnouncementNotification.title":
+		if e.complexity.GalleryAnnouncementNotification.Title == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.Title(childComplexity), true
+
+	case "GalleryAnnouncementNotification.updatedTime":
+		if e.complexity.GalleryAnnouncementNotification.UpdatedTime == nil {
+			break
+		}
+
+		return e.complexity.GalleryAnnouncementNotification.UpdatedTime(childComplexity), true
 
 	case "GalleryInfoUpdatedFeedEventData.action":
 		if e.complexity.GalleryInfoUpdatedFeedEventData.Action == nil {
@@ -11534,6 +11641,29 @@ type YouReceivedTopActivityBadgeNotification implements Notification & Node {
   updatedTime: Time
 
   threshold: Int!
+}
+
+enum Platform {
+  Web
+  Mobile
+  All
+}
+
+type GalleryAnnouncementNotification implements Notification & Node {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  platform: Platform!
+  internalId: String!
+  imageUrl: String
+  title: String
+  description: String
+  ctaText: String
+  ctaLink: String
+  pushNotificationText: String
 }
 
 type ClearAllNotificationsPayload {
@@ -29239,6 +29369,551 @@ func (ec *executionContext) fieldContext_Gallery_collections(ctx context.Context
 				return ec.fieldContext_Collection_tokens(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Collection", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_id(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.GqlID)
+	fc.Result = res
+	return ec.marshalNID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐGqlID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_dbid(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_dbid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Dbid, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(persist.DBID)
+	fc.Result = res
+	return ec.marshalNDBID2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐDBID(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_dbid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type DBID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_seen(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_seen(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Seen, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_seen(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_creationTime(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_creationTime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreationTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_creationTime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_updatedTime(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_updatedTime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_updatedTime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_platform(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_platform(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Platform, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(model.Platform)
+	fc.Result = res
+	return ec.marshalNPlatform2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPlatform(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_platform(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Platform does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_internalId(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_internalId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.InternalID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_internalId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_imageUrl(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_imageUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ImageURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_imageUrl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_title(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_title(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Title, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_title(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_description(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_description(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Description, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_description(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_ctaText(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_ctaText(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CtaText, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_ctaText(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_ctaLink(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_ctaLink(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CtaLink, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_ctaLink(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _GalleryAnnouncementNotification_pushNotificationText(ctx context.Context, field graphql.CollectedField, obj *model.GalleryAnnouncementNotification) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GalleryAnnouncementNotification_pushNotificationText(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PushNotificationText, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GalleryAnnouncementNotification_pushNotificationText(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GalleryAnnouncementNotification",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -69884,6 +70559,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._YouReceivedTopActivityBadgeNotification(ctx, sel, obj)
+	case model.GalleryAnnouncementNotification:
+		return ec._GalleryAnnouncementNotification(ctx, sel, &obj)
+	case *model.GalleryAnnouncementNotification:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._GalleryAnnouncementNotification(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -70010,6 +70692,13 @@ func (ec *executionContext) _Notification(ctx context.Context, sel ast.Selection
 			return graphql.Null
 		}
 		return ec._YouReceivedTopActivityBadgeNotification(ctx, sel, obj)
+	case model.GalleryAnnouncementNotification:
+		return ec._GalleryAnnouncementNotification(ctx, sel, &obj)
+	case *model.GalleryAnnouncementNotification:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._GalleryAnnouncementNotification(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -76212,6 +76901,91 @@ func (ec *executionContext) _Gallery(ctx context.Context, sel ast.SelectionSet, 
 				return innerFunc(ctx)
 
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var galleryAnnouncementNotificationImplementors = []string{"GalleryAnnouncementNotification", "Notification", "Node"}
+
+func (ec *executionContext) _GalleryAnnouncementNotification(ctx context.Context, sel ast.SelectionSet, obj *model.GalleryAnnouncementNotification) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, galleryAnnouncementNotificationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("GalleryAnnouncementNotification")
+		case "id":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "dbid":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_dbid(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "seen":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_seen(ctx, field, obj)
+
+		case "creationTime":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_creationTime(ctx, field, obj)
+
+		case "updatedTime":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_updatedTime(ctx, field, obj)
+
+		case "platform":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_platform(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "internalId":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_internalId(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "imageUrl":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_imageUrl(ctx, field, obj)
+
+		case "title":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_title(ctx, field, obj)
+
+		case "description":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_description(ctx, field, obj)
+
+		case "ctaText":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_ctaText(ctx, field, obj)
+
+		case "ctaLink":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_ctaLink(ctx, field, obj)
+
+		case "pushNotificationText":
+
+			out.Values[i] = ec._GalleryAnnouncementNotification_pushNotificationText(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -85159,6 +85933,16 @@ func (ec *executionContext) marshalNPageInfo2ᚖgithubᚗcomᚋmikeydubᚋgoᚑg
 		return graphql.Null
 	}
 	return ec._PageInfo(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNPlatform2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPlatform(ctx context.Context, v interface{}) (model.Platform, error) {
+	var res model.Platform
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNPlatform2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPlatform(ctx context.Context, sel ast.SelectionSet, v model.Platform) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNPost2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPost(ctx context.Context, sel ast.SelectionSet, v model.Post) graphql.Marshaler {

--- a/graphql/model/gqlidgen_gen.go
+++ b/graphql/model/gqlidgen_gen.go
@@ -56,6 +56,10 @@ func (r *Gallery) ID() GqlID {
 	return GqlID(fmt.Sprintf("Gallery:%s", r.Dbid))
 }
 
+func (r *GalleryAnnouncementNotification) ID() GqlID {
+	return GqlID(fmt.Sprintf("GalleryAnnouncementNotification:%s", r.Dbid))
+}
+
 func (r *GalleryUser) ID() GqlID {
 	return GqlID(fmt.Sprintf("GalleryUser:%s", r.Dbid))
 }
@@ -175,6 +179,7 @@ type NodeFetcher struct {
 	OnDeletedNode                                      func(ctx context.Context, dbid persist.DBID) (*DeletedNode, error)
 	OnFeedEvent                                        func(ctx context.Context, dbid persist.DBID) (*FeedEvent, error)
 	OnGallery                                          func(ctx context.Context, dbid persist.DBID) (*Gallery, error)
+	OnGalleryAnnouncementNotification                  func(ctx context.Context, dbid persist.DBID) (*GalleryAnnouncementNotification, error)
 	OnGalleryUser                                      func(ctx context.Context, dbid persist.DBID) (*GalleryUser, error)
 	OnMembershipTier                                   func(ctx context.Context, dbid persist.DBID) (*MembershipTier, error)
 	OnMerchToken                                       func(ctx context.Context, tokenId string) (*MerchToken, error)
@@ -257,6 +262,11 @@ func (n *NodeFetcher) GetNodeByGqlID(ctx context.Context, id GqlID) (Node, error
 			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'Gallery' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
 		}
 		return n.OnGallery(ctx, persist.DBID(ids[0]))
+	case "GalleryAnnouncementNotification":
+		if len(ids) != 1 {
+			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'GalleryAnnouncementNotification' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
+		}
+		return n.OnGalleryAnnouncementNotification(ctx, persist.DBID(ids[0]))
 	case "GalleryUser":
 		if len(ids) != 1 {
 			return nil, ErrInvalidIDFormat{message: fmt.Sprintf("'GalleryUser' type requires 1 ID component(s) (%d component(s) supplied)", len(ids))}
@@ -407,6 +417,8 @@ func (n *NodeFetcher) ValidateHandlers() {
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnFeedEvent")
 	case n.OnGallery == nil:
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnGallery")
+	case n.OnGalleryAnnouncementNotification == nil:
+		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnGalleryAnnouncementNotification")
 	case n.OnGalleryUser == nil:
 		panic("NodeFetcher handler validation failed: no handler set for NodeFetcher.OnGalleryUser")
 	case n.OnMembershipTier == nil:

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1502,6 +1502,24 @@ type Gallery struct {
 func (Gallery) IsNode()                      {}
 func (Gallery) IsGalleryByIDPayloadOrError() {}
 
+type GalleryAnnouncementNotification struct {
+	Dbid                 persist.DBID `json:"dbid"`
+	Seen                 *bool        `json:"seen"`
+	CreationTime         *time.Time   `json:"creationTime"`
+	UpdatedTime          *time.Time   `json:"updatedTime"`
+	Platform             Platform     `json:"platform"`
+	InternalID           string       `json:"internalId"`
+	ImageURL             *string      `json:"imageUrl"`
+	Title                *string      `json:"title"`
+	Description          *string      `json:"description"`
+	CtaText              *string      `json:"ctaText"`
+	CtaLink              *string      `json:"ctaLink"`
+	PushNotificationText *string      `json:"pushNotificationText"`
+}
+
+func (GalleryAnnouncementNotification) IsNotification() {}
+func (GalleryAnnouncementNotification) IsNode()         {}
+
 type GalleryInfoUpdatedFeedEventData struct {
 	EventTime      *time.Time      `json:"eventTime"`
 	Owner          *GalleryUser    `json:"owner"`
@@ -3039,6 +3057,49 @@ func (e *MerchType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e MerchType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type Platform string
+
+const (
+	PlatformWeb    Platform = "Web"
+	PlatformMobile Platform = "Mobile"
+	PlatformAll    Platform = "All"
+)
+
+var AllPlatform = []Platform{
+	PlatformWeb,
+	PlatformMobile,
+	PlatformAll,
+}
+
+func (e Platform) IsValid() bool {
+	switch e {
+	case PlatformWeb, PlatformMobile, PlatformAll:
+		return true
+	}
+	return false
+}
+
+func (e Platform) String() string {
+	return string(e)
+}
+
+func (e *Platform) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = Platform(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid Platform", str)
+	}
+	return nil
+}
+
+func (e Platform) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -9,10 +9,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"sort"
 	"strings"
 	"time"
+
+	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 
 	"golang.org/x/net/html"
 
@@ -81,6 +82,7 @@ var nodeFetcher = model.NodeFetcher{
 	OnSomeonePostedYourWorkNotification:                fetchNotificationByID[model.SomeonePostedYourWorkNotification],
 	OnSomeoneYouFollowPostedTheirFirstPostNotification: fetchNotificationByID[model.SomeoneYouFollowPostedTheirFirstPostNotification],
 	OnYouReceivedTopActivityBadgeNotification:          fetchNotificationByID[model.YouReceivedTopActivityBadgeNotification],
+	OnGalleryAnnouncementNotification:                  fetchNotificationByID[model.GalleryAnnouncementNotification],
 }
 
 // T any is a notification type, will panic if it is not a notification type

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2259,6 +2259,29 @@ type YouReceivedTopActivityBadgeNotification implements Notification & Node {
   threshold: Int!
 }
 
+enum Platform {
+  Web
+  Mobile
+  All
+}
+
+type GalleryAnnouncementNotification implements Notification & Node {
+  id: ID!
+  dbid: DBID!
+  seen: Boolean
+  creationTime: Time
+  updatedTime: Time
+
+  platform: Platform!
+  internalId: String!
+  imageUrl: String
+  title: String
+  description: String
+  ctaText: String
+  ctaLink: String
+  pushNotificationText: String
+}
+
 type ClearAllNotificationsPayload {
   notifications: [Notification]
 }


### PR DESCRIPTION
Introduce a new notification type that we can arbitrarily send out to clients (first one will be the holiday NFT collab announcement next week)

```graphql
type GalleryAnnouncementNotification implements Notification & Node {
  id: ID!
  dbid: DBID!
  seen: Boolean
  creationTime: Time
  updatedTime: Time

  platform: Platform!
  internalId: String!
  imageUrl: String
  title: String
  description: String
  ctaText: String
  ctaLink: String
  pushNotificationText: String
}
```