### PR TITLE
Use actual communities in the sharedCommunities resolver

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -2888,24 +2888,24 @@ func (b *GetProfileImageByIDBatchResults) Close() error {
 	return b.br.Close()
 }
 
-const getSharedContractsBatchPaginate = `-- name: GetSharedContractsBatchPaginate :batchmany
-select contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain, a.displayed as displayed_by_user_a, b.displayed as displayed_by_user_b, a.owned_count
-from owned_contracts a, owned_contracts b, contracts
-left join marketplace_contracts on contracts.id = marketplace_contracts.contract_id
+const getSharedCommunitiesBatchPaginate = `-- name: GetSharedCommunitiesBatchPaginate :batchmany
+select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url, a.displayed as displayed_by_user_a, b.displayed as displayed_by_user_b, a.owned_count
+from owned_communities a, owned_communities b, communities
+left join contracts on communities.contract_id = contracts.id
+left join marketplace_contracts on communities.contract_id = marketplace_contracts.contract_id
 where a.user_id = $1
   and b.user_id = $2
-  and a.contract_id = b.contract_id
-  and a.contract_id = contracts.id
+  and a.community_id = b.community_id
+  and a.community_id = communities.id
   and marketplace_contracts.contract_id is null
-  and contracts.name is not null
-  and contracts.name != ''
-  and contracts.name != 'Unidentified contract'
-  and not contracts.is_provider_marked_spam
+  and communities.name != ''
+  and communities.name != 'Unidentified contract'
+  and (contracts.is_provider_marked_spam is null or contracts.is_provider_marked_spam = false)
   and (
     a.displayed,
     b.displayed,
     a.owned_count,
-    contracts.id
+    communities.id
   ) > (
     $3,
     $4,
@@ -2916,25 +2916,25 @@ where a.user_id = $1
     a.displayed,
     b.displayed,
     a.owned_count,
-    contracts.id
+    communities.id
   ) < (
     $7,
     $8,
     $9::int,
     $10
   )
-order by case when $11::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end desc,
-        case when not $11::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end asc
+order by case when $11::bool then (a.displayed, b.displayed, a.owned_count, communities.id) end desc,
+        case when not $11::bool then (a.displayed, b.displayed, a.owned_count, communities.id) end asc
 limit $12
 `
 
-type GetSharedContractsBatchPaginateBatchResults struct {
+type GetSharedCommunitiesBatchPaginateBatchResults struct {
 	br     pgx.BatchResults
 	tot    int
 	closed bool
 }
 
-type GetSharedContractsBatchPaginateParams struct {
+type GetSharedCommunitiesBatchPaginateParams struct {
 	UserAID                   persist.DBID `db:"user_a_id" json:"user_a_id"`
 	UserBID                   persist.DBID `db:"user_b_id" json:"user_b_id"`
 	CurBeforeDisplayedByUserA bool         `db:"cur_before_displayed_by_user_a" json:"cur_before_displayed_by_user_a"`
@@ -2949,32 +2949,34 @@ type GetSharedContractsBatchPaginateParams struct {
 	Limit                     int32        `db:"limit" json:"limit"`
 }
 
-type GetSharedContractsBatchPaginateRow struct {
-	ID                    persist.DBID    `db:"id" json:"id"`
-	Deleted               bool            `db:"deleted" json:"deleted"`
-	Version               sql.NullInt32   `db:"version" json:"version"`
-	CreatedAt             time.Time       `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time       `db:"last_updated" json:"last_updated"`
-	Name                  sql.NullString  `db:"name" json:"name"`
-	Symbol                sql.NullString  `db:"symbol" json:"symbol"`
-	Address               persist.Address `db:"address" json:"address"`
-	CreatorAddress        persist.Address `db:"creator_address" json:"creator_address"`
-	Chain                 persist.Chain   `db:"chain" json:"chain"`
-	ProfileBannerUrl      sql.NullString  `db:"profile_banner_url" json:"profile_banner_url"`
-	ProfileImageUrl       sql.NullString  `db:"profile_image_url" json:"profile_image_url"`
-	BadgeUrl              sql.NullString  `db:"badge_url" json:"badge_url"`
-	Description           sql.NullString  `db:"description" json:"description"`
-	OwnerAddress          persist.Address `db:"owner_address" json:"owner_address"`
-	IsProviderMarkedSpam  bool            `db:"is_provider_marked_spam" json:"is_provider_marked_spam"`
-	ParentID              persist.DBID    `db:"parent_id" json:"parent_id"`
-	OverrideCreatorUserID persist.DBID    `db:"override_creator_user_id" json:"override_creator_user_id"`
-	L1Chain               persist.L1Chain `db:"l1_chain" json:"l1_chain"`
-	DisplayedByUserA      bool            `db:"displayed_by_user_a" json:"displayed_by_user_a"`
-	DisplayedByUserB      bool            `db:"displayed_by_user_b" json:"displayed_by_user_b"`
-	OwnedCount            int64           `db:"owned_count" json:"owned_count"`
+type GetSharedCommunitiesBatchPaginateRow struct {
+	ID                      persist.DBID          `db:"id" json:"id"`
+	Version                 int32                 `db:"version" json:"version"`
+	CommunityType           persist.CommunityType `db:"community_type" json:"community_type"`
+	Key1                    string                `db:"key1" json:"key1"`
+	Key2                    string                `db:"key2" json:"key2"`
+	Key3                    string                `db:"key3" json:"key3"`
+	Key4                    string                `db:"key4" json:"key4"`
+	Name                    string                `db:"name" json:"name"`
+	OverrideName            sql.NullString        `db:"override_name" json:"override_name"`
+	Description             string                `db:"description" json:"description"`
+	OverrideDescription     sql.NullString        `db:"override_description" json:"override_description"`
+	ProfileImageUrl         sql.NullString        `db:"profile_image_url" json:"profile_image_url"`
+	OverrideProfileImageUrl sql.NullString        `db:"override_profile_image_url" json:"override_profile_image_url"`
+	BadgeUrl                sql.NullString        `db:"badge_url" json:"badge_url"`
+	OverrideBadgeUrl        sql.NullString        `db:"override_badge_url" json:"override_badge_url"`
+	ContractID              persist.DBID          `db:"contract_id" json:"contract_id"`
+	CreatedAt               time.Time             `db:"created_at" json:"created_at"`
+	LastUpdated             time.Time             `db:"last_updated" json:"last_updated"`
+	Deleted                 bool                  `db:"deleted" json:"deleted"`
+	WebsiteUrl              sql.NullString        `db:"website_url" json:"website_url"`
+	OverrideWebsiteUrl      sql.NullString        `db:"override_website_url" json:"override_website_url"`
+	DisplayedByUserA        bool                  `db:"displayed_by_user_a" json:"displayed_by_user_a"`
+	DisplayedByUserB        bool                  `db:"displayed_by_user_b" json:"displayed_by_user_b"`
+	OwnedCount              int64                 `db:"owned_count" json:"owned_count"`
 }
 
-func (q *Queries) GetSharedContractsBatchPaginate(ctx context.Context, arg []GetSharedContractsBatchPaginateParams) *GetSharedContractsBatchPaginateBatchResults {
+func (q *Queries) GetSharedCommunitiesBatchPaginate(ctx context.Context, arg []GetSharedCommunitiesBatchPaginateParams) *GetSharedCommunitiesBatchPaginateBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
 		vals := []interface{}{
@@ -2991,16 +2993,16 @@ func (q *Queries) GetSharedContractsBatchPaginate(ctx context.Context, arg []Get
 			a.PagingForward,
 			a.Limit,
 		}
-		batch.Queue(getSharedContractsBatchPaginate, vals...)
+		batch.Queue(getSharedCommunitiesBatchPaginate, vals...)
 	}
 	br := q.db.SendBatch(ctx, batch)
-	return &GetSharedContractsBatchPaginateBatchResults{br, len(arg), false}
+	return &GetSharedCommunitiesBatchPaginateBatchResults{br, len(arg), false}
 }
 
-func (b *GetSharedContractsBatchPaginateBatchResults) Query(f func(int, []GetSharedContractsBatchPaginateRow, error)) {
+func (b *GetSharedCommunitiesBatchPaginateBatchResults) Query(f func(int, []GetSharedCommunitiesBatchPaginateRow, error)) {
 	defer b.br.Close()
 	for t := 0; t < b.tot; t++ {
-		var items []GetSharedContractsBatchPaginateRow
+		var items []GetSharedCommunitiesBatchPaginateRow
 		if b.closed {
 			if f != nil {
 				f(t, items, ErrBatchAlreadyClosed)
@@ -3014,27 +3016,29 @@ func (b *GetSharedContractsBatchPaginateBatchResults) Query(f func(int, []GetSha
 				return err
 			}
 			for rows.Next() {
-				var i GetSharedContractsBatchPaginateRow
+				var i GetSharedCommunitiesBatchPaginateRow
 				if err := rows.Scan(
 					&i.ID,
-					&i.Deleted,
 					&i.Version,
+					&i.CommunityType,
+					&i.Key1,
+					&i.Key2,
+					&i.Key3,
+					&i.Key4,
+					&i.Name,
+					&i.OverrideName,
+					&i.Description,
+					&i.OverrideDescription,
+					&i.ProfileImageUrl,
+					&i.OverrideProfileImageUrl,
+					&i.BadgeUrl,
+					&i.OverrideBadgeUrl,
+					&i.ContractID,
 					&i.CreatedAt,
 					&i.LastUpdated,
-					&i.Name,
-					&i.Symbol,
-					&i.Address,
-					&i.CreatorAddress,
-					&i.Chain,
-					&i.ProfileBannerUrl,
-					&i.ProfileImageUrl,
-					&i.BadgeUrl,
-					&i.Description,
-					&i.OwnerAddress,
-					&i.IsProviderMarkedSpam,
-					&i.ParentID,
-					&i.OverrideCreatorUserID,
-					&i.L1Chain,
+					&i.Deleted,
+					&i.WebsiteUrl,
+					&i.OverrideWebsiteUrl,
 					&i.DisplayedByUserA,
 					&i.DisplayedByUserB,
 					&i.OwnedCount,
@@ -3051,7 +3055,7 @@ func (b *GetSharedContractsBatchPaginateBatchResults) Query(f func(int, []GetSha
 	}
 }
 
-func (b *GetSharedContractsBatchPaginateBatchResults) Close() error {
+func (b *GetSharedCommunitiesBatchPaginateBatchResults) Close() error {
 	b.closed = true
 	return b.br.Close()
 }

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -395,6 +395,16 @@ type Notification struct {
 	MentionID   persist.DBID             `db:"mention_id" json:"mention_id"`
 }
 
+type OwnedCommunity struct {
+	UserID         persist.DBID `db:"user_id" json:"user_id"`
+	UserCreatedAt  time.Time    `db:"user_created_at" json:"user_created_at"`
+	CommunityID    persist.DBID `db:"community_id" json:"community_id"`
+	OwnedCount     int64        `db:"owned_count" json:"owned_count"`
+	DisplayedCount int64        `db:"displayed_count" json:"displayed_count"`
+	Displayed      bool         `db:"displayed" json:"displayed"`
+	LastUpdated    time.Time    `db:"last_updated" json:"last_updated"`
+}
+
 type OwnedContract struct {
 	UserID         persist.DBID `db:"user_id" json:"user_id"`
 	UserCreatedAt  time.Time    `db:"user_created_at" json:"user_created_at"`

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -264,28 +264,28 @@ func (q *Queries) CountPostsByUserID(ctx context.Context, actorID persist.DBID) 
 	return count, err
 }
 
-const countSharedContracts = `-- name: CountSharedContracts :one
+const countSharedCommunities = `-- name: CountSharedCommunities :one
 select count(*)
-from owned_contracts a, owned_contracts b, contracts
-left join marketplace_contracts on contracts.id = marketplace_contracts.contract_id
+from owned_communities a, owned_communities b, communities
+left join contracts on communities.contract_id = contracts.id
+left join marketplace_contracts on communities.contract_id = marketplace_contracts.contract_id
 where a.user_id = $1
   and b.user_id = $2
-  and a.contract_id = b.contract_id
-  and a.contract_id = contracts.id
+  and a.community_id = b.community_id
+  and a.community_id = communities.id
   and marketplace_contracts.contract_id is null
-  and contracts.name is not null
-  and contracts.name != ''
-  and contracts.name != 'Unidentified contract'
-  and not contracts.is_provider_marked_spam
+  and communities.name != ''
+  and communities.name != 'Unidentified contract'
+  and (contracts.is_provider_marked_spam is null or contracts.is_provider_marked_spam = false)
 `
 
-type CountSharedContractsParams struct {
+type CountSharedCommunitiesParams struct {
 	UserAID persist.DBID `db:"user_a_id" json:"user_a_id"`
 	UserBID persist.DBID `db:"user_b_id" json:"user_b_id"`
 }
 
-func (q *Queries) CountSharedContracts(ctx context.Context, arg CountSharedContractsParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countSharedContracts, arg.UserAID, arg.UserBID)
+func (q *Queries) CountSharedCommunities(ctx context.Context, arg CountSharedCommunitiesParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countSharedCommunities, arg.UserAID, arg.UserBID)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/db/migrations/core/000136_owned_communities_view.up.sql
+++ b/db/migrations/core/000136_owned_communities_view.up.sql
@@ -1,0 +1,85 @@
+create materialized view owned_communities as (
+    with community_tokens as (
+        select c.id as community_id, t.id as token_id, t.owner_user_id as owner_user_id
+        from communities c, tokens t
+        where c.community_type = 0
+            and t.contract_id = c.contract_id
+            and not c.deleted
+            and not t.deleted
+
+    union all
+
+    select c.id as community_id, t.id as token_id, t.owner_user_id as owner_user_id
+        from communities c, tokens t, token_community_memberships tcm
+        where c.community_type != 0
+            and t.token_definition_id = tcm.token_definition_id
+            and tcm.community_id = c.id
+            and not c.deleted
+            and not t.deleted
+            and not tcm.deleted
+    ),
+
+    owned_communities as (
+    select
+      users.id as user_id,
+      users.created_at as user_created_at,
+      community_tokens.community_id as community_id,
+      count(tokens.id) as owned_count
+    from users
+    join tokens on
+      tokens.deleted = false
+      and users.id = tokens.owner_user_id
+      and coalesce(tokens.is_user_marked_spam, false) = false
+    join community_tokens on
+      tokens.id = community_tokens.token_id
+    where
+      users.deleted = false
+      and users.universal = false
+    group by
+      users.id,
+      community_tokens.community_id
+  ),
+  displayed_tokens as (
+      select
+        owned_communities.user_id,
+        owned_communities.community_id,
+        community_tokens.token_id
+      from owned_communities, galleries, collections, community_tokens
+      where
+        galleries.deleted = false
+        and collections.deleted = false
+        and galleries.owner_user_id = owned_communities.user_id
+        and collections.owner_user_id = owned_communities.user_id
+        and community_tokens.owner_user_id = owned_communities.user_id
+        and community_tokens.community_id = owned_communities.community_id
+        and community_tokens.token_id = any(collections.nfts)
+      group by
+        owned_communities.user_id,
+        owned_communities.community_id,
+        community_tokens.token_id
+  ),
+  displayed_communities as (
+    select user_id, community_id, count(token_id) as displayed_count from displayed_tokens
+    group by
+      user_id,
+      community_id
+  )
+  select
+      owned_communities.user_id,
+      owned_communities.user_created_at,
+      owned_communities.community_id,
+      owned_communities.owned_count,
+      coalesce(displayed_communities.displayed_count, 0) as displayed_count,
+      (displayed_communities.displayed_count is not null)::bool as displayed,
+      now()::timestamptz as last_updated
+  from owned_communities
+    left join displayed_communities on
+      displayed_communities.user_id = owned_communities.user_id and
+      displayed_communities.community_id = owned_communities.community_id
+);
+
+create unique index owned_communities_user_community_idx on owned_communities(user_id, community_id);
+create index owned_communities_user_displayed_idx on owned_communities(user_id, displayed);
+create index owned_communities_user_created_at_idx on owned_communities(user_created_at);
+
+select cron.schedule('refresh-owned-communities', '30 */3 * * *', 'refresh materialized view concurrently owned_communities with data');

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1279,24 +1279,24 @@ where a.follower = @follower
 	and b.deleted = false
 	and users.deleted = false;
 
--- name: GetSharedContractsBatchPaginate :batchmany
-select contracts.*, a.displayed as displayed_by_user_a, b.displayed as displayed_by_user_b, a.owned_count
-from owned_contracts a, owned_contracts b, contracts
-left join marketplace_contracts on contracts.id = marketplace_contracts.contract_id
+-- name: GetSharedCommunitiesBatchPaginate :batchmany
+select communities.*, a.displayed as displayed_by_user_a, b.displayed as displayed_by_user_b, a.owned_count
+from owned_communities a, owned_communities b, communities
+left join contracts on communities.contract_id = contracts.id
+left join marketplace_contracts on communities.contract_id = marketplace_contracts.contract_id
 where a.user_id = @user_a_id
   and b.user_id = @user_b_id
-  and a.contract_id = b.contract_id
-  and a.contract_id = contracts.id
+  and a.community_id = b.community_id
+  and a.community_id = communities.id
   and marketplace_contracts.contract_id is null
-  and contracts.name is not null
-  and contracts.name != ''
-  and contracts.name != 'Unidentified contract'
-  and not contracts.is_provider_marked_spam
+  and communities.name != ''
+  and communities.name != 'Unidentified contract'
+  and (contracts.is_provider_marked_spam is null or contracts.is_provider_marked_spam = false)
   and (
     a.displayed,
     b.displayed,
     a.owned_count,
-    contracts.id
+    communities.id
   ) > (
     sqlc.arg('cur_before_displayed_by_user_a'),
     sqlc.arg('cur_before_displayed_by_user_b'),
@@ -1307,15 +1307,15 @@ where a.user_id = @user_a_id
     a.displayed,
     b.displayed,
     a.owned_count,
-    contracts.id
+    communities.id
   ) < (
     sqlc.arg('cur_after_displayed_by_user_a'),
     sqlc.arg('cur_after_displayed_by_user_b'),
     sqlc.arg('cur_after_owned_count')::int,
     sqlc.arg('cur_after_contract_id')
   )
-order by case when sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end desc,
-        case when not sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, contracts.id) end asc
+order by case when sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, communities.id) end desc,
+        case when not sqlc.arg('paging_forward')::bool then (a.displayed, b.displayed, a.owned_count, communities.id) end asc
 limit sqlc.arg('limit');
 
 -- name: GetCreatedContractsBatchPaginate :batchmany
@@ -1329,19 +1329,19 @@ order by case when sqlc.arg('paging_forward')::bool then (contracts.created_at, 
         case when not sqlc.arg('paging_forward')::bool then (contracts.created_at, contracts.id) end desc
 limit sqlc.arg('limit');
 
--- name: CountSharedContracts :one
+-- name: CountSharedCommunities :one
 select count(*)
-from owned_contracts a, owned_contracts b, contracts
-left join marketplace_contracts on contracts.id = marketplace_contracts.contract_id
+from owned_communities a, owned_communities b, communities
+left join contracts on communities.contract_id = contracts.id
+left join marketplace_contracts on communities.contract_id = marketplace_contracts.contract_id
 where a.user_id = @user_a_id
   and b.user_id = @user_b_id
-  and a.contract_id = b.contract_id
-  and a.contract_id = contracts.id
+  and a.community_id = b.community_id
+  and a.community_id = communities.id
   and marketplace_contracts.contract_id is null
-  and contracts.name is not null
-  and contracts.name != ''
-  and contracts.name != 'Unidentified contract'
-  and not contracts.is_provider_marked_spam;
+  and communities.name != ''
+  and communities.name != 'Unidentified contract'
+  and (contracts.is_provider_marked_spam is null or contracts.is_provider_marked_spam = false);
 
 -- name: AddPiiAccountCreationInfo :exec
 insert into pii.account_creation_info (user_id, ip_address, created_at) values (@user_id, @ip_address, now())

--- a/graphql/dataloader/api_gen.go
+++ b/graphql/dataloader/api_gen.go
@@ -56,7 +56,7 @@ type Loaders struct {
 	GetOwnersByContractIdBatchPaginate       *GetOwnersByContractIdBatchPaginate
 	GetPostByIdBatch                         *GetPostByIdBatch
 	GetProfileImageByID                      *GetProfileImageByID
-	GetSharedContractsBatchPaginate          *GetSharedContractsBatchPaginate
+	GetSharedCommunitiesBatchPaginate        *GetSharedCommunitiesBatchPaginate
 	GetSharedFollowersBatchPaginate          *GetSharedFollowersBatchPaginate
 	GetTokenByIdBatch                        *GetTokenByIdBatch
 	GetTokenByIdIgnoreDisplayableBatch       *GetTokenByIdIgnoreDisplayableBatch
@@ -135,7 +135,7 @@ func NewLoaders(ctx context.Context, q *coredb.Queries, disableCaching bool, pre
 	loaders.GetOwnersByContractIdBatchPaginate = newGetOwnersByContractIdBatchPaginate(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetOwnersByContractIdBatchPaginate(q), preFetchHook, postFetchHook)
 	loaders.GetPostByIdBatch = newGetPostByIdBatch(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetPostByIdBatch(q), preFetchHook, postFetchHook)
 	loaders.GetProfileImageByID = newGetProfileImageByID(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetProfileImageByID(q), preFetchHook, postFetchHook)
-	loaders.GetSharedContractsBatchPaginate = newGetSharedContractsBatchPaginate(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetSharedContractsBatchPaginate(q), preFetchHook, postFetchHook)
+	loaders.GetSharedCommunitiesBatchPaginate = newGetSharedCommunitiesBatchPaginate(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetSharedCommunitiesBatchPaginate(q), preFetchHook, postFetchHook)
 	loaders.GetSharedFollowersBatchPaginate = newGetSharedFollowersBatchPaginate(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetSharedFollowersBatchPaginate(q), preFetchHook, postFetchHook)
 	loaders.GetTokenByIdBatch = newGetTokenByIdBatch(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetTokenByIdBatch(q), preFetchHook, postFetchHook)
 	loaders.GetTokenByIdIgnoreDisplayableBatch = newGetTokenByIdIgnoreDisplayableBatch(ctx, 100, time.Duration(2000000), !disableCaching, true, loadGetTokenByIdIgnoreDisplayableBatch(q), preFetchHook, postFetchHook)
@@ -1220,15 +1220,15 @@ func loadGetProfileImageByID(q *coredb.Queries) func(context.Context, *GetProfil
 	}
 }
 
-func loadGetSharedContractsBatchPaginate(q *coredb.Queries) func(context.Context, *GetSharedContractsBatchPaginate, []coredb.GetSharedContractsBatchPaginateParams) ([][]coredb.GetSharedContractsBatchPaginateRow, []error) {
-	return func(ctx context.Context, d *GetSharedContractsBatchPaginate, params []coredb.GetSharedContractsBatchPaginateParams) ([][]coredb.GetSharedContractsBatchPaginateRow, []error) {
-		results := make([][]coredb.GetSharedContractsBatchPaginateRow, len(params))
+func loadGetSharedCommunitiesBatchPaginate(q *coredb.Queries) func(context.Context, *GetSharedCommunitiesBatchPaginate, []coredb.GetSharedCommunitiesBatchPaginateParams) ([][]coredb.GetSharedCommunitiesBatchPaginateRow, []error) {
+	return func(ctx context.Context, d *GetSharedCommunitiesBatchPaginate, params []coredb.GetSharedCommunitiesBatchPaginateParams) ([][]coredb.GetSharedCommunitiesBatchPaginateRow, []error) {
+		results := make([][]coredb.GetSharedCommunitiesBatchPaginateRow, len(params))
 		errors := make([]error, len(params))
 
-		b := q.GetSharedContractsBatchPaginate(ctx, params)
+		b := q.GetSharedCommunitiesBatchPaginate(ctx, params)
 		defer b.Close()
 
-		b.Query(func(i int, r []coredb.GetSharedContractsBatchPaginateRow, err error) {
+		b.Query(func(i int, r []coredb.GetSharedCommunitiesBatchPaginateRow, err error) {
 			results[i], errors[i] = r, err
 		})
 

--- a/graphql/dataloader/dataloaders_gen.go
+++ b/graphql/dataloader/dataloaders_gen.go
@@ -1626,34 +1626,34 @@ func newGetProfileImageByID(
 	return d
 }
 
-// GetSharedContractsBatchPaginate batches and caches requests
-type GetSharedContractsBatchPaginate struct {
-	generator.Dataloader[coredb.GetSharedContractsBatchPaginateParams, []coredb.GetSharedContractsBatchPaginateRow]
+// GetSharedCommunitiesBatchPaginate batches and caches requests
+type GetSharedCommunitiesBatchPaginate struct {
+	generator.Dataloader[coredb.GetSharedCommunitiesBatchPaginateParams, []coredb.GetSharedCommunitiesBatchPaginateRow]
 }
 
-// newGetSharedContractsBatchPaginate creates a new GetSharedContractsBatchPaginate with the given settings, functions, and options
-func newGetSharedContractsBatchPaginate(
+// newGetSharedCommunitiesBatchPaginate creates a new GetSharedCommunitiesBatchPaginate with the given settings, functions, and options
+func newGetSharedCommunitiesBatchPaginate(
 	ctx context.Context,
 	maxBatchSize int,
 	batchTimeout time.Duration,
 	cacheResults bool,
 	publishResults bool,
-	fetch func(context.Context, *GetSharedContractsBatchPaginate, []coredb.GetSharedContractsBatchPaginateParams) ([][]coredb.GetSharedContractsBatchPaginateRow, []error),
+	fetch func(context.Context, *GetSharedCommunitiesBatchPaginate, []coredb.GetSharedCommunitiesBatchPaginateParams) ([][]coredb.GetSharedCommunitiesBatchPaginateRow, []error),
 	preFetchHook PreFetchHook,
 	postFetchHook PostFetchHook,
-) *GetSharedContractsBatchPaginate {
-	d := &GetSharedContractsBatchPaginate{}
+) *GetSharedCommunitiesBatchPaginate {
+	d := &GetSharedCommunitiesBatchPaginate{}
 
-	fetchWithHooks := func(ctx context.Context, keys []coredb.GetSharedContractsBatchPaginateParams) ([][]coredb.GetSharedContractsBatchPaginateRow, []error) {
+	fetchWithHooks := func(ctx context.Context, keys []coredb.GetSharedCommunitiesBatchPaginateParams) ([][]coredb.GetSharedCommunitiesBatchPaginateRow, []error) {
 		// Allow the preFetchHook to modify and return a new context
 		if preFetchHook != nil {
-			ctx = preFetchHook(ctx, "GetSharedContractsBatchPaginate")
+			ctx = preFetchHook(ctx, "GetSharedCommunitiesBatchPaginate")
 		}
 
 		results, errors := fetch(ctx, d, keys)
 
 		if postFetchHook != nil {
-			postFetchHook(ctx, "GetSharedContractsBatchPaginate")
+			postFetchHook(ctx, "GetSharedCommunitiesBatchPaginate")
 		}
 
 		return results, errors

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -755,27 +755,23 @@ func (r *galleryUserResolver) SharedFollowers(ctx context.Context, obj *model.Ga
 
 // SharedCommunities is the resolver for the sharedCommunities field.
 func (r *galleryUserResolver) SharedCommunities(ctx context.Context, obj *model.GalleryUser, before *string, after *string, first *int, last *int) (*model.CommunitiesConnection, error) {
-	// TODO: Currently used by frontend, but it's okay if we don't return shared communities for a bit.
-	// Needs to be updated to work with the new communities table.
-	return nil, nil
+	communities, pageInfo, err := publicapi.For(ctx).User.SharedCommunities(ctx, obj.UserID, before, after, first, last)
+	if err != nil {
+		return nil, err
+	}
 
-	//communities, pageInfo, err := publicapi.For(ctx).User.SharedCommunities(ctx, obj.UserID, before, after, first, last)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//
-	//edges := make([]*model.CommunityEdge, len(communities))
-	//for i, community := range communities {
-	//	edges[i] = &model.CommunityEdge{
-	//		Node:   contractToCommunityModel(ctx, community, util.ToPointer(false)),
-	//		Cursor: nil, // not used by relay, but relay will complain without this field existing
-	//	}
-	//}
-	//
-	//return &model.CommunitiesConnection{
-	//	Edges:    edges,
-	//	PageInfo: pageInfoToModel(ctx, pageInfo),
-	//}, nil
+	edges := make([]*model.CommunityEdge, len(communities))
+	for i, community := range communities {
+		edges[i] = &model.CommunityEdge{
+			Node:   communityToModel(ctx, community),
+			Cursor: nil, // not used by relay, but relay will complain without this field existing
+		}
+	}
+
+	return &model.CommunitiesConnection{
+		Edges:    edges,
+		PageInfo: pageInfoToModel(ctx, pageInfo),
+	}, nil
 }
 
 // CreatedCommunities is the resolver for the createdCommunities field.

--- a/publicapi/pagination.go
+++ b/publicapi/pagination.go
@@ -323,28 +323,28 @@ func (p *sharedFollowersPaginator) paginate(before *string, after *string, first
 	return paginator.paginate(before, after, first, last)
 }
 
-type sharedContractsPaginatorParams struct {
+type sharedCommunitiesPaginatorParams struct {
 	Limit                        int32
 	CursorBeforeDisplayedByUserA bool
 	CursorBeforeDisplayedByUserB bool
 	CursorBeforeOwnedCount       int
-	CursorBeforeContractID       persist.DBID
+	CursorBeforeCommunityID      persist.DBID
 	CursorAfterDisplayedByUserA  bool
 	CursorAfterDisplayedByUserB  bool
 	CursorAfterOwnedCount        int
-	CursorAfterContractID        persist.DBID
+	CursorAfterCommunityID       persist.DBID
 	PagingForward                bool
 }
 
-type sharedContractsPaginator struct {
+type sharedCommunitiesPaginator struct {
 	// QueryFunc returns paginated results for the given paging parameters
-	QueryFunc func(params sharedContractsPaginatorParams) ([]interface{}, error)
+	QueryFunc func(params sharedCommunitiesPaginatorParams) ([]interface{}, error)
 
 	// CursorFunc returns:
-	//  * A bool indicating that userA displays the contract on their gallery
-	//  * A bool indicating that userB displays the contract on their gallery
-	//  * An int indicating how many tokens userA owns for a contract
-	//  * A DBID indicating the ID of the contract
+	//  * A bool indicating that userA displays the community on their gallery
+	//  * A bool indicating that userB displays the community on their gallery
+	//  * An int indicating how many tokens userA owns for a community
+	//  * A DBID indicating the ID of the community
 	CursorFunc func(node interface{}) (bool, bool, int64, persist.DBID, error)
 
 	// CountFunc returns the total number of items that can be paginated. May be nil, in which
@@ -352,7 +352,7 @@ type sharedContractsPaginator struct {
 	CountFunc func() (count int, err error)
 }
 
-func (p *sharedContractsPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
+func (p *sharedCommunitiesPaginator) paginate(before *string, after *string, first *int, last *int) ([]interface{}, PageInfo, error) {
 	queryFunc := func(limit int32, pagingForward bool) ([]interface{}, error) {
 		beforeCur := cursors.NewBoolBoolIntIDCursor()
 		beforeCur.Bool1 = false
@@ -377,16 +377,16 @@ func (p *sharedContractsPaginator) paginate(before *string, after *string, first
 			}
 		}
 
-		queryParams := sharedContractsPaginatorParams{
+		queryParams := sharedCommunitiesPaginatorParams{
 			Limit:                        limit,
 			CursorBeforeDisplayedByUserA: beforeCur.Bool1,
 			CursorBeforeDisplayedByUserB: beforeCur.Bool2,
 			CursorBeforeOwnedCount:       int(beforeCur.Int),
-			CursorBeforeContractID:       beforeCur.ID,
+			CursorBeforeCommunityID:      beforeCur.ID,
 			CursorAfterDisplayedByUserA:  afterCur.Bool1,
 			CursorAfterDisplayedByUserB:  afterCur.Bool2,
 			CursorAfterOwnedCount:        int(afterCur.Int),
-			CursorAfterContractID:        afterCur.ID,
+			CursorAfterCommunityID:       afterCur.ID,
 			PagingForward:                pagingForward,
 		}
 


### PR DESCRIPTION
# What's new?

This PR creates the `owned_communities` materialized view, which is almost identical to the existing `owned_contracts` materialized view, except that also includes communities.

The "get shared communities" resolver is also updated to use this view instead of the contracts view, so users can see which subcommunities they have in common with others.