### PR TITLE
Add mintUrl to TokenDefinitionType

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -1487,6 +1487,7 @@ type ComplexityRoot struct {
 		ID            func(childComplexity int) int
 		LastUpdated   func(childComplexity int) int
 		Media         func(childComplexity int) int
+		MintURL       func(childComplexity int) int
 		Name          func(childComplexity int) int
 		TokenID       func(childComplexity int) int
 		TokenMetadata func(childComplexity int) int
@@ -2163,6 +2164,8 @@ type TokenDefinitionResolver interface {
 	TokenMetadata(ctx context.Context, obj *model.TokenDefinition) (*string, error)
 	Community(ctx context.Context, obj *model.TokenDefinition) (*model.Community, error)
 	Communities(ctx context.Context, obj *model.TokenDefinition) ([]*model.Community, error)
+
+	MintURL(ctx context.Context, obj *model.TokenDefinition) (*string, error)
 }
 type TokenHolderResolver interface {
 	Wallets(ctx context.Context, obj *model.TokenHolder) ([]*model.Wallet, error)
@@ -8407,6 +8410,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.TokenDefinition.Media(childComplexity), true
 
+	case "TokenDefinition.mintUrl":
+		if e.complexity.TokenDefinition.MintURL == nil {
+			break
+		}
+
+		return e.complexity.TokenDefinition.MintURL(childComplexity), true
+
 	case "TokenDefinition.name":
 		if e.complexity.TokenDefinition.Name == nil {
 			break
@@ -9824,6 +9834,7 @@ type TokenDefinition implements Node @goEmbedHelper {
   community: Community @goField(forceResolver: true)
   communities: [Community] @goField(forceResolver: true)
   externalUrl: String
+  mintUrl: String @goField(forceResolver: true)
 }
 
 type Token implements Node @goEmbedHelper {
@@ -55644,6 +55655,8 @@ func (ec *executionContext) fieldContext_Token_definition(ctx context.Context, f
 				return ec.fieldContext_TokenDefinition_communities(ctx, field)
 			case "externalUrl":
 				return ec.fieldContext_TokenDefinition_externalUrl(ctx, field)
+			case "mintUrl":
+				return ec.fieldContext_TokenDefinition_mintUrl(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TokenDefinition", field.Name)
 		},
@@ -57521,6 +57534,47 @@ func (ec *executionContext) fieldContext_TokenDefinition_externalUrl(ctx context
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenDefinition_mintUrl(ctx context.Context, field graphql.CollectedField, obj *model.TokenDefinition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TokenDefinition_mintUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TokenDefinition().MintURL(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TokenDefinition_mintUrl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TokenDefinition",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -83298,6 +83352,23 @@ func (ec *executionContext) _TokenDefinition(ctx context.Context, sel ast.Select
 
 			out.Values[i] = ec._TokenDefinition_externalUrl(ctx, field, obj)
 
+		case "mintUrl":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TokenDefinition_mintUrl(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -2511,6 +2511,7 @@ type TokenDefinition struct {
 	Community     *Community     `json:"community"`
 	Communities   []*Community   `json:"communities"`
 	ExternalURL   *string        `json:"externalUrl"`
+	MintURL       *string        `json:"mintUrl"`
 }
 
 func (TokenDefinition) IsNode() {}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -3189,6 +3189,30 @@ func (r *tokenDefinitionResolver) Communities(ctx context.Context, obj *model.To
 	return resolveCommunitiesByTokenDefinitionID(ctx, obj.Dbid)
 }
 
+// MintURL is the resolver for the mintUrl field.
+func (r *tokenDefinitionResolver) MintURL(ctx context.Context, obj *model.TokenDefinition) (*string, error) {
+	contract, err := publicapi.For(ctx).Contract.GetContractByID(ctx, obj.HelperTokenDefinitionData.Definition.ContractID)
+	if err != nil {
+		return nil, err
+	}
+
+	var mintURL string
+
+	if contract.Address != "" && !contract.IsProviderMarkedSpam {
+		if contract.Chain == persist.ChainZora {
+			mintURL = fmt.Sprintf("https://zora.co/collect/zora:%s/%s", contract.Address, obj.HelperTokenDefinitionData.Definition.TokenID.Base10String())
+		} else if contract.Chain == persist.ChainBase {
+			mintURL = fmt.Sprintf("https://mint.fun/base/%s", contract.Address)
+		} else if contract.Chain == persist.ChainOptimism {
+			mintURL = fmt.Sprintf("https://mint.fun/op/%s", contract.Address)
+		} else if contract.Chain == persist.ChainETH {
+			mintURL = fmt.Sprintf("https://mint.fun/ethereum/%s", contract.Address)
+		}
+	}
+
+	return &mintURL, nil
+}
+
 // Wallets is the resolver for the wallets field.
 func (r *tokenHolderResolver) Wallets(ctx context.Context, obj *model.TokenHolder) ([]*model.Wallet, error) {
 	wallets := make([]*model.Wallet, 0, len(obj.WalletIds))

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -440,6 +440,7 @@ type TokenDefinition implements Node @goEmbedHelper {
   community: Community @goField(forceResolver: true)
   communities: [Community] @goField(forceResolver: true)
   externalUrl: String
+  mintUrl: String @goField(forceResolver: true)
 }
 
 type Token implements Node @goEmbedHelper {


### PR DESCRIPTION
Adds `mintUrl` to the `TokenDefinition` type. This differs from the `Contract` and `Community` mint URLs by providing a token-specific URL when applicable.
```graphql
type TokenDefinition {
    mintUrl: String @goField(forceResolver: true)
}
```