### PR TITLE
Change holder syncs to append only

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -95,7 +95,7 @@ func testTokenSyncs(t *testing.T) {
 		{title: "should sync new tokens multichain", run: testSyncNewTokensMultichain},
 		{title: "should submit new tokens to tokenprocessing", run: testSyncOnlySubmitsNewTokens},
 		{title: "should not submit old tokens to tokenprocessing", run: testSyncSkipsSubmittingOldTokens},
-		{title: "should delete old tokens", run: testSyncDeletesOldTokens},
+		{title: "should not delete old tokens", run: testSyncNotDeletesOldTokens},
 		{title: "should combine all tokens from providers", run: testSyncShouldCombineProviders},
 		{title: "should merge duplicates within provider", run: testSyncShouldMergeDuplicatesInProvider},
 		{title: "should merge duplicates across providers", run: testSyncShouldMergeDuplicatesAcrossProviders},
@@ -979,7 +979,7 @@ func testSyncSkipsSubmittingOldTokens(t *testing.T) {
 	tokenRecorder.AssertNotCalled(t, "Send")
 }
 
-func testSyncDeletesOldTokens(t *testing.T) {
+func testSyncNotDeletesOldTokens(t *testing.T) {
 	userF := newUserWithTokensFixture(t)
 	provider := newStubProvider(withDummyTokenN(multichain.ChainAgnosticContract{Address: "0x1337"}, userF.Wallet.Address, 4))
 	h := handlerWithProviders(t, submitUserTokensNoop, provider)
@@ -988,7 +988,7 @@ func testSyncDeletesOldTokens(t *testing.T) {
 	response, err := syncTokensMutation(context.Background(), c, []Chain{ChainEthereum}, nil)
 
 	require.NoError(t, err)
-	assertSyncedTokens(t, response, err, 4)
+	assertSyncedTokens(t, response, err, 4+len(userF.TokenIDs))
 }
 
 func testSyncShouldCombineProviders(t *testing.T) {

--- a/graphql/stub_test.go
+++ b/graphql/stub_test.go
@@ -29,6 +29,7 @@ type stubProvider struct {
 	Tokens        []multichain.ChainAgnosticToken
 	FetchMetadata func() (persist.TokenMetadata, error)
 	Info          multichain.BlockchainInfo
+	RetErr        error
 }
 
 func (p stubProvider) GetBlockchainInfo() multichain.BlockchainInfo {
@@ -36,7 +37,7 @@ func (p stubProvider) GetBlockchainInfo() multichain.BlockchainInfo {
 }
 
 func (p stubProvider) GetTokensByWalletAddress(ctx context.Context, address persist.Address) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
-	return p.Tokens, p.Contracts, nil
+	return p.Tokens, p.Contracts, p.RetErr
 }
 
 func (p stubProvider) GetTokensIncrementallyByWalletAddress(ctx context.Context, address persist.Address) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
@@ -96,6 +97,13 @@ func withContracts(contracts []multichain.ChainAgnosticContract) providerOpt {
 func withTokens(tokens []multichain.ChainAgnosticToken) providerOpt {
 	return func(p *stubProvider) {
 		p.Tokens = tokens
+	}
+}
+
+// withReturnError configures the stubProvider to return an error
+func withReturnError(err error) providerOpt {
+	return func(p *stubProvider) {
+		p.RetErr = err
 	}
 }
 

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -53,11 +53,9 @@ func (m *Metadata) UnmarshalJSON(data []byte) error {
 
 		asString := ""
 		if err := json.Unmarshal(data, &asString); err != nil {
-			fmt.Printf("failed to unmarshal Metadata as string: %s", err)
-			return nil
+			return err
 		}
 
-		fmt.Println("Metadata as string:", asString)
 		return nil
 	}
 

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -322,10 +322,11 @@ func (p *Provider) SyncTokensByUserID(ctx context.Context, userID persist.DBID, 
 	go func() {
 		defer close(incomingTokens)
 		defer close(incomingContracts)
+		defer close(errChan)
 		wg.Wait()
 	}()
 
-	_, err = p.receiveSyncedTokensForUser(ctx, user, chains, incomingTokens, incomingContracts, errChan, true)
+	_, err = p.receiveSyncedTokensForUser(ctx, user, chains, incomingTokens, incomingContracts, errChan)
 	return err
 }
 
@@ -604,10 +605,11 @@ func (p *Provider) SyncTokensByUserIDAndTokenIdentifiers(ctx context.Context, us
 	go func() {
 		defer close(incomingTokens)
 		defer close(incomingContracts)
+		defer close(errChan)
 		wg.Wait()
 	}()
 
-	return p.receiveSyncedTokensForUser(ctx, user, chains, incomingTokens, incomingContracts, errChan, false)
+	return p.receiveSyncedTokensForUser(ctx, user, chains, incomingTokens, incomingContracts, errChan)
 }
 
 // TokenExists checks if a token exists according to any provider by its identifiers. It returns nil if the token exists.
@@ -682,34 +684,59 @@ func (p *Provider) SyncTokenByUserWalletsAndTokenIdentifiersRetry(ctx context.Co
 	return token, err
 }
 
-func (p *Provider) receiveSyncedTokensForUser(ctx context.Context, user persist.User, chains []persist.Chain, incomingTokens chan chainTokens, incomingContracts chan chainContracts, errChan chan error, replace bool) ([]op.TokenFullDetails, error) {
+func (p *Provider) receiveSyncedTokensForUser(ctx context.Context, user persist.User, chains []persist.Chain, tokensCh <-chan chainTokens, contractsCh <-chan chainContracts, errCh <-chan error) ([]op.TokenFullDetails, error) {
 	tokensFromProviders := make([]chainTokens, 0, len(user.Wallets))
 	contractsFromProviders := make([]chainContracts, 0, len(user.Wallets))
-
-	errs := []error{}
 	discrepencyLog := map[int]int{}
 
-outer:
+	var tokenOpen, contractOpen bool
+	var tokens chainTokens
+	var contracts chainContracts
+	var err error
+
+receiverLoop:
 	for {
 		select {
-		case incomingTokens := <-incomingTokens:
-			discrepencyLog[incomingTokens.priority] = len(incomingTokens.tokens)
-			tokensFromProviders = append(tokensFromProviders, incomingTokens)
-			logger.For(ctx).Infof("received %d incoming agnostic tokens for user %s", len(incomingTokens.tokens), user.ID)
-		case incomingContracts, ok := <-incomingContracts:
-			if !ok {
-				break outer
+		case tokens, tokenOpen = <-tokensCh:
+			if tokenOpen {
+				discrepencyLog[tokens.priority] = len(tokens.tokens)
+				tokensFromProviders = append(tokensFromProviders, tokens)
+				logger.For(ctx).Infof("received %d incoming agnostic tokens for user %s", len(tokens.tokens), user.ID)
+				continue
 			}
-			contractsFromProviders = append(contractsFromProviders, incomingContracts)
+			if !contractOpen {
+				break receiverLoop
+			}
+		case contracts, contractOpen = <-contractsCh:
+			if contractOpen {
+				contractsFromProviders = append(contractsFromProviders, contracts)
+				continue
+			}
+			if !tokenOpen {
+				break receiverLoop
+			}
+		case e := <-errCh:
+			if e != nil {
+				err = e
+			}
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case err := <-errChan:
-			errs = append(errs, err)
 		}
 	}
-	if len(errs) > 0 && len(tokensFromProviders) == 0 {
-		return nil, util.MultiErr(errs)
+
+	for e := range errCh {
+		if e != nil {
+			err = e
+		}
 	}
+
+	if err != nil {
+		if len(contractsFromProviders) == 0 {
+			return nil, err
+		}
+		logger.For(ctx).Warnf("error occured by a provider: %s; continuing since others succeeded", err)
+	}
+
 	if !util.AllEqual(util.MapValues(discrepencyLog)) {
 		logger.For(ctx).Debugf("discrepency: %+v", discrepencyLog)
 	}
@@ -724,17 +751,8 @@ outer:
 		return nil, err
 	}
 
-	var newTokens []op.TokenFullDetails
-	if replace {
-		_, newTokens, err = p.ReplaceHolderTokensForUser(ctx, user, tokensFromProviders, persistedContracts, chains, currentTokens)
-	} else {
-		_, newTokens, err = p.AddHolderTokensToUser(ctx, user, tokensFromProviders, persistedContracts, currentTokens)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	return newTokens, nil
+	_, newTokens, err := p.AddHolderTokensToUser(ctx, user, tokensFromProviders, persistedContracts, currentTokens)
+	return newTokens, err
 }
 
 func (p *Provider) receiveSyncedCreatedTokensIncrementallyForUser(ctx context.Context, user persist.User, chains []persist.Chain, result <-chan chainTokensAndContracts, errChan chan error) error {
@@ -811,7 +829,7 @@ outer:
 		}
 	}
 	if len(errs) > 0 && totalTokensReceived == 0 {
-		return nil, nil, util.MultiErr(errs)
+		return nil, nil, errs[0]
 	}
 
 	return currentTokens, currentContracts, nil
@@ -944,7 +962,7 @@ outer:
 	}
 
 	if len(errs) > 0 && len(tokensFromProviders) == 0 {
-		return util.MultiErr(errs)
+		return errs[0]
 	}
 	if !util.AllEqual(util.MapValues(discrepencyLog)) {
 		logger.For(ctx).Debugf("discrepency: %+v", discrepencyLog)
@@ -1736,26 +1754,11 @@ func chainTokensToUpsertableTokenDefinitions(ctx context.Context, chainTokens []
 	}
 
 	tokenDefinitions := make([]db.TokenDefinition, 0, len(definitions))
-	for _, definition := range definitions {
-		go logFallbackFailure(ctx, definition)
-		tokenDefinitions = append(tokenDefinitions, definition)
+	for _, d := range definitions {
+		tokenDefinitions = append(tokenDefinitions, d)
 	}
 
 	return tokenDefinitions
-}
-
-func logFallbackFailure(ctx context.Context, tdef db.TokenDefinition) {
-	// make a get request to the fallback media url that disregards the response and just checks for valid statuses, logging any non-200 status codes
-	if tdef.FallbackMedia.ImageURL != "" {
-		resp, err := http.Get(tdef.FallbackMedia.ImageURL.String())
-		if err != nil || resp.StatusCode != http.StatusOK {
-			msg := fmt.Sprintf("error making request to fallback media url for token %s: (url: %s) (err: %s)", tdef.ID, tdef.FallbackMedia.ImageURL, err)
-			if resp != nil {
-				msg += fmt.Sprintf(" (status: %d)", resp.StatusCode)
-			}
-			logger.For(ctx).Error(msg)
-		}
-	}
 }
 
 // chainTokensToUpsertableTokens returns a unique slice of tokens that are ready to be upserted into the database.


### PR DESCRIPTION
**Changes**
* Change holder syncs to append only instead of replacing holder tokens for now
* Fix race condition in `receiveSyncedTokensForUser` where the error returned from a provider may not get checked
* Minor changes to the Alchemy provider: fix bug where the error from marshalling wasn't returned and also remove extra print statement
* Remove `logFallbackFailure` - this could create an uncapped number of goroutines, so I removed it for now
* Add a test that checks that tokens aren't deleted from a failing provider
* Remove multiErr from syncs and instead returns the latest error so that it can get wrapped properly to the correct graphQL error type