### PR TITLE
Fix creator sync

### DIFF
--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -62,10 +62,10 @@ type PublicAPI struct {
 }
 
 func New(ctx context.Context, disableDataloaderCaching bool, repos *postgres.Repositories, queries *db.Queries, httpClient *http.Client, ethClient *ethclient.Client, ipfsClient *shell.Shell,
-	arweaveClient *goar.Client, storageClient *storage.Client, multichainProvider *multichain.Provider, taskClient *task.Client, throttler *throttle.Locker, secrets *secretmanager.Client, apq *apq.APQCache, feedCache *redis.Cache, socialCache *redis.Cache, authRefreshCache *redis.Cache, magicClient *magicclient.API) *PublicAPI {
+	arweaveClient *goar.Client, storageClient *storage.Client, multichainProvider *multichain.Provider, taskClient *task.Client, throttler *throttle.Locker, secrets *secretmanager.Client, apq *apq.APQCache, feedCache, socialCache, authRefreshCache, tokenManageCache *redis.Cache, magicClient *magicclient.API) *PublicAPI {
 	loaders := dataloader.NewLoaders(ctx, queries, disableDataloaderCaching, tracing.DataloaderPreFetchHook, tracing.DataloaderPostFetchHook)
 	validator := validate.WithCustomValidators()
-	tokenManager := tokenmanage.New(ctx, taskClient)
+	tokenManager := tokenmanage.New(ctx, taskClient, tokenManageCache)
 
 	return &PublicAPI{
 		repos:     repos,

--- a/server/handler.go
+++ b/server/handler.go
@@ -46,24 +46,24 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 )
 
-func handlersInit(router *gin.Engine, repos *postgres.Repositories, queries *db.Queries, httpClient *http.Client, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, mcProvider *multichain.Provider, throttler *throttle.Locker, taskClient *task.Client, pub *pubsub.Client, lock *redislock.Client, secrets *secretmanager.Client, graphqlAPQCache *redis.Cache, feedCache *redis.Cache, socialCache *redis.Cache, authRefreshCache *redis.Cache, magicClient *magicclient.API, recommender *recommend.Recommender, p *userpref.Personalization) *gin.Engine {
+func handlersInit(router *gin.Engine, repos *postgres.Repositories, queries *db.Queries, httpClient *http.Client, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, mcProvider *multichain.Provider, throttler *throttle.Locker, taskClient *task.Client, pub *pubsub.Client, lock *redislock.Client, secrets *secretmanager.Client, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache *redis.Cache, magicClient *magicclient.API, recommender *recommend.Recommender, p *userpref.Personalization) *gin.Engine {
 
 	graphqlGroup := router.Group("/glry/graphql")
-	graphqlHandlersInit(graphqlGroup, repos, queries, httpClient, ethClient, ipfsClient, arweaveClient, stg, mcProvider, throttler, taskClient, pub, lock, secrets, graphqlAPQCache, feedCache, socialCache, authRefreshCache, magicClient, recommender, p)
+	graphqlHandlersInit(graphqlGroup, repos, queries, httpClient, ethClient, ipfsClient, arweaveClient, stg, mcProvider, throttler, taskClient, pub, lock, secrets, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, magicClient, recommender, p)
 
 	router.GET("/alive", util.HealthCheckHandler())
 
 	return router
 }
 
-func graphqlHandlersInit(parent *gin.RouterGroup, repos *postgres.Repositories, queries *db.Queries, httpClient *http.Client, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, mcProvider *multichain.Provider, throttler *throttle.Locker, taskClient *task.Client, pub *pubsub.Client, lock *redislock.Client, secrets *secretmanager.Client, graphqlAPQCache *redis.Cache, feedCache *redis.Cache, socialCache *redis.Cache, authRefreshCache *redis.Cache, magicClient *magicclient.API, recommender *recommend.Recommender, p *userpref.Personalization) {
-	handler := graphqlHandler(repos, queries, httpClient, ethClient, ipfsClient, arweaveClient, storageClient, mcProvider, throttler, taskClient, pub, lock, secrets, graphqlAPQCache, feedCache, socialCache, authRefreshCache, magicClient, recommender, p)
+func graphqlHandlersInit(parent *gin.RouterGroup, repos *postgres.Repositories, queries *db.Queries, httpClient *http.Client, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, mcProvider *multichain.Provider, throttler *throttle.Locker, taskClient *task.Client, pub *pubsub.Client, lock *redislock.Client, secrets *secretmanager.Client, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache *redis.Cache, magicClient *magicclient.API, recommender *recommend.Recommender, p *userpref.Personalization) {
+	handler := graphqlHandler(repos, queries, httpClient, ethClient, ipfsClient, arweaveClient, storageClient, mcProvider, throttler, taskClient, pub, lock, secrets, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, magicClient, recommender, p)
 	parent.Any("/query", middleware.ContinueSession(queries, authRefreshCache), handler)
 	parent.Any("/query/:operationName", middleware.ContinueSession(queries, authRefreshCache), handler)
 	parent.GET("/playground", graphqlPlaygroundHandler())
 }
 
-func graphqlHandler(repos *postgres.Repositories, queries *db.Queries, httpClient *http.Client, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, mp *multichain.Provider, throttler *throttle.Locker, taskClient *task.Client, pub *pubsub.Client, lock *redislock.Client, secrets *secretmanager.Client, graphqlAPQCache *redis.Cache, feedCache *redis.Cache, socialCache *redis.Cache, authRefreshCache *redis.Cache, magicClient *magicclient.API, recommender *recommend.Recommender, p *userpref.Personalization) gin.HandlerFunc {
+func graphqlHandler(repos *postgres.Repositories, queries *db.Queries, httpClient *http.Client, ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, storageClient *storage.Client, mp *multichain.Provider, throttler *throttle.Locker, taskClient *task.Client, pub *pubsub.Client, lock *redislock.Client, secrets *secretmanager.Client, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache *redis.Cache, magicClient *magicclient.API, recommender *recommend.Recommender, p *userpref.Personalization) gin.HandlerFunc {
 	config := generated.Config{Resolvers: &graphql.Resolver{}}
 	config.Directives.AuthRequired = graphql.AuthRequiredDirectiveHandler()
 	config.Directives.RestrictEnvironment = graphql.RestrictEnvironmentDirectiveHandler()
@@ -121,7 +121,7 @@ func graphqlHandler(repos *postgres.Repositories, queries *db.Queries, httpClien
 	h.AroundFields(graphql.RemapAndReportErrors)
 
 	newPublicAPI := func(ctx context.Context, disableDataloaderCaching bool) *publicapi.PublicAPI {
-		return publicapi.New(ctx, disableDataloaderCaching, repos, queries, httpClient, ethClient, ipfsClient, arweaveClient, storageClient, mp, taskClient, throttler, secrets, apqCache, feedCache, socialCache, authRefreshCache, magicClient)
+		return publicapi.New(ctx, disableDataloaderCaching, repos, queries, httpClient, ethClient, ipfsClient, arweaveClient, storageClient, mp, taskClient, throttler, secrets, apqCache, feedCache, socialCache, authRefreshCache, tokenManageCache, magicClient)
 	}
 
 	notificationsHandler := notifications.New(queries, pub, taskClient, lock, true)

--- a/server/inject.go
+++ b/server/inject.go
@@ -117,7 +117,7 @@ func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.
 	wire.Build(
 		wire.Bind(new(multichain.NameResolver), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.Verifier), util.ToPointer(indexerProvider)),
-		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(fallbackProvider)),
+		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(openseaProvider)),
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(fallbackProvider)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(fallbackProvider)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(fallbackProvider)),

--- a/server/server.go
+++ b/server/server.go
@@ -128,11 +128,12 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	feedCache := redis.NewCache(redis.FeedCache)
 	socialCache := redis.NewCache(redis.SocialCache)
 	authRefreshCache := redis.NewCache(redis.AuthTokenForceRefreshCache)
+	tokenManageCache := redis.NewCache(redis.TokenManageCache)
 
 	recommender.Loop(ctx, time.NewTicker(time.Hour))
 	p.Loop(ctx, time.NewTicker(time.Minute*15))
 
-	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, c.MagicLinkClient, recommender, p)
+	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, c.MagicLinkClient, recommender, p)
 }
 
 func newSecretsClient() *secretmanager.Client {

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -53,7 +53,7 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 	serverPolygonProviderList := polygonProviderSet(httpClient, serverTokenMetadataCache)
 	serverArbitrumProviderList := arbitrumProviderSet(httpClient, serverTokenMetadataCache)
 	v := newMultichainSet(serverEthProviderList, serverOptimismProviderList, serverTezosProviderList, serverPoapProviderList, serverZoraProviderList, serverBaseProviderList, serverPolygonProviderList, serverArbitrumProviderList)
-	manager := tokenmanage.New(ctx, client)
+	manager := tokenmanage.New(ctx, client, cache)
 	submitTokensF := newSubmitBatch(manager)
 	provider := &multichain.Provider{
 		Repos:        repositories,
@@ -89,7 +89,7 @@ var (
 
 // ethProvidersConfig is a wire injector that binds multichain interfaces to their concrete Ethereum implementations
 func ethProvidersConfig(indexerProvider *eth.Provider, openseaProvider *opensea.Provider, fallbackProvider multichain.SyncFailureFallbackProvider) ethProviderList {
-	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, fallbackProvider, fallbackProvider, fallbackProvider, fallbackProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider)
+	serverEthProviderList := ethRequirements(indexerProvider, indexerProvider, openseaProvider, fallbackProvider, fallbackProvider, fallbackProvider, fallbackProvider, indexerProvider, indexerProvider, indexerProvider, indexerProvider)
 	return serverEthProviderList
 }
 

--- a/service/tokenmanage/tokenmanage.go
+++ b/service/tokenmanage/tokenmanage.go
@@ -25,8 +25,7 @@ type Manager struct {
 	maxRetryF MaxRetryF
 }
 
-func New(ctx context.Context, taskClient *task.Client) *Manager {
-	cache := redis.NewCache(redis.TokenManageCache)
+func New(ctx context.Context, taskClient *task.Client, cache *redis.Cache) *Manager {
 	return &Manager{
 		cache:           cache,
 		processRegistry: &registry{cache},
@@ -35,8 +34,8 @@ func New(ctx context.Context, taskClient *task.Client) *Manager {
 	}
 }
 
-func NewWithRetries(ctx context.Context, taskClient *task.Client, maxRetryF MaxRetryF) *Manager {
-	m := New(ctx, taskClient)
+func NewWithRetries(ctx context.Context, taskClient *task.Client, cache *redis.Cache, maxRetryF MaxRetryF) *Manager {
+	m := New(ctx, taskClient, cache)
 	m.maxRetryF = maxRetryF
 	m.delayer = limiters.NewKeyRateLimiter(ctx, m.cache, "retry", 2, 1*time.Minute)
 	return m

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -68,7 +68,7 @@ func CoreInitServer(ctx context.Context, clients *server.Clients, mc *multichain
 	t := newThrottler()
 	tp := NewTokenProcessor(clients.Queries, clients.HTTPClient, mc, clients.IPFSClient, clients.ArweaveClient, clients.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"), metric.NewLogMetricReporter())
 
-	return handlersInitServer(ctx, router, tp, mc, clients.Repos, t, clients.TaskClient)
+	return handlersInitServer(ctx, router, tp, mc, clients.Repos, t, clients.TaskClient, redis.NewCache(redis.TokenManageCache))
 }
 
 func setDefaults() {


### PR DESCRIPTION
**Changes**
* Fixes how contracts and tokens are received for creator syncs
* Fixes bug where a new tokenmanage redis cache was created per request, now the cache is initialized once and shared
* Fixes bug where the OpenSea provider wasn't used for Ethereum!
* Renamed `errWithPriority` to `errWithProvider` - also added the name of the provider in the error message