### PR TITLE
Add fxhash retries

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -452,9 +452,9 @@ func tezosFallbackProvider(e envInit, httpClient *http.Client) multichain.SyncWi
 	return multichain.SyncWithContractEvalFallbackProvider{}
 }
 
-func tezosTokenEvalFunc() func(context.Context, multichain.ChainAgnosticToken) bool {
-	return func(ctx context.Context, token multichain.ChainAgnosticToken) bool {
-		return tezos.IsSigned(ctx, token) && tezos.ContainsTezosKeywords(ctx, token)
+func tezosTokenEvalFunc() func(multichain.ChainAgnosticToken) bool {
+	return func(t multichain.ChainAgnosticToken) bool {
+		return tezos.IsFxHashSigned(t.ContractAddress, t.Descriptors.Name) && tezos.ContainsTezosKeywords(t)
 	}
 }
 

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -414,9 +414,9 @@ func newMultichainSet(
 	return chainToProviders
 }
 
-func tezosTokenEvalFunc() func(context.Context, multichain.ChainAgnosticToken) bool {
-	return func(ctx context.Context, token multichain.ChainAgnosticToken) bool {
-		return tezos.IsSigned(ctx, token) && tezos.ContainsTezosKeywords(ctx, token)
+func tezosTokenEvalFunc() func(multichain.ChainAgnosticToken) bool {
+	return func(t multichain.ChainAgnosticToken) bool {
+		return tezos.IsFxHashSigned(t.ContractAddress, t.Descriptors.Name) && tezos.ContainsTezosKeywords(t)
 	}
 }
 

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -1066,19 +1066,19 @@ func (b balance) ToBigInt() *big.Int {
 	return asInt
 }
 
-// IsSigned returns false if the token is an unsigned FxHash token (metadata hasn't yet been uploaded to the FxHash contract).
+// IsFxHashSigned returns false if the token is an unsigned FxHash token (metadata hasn't yet been uploaded to the FxHash contract).
 // It's possible for tzkt to index a token before FxHash signs a token which results in the API returning placeholder metadata.
 // This seems to happen infrequently, but there are a few cases where the token is never updated with the signed metadata
 // (either because of tzkt failing to update the metadata, or FxHash never signing the token). If it's the former, we want to
 // fallback to an alternative provider in case there might be usable metadata elsewhere.
-func IsSigned(ctx context.Context, token multichain.ChainAgnosticToken) bool {
-	return !IsFxHash(token.ContractAddress) || token.Descriptors.Name != "[WAITING TO BE SIGNED]"
+func IsFxHashSigned(contract persist.Address, tokenName string) bool {
+	return !IsFxHash(contract) || tokenName != "[WAITING TO BE SIGNED]"
 }
 
 // ContainsTezosKeywords returns true if the token's metadata has at least one non-empty Tezos keyword.
 // The tzkt API sometimes returns completely empty metadata, in which case we want to fallback
 // to an alternative provider.
-func ContainsTezosKeywords(ctx context.Context, token multichain.ChainAgnosticToken) bool {
+func ContainsTezosKeywords(token multichain.ChainAgnosticToken) bool {
 	imageKeywords, animationKeywords := persist.ChainTezos.BaseKeywords()
 	for field, val := range token.TokenMetadata {
 

--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/multichain"
-	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/redis"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
@@ -17,30 +15,17 @@ import (
 	"github.com/mikeydub/go-gallery/service/tokenmanage"
 )
 
-const defaultSyncMaxRetries = 4
-
-var (
-	prohibitionContract = persist.NewContractIdentifiers("0x47a91457a3a1f700097199fd63c039c4784384ab", persist.ChainArbitrum)
-	ensContract         = persist.NewContractIdentifiers(eth.EnsAddress, persist.ChainETH)
-)
-
-var contractSpecificRetries = map[persist.ContractIdentifiers]int{prohibitionContract: 24}
-
 func handlersInitServer(ctx context.Context, router *gin.Engine, tp *tokenProcessor, mc *multichain.Provider, repos *postgres.Repositories, throttler *throttle.Locker, taskClient *task.Client, tokenManageCache *redis.Cache) *gin.Engine {
-	// Retry tokens that failed during syncs, but don't retry tokens that failed during manual refreshes
-	noRetryManager := tokenmanage.New(ctx, taskClient, tokenManageCache)
-	retryManager := tokenmanage.NewWithRetries(ctx, taskClient, tokenManageCache, syncMaxRetries)
-
 	mediaGroup := router.Group("/media")
 	mediaGroup.POST("/process", func(c *gin.Context) {
 		if hub := sentryutil.SentryHubFromContext(c); hub != nil {
 			hub.Scope().AddEventProcessor(sentryutil.SpanFilterEventProcessor(c, 1000, 1*time.Millisecond, 8, true))
 		}
-		processBatch(tp, mc.Queries, retryManager)(c)
+		processBatch(tp, mc.Queries, taskClient, tokenManageCache)(c)
 	})
-	mediaGroup.POST("/process/token", processMediaForTokenIdentifiers(tp, mc.Queries, noRetryManager))
-	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, retryManager))
-	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, retryManager, mc, repos.UserRepository))
+	mediaGroup.POST("/process/token", processMediaForTokenIdentifiers(tp, mc.Queries, tokenmanage.New(ctx, taskClient, tokenManageCache)))
+	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, taskClient, tokenManageCache))
+	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, mc, repos.UserRepository, taskClient, tokenManageCache))
 	ownersGroup := router.Group("/owners")
 	ownersGroup.POST("/process/user", processOwnersForUserTokens(mc, mc.Queries))
 	ownersGroup.POST("/process/alchemy", processOwnersForAlchemyTokens(mc, mc.Queries))
@@ -50,12 +35,4 @@ func handlersInitServer(ctx context.Context, router *gin.Engine, tp *tokenProces
 	contractsGroup.POST("/detect-spam", detectSpamContracts(mc.Queries))
 
 	return router
-}
-
-func syncMaxRetries(tID persist.TokenIdentifiers) int {
-	cID := persist.NewContractIdentifiers(tID.ContractAddress, tID.Chain)
-	if retries, ok := contractSpecificRetries[cID]; ok {
-		return retries
-	}
-	return defaultSyncMaxRetries
 }

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -66,7 +66,7 @@ type tokenProcessingJob struct {
 	defaultMetadata persist.TokenMetadata
 	// isSpamJob indicates that the job is processing a spam token. It's currently used to exclude events from Sentry.
 	isSpamJob bool
-	// requireImage indicates that the pipeline should return an error if Prohibition image URL is present but an image wasn't cached.
+	// requireImage indicates that the pipeline should return an error if an image URL is present but an image wasn't cached.
 	requireImage bool
 	// requireFxHashSigned indicates that the pipeline should return an error if the token is FxHash but it isn't signed yet.
 	requireFxHashSigned bool
@@ -106,6 +106,14 @@ func (pOpts) WithIsSpamJob(isSpamJob bool) PipelineOption {
 func (pOpts) WithRequireImage() PipelineOption {
 	return func(j *tokenProcessingJob) {
 		j.requireImage = true
+	}
+}
+
+func (pOpts) WithRequireProhibitionimage(c db.Contract) PipelineOption {
+	return func(j *tokenProcessingJob) {
+		if isProhibition(c) {
+			j.requireImage = true
+		}
 	}
 }
 

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -14,7 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/googleapi"
 
-	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/metric"
@@ -26,7 +26,7 @@ import (
 )
 
 type tokenProcessor struct {
-	queries       *coredb.Queries
+	queries       *db.Queries
 	httpClient    *http.Client
 	mc            *multichain.Provider
 	ipfsClient    *shell.Shell
@@ -36,7 +36,7 @@ type tokenProcessor struct {
 	mr            metric.MetricReporter
 }
 
-func NewTokenProcessor(queries *coredb.Queries, httpClient *http.Client, mc *multichain.Provider, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, tokenBucket string, mr metric.MetricReporter) *tokenProcessor {
+func NewTokenProcessor(queries *db.Queries, httpClient *http.Client, mc *multichain.Provider, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, tokenBucket string, mr metric.MetricReporter) *tokenProcessor {
 	return &tokenProcessor{
 		queries:       queries,
 		mc:            mc,
@@ -66,8 +66,11 @@ type tokenProcessingJob struct {
 	defaultMetadata persist.TokenMetadata
 	// isSpamJob indicates that the job is processing a spam token. It's currently used to exclude events from Sentry.
 	isSpamJob bool
-	// requireImage indicates that the pipeline should return an error if an image URL is present but an image wasn't cached.
+	// requireImage indicates that the pipeline should return an error if Prohibition image URL is present but an image wasn't cached.
 	requireImage bool
+	// requireFxHashSigned indicates that the pipeline should return an error if the token is FxHash but it isn't signed yet.
+	requireFxHashSigned bool
+	fxHashIsSignedF     func() bool
 }
 
 type PipelineOption func(*tokenProcessingJob)
@@ -106,6 +109,15 @@ func (pOpts) WithRequireImage() PipelineOption {
 	}
 }
 
+func (pOpts) WithRequireFxHashSigned(td db.TokenDefinition, c db.Contract) PipelineOption {
+	return func(j *tokenProcessingJob) {
+		if isFxHash(td, c) {
+			j.requireFxHashSigned = true
+			j.fxHashIsSignedF = func() bool { return isFxHashSigned(td, c) }
+		}
+	}
+}
+
 type ErrImageResultRequired struct{ Err error }
 
 func (e ErrImageResultRequired) Unwrap() error { return e.Err }
@@ -123,7 +135,10 @@ type ErrBadToken struct{ Err error }
 func (e ErrBadToken) Unwrap() error { return e.Err }
 func (m ErrBadToken) Error() string { return fmt.Sprintf("issue with token: %s", m.Err) }
 
-func (tp *tokenProcessor) ProcessTokenPipeline(ctx context.Context, token persist.TokenIdentifiers, contract persist.ContractIdentifiers, cause persist.ProcessingCause, opts ...PipelineOption) (coredb.TokenMedia, error) {
+// ErrRequiredSignedToken indicates that the token isn't signed
+var ErrRequiredSignedToken = errors.New("token isn't signed")
+
+func (tp *tokenProcessor) ProcessTokenPipeline(ctx context.Context, token persist.TokenIdentifiers, contract persist.ContractIdentifiers, cause persist.ProcessingCause, opts ...PipelineOption) (db.TokenMedia, error) {
 	runID := persist.GenerateID()
 
 	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"runID": runID})
@@ -153,7 +168,7 @@ func (tp *tokenProcessor) ProcessTokenPipeline(ctx context.Context, token persis
 }
 
 // Run runs the pipeline, returning the media that was created by the run.
-func (tpj *tokenProcessingJob) Run(ctx context.Context) (coredb.TokenMedia, error) {
+func (tpj *tokenProcessingJob) Run(ctx context.Context) (db.TokenMedia, error) {
 	span, ctx := tracing.StartSpan(ctx, "pipeline.run", fmt.Sprintf("run %s", tpj.id))
 	defer tracing.FinishSpan(span)
 
@@ -179,15 +194,18 @@ func findURLsToDownloadFrom(ctx context.Context, tpj *tokenProcessingJob, metada
 }
 
 func wrapWithBadTokenErr(err error) error {
-	if errors.Is(err, media.ErrNoMediaURLs) || util.ErrorIs[errInvalidMedia](err) || util.ErrorIs[errNoDataFromReader](err) {
+	if errors.Is(err, media.ErrNoMediaURLs) || util.ErrorIs[errInvalidMedia](err) || util.ErrorIs[errNoDataFromReader](err) || errors.Is(err, ErrRequiredSignedToken) {
 		err = ErrBadToken{Err: err}
 	}
 	return err
 }
 
-func createErrFromResults(animResult cacheResult, imgResult cacheResult, imageRequired bool) error {
-	if imageRequired && !imgResult.IsSuccess() {
+func (tpj *tokenProcessingJob) createErrFromResults(animResult cacheResult, imgResult cacheResult, requireImg, requireSigned bool) error {
+	if requireImg && !imgResult.IsSuccess() {
 		return ErrImageResultRequired{Err: wrapWithBadTokenErr(imgResult.err)}
+	}
+	if requireSigned && !tpj.fxHashIsSignedF() {
+		return wrapWithBadTokenErr(ErrRequiredSignedToken)
 	}
 	if animResult.IsSuccess() || imgResult.IsSuccess() {
 		return nil
@@ -201,6 +219,7 @@ func createErrFromResults(animResult cacheResult, imgResult cacheResult, imageRe
 func (tpj *tokenProcessingJob) createMediaForToken(ctx context.Context) (persist.Media, persist.TokenMetadata, error) {
 	traceCallback, ctx := persist.TrackStepStatus(ctx, &tpj.pipelineMetadata.CreateMedia, "CreateMedia")
 	defer traceCallback()
+
 	metadata := tpj.retrieveMetadata(ctx)
 
 	imgURL, pfpURL, animURL, err := findURLsToDownloadFrom(ctx, tpj, metadata)
@@ -208,7 +227,11 @@ func (tpj *tokenProcessingJob) createMediaForToken(ctx context.Context) (persist
 		return persist.Media{MediaType: persist.MediaTypeUnknown}, metadata, wrapWithBadTokenErr(err)
 	}
 
-	newMedia, err := tpj.cacheMediaFromURLs(ctx, imgURL, pfpURL, animURL)
+	newMedia, err := tpj.cacheMediaFromURLs(ctx, imgURL, pfpURL, animURL,
+		tpj.requireImage && imgURL != "", // is image required?
+		tpj.requireFxHashSigned,          // is signed token required?
+	)
+
 	return newMedia, metadata, err
 }
 
@@ -390,14 +413,19 @@ func (tpj *tokenProcessingJob) cacheMediaSources(
 	return imgResult, pfpResult, animResult
 }
 
-func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, pfpURL media.ImageURL, animURL media.AnimationURL) (m persist.Media, err error) {
-	imgRequired := tpj.requireImage && imgURL != ""
-	ctx = logger.NewContextWithFields(ctx, logrus.Fields{"imgURL": imgURL, "pfpURL": pfpURL, "animURL": animURL, "imgRequired": imgRequired})
+func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, pfpURL media.ImageURL, animURL media.AnimationURL, requireImg, requireSigned bool) (m persist.Media, err error) {
+	ctx = logger.NewContextWithFields(ctx, logrus.Fields{
+		"imgURL":        imgURL,
+		"pfpURL":        pfpURL,
+		"animURL":       animURL,
+		"requireImg":    requireImg,
+		"requireSigned": requireSigned,
+	})
 
 	imgResult, pfpResult, animResult := tpj.cacheMediaFromOriginalURLs(ctx, imgURL, pfpURL, animURL)
 
-	if (!imgRequired && animResult.IsSuccess()) || imgResult.IsSuccess() {
-		err = createErrFromResults(animResult, imgResult, imgRequired)
+	if (!requireImg && animResult.IsSuccess()) || imgResult.IsSuccess() {
+		err = tpj.createErrFromResults(animResult, imgResult, requireImg, requireSigned)
 		return createMediaFromResults(ctx, tpj, animResult, imgResult, pfpResult), err
 	}
 
@@ -415,7 +443,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, p
 
 	// Now check if we got any result from OpenSea
 	if animResult.IsSuccess() || imgResult.IsSuccess() {
-		err = createErrFromResults(animResult, imgResult, imgRequired)
+		err = tpj.createErrFromResults(animResult, imgResult, requireImg, requireSigned)
 		return createMediaFromResults(ctx, tpj, animResult, imgResult, pfpResult), err
 	}
 
@@ -423,7 +451,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, p
 	defer traceCallback()
 
 	// At this point we don't have a way to make media so we return an error
-	err = createErrFromResults(animResult, imgResult, imgRequired)
+	err = tpj.createErrFromResults(animResult, imgResult, requireImg, requireSigned)
 	return mustCreateMediaFromErr(ctx, err, tpj), err
 }
 
@@ -468,20 +496,20 @@ func toJSONB(v any) (pgtype.JSONB, error) {
 	return j, err
 }
 
-func (tpj *tokenProcessingJob) persistResults(ctx context.Context, media persist.Media, metadata persist.TokenMetadata) (coredb.TokenMedia, error) {
+func (tpj *tokenProcessingJob) persistResults(ctx context.Context, media persist.Media, metadata persist.TokenMetadata) (db.TokenMedia, error) {
 	newMedia, err := toJSONB(media)
 	if err != nil {
-		return coredb.TokenMedia{}, err
+		return db.TokenMedia{}, err
 	}
 
 	newMetadata, err := toJSONB(metadata)
 	if err != nil {
-		return coredb.TokenMedia{}, err
+		return db.TokenMedia{}, err
 	}
 
 	name, description := findNameAndDescription(metadata)
 
-	params := coredb.InsertTokenPipelineResultsParams{
+	params := db.InsertTokenPipelineResultsParams{
 		ProcessingJobID:  tpj.id,
 		PipelineMetadata: *tpj.pipelineMetadata,
 		ProcessingCause:  tpj.cause,
@@ -536,7 +564,7 @@ func pipelineErroredMetric() metric.Measure {
 	return metric.Measure{Name: metricPipelineErrored}
 }
 
-func recordPipelineEndState(ctx context.Context, mr metric.MetricReporter, chain persist.Chain, tokenMedia coredb.TokenMedia, err error, d time.Duration, cause persist.ProcessingCause) {
+func recordPipelineEndState(ctx context.Context, mr metric.MetricReporter, chain persist.Chain, tokenMedia db.TokenMedia, err error, d time.Duration, cause persist.ProcessingCause) {
 	baseOpts := append([]any{}, metric.LogOptions.WithTags(map[string]string{
 		"chain":      fmt.Sprintf("%d", chain),
 		"mediaType":  tokenMedia.Media.MediaType.String(),

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -931,6 +931,15 @@ func isFxHash(td db.TokenDefinition, c db.Contract) bool {
 	return false
 }
 
-func isFxHashSigned(td db.TokenDefinition, c db.Contract) bool {
-	return !isFxHash(td, c) || td.Name.String != "[WAITING TO BE SIGNED]"
+func isFxHashSigned(td db.TokenDefinition, c db.Contract, m persist.TokenMetadata) bool {
+	if !isFxHash(td, c) {
+		return true
+	}
+	if td.Chain == persist.ChainTezos {
+		return tezos.IsFxHashSigned(c.Address, td.Name.String)
+	}
+	if td.Chain == persist.ChainETH {
+		return m["authenticityHash"] != "" && m["authenticityHash"] != nil
+	}
+	return true
 }

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -18,13 +18,16 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sourcegraph/conc/pool"
 
-	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/event"
+	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
+	"github.com/mikeydub/go-gallery/service/multichain/tezos"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
+	"github.com/mikeydub/go-gallery/service/redis"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/task"
 	"github.com/mikeydub/go-gallery/service/tokenmanage"
@@ -38,7 +41,7 @@ type ProcessMediaForTokenInput struct {
 	Chain           persist.Chain   `json:"chain"`
 }
 
-func processBatch(tp *tokenProcessor, queries *coredb.Queries, tm *tokenmanage.Manager) gin.HandlerFunc {
+func processBatch(tp *tokenProcessor, queries *db.Queries, taskClient *task.Client, cache *redis.Cache) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input task.TokenProcessingBatchMessage
 		if err := c.ShouldBindJSON(&input); err != nil {
@@ -66,8 +69,13 @@ func processBatch(tp *tokenProcessor, queries *coredb.Queries, tm *tokenmanage.M
 					return err
 				}
 
+				tm := tokenmanage.NewWithRetries(reqCtx, taskClient, cache, numRetriesF(td, c))
+
 				ctx := sentryutil.NewSentryHubContext(reqCtx)
-				_, err = runManagedPipeline(ctx, tp, tm, td, persist.ProcessingCauseSync, 0, addIsSpamJobOption(c))
+				_, err = runManagedPipeline(ctx, tp, tm, td, persist.ProcessingCauseSync, 0,
+					addIsSpamJobOption(c),
+					PipelineOpts.WithRequireFxHashSigned(td, c), // Require token to be signed if it is an FxHash token
+				)
 				return err
 			})
 		}
@@ -79,7 +87,7 @@ func processBatch(tp *tokenProcessor, queries *coredb.Queries, tm *tokenmanage.M
 	}
 }
 
-func processMediaForTokenIdentifiers(tp *tokenProcessor, queries *coredb.Queries, tm *tokenmanage.Manager) gin.HandlerFunc {
+func processMediaForTokenIdentifiers(tp *tokenProcessor, queries *db.Queries, tm *tokenmanage.Manager) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input ProcessMediaForTokenInput
 		if err := c.ShouldBindJSON(&input); err != nil {
@@ -87,7 +95,7 @@ func processMediaForTokenIdentifiers(tp *tokenProcessor, queries *coredb.Queries
 			return
 		}
 
-		td, err := queries.GetTokenDefinitionByTokenIdentifiers(c, coredb.GetTokenDefinitionByTokenIdentifiersParams{
+		td, err := queries.GetTokenDefinitionByTokenIdentifiers(c, db.GetTokenDefinitionByTokenIdentifiersParams{
 			Chain:           input.Chain,
 			ContractAddress: input.ContractAddress,
 			TokenID:         input.TokenID,
@@ -127,7 +135,7 @@ func processMediaForTokenIdentifiers(tp *tokenProcessor, queries *coredb.Queries
 }
 
 // processMediaForTokenManaged processes a single token instance. It's only called for tokens that failed during a sync.
-func processMediaForTokenManaged(tp *tokenProcessor, queries *coredb.Queries, tm *tokenmanage.Manager) gin.HandlerFunc {
+func processMediaForTokenManaged(tp *tokenProcessor, queries *db.Queries, taskClient *task.Client, cache *redis.Cache) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input task.TokenProcessingTokenMessage
 
@@ -159,6 +167,8 @@ func processMediaForTokenManaged(tp *tokenProcessor, queries *coredb.Queries, tm
 			return
 		}
 
+		tm := tokenmanage.NewWithRetries(c, taskClient, cache, numRetriesF(td, contract))
+
 		runManagedPipeline(c, tp, tm, td, persist.ProcessingCauseSyncRetry, input.Attempts, addIsSpamJobOption(contract))
 
 		// We always return a 200 because retries are managed by the token manager and we don't want the queue retrying the current message.
@@ -166,7 +176,7 @@ func processMediaForTokenManaged(tp *tokenProcessor, queries *coredb.Queries, tm
 	}
 }
 
-func processOwnersForUserTokens(mc *multichain.Provider, queries *coredb.Queries) gin.HandlerFunc {
+func processOwnersForUserTokens(mc *multichain.Provider, queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input task.TokenProcessingUserTokensMessage
 		if err := c.ShouldBindJSON(&input); err != nil {
@@ -206,7 +216,7 @@ func processOwnersForUserTokens(mc *multichain.Provider, queries *coredb.Queries
 				}
 
 				// one event per token identifier (grouping ERC-1155s)
-				err = event.Dispatch(c, coredb.Event{
+				err = event.Dispatch(c, db.Event{
 					ID:             persist.GenerateID(),
 					ActorID:        persist.DBIDToNullStr(input.UserID),
 					ResourceTypeID: persist.ResourceTypeToken,
@@ -310,7 +320,7 @@ var alchemyIPs = []string{
 	"34.237.24.169",
 }
 
-func processOwnersForAlchemyTokens(mc *multichain.Provider, queries *coredb.Queries) gin.HandlerFunc {
+func processOwnersForAlchemyTokens(mc *multichain.Provider, queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		if !util.Contains(alchemyIPs, c.ClientIP()) {
@@ -372,7 +382,7 @@ func processOwnersForAlchemyTokens(mc *multichain.Provider, queries *coredb.Quer
 
 			userID, ok := addressToUsers[persist.NewChainAddress(activity.ToAddress, chain)]
 			if !ok {
-				user, err := queries.GetUserByAddressAndL1(c, coredb.GetUserByAddressAndL1Params{
+				user, err := queries.GetUserByAddressAndL1(c, db.GetUserByAddressAndL1Params{
 					Address: persist.Address(chain.NormalizeAddress(activity.ToAddress)),
 					L1Chain: persist.L1Chain(persist.ChainETH),
 				})
@@ -474,7 +484,7 @@ func processOwnersForAlchemyTokens(mc *multichain.Provider, queries *coredb.Quer
 					}
 
 					// one event per token identifier (grouping ERC-1155s)
-					err = event.Dispatch(c, coredb.Event{
+					err = event.Dispatch(c, db.Event{
 						ID:             persist.GenerateID(),
 						ActorID:        persist.DBIDToNullStr(userID),
 						ResourceTypeID: persist.ResourceTypeToken,
@@ -535,7 +545,7 @@ type GoldskyToken1155Holder struct {
 
 }
 
-func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Queries) gin.HandlerFunc {
+func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		var in GoldskyWebhookInput
@@ -559,7 +569,7 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 		}
 
 		userAddress := persist.Address(strings.ToLower(fullIDs[0]))
-		user, _ := queries.GetUserByAddressAndL1(c, coredb.GetUserByAddressAndL1Params{
+		user, _ := queries.GetUserByAddressAndL1(c, db.GetUserByAddressAndL1Params{
 			Address: userAddress,
 			L1Chain: persist.ChainZora.L1Chain(),
 		})
@@ -579,7 +589,7 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 		}
 		tokenID := persist.TokenID(bigTokenID.Text(16))
 
-		beforeToken, _ := queries.GetTokenByUserTokenIdentifiers(c, coredb.GetTokenByUserTokenIdentifiersParams{
+		beforeToken, _ := queries.GetTokenByUserTokenIdentifiers(c, db.GetTokenByUserTokenIdentifiersParams{
 			OwnerID:         user.ID,
 			TokenID:         tokenID,
 			Chain:           persist.ChainZora,
@@ -627,7 +637,7 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 			}
 
 			// one event per token identifier (grouping ERC-1155s)
-			err = event.Dispatch(c, coredb.Event{
+			err = event.Dispatch(c, db.Event{
 				ID:             persist.GenerateID(),
 				ActorID:        persist.DBIDToNullStr(user.ID),
 				ResourceTypeID: persist.ResourceTypeToken,
@@ -650,9 +660,9 @@ func processOwnersForGoldskyTokens(mc *multichain.Provider, queries *coredb.Quer
 }
 
 // detectSpamContracts refreshes the alchemy_spam_contracts table with marked contracts from Alchemy
-func detectSpamContracts(queries *coredb.Queries) gin.HandlerFunc {
+func detectSpamContracts(queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var params coredb.InsertSpamContractsParams
+		var params db.InsertSpamContractsParams
 
 		now := time.Now()
 
@@ -731,7 +741,7 @@ func detectSpamContracts(queries *coredb.Queries) gin.HandlerFunc {
 	}
 }
 
-func processWalletRemoval(queries *coredb.Queries) gin.HandlerFunc {
+func processWalletRemoval(queries *db.Queries) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input task.TokenProcessingWalletRemovalMessage
 		if err := c.ShouldBindJSON(&input); err != nil {
@@ -745,7 +755,7 @@ func processWalletRemoval(queries *coredb.Queries) gin.HandlerFunc {
 		// processing multiple wallet removals, we'll just process them in a loop here, because tuning the
 		// underlying query to handle multiple wallet removals at a time is difficult.
 		for _, walletID := range input.WalletIDs {
-			err := queries.RemoveWalletFromTokens(c, coredb.RemoveWalletFromTokensParams{
+			err := queries.RemoveWalletFromTokens(c, db.RemoveWalletFromTokensParams{
 				WalletID: walletID.String(),
 				UserID:   input.UserID,
 			})
@@ -765,7 +775,7 @@ func processWalletRemoval(queries *coredb.Queries) gin.HandlerFunc {
 	}
 }
 
-func processPostPreflight(tp *tokenProcessor, tm *tokenmanage.Manager, mc *multichain.Provider, userRepo *postgres.UserRepository) gin.HandlerFunc {
+func processPostPreflight(tp *tokenProcessor, mc *multichain.Provider, userRepo *postgres.UserRepository, taskClient *task.Client, cache *redis.Cache) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input task.PostPreflightMessage
 
@@ -775,7 +785,7 @@ func processPostPreflight(tp *tokenProcessor, tm *tokenmanage.Manager, mc *multi
 			return
 		}
 
-		existingMedia, err := mc.Queries.GetMediaByTokenIdentifiersIgnoringStatus(c, coredb.GetMediaByTokenIdentifiersIgnoringStatusParams{
+		existingMedia, err := mc.Queries.GetMediaByTokenIdentifiersIgnoringStatus(c, db.GetMediaByTokenIdentifiersIgnoringStatusParams{
 			Chain:           input.Token.Chain,
 			ContractAddress: input.Token.ContractAddress,
 			TokenID:         input.Token.TokenID,
@@ -805,9 +815,12 @@ func processPostPreflight(tp *tokenProcessor, tm *tokenmanage.Manager, mc *multi
 				return
 			}
 
+			tm := tokenmanage.NewWithRetries(c, taskClient, cache, numRetriesF(td, contract))
+
 			runManagedPipeline(c, tp, tm, td, persist.ProcessingCausePostPreflight, 0,
 				addIsSpamJobOption(contract),
-				PipelineOpts.WithRequireImage(), // Require an image if available
+				PipelineOpts.WithRequireImage(),                    // Require an image if available
+				PipelineOpts.WithRequireFxHashSigned(td, contract), // Require token to be signed if it is an FxHash token
 			)
 		}
 
@@ -834,7 +847,7 @@ func processPostPreflight(tp *tokenProcessor, tm *tokenmanage.Manager, mc *multi
 	}
 }
 
-func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage.Manager, td coredb.TokenDefinition, cause persist.ProcessingCause, attempts int, opts ...PipelineOption) (coredb.TokenMedia, error) {
+func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage.Manager, td db.TokenDefinition, cause persist.ProcessingCause, attempts int, opts ...PipelineOption) (db.TokenMedia, error) {
 	ctx = logger.NewContextWithFields(ctx, logrus.Fields{
 		"tokenDefinitionDBID": td.ID,
 		"contractDBID":        td.ContractID,
@@ -848,7 +861,7 @@ func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage
 	cID := persist.NewContractIdentifiers(td.ContractAddress, td.Chain)
 	closing, err := tm.StartProcessing(ctx, td.ID, tID, attempts)
 	if err != nil {
-		return coredb.TokenMedia{}, err
+		return db.TokenMedia{}, err
 	}
 	runOpts := append([]PipelineOption{}, addContractRunOptions(cID)...)
 	runOpts = append(runOpts, addContextRunOptions(cause)...)
@@ -875,6 +888,42 @@ func addContractRunOptions(contract persist.ContractIdentifiers) (opts []Pipelin
 	return opts
 }
 
-func addIsSpamJobOption(c coredb.Contract) PipelineOption {
+func addIsSpamJobOption(c db.Contract) PipelineOption {
 	return PipelineOpts.WithIsSpamJob(c.IsProviderMarkedSpam)
+}
+
+var (
+	defaultSyncMaxRetries = 4
+	prohibitionContract   = persist.NewContractIdentifiers("0x47a91457a3a1f700097199fd63c039c4784384ab", persist.ChainArbitrum)
+	ensContract           = persist.NewContractIdentifiers(eth.EnsAddress, persist.ChainETH)
+)
+
+// numRetriesF returns a function that when called, returns the number of retries allotted for a token and contract
+func numRetriesF(td db.TokenDefinition, c db.Contract) tokenmanage.NumRetryF {
+	return func() int {
+		if persist.NewContractIdentifiers(c.Address, c.Chain) == prohibitionContract || isFxHash(td, c) {
+			return 24
+		}
+		return defaultSyncMaxRetries
+	}
+}
+
+func isFxHash(td db.TokenDefinition, c db.Contract) bool {
+	if td.Chain == persist.ChainTezos && tezos.IsFxHash(c.Address) {
+		return true
+	}
+	if td.Chain == persist.ChainETH {
+		if strings.ToLower(c.Symbol.String) == "fxgen" {
+			return true
+		}
+		parsed, _ := url.Parse(td.Metadata["external_url"].(string))
+		if td.Chain == persist.ChainETH && strings.HasPrefix(parsed.Hostname(), "fxhash") {
+			return true
+		}
+	}
+	return false
+}
+
+func isFxHashSigned(td db.TokenDefinition, c db.Contract) bool {
+	return !isFxHash(td, c) || td.Name.String != "[WAITING TO BE SIGNED]"
 }


### PR DESCRIPTION
Changes:
* FxHash tokens are automatically retried on syncs if not signed, up to 24 times
* Prohibition tokens are automatically retried on syncs if unable to process an image, up to 24 times. This was only enabled for Share-to-Gallery previously.