### PR TITLE
Benny/announcement

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -515,7 +515,7 @@ func (q *Queries) CreateAdmireNotification(ctx context.Context, arg CreateAdmire
 const createAnnouncementNotifications = `-- name: CreateAnnouncementNotifications :many
 WITH 
 id_with_row_number AS (
-    SELECT unnest($4::varchar(255)[]) AS id, row_number() OVER (ORDER BY unnest($4::varchar(255)[])) AS rn
+    SELECT unnest($5::varchar(255)[]) AS id, row_number() OVER (ORDER BY unnest($5::varchar(255)[])) AS rn
 ),
 user_with_row_number AS (
     SELECT id AS user_id, row_number() OVER () AS rn
@@ -537,7 +537,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM notifications n
     WHERE n.owner_id = u.user_id 
-    AND n.data ->> 'internal_id' = $2 ->> 'internal_id'
+    AND n.data ->> 'internal_id' = $4::varchar
 )
 RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, mention_id, community_id
 `
@@ -546,6 +546,7 @@ type CreateAnnouncementNotificationsParams struct {
 	Action   persist.Action           `db:"action" json:"action"`
 	Data     persist.NotificationData `db:"data" json:"data"`
 	EventIds persist.DBIDList         `db:"event_ids" json:"event_ids"`
+	Internal string                   `db:"internal" json:"internal"`
 	Ids      []string                 `db:"ids" json:"ids"`
 }
 
@@ -558,6 +559,7 @@ func (q *Queries) CreateAnnouncementNotifications(ctx context.Context, arg Creat
 		arg.Action,
 		arg.Data,
 		arg.EventIds,
+		arg.Internal,
 		arg.Ids,
 	)
 	if err != nil {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -912,7 +912,7 @@ func (q *Queries) CreateContractNotification(ctx context.Context, arg CreateCont
 }
 
 const createDataOnlyEvent = `-- name: CreateDataOnlyEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id, mention_id
+INSERT INTO events (id, actor_id, action, resource_type_id, data, group_id, caption, subject_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id, mention_id
 `
 
 type CreateDataOnlyEventParams struct {
@@ -923,6 +923,7 @@ type CreateDataOnlyEventParams struct {
 	Data           persist.EventData    `db:"data" json:"data"`
 	GroupID        sql.NullString       `db:"group_id" json:"group_id"`
 	Caption        sql.NullString       `db:"caption" json:"caption"`
+	SubjectID      persist.DBID         `db:"subject_id" json:"subject_id"`
 }
 
 func (q *Queries) CreateDataOnlyEvent(ctx context.Context, arg CreateDataOnlyEventParams) (Event, error) {
@@ -934,6 +935,7 @@ func (q *Queries) CreateDataOnlyEvent(ctx context.Context, arg CreateDataOnlyEve
 		arg.Data,
 		arg.GroupID,
 		arg.Caption,
+		arg.SubjectID,
 	)
 	var i Event
 	err := row.Scan(

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -533,6 +533,12 @@ FROM
     id_with_row_number i
 JOIN 
     user_with_row_number u ON i.rn = u.rn
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM notifications n
+    WHERE n.owner_id = u.user_id 
+    AND n.data ->> 'internal_id' = $2 ->> 'internal_id'
+)
 RETURNING id, deleted, owner_id, version, last_updated, created_at, action, data, event_ids, feed_event_id, comment_id, gallery_id, seen, amount, post_id, token_id, mention_id, community_id
 `
 

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -911,6 +911,59 @@ func (q *Queries) CreateContractNotification(ctx context.Context, arg CreateCont
 	return i, err
 }
 
+const createDataOnlyEvent = `-- name: CreateDataOnlyEvent :one
+INSERT INTO events (id, actor_id, action, resource_type_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, version, actor_id, resource_type_id, subject_id, user_id, token_id, collection_id, action, data, deleted, last_updated, created_at, gallery_id, comment_id, admire_id, feed_event_id, external_id, caption, group_id, post_id, contract_id, mention_id
+`
+
+type CreateDataOnlyEventParams struct {
+	ID             persist.DBID         `db:"id" json:"id"`
+	ActorID        sql.NullString       `db:"actor_id" json:"actor_id"`
+	Action         persist.Action       `db:"action" json:"action"`
+	ResourceTypeID persist.ResourceType `db:"resource_type_id" json:"resource_type_id"`
+	Data           persist.EventData    `db:"data" json:"data"`
+	GroupID        sql.NullString       `db:"group_id" json:"group_id"`
+	Caption        sql.NullString       `db:"caption" json:"caption"`
+}
+
+func (q *Queries) CreateDataOnlyEvent(ctx context.Context, arg CreateDataOnlyEventParams) (Event, error) {
+	row := q.db.QueryRow(ctx, createDataOnlyEvent,
+		arg.ID,
+		arg.ActorID,
+		arg.Action,
+		arg.ResourceTypeID,
+		arg.Data,
+		arg.GroupID,
+		arg.Caption,
+	)
+	var i Event
+	err := row.Scan(
+		&i.ID,
+		&i.Version,
+		&i.ActorID,
+		&i.ResourceTypeID,
+		&i.SubjectID,
+		&i.UserID,
+		&i.TokenID,
+		&i.CollectionID,
+		&i.Action,
+		&i.Data,
+		&i.Deleted,
+		&i.LastUpdated,
+		&i.CreatedAt,
+		&i.GalleryID,
+		&i.CommentID,
+		&i.AdmireID,
+		&i.FeedEventID,
+		&i.ExternalID,
+		&i.Caption,
+		&i.GroupID,
+		&i.PostID,
+		&i.ContractID,
+		&i.MentionID,
+	)
+	return i, err
+}
+
 const createFeedEvent = `-- name: CreateFeedEvent :one
 INSERT INTO feed_events (id, owner_id, action, data, event_time, event_ids, group_id, caption) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id, version, owner_id, action, data, event_time, event_ids, deleted, last_updated, created_at, caption, group_id
 `

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -426,7 +426,7 @@ INSERT INTO events (id, actor_id, action, resource_type_id, contract_id, subject
 INSERT INTO events (id, actor_id, action, resource_type_id, user_id, subject_id, post_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;
 
 -- name: CreateDataOnlyEvent :one
-INSERT INTO events (id, actor_id, action, resource_type_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;
+INSERT INTO events (id, actor_id, action, resource_type_id, data, group_id, caption, subject_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *;
 
 -- name: CreateAdmireEvent :one
 INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, token_id, comment_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), sqlc.narg('token'), sqlc.narg('comment'), $6, $7, $8, $9) RETURNING *;

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -914,6 +914,12 @@ FROM
     id_with_row_number i
 JOIN 
     user_with_row_number u ON i.rn = u.rn
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM notifications n
+    WHERE n.owner_id = u.user_id 
+    AND n.data ->> 'internal_id' = $2 ->> 'internal_id'
+)
 RETURNING *;
 
 -- name: CountAllUsers :one

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -425,6 +425,9 @@ INSERT INTO events (id, actor_id, action, resource_type_id, contract_id, subject
 -- name: CreatePostEvent :one
 INSERT INTO events (id, actor_id, action, resource_type_id, user_id, subject_id, post_id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;
 
+-- name: CreateDataOnlyEvent :one
+INSERT INTO events (id, actor_id, action, resource_type_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;
+
 -- name: CreateAdmireEvent :one
 INSERT INTO events (id, actor_id, action, resource_type_id, admire_id, feed_event_id, post_id, token_id, comment_id, subject_id, data, group_id, caption) VALUES ($1, $2, $3, $4, $5, sqlc.narg('feed_event'), sqlc.narg('post'), sqlc.narg('token'), sqlc.narg('comment'), $6, $7, $8, $9) RETURNING *;
 

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -918,7 +918,7 @@ WHERE NOT EXISTS (
     SELECT 1
     FROM notifications n
     WHERE n.owner_id = u.user_id 
-    AND n.data ->> 'internal_id' = $2 ->> 'internal_id'
+    AND n.data ->> 'internal_id' = sqlc.arg('internal')::varchar
 )
 RETURNING *;
 

--- a/emails/handler.go
+++ b/emails/handler.go
@@ -54,7 +54,7 @@ func handlersInitServer(router *gin.Engine, loaders *dataloader.Loaders, queries
 
 	notificationsGroup := router.Group("/notifications")
 	notificationsGroup.GET("/send", middleware.CloudSchedulerMiddleware, sendNotificationEmails(queries, s, r))
-	notificationsGroup.POST("/announcement", middleware.RetoolMiddleware, useEventHandler(queries, psub, t, notifLock), sendAnnouncementNotification())
+	notificationsGroup.POST("/announcement", middleware.RetoolMiddleware, useEventHandler(queries, psub, t, notifLock), sendAnnouncementNotification(queries))
 
 	return router
 }

--- a/emails/send.go
+++ b/emails/send.go
@@ -169,7 +169,7 @@ func sendAnnouncementNotification(q *coredb.Queries) gin.HandlerFunc {
 
 		err = event.Dispatch(c, coredb.Event{
 			ID:             persist.GenerateID(),
-			ResourceTypeID: persist.ResourceTypeUser,
+			ResourceTypeID: persist.ResourceTypeAllUsers,
 			Action:         persist.ActionAnnouncement,
 			UserID:         galleryUser.ID,
 			ActorID:        persist.DBIDToNullStr(galleryUser.ID),

--- a/emails/send.go
+++ b/emails/send.go
@@ -172,6 +172,7 @@ func sendAnnouncementNotification(q *coredb.Queries) gin.HandlerFunc {
 			ResourceTypeID: persist.ResourceTypeAllUsers,
 			Action:         persist.ActionAnnouncement,
 			UserID:         galleryUser.ID,
+			SubjectID:      galleryUser.ID,
 			ActorID:        persist.DBIDToNullStr(galleryUser.ID),
 			Data: persist.EventData{
 				AnnouncementDetails: &in,

--- a/emails/send.go
+++ b/emails/send.go
@@ -155,15 +155,15 @@ func sendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, r *redi
 }
 
 func sendAnnouncementNotification() gin.HandlerFunc {
-	return func(ctx *gin.Context) {
+	return func(c *gin.Context) {
 		var in persist.AnnouncementDetails
-		err := ctx.ShouldBindJSON(&in)
+		err := c.ShouldBindJSON(&in)
 		if err != nil {
-			util.ErrResponse(ctx, http.StatusBadRequest, err)
+			util.ErrResponse(c, http.StatusBadRequest, err)
 			return
 		}
 
-		err = event.Dispatch(ctx, coredb.Event{
+		err = event.Dispatch(c, coredb.Event{
 			ID:             persist.GenerateID(),
 			ResourceTypeID: persist.ResourceTypeUser,
 			Action:         persist.ActionAnnouncement,
@@ -171,6 +171,12 @@ func sendAnnouncementNotification() gin.HandlerFunc {
 				AnnouncementDetails: &in,
 			},
 		})
+		if err != nil {
+			util.ErrResponse(c, http.StatusInternalServerError, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, util.SuccessResponse{Success: true})
 	}
 }
 

--- a/emails/send.go
+++ b/emails/send.go
@@ -154,7 +154,11 @@ func sendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, r *redi
 	}
 }
 
-func sendAnnouncementNotification() gin.HandlerFunc {
+func sendAnnouncementNotification(q *coredb.Queries) gin.HandlerFunc {
+	galleryUser, err := q.GetUserByUsername(context.Background(), "gallery")
+	if err != nil {
+		panic(err)
+	}
 	return func(c *gin.Context) {
 		var in persist.AnnouncementDetails
 		err := c.ShouldBindJSON(&in)
@@ -167,6 +171,8 @@ func sendAnnouncementNotification() gin.HandlerFunc {
 			ID:             persist.GenerateID(),
 			ResourceTypeID: persist.ResourceTypeUser,
 			Action:         persist.ActionAnnouncement,
+			UserID:         galleryUser.ID,
+			ActorID:        persist.DBIDToNullStr(galleryUser.ID),
 			Data: persist.EventData{
 				AnnouncementDetails: &in,
 			},

--- a/event/event.go
+++ b/event/event.go
@@ -57,7 +57,8 @@ func AddTo(ctx *gin.Context, disableDataloaderCaching bool, notif *notifications
 
 	notifications := newEventDispatcher()
 	notificationHandler := newNotificationHandler(notif, disableDataloaderCaching, queries)
-	followerNotificationHandler := newFollowerNotificationHandler(notif, disableDataloaderCaching, queries)
+	followerNotificationHandler := newFollowerNotificationHandler(notif)
+	announcementNotificationHandler := newAnnouncementNotificationHandler(notif)
 	sender.addDelayedHandler(notifications, persist.ActionUserFollowedUsers, notificationHandler)
 	sender.addDelayedHandler(notifications, persist.ActionAdmiredFeedEvent, notificationHandler)
 	sender.addDelayedHandler(notifications, persist.ActionAdmiredToken, notificationHandler)
@@ -73,6 +74,7 @@ func AddTo(ctx *gin.Context, disableDataloaderCaching bool, notif *notifications
 	sender.addDelayedHandler(notifications, persist.ActionUserPostedYourWork, notificationHandler)
 	sender.addDelayedHandler(notifications, persist.ActionUserPostedFirstPost, followerNotificationHandler)
 	sender.addDelayedHandler(notifications, persist.ActionTopActivityBadgeReceived, notificationHandler)
+	sender.addDelayedHandler(notifications, persist.ActionAnnouncement, announcementNotificationHandler)
 
 	sender.feed = feed
 	sender.notifications = notifications
@@ -592,14 +594,12 @@ func (h notificationHandler) createNotificationDataForEvent(event db.Event) (dat
 
 // followerNotificationHandler handles events for consumption as notifications.
 type followerNotificationHandler struct {
-	dataloaders          *dataloader.Loaders
 	notificationHandlers *notifications.NotificationHandlers
 }
 
-func newFollowerNotificationHandler(notifiers *notifications.NotificationHandlers, disableDataloaderCaching bool, queries *db.Queries) *followerNotificationHandler {
+func newFollowerNotificationHandler(notifiers *notifications.NotificationHandlers) *followerNotificationHandler {
 	return &followerNotificationHandler{
 		notificationHandlers: notifiers,
-		dataloaders:          dataloader.NewLoaders(context.Background(), queries, disableDataloaderCaching, tracing.DataloaderPreFetchHook, tracing.DataloaderPostFetchHook),
 	}
 }
 
@@ -615,6 +615,28 @@ func (h followerNotificationHandler) handleDelayed(ctx context.Context, persiste
 		TokenID:     persistedEvent.TokenID,
 		ContractID:  persistedEvent.ContractID,
 		MentionID:   persistedEvent.MentionID,
+	})
+}
+
+// global handles events for consumption as global notifications.
+type announcementNotificationHandler struct {
+	notificationHandlers *notifications.NotificationHandlers
+}
+
+func newAnnouncementNotificationHandler(notifiers *notifications.NotificationHandlers) *announcementNotificationHandler {
+	return &announcementNotificationHandler{
+		notificationHandlers: notifiers,
+	}
+}
+
+func (h announcementNotificationHandler) handleDelayed(ctx context.Context, persistedEvent db.Event) error {
+	return h.notificationHandlers.Notifications.Dispatch(ctx, db.Notification{
+		// no owner or data for follower notifications
+		Action:   persistedEvent.Action,
+		EventIds: persist.DBIDList{persistedEvent.ID},
+		Data: persist.NotificationData{
+			AnnouncementDetails: persistedEvent.Data.AnnouncementDetails,
+		},
 	})
 }
 

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -9625,7 +9625,6 @@ input ChainPubKeyInput {
   chain: Chain! @goField(forceResolver: true)
 }
 
-
 type ContractCommunityKey {
   contract: ChainAddress
 }
@@ -9635,8 +9634,8 @@ input ContractCommunityKeyInput {
 }
 
 type ArtBlocksCommunityKey {
-    contract: ChainAddress
-    projectID: String
+  contract: ChainAddress
+  projectID: String
 }
 
 input ArtBlocksCommunityKeyInput {
@@ -10125,8 +10124,7 @@ type Community implements Node @goEmbedHelper {
   creatorAddress: ChainAddress
     @goField(forceResolver: true)
     @deprecated(reason: "Use Community.creators to get an address")
-  creator: GalleryUserOrAddress
-    @goField(forceResolver: true)
+  creator: GalleryUserOrAddress @goField(forceResolver: true)
 
   tokensInCommunity(
     before: String
@@ -10296,13 +10294,13 @@ type UserEmail {
 type EmailNotificationSettings {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
-  unsubscribedFromDigest: Boolean # TODO make this non-nullable
+  unsubscribedFromDigest: Boolean # TODO -DIGEST make this non-nullable
 }
 
 input UpdateEmailNotificationSettingsInput {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
-  unsubscribedFromDigest: Boolean # TODO make this non-nullable
+  unsubscribedFromDigest: Boolean # TODO -DIGEST make this non-nullable
 }
 
 input UnsubscribeFromEmailTypeInput {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1099,6 +1099,22 @@ func notificationToModel(notif db.Notification) (model.Notification, error) {
 			Comment:      nil, // handled by dedicated resolver
 			Admirers:     nil, // handled by dedicated resolver
 		}, nil
+	case persist.ActionAnnouncement:
+		return model.GalleryAnnouncementNotification{
+			Dbid:                 notif.ID,
+			Seen:                 &notif.Seen,
+			CreationTime:         &notif.CreatedAt,
+			UpdatedTime:          &notif.LastUpdated,
+			Platform:             model.Platform(notif.Data.AnnouncementDetails.Platform),
+			InternalID:           notif.Data.AnnouncementDetails.InternalID,
+			ImageURL:             util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.ImageURL),
+			Title:                util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.Title),
+			Description:          util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.Description),
+			CtaText:              util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.CTALink),
+			CtaLink:              util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.CTAText),
+			PushNotificationText: util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.PushNotificationText),
+		}, nil
+
 	default:
 		return nil, fmt.Errorf("unknown notification action: %s", notif.Action)
 	}

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1111,8 +1111,8 @@ func notificationToModel(notif db.Notification) (model.Notification, error) {
 			ImageURL:             util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.ImageURL),
 			Title:                util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.Title),
 			Description:          util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.Description),
-			CtaText:              util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.CTALink),
-			CtaLink:              util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.CTAText),
+			CtaText:              util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.CTAText),
+			CtaLink:              util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.CTALink),
 			PushNotificationText: util.StringToPointerIfNotEmpty(notif.Data.AnnouncementDetails.PushNotificationText),
 		}, nil
 

--- a/secrets/dev/emails-server-env.yaml
+++ b/secrets/dev/emails-server-env.yaml
@@ -18,6 +18,10 @@ SENDGRID_DIGEST_TEMPLATE_ID: ENC[AES256_GCM,data:P3I+WeA603/HOKwlGOEg7JZQWFS8w+O
 SENDGRID_VERIFICATION_TEMPLATE_ID: ENC[AES256_GCM,data:eHCDyF5BxRcbY6eZ1vzlJhMNCgfjMGeEnZY1FMEdD0cVKQ==,iv:l2YPYWUdiq4bmDS5JRSzmPqTc0uWAShd66ck1he+rU0=,tag:PUNs6SC5hSwTkOooZknuPA==,type:str]
 ADMIN_PASS: ENC[AES256_GCM,data:e3KL5ArncPTMZNQ2zqxDDqzYdw0=,iv:c/nc/nUaQdH3/VXvs7/2+ehXILIUbba1c6fkolHoM0A=,tag:JflvT3ZM5gAXqIYbpcv3Pg==,type:str]
 RETOOL_AUTH_TOKEN: ENC[AES256_GCM,data:7TA+aEYaLcBmjr1VZRtEh+lqxVgqwR5ot0fA7nbY,iv:fwbAHF5rfjn6B63hmBhiCiLtHx7Alz8X0AnyBfC1jMk=,tag:TWCbLZ5ETikfIz4fazyDrQ==,type:str]
+GCLOUD_PUSH_NOTIFICATIONS_QUEUE: ENC[AES256_GCM,data:h6ECdTwCoyQv9z0XQaDWE3/t3T0ay+VFiZZ2VgOdm4i2rTY10A1uh5k9aOfr6jGF9VLzUCAmUBXZEdp+O0oHu2nE/Ch2MBbf,iv:8vz4PqEqUaRSxOPBAuHa++TxooEYu35NgIDjkOb44VM=,tag:maIgcJDzsQB+egyP8W1xyA==,type:str]
+PUSH_NOTIFICATIONS_URL: ENC[AES256_GCM,data:kYOoPtjYnm3u2tJcMeN1TEbUmwXEK0wdKuzI1alzOisi0yC2BkorcN02e8V5EIs/VHN4egg=,iv:a2Wg/Q5l+KpwrGBsW4/M8ethzy/6Zj6Q5eXJnrfFf/Y=,tag:ymOxW6WQew3UPY0JIQfL1w==,type:str]
+PUSH_NOTIFICATIONS_SECRET: ENC[AES256_GCM,data:5Flj7eN6GaUb8ZvIbQ5p4zx+fehOFHT/eZbEC/x/lhE=,iv:+mN0gxlZNSCsyESRXYk6VdNymP89aXoy9/RePPTaCk8=,tag:N4A1qiCOeRY8rC98BAQUhQ==,type:str]
+PUBSUB_TOPIC_NEW_NOTIFICATIONS: ENC[AES256_GCM,data:BhQDnBs09/PGeqD33bRtBnGTx4pP,iv:sUM8tkvpLGINfsgftYXV2ETB9CyX5ilhUa2PcoUXJ9c=,tag:1zo4Zzj9Jt+VwjUd1O84IQ==,type:str]
 EMAILS_TASK_SECRET: ENC[AES256_GCM,data:ft1SjQRS9ZJUjjoaLDTfSTD09ax0YKD+SE5KDdR1nks=,iv:fE0stxHLPmE1SypbM3fZUjhSISCHxJuiwkN7aLtZ8yE=,tag:lVLx3Sq+Gtmi6/5CP4+Tdw==,type:str]
 sops:
     kms: []
@@ -28,8 +32,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-05T22:57:20Z"
-    mac: ENC[AES256_GCM,data:uhRDXc/RZSxHKHL00rsrPeD2WIzxzF4/h8/Dq7LVIRihOHQ5VgUIzn/9taiy3iHx08t1yjQQnABxDwmz3g1cGuMdiqPEsS/ruZFGkZMt5pbFwR2hq4UBG7lAkGfbM6VjPC+YkZ/OwFBXdfP0K87sfpqufVTC/F2nVFqOQ4FFVpk=,iv:f4paV3n6QF0k+3tEinB9dkLbiv2WQ9kHbaQiE0nLiHc=,tag:fdYmfL7MYffGTYO6N7rffQ==,type:str]
+    lastmodified: "2023-12-20T01:12:32Z"
+    mac: ENC[AES256_GCM,data:BVOY4pLyMkeMWe4rbLAbgKESIdd1dButUOb9VVthbgtMWzTBCWxQW3TyWbB0k6x7FpVsztytqXHJ67hPVClZwIEtmSrGPR16NXtX/eo6dLSfhZO5JPNliKWR7pr5vu83v7jbt5guOVADCkwwiKpqvwutevYjeLTJfUjWf1mEqeg=,iv:sBjwkx+C/mBjfLyXl5vq3H1cXN3DMYHrDtNhlhZT6u8=,tag:4fy2HMEilVnw03hnUiyo7w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/emails-server-env.yaml
+++ b/secrets/prod/emails-server-env.yaml
@@ -20,6 +20,10 @@ ADMIN_PASS: ENC[AES256_GCM,data:0a5zN+TnXU9aysMCI+Gz2nqXmU8=,iv:wn6sQ1uxF1uoqyEf
 GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:WHjiJNS8slNKJQU9+3Un8cGh8w==,iv:dTgkj/bxhSL7ME1Ocivi+C/ZyHjyeoEUk6cD3fabkOw=,tag:ByguVZxWzWeOJZwP1jS7qA==,type:str]
 RETOOL_AUTH_TOKEN: ENC[AES256_GCM,data:qF6hY25zr7NpXnN05ZcK/ohfmam1jK8ibLvB/TYw,iv:tfN82f8c8RuR+khb68N0+UVWFsHwQuRaXOG2fXJevBE=,tag:zyYJTHsZNBjARxgBq4BEjA==,type:str]
 SCHEDULER_AUDIENCE: ENC[AES256_GCM,data:UtW9eZanuT6FSTveVBg0vB84/CNNivqBdmdzvJqRkY1kZS3ykYh/dK8=,iv:AbJCO3F6/HxxqopuQcAq0JzIrkJZ24MZAF0px2HE/NQ=,tag:lJXgKnbsvMPabtlE7EMaMg==,type:str]
+PUBSUB_TOPIC_NEW_NOTIFICATIONS: ENC[AES256_GCM,data:ymDorDfKvWNNg8nONB7S0FA=,iv:a4/db54lCXkUQTm1fuo5z4Dyl2p+lTssjCp8v/BYqFI=,tag:NQf87F/ONip5lDBSHWewog==,type:str]
+GCLOUD_PUSH_NOTIFICATIONS_QUEUE: ENC[AES256_GCM,data:rBkD1A09cEH/v2YirEBSF+TsLLjzusy/T6fw+Kxkjmu6U5CCDRdz9s7saVpVfxZb4FstEY5/I77b9NsjLNKyS/HX12YGv9iKEQ==,iv:5/7AfNQDUSPROIhseeEDnqxNRxsh7zf9A7NdQDD+Mjs=,tag:nTeInzfBaf0qaSS0tyN+pA==,type:str]
+PUSH_NOTIFICATIONS_URL: ENC[AES256_GCM,data:Fdp+J2M/cy4OgBNZXhBfYWHDACC8ZRKaPxxW3bCMBCaPLb0++uSZy8MNXUFOEqT75w==,iv:ecCqA/apzpuiIYD+jmv18KQCRITgk/1b6kRV4jmUXRE=,tag:OB3iWL1B1PCMLkf+sps/IQ==,type:str]
+PUSH_NOTIFICATIONS_SECRET: ENC[AES256_GCM,data:FJdgAFHzIpiBbZWpaXuIum1YU0SF0dOmvnuv2gaLGAE=,iv:Y52ooFtrtTMZPCWd8TQZ9R1FFJW2JRVryn3nWQHLFV8=,tag:KwJA7lVI3NF6/boj++yXZQ==,type:str]
 EMAILS_TASK_SECRET: ENC[AES256_GCM,data:XNSxOjJqpyXgHZL4Phdi+ut2+RaBC4G7mUzmwZ2/r2o=,iv:PviLUREgRnzYmrQR7+ntAm52tYG7lyd4oQMKpp/aJi4=,tag:tLNbwvT8azKy8Cd0ubLg3Q==,type:str]
 sops:
     kms: []
@@ -30,8 +34,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-12-07T23:08:01Z"
-    mac: ENC[AES256_GCM,data:wyAvK3hPs+BIydzzzBBEW51RuxEHYkTNbPlWzbO3E0WVa+AMZdzAAMx01MGFBpCg3o30yIuoLcx+cui30HCgjdHo4+Wfeiacyd/LC3k0zf0UFKAdGW1trofh5GbS2m+TwcR/6TO5ocY91QdPA1VqfMm9KTTntisrpY3h8LJW97E=,iv:yF1muB2rVfaNfKvYeBUnqpouK7F13w+audzcGlpJ+6c=,tag:xKz12AqzFnCw2PCG/zpY8g==,type:str]
+    lastmodified: "2023-12-20T00:20:26Z"
+    mac: ENC[AES256_GCM,data:LWi0+ZpMlF5ZFAsFas37l8cR3RJD93H8aH0ocZnGpJ7FGMkORyrka2kVGZOoi+jZc7cbdSyh1bsBjN1mjJeye4JfbRf2nleKgsRVyXeISPh2NjWYXPX+S8C/QpEQG8bZaQvTopXs3jQsGW2M0AafVCED4cL4HVPQBR9+0LyR+uI=,iv:+C3PPO+ZPPw2XQje+O7R35j3M/t8EPlkhe14r6iKvwU=,tag:o9azc6B2AxM8fnTQq+f3Ew==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -201,6 +201,7 @@ func (d *Provider) GetTokenByTokenIdentifiersAndOwner(ctx context.Context, ti mu
 	}
 
 	if resultToken.TokenID == "" || resultContract.Address == "" {
+		logger.For(ctx).Errorf("no token found for identifiers %+v (%+v | %+v) [%+v]", ti, resultToken, resultContract, tokens)
 		return multichain.ChainAgnosticToken{}, multichain.ChainAgnosticContract{}, fmt.Errorf("no token found for identifiers %+v", ti)
 	}
 

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"cloud.google.com/go/pubsub"
@@ -20,7 +19,6 @@ import (
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
-	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -1220,7 +1218,7 @@ func insertAndPublishAnnouncementNotifs(ctx context.Context, notif db.Notificati
 		return fmt.Errorf("failed to create notification: %w", err)
 	}
 
-	if (strings.EqualFold(notif.Data.AnnouncementDetails.Platform, model.PlatformMobile.String()) || strings.EqualFold(notif.Data.AnnouncementDetails.Platform, model.PlatformAll.String())) && notif.Data.AnnouncementDetails.PushNotificationText != "" {
+	if (notif.Data.AnnouncementDetails.Platform == persist.AnnouncementPlatformAll || notif.Data.AnnouncementDetails.Platform == persist.AnnouncementPlatformMobile) && notif.Data.AnnouncementDetails.PushNotificationText != "" {
 		logger.For(ctx).Infof("sending push notifications for announcement: %s", notif.Data.AnnouncementDetails.InternalID)
 		p := pool.New().WithErrors().WithContext(ctx).WithMaxGoroutines(10)
 		for _, notif := range notifs {

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -1505,6 +1505,7 @@ func addGlobalNotifications(ctx context.Context, notif db.Notification, queries 
 		Action:   notif.Action,
 		Data:     notif.Data,
 		EventIds: notif.EventIds,
+		Internal: notif.Data.AnnouncementDetails.InternalID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create follower notifications: %w", err)

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/pubsub"
@@ -19,6 +20,7 @@ import (
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
+	"github.com/mikeydub/go-gallery/graphql/model"
 	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
@@ -196,6 +198,7 @@ func New(queries *db.Queries, pub *pubsub.Client, taskClient *task.Client, lock 
 	tokenGroupedHandler := tokenIDGroupedNotificationHandler{queries: queries, pubSub: pub, taskClient: taskClient, limiter: limiter}
 	viewHandler := viewedNotificationHandler{queries: queries, pubSub: pub, taskClient: taskClient, limiter: limiter}
 	topActivityHandler := topActivityHandler{queries: queries, pubSub: pub, taskClient: taskClient, limiter: limiter}
+	announcementHandler := announcementNotificationHandler{queries: queries, pubSub: pub, taskClient: taskClient, limiter: limiter}
 
 	// notification actions that are grouped by owner
 	notifDispatcher.AddHandler(persist.ActionUserFollowedUsers, ownerGroupedHandler)
@@ -223,6 +226,9 @@ func New(queries *db.Queries, pub *pubsub.Client, taskClient *task.Client, lock 
 
 	// viewed notifications are handled separately
 	notifDispatcher.AddHandler(persist.ActionViewedGallery, viewHandler)
+
+	// announcements are handled separately
+	notifDispatcher.AddHandler(persist.ActionAnnouncement, announcementHandler)
 
 	new := map[persist.DBID]chan db.Notification{}
 	updated := map[persist.DBID]chan db.Notification{}
@@ -339,6 +345,17 @@ type followerNotificationHandler struct {
 
 func (h followerNotificationHandler) Handle(ctx context.Context, notif db.Notification) error {
 	return insertAndPublishFollowerNotifs(ctx, notif, h.queries, h.pubSub, h.taskClient, h.limiter)
+}
+
+type announcementNotificationHandler struct {
+	queries    *db.Queries
+	pubSub     *pubsub.Client
+	taskClient *task.Client
+	limiter    *pushLimiter
+}
+
+func (h announcementNotificationHandler) Handle(ctx context.Context, notif db.Notification) error {
+	return insertAndPublishAnnouncementNotifs(ctx, notif, h.queries, h.pubSub, h.taskClient, h.limiter)
 }
 
 type ownerGroupedNotificationHandler struct {
@@ -779,6 +796,14 @@ func createPushMessage(ctx context.Context, notif db.Notification, queries *db.Q
 		return message, nil
 	}
 
+	if notif.Action == persist.ActionAnnouncement {
+		if err := limiter.tryUsers(ctx, notif.OwnerID); err != nil {
+			return task.PushNotificationMessage{}, err
+		}
+
+		return message, nil
+	}
+
 	return task.PushNotificationMessage{}, fmt.Errorf("unsupported notification action: %s", notif.Action)
 }
 
@@ -1069,6 +1094,11 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 			Actor:  "You",
 			Action: "received a new badge for being amongst the top active users on Gallery this week!",
 		}, nil
+
+	case persist.ActionAnnouncement:
+		return UserFacingNotificationData{
+			Action: n.Data.AnnouncementDetails.PushNotificationText,
+		}, nil
 	default:
 		return UserFacingNotificationData{}, fmt.Errorf("unknown action %s", n.Action)
 	}
@@ -1101,7 +1131,9 @@ func actionSupportsPushNotifications(action persist.Action) bool {
 	case persist.ActionUserPostedFirstPost:
 		return true
 	case persist.ActionTopActivityBadgeReceived:
-		return false
+		return false // TODO -activity
+	case persist.ActionAnnouncement:
+		return true
 	default:
 		return false
 	}
@@ -1175,6 +1207,28 @@ func insertAndPublishFollowerNotifs(ctx context.Context, notif db.Notification, 
 		p.Go(func(ctx context.Context) error {
 			return sendNotifications(ctx, notif, queries, taskClient, limiter, ps)
 		})
+	}
+
+	logger.For(ctx).Infof("pushed new notification to pubsub: %s", notif.OwnerID)
+
+	return nil
+}
+
+func insertAndPublishAnnouncementNotifs(ctx context.Context, notif db.Notification, queries *db.Queries, ps *pubsub.Client, taskClient *task.Client, limiter *pushLimiter) error {
+	notifs, err := addGlobalNotifications(ctx, notif, queries)
+	if err != nil {
+		return fmt.Errorf("failed to create notification: %w", err)
+	}
+
+	if (strings.EqualFold(notif.Data.AnnouncementDetails.Platform, model.PlatformMobile.String()) || strings.EqualFold(notif.Data.AnnouncementDetails.Platform, model.PlatformAll.String())) && notif.Data.AnnouncementDetails.PushNotificationText != "" {
+		logger.For(ctx).Infof("sending push notifications for announcement: %s", notif.Data.AnnouncementDetails.InternalID)
+		p := pool.New().WithErrors().WithContext(ctx).WithMaxGoroutines(10)
+		for _, notif := range notifs {
+			notif := notif
+			p.Go(func(ctx context.Context) error {
+				return sendNotifications(ctx, notif, queries, taskClient, limiter, ps)
+			})
+		}
 	}
 
 	logger.For(ctx).Infof("pushed new notification to pubsub: %s", notif.OwnerID)
@@ -1434,6 +1488,31 @@ func addFollowerNotifications(ctx context.Context, notif db.Notification, querie
 	default:
 		return nil, fmt.Errorf("unknown follower notification action: %s", notif.Action)
 	}
+}
+
+func addGlobalNotifications(ctx context.Context, notif db.Notification, queries *db.Queries) ([]db.Notification, error) {
+
+	userCount, err := queries.CountAllUsers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, userCount)
+	for i := 0; i < int(userCount); i++ {
+		ids[i] = persist.GenerateID().String()
+	}
+
+	notifs, err := queries.CreateAnnouncementNotifications(ctx, db.CreateAnnouncementNotificationsParams{
+		Ids:      ids,
+		Action:   notif.Action,
+		Data:     notif.Data,
+		EventIds: notif.EventIds,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create follower notifications: %w", err)
+	}
+
+	return notifs, nil
 }
 
 func (l lockKey) String() string {

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -18,6 +18,7 @@ const (
 	ResourceTypeComment
 	ResourceTypeContract
 	ResourceTypePost
+	ResourceTypeAllUsers
 	ActionUserCreated                     Action = "UserCreated"
 	ActionUserFollowedUsers               Action = "UserFollowedUsers"
 	ActionUserPosted                      Action = "UserPosted"

--- a/service/persist/event.go
+++ b/service/persist/event.go
@@ -43,28 +43,30 @@ const (
 	ActionGalleryInfoUpdated              Action = "GalleryInfoUpdated"
 	ActionNewTokensReceived               Action = "NewTokensReceived"
 	ActionTopActivityBadgeReceived        Action = "ActivityBadgeReceived"
+	ActionAnnouncement                    Action = "Announcement"
 )
 
 type EventData struct {
-	UserBio                             string            `json:"user_bio"`
-	UserFollowedBack                    bool              `json:"user_followed_back"`
-	UserRefollowed                      bool              `json:"user_refollowed"`
-	NewTokenID                          DBID              `json:"new_token_id"`
-	NewTokenQuantity                    HexString         `json:"new_token_quantity"`
-	TokenCollectorsNote                 string            `json:"token_collectors_note"`
-	TokenCollectionID                   DBID              `json:"token_collection_id"`
-	TokenContractID                     DBID              `json:"token_contract_id"`
-	TokenDefinitionID                   DBID              `json:"token_definition_id"`
-	CollectionTokenIDs                  DBIDList          `json:"collection_token_ids"`
-	CollectionCollectorsNote            string            `json:"collection_collectors_note"`
-	GalleryName                         *string           `json:"gallery_name"`
-	GalleryDescription                  *string           `json:"gallery_description"`
-	GalleryNewCollectionCollectorsNotes map[DBID]string   `json:"gallery_new_collection_collectors_notes"`
-	GalleryNewTokenIDs                  map[DBID]DBIDList `json:"gallery_new_token_ids"`
-	GalleryNewCollections               DBIDList          `json:"gallery_new_collections"`
-	GalleryNewTokenCollectorsNotes      map[DBID]string   `json:"gallery_new_token_collectors_notes"`
-	ActivityBadgeThreshold              int               `json:"activity_badge_threshold"`
-	NewTopActiveUser                    bool              `json:"new_top_active_user"`
+	UserBio                             string               `json:"user_bio"`
+	UserFollowedBack                    bool                 `json:"user_followed_back"`
+	UserRefollowed                      bool                 `json:"user_refollowed"`
+	NewTokenID                          DBID                 `json:"new_token_id"`
+	NewTokenQuantity                    HexString            `json:"new_token_quantity"`
+	TokenCollectorsNote                 string               `json:"token_collectors_note"`
+	TokenCollectionID                   DBID                 `json:"token_collection_id"`
+	TokenContractID                     DBID                 `json:"token_contract_id"`
+	TokenDefinitionID                   DBID                 `json:"token_definition_id"`
+	CollectionTokenIDs                  DBIDList             `json:"collection_token_ids"`
+	CollectionCollectorsNote            string               `json:"collection_collectors_note"`
+	GalleryName                         *string              `json:"gallery_name"`
+	GalleryDescription                  *string              `json:"gallery_description"`
+	GalleryNewCollectionCollectorsNotes map[DBID]string      `json:"gallery_new_collection_collectors_notes"`
+	GalleryNewTokenIDs                  map[DBID]DBIDList    `json:"gallery_new_token_ids"`
+	GalleryNewCollections               DBIDList             `json:"gallery_new_collections"`
+	GalleryNewTokenCollectorsNotes      map[DBID]string      `json:"gallery_new_token_collectors_notes"`
+	ActivityBadgeThreshold              int                  `json:"activity_badge_threshold"`
+	NewTopActiveUser                    bool                 `json:"new_top_active_user"`
+	AnnouncementDetails                 *AnnouncementDetails `json:"announcement_details"`
 }
 
 type FeedEventData struct {

--- a/service/persist/notification.go
+++ b/service/persist/notification.go
@@ -5,8 +5,8 @@ import (
 )
 
 type AnnouncementDetails struct {
-	Platform             string `json:"platform"`
-	InternalID           string `json:"internal_id"`
+	Platform             string `json:"platform" binding:"required"`
+	InternalID           string `json:"internal_id" binding:"required"`
 	ImageURL             string `json:"image_url,omitempty"`
 	Title                string `json:"title,omitempty"`
 	Description          string `json:"description,omitempty"`

--- a/service/persist/notification.go
+++ b/service/persist/notification.go
@@ -1,18 +1,77 @@
 package persist
 
 import (
+	"fmt"
+	"io"
+	"strings"
+
 	"github.com/mikeydub/go-gallery/util"
 )
 
+type AnnouncementPlatform string
+
+const (
+	AnnouncementPlatformWeb    AnnouncementPlatform = "Web"
+	AnnouncementPlatformMobile AnnouncementPlatform = "Mobile"
+	AnnouncementPlatformAll    AnnouncementPlatform = "All"
+)
+
+func (a AnnouncementPlatform) String() string {
+	return string(a)
+}
+
+func (a AnnouncementPlatform) IsValid() bool {
+	switch a {
+	case AnnouncementPlatformWeb, AnnouncementPlatformAll, AnnouncementPlatformMobile:
+		return true
+	default:
+		return false
+	}
+}
+
+// UnmarshalGQL implements the graphql.Unmarshaler interface
+func (c *AnnouncementPlatform) UnmarshalGQL(v interface{}) error {
+	n, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("chain must be a string")
+	}
+
+	switch strings.ToLower(n) {
+	case "web":
+		*c = AnnouncementPlatformWeb
+	case "all":
+		*c = AnnouncementPlatformAll
+	case "mobile":
+		*c = AnnouncementPlatformMobile
+	default:
+		return fmt.Errorf("invalid announcement platform: %s", n)
+	}
+	return nil
+}
+
+// MarshalGQL implements the graphql.Marshaler interface
+func (c AnnouncementPlatform) MarshalGQL(w io.Writer) {
+	switch c {
+	case AnnouncementPlatformWeb:
+		w.Write([]byte(`"Web"`))
+	case AnnouncementPlatformMobile:
+		w.Write([]byte(`"Mobile"`))
+	case AnnouncementPlatformAll:
+		w.Write([]byte(`"All"`))
+	default:
+		panic("invalid announcement platform")
+	}
+}
+
 type AnnouncementDetails struct {
-	Platform             string `json:"platform" binding:"required"`
-	InternalID           string `json:"internal_id" binding:"required"`
-	ImageURL             string `json:"image_url,omitempty"`
-	Title                string `json:"title,omitempty"`
-	Description          string `json:"description,omitempty"`
-	CTAText              string `json:"cta_text,omitempty"`
-	CTALink              string `json:"cta_link,omitempty"`
-	PushNotificationText string `json:"push_notification_text,omitempty"`
+	Platform             AnnouncementPlatform `json:"platform" binding:"required"`
+	InternalID           string               `json:"internal_id" binding:"required"`
+	ImageURL             string               `json:"image_url,omitempty"`
+	Title                string               `json:"title,omitempty"`
+	Description          string               `json:"description,omitempty"`
+	CTAText              string               `json:"cta_text,omitempty"`
+	CTALink              string               `json:"cta_link,omitempty"`
+	PushNotificationText string               `json:"push_notification_text,omitempty"`
 }
 
 type NotificationData struct {

--- a/service/persist/notification.go
+++ b/service/persist/notification.go
@@ -4,18 +4,30 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 )
 
+type AnnouncementDetails struct {
+	Platform             string `json:"platform"`
+	InternalID           string `json:"internal_id"`
+	ImageURL             string `json:"image_url,omitempty"`
+	Title                string `json:"title,omitempty"`
+	Description          string `json:"description,omitempty"`
+	CTAText              string `json:"cta_text,omitempty"`
+	CTALink              string `json:"cta_link,omitempty"`
+	PushNotificationText string `json:"push_notification_text,omitempty"`
+}
+
 type NotificationData struct {
-	AuthedViewerIDs        []DBID    `json:"viewer_ids,omitempty"`
-	UnauthedViewerIDs      []string  `json:"unauthed_viewer_ids,omitempty"`
-	FollowerIDs            []DBID    `json:"follower_ids,omitempty"`
-	AdmirerIDs             []DBID    `json:"admirer_ids,omitempty"`
-	FollowedBack           NullBool  `json:"followed_back,omitempty"`
-	Refollowed             NullBool  `json:"refollowed,omitempty"`
-	NewTokenID             DBID      `json:"new_token_id,omitempty"`
-	NewTokenQuantity       HexString `json:"new_token_quantity,omitempty"`
-	OriginalCommentID      DBID      `json:"original_comment_id,omitempty"`
-	ActivityBadgeThreshold int       `json:"activity_badge_threshold,omitempty"`
-	NewTopActiveUser       bool      `json:"new_top_active_user,omitempty"`
+	AuthedViewerIDs        []DBID               `json:"viewer_ids,omitempty"`
+	UnauthedViewerIDs      []string             `json:"unauthed_viewer_ids,omitempty"`
+	FollowerIDs            []DBID               `json:"follower_ids,omitempty"`
+	AdmirerIDs             []DBID               `json:"admirer_ids,omitempty"`
+	FollowedBack           NullBool             `json:"followed_back,omitempty"`
+	Refollowed             NullBool             `json:"refollowed,omitempty"`
+	NewTokenID             DBID                 `json:"new_token_id,omitempty"`
+	NewTokenQuantity       HexString            `json:"new_token_quantity,omitempty"`
+	OriginalCommentID      DBID                 `json:"original_comment_id,omitempty"`
+	ActivityBadgeThreshold int                  `json:"activity_badge_threshold,omitempty"`
+	NewTopActiveUser       bool                 `json:"new_top_active_user,omitempty"`
+	AnnouncementDetails    *AnnouncementDetails `json:"announcement_details,omitempty"`
 }
 
 func (n NotificationData) Validate() NotificationData {
@@ -31,6 +43,7 @@ func (n NotificationData) Validate() NotificationData {
 	result.Refollowed = n.Refollowed
 	result.ActivityBadgeThreshold = n.ActivityBadgeThreshold
 	result.NewTopActiveUser = n.NewTopActiveUser
+	result.AnnouncementDetails = n.AnnouncementDetails
 
 	return result
 }
@@ -50,6 +63,11 @@ func (n NotificationData) Concat(other NotificationData) NotificationData {
 		return i > 0
 	})
 	result.NewTopActiveUser = other.NewTopActiveUser || n.NewTopActiveUser
+	if other.AnnouncementDetails != nil {
+		result.AnnouncementDetails = other.AnnouncementDetails
+	} else {
+		result.AnnouncementDetails = n.AnnouncementDetails
+	}
 
 	return result.Validate()
 }

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -187,6 +187,7 @@ func (r *EventRepository) AddDataOnlyEvent(ctx context.Context, event db.Event) 
 		Data:           event.Data,
 		GroupID:        event.GroupID,
 		Caption:        event.Caption,
+		SubjectID:      event.SubjectID,
 	})
 	return &event, err
 }

--- a/service/persist/postgres/event.go
+++ b/service/persist/postgres/event.go
@@ -35,6 +35,8 @@ func (r *EventRepository) Add(ctx context.Context, event db.Event) (*db.Event, e
 		return r.AddContractEvent(ctx, event)
 	case persist.ResourceTypePost:
 		return r.AddPostEvent(ctx, event)
+	case persist.ResourceTypeAllUsers:
+		return r.AddDataOnlyEvent(ctx, event)
 	default:
 		return nil, persist.ErrUnknownResourceType{ResourceType: event.ResourceTypeID}
 	}
@@ -172,6 +174,19 @@ func (r *EventRepository) AddPostEvent(ctx context.Context, event db.Event) (*db
 		UserID:         event.UserID,
 		SubjectID:      event.SubjectID,
 		PostID:         event.PostID,
+	})
+	return &event, err
+}
+
+func (r *EventRepository) AddDataOnlyEvent(ctx context.Context, event db.Event) (*db.Event, error) {
+	event, err := r.Queries.CreateDataOnlyEvent(ctx, db.CreateDataOnlyEventParams{
+		ID:             persist.GenerateID(),
+		ActorID:        event.ActorID,
+		Action:         event.Action,
+		ResourceTypeID: event.ResourceTypeID,
+		Data:           event.Data,
+		GroupID:        event.GroupID,
+		Caption:        event.Caption,
 	})
 	return &event, err
 }

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -544,6 +544,8 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 			return
 		}
 
+		logger.For(c).WithFields(logrus.Fields{"user_id": in.Data.New.User, "token_id": in.Data.New.ID, "token_and_contract": in.Data.New.TokenAndContract, "balance": in.Data.New.Balance}).Infof("GOLDSKY: %s - Processing Goldsky User Tokens Refresh", in.Data.New.User)
+
 		signature := c.GetHeader("goldsky-webhook-secret")
 		if signature != env.GetString("GOLDSKY_WEBHOOK_SECRET") {
 			util.ErrResponse(c, http.StatusUnauthorized, fmt.Errorf("invalid goldsky signature"))
@@ -562,6 +564,7 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 			L1Chain: persist.ChainZora.L1Chain(),
 		})
 		if user.ID == "" {
+			logger.For(c).Warnf("user not found for address: %s", userAddress)
 			// it is a valid response to not find a user, not every transfer exists on gallery
 			c.String(http.StatusOK, fmt.Sprintf("user not found for address: %s", userAddress))
 			return
@@ -570,6 +573,7 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 		contractAddress := persist.Address(strings.ToLower(fullIDs[1]))
 		bigTokenID, ok := big.NewInt(0).SetString(fullIDs[2], 10)
 		if !ok {
+			logger.For(c).Errorf("invalid token and contract: %s", in.Data.New.TokenAndContract)
 			util.ErrResponse(c, http.StatusInternalServerError, fmt.Errorf("invalid token and contract: %s", in.Data.New.TokenAndContract))
 			return
 		}

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -544,7 +544,7 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 			return
 		}
 
-		logger.For(c).WithFields(logrus.Fields{"user_id": in.Data.New.User, "token_id": in.Data.New.ID, "token_and_contract": in.Data.New.TokenAndContract, "balance": in.Data.New.Balance}).Infof("GOLDSKY: %s - Processing Goldsky User Tokens Refresh", in.Data.New.User)
+		logger.For(c).WithFields(logrus.Fields{"user_address": in.Data.New.User, "token_id": in.Data.New.ID, "token_and_contract": in.Data.New.TokenAndContract, "balance": in.Data.New.Balance}).Infof("GOLDSKY: %s - Processing Goldsky User Tokens Refresh", in.Data.New.User)
 
 		signature := c.GetHeader("goldsky-webhook-secret")
 		if signature != env.GetString("GOLDSKY_WEBHOOK_SECRET") {
@@ -607,6 +607,8 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 
 		if len(newTokens) == 0 {
 			l.Info("no new tokens found")
+		} else {
+			l.Infof("found %d new tokens", len(newTokens))
 		}
 
 		for _, token := range newTokens {


### PR DESCRIPTION
Changes:

- **Added** new notification handlers for the new `ActionAnnouncement` event action type
- **Added** a handler on the email service (maybe we can rename this service eventually to something more involving "sending lots of users messages"). 

I think in an ideal word there is a better solution than this. This works because it functions practically the same as the `UserPostedFirstPostNotification` (one notification fans out to the followers of a user) but it sends even more notifications because it is to all users. I originally was playing around with adding a new `global` bool column on the notification table and have get notification queries check for global notifications but there are two problems with that:

1. It does not feel right for the `UserPostedFirstPostNotification` to still fanout
2. How could a user mark a notification as "seen" if every user is referencing that same row in the DB

Maybe in the future we could add a new `user_notifications` table that could pull out "seen" and then the notifications table can have a sort of "match" field that will determine how notifications are included in a user's notifications, whether it is always included (like this announcement), only included if they are the follower of the owner_id (in the case of the first post), or only included when they are directly the owner (every other notification). 

That seems like overkill for the purpose of getting this out and fanning out notifications to all users is not too much of a burden for our backend to handle for now.