### PR TITLE
Tokenprocessing fxhash updates

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -3244,7 +3244,7 @@ func (b *GetSharedFollowersBatchPaginateBatchResults) Close() error {
 }
 
 const getTokenByIdBatch = `-- name: GetTokenByIdBatch :batchone
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash
 from tokens t
 join token_definitions td on t.token_definition_id = td.id
 where t.id = $1 and t.displayable and t.deleted = false and td.deleted = false
@@ -3317,6 +3317,7 @@ func (b *GetTokenByIdBatchBatchResults) QueryRow(f func(int, GetTokenByIdBatchRo
 			&i.TokenDefinition.ContractAddress,
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -3330,7 +3331,7 @@ func (b *GetTokenByIdBatchBatchResults) Close() error {
 }
 
 const getTokenByIdIgnoreDisplayableBatch = `-- name: GetTokenByIdIgnoreDisplayableBatch :batchone
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted
 from tokens t
 join token_definitions td on t.token_definition_id = td.id
 join token_medias tm on td.token_media_id = tm.id
@@ -3405,6 +3406,7 @@ func (b *GetTokenByIdIgnoreDisplayableBatchBatchResults) QueryRow(f func(int, Ge
 			&i.TokenDefinition.ContractAddress,
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
 			&i.TokenMedia.ID,
 			&i.TokenMedia.CreatedAt,
 			&i.TokenMedia.LastUpdated,
@@ -3426,7 +3428,7 @@ func (b *GetTokenByIdIgnoreDisplayableBatchBatchResults) Close() error {
 }
 
 const getTokenByUserTokenIdentifiersBatch = `-- name: GetTokenByUserTokenIdentifiersBatch :batchone
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain
 from tokens t, token_definitions td, contracts c
 where t.token_definition_id = td.id
     and td.contract_id = c.id
@@ -3519,6 +3521,7 @@ func (b *GetTokenByUserTokenIdentifiersBatchBatchResults) QueryRow(f func(int, G
 			&i.TokenDefinition.ContractAddress,
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
 			&i.Contract.ID,
 			&i.Contract.Deleted,
 			&i.Contract.Version,
@@ -3551,7 +3554,7 @@ func (b *GetTokenByUserTokenIdentifiersBatchBatchResults) Close() error {
 }
 
 const getTokenByUserTokenIdentifiersIgnoreDisplayableBatch = `-- name: GetTokenByUserTokenIdentifiersIgnoreDisplayableBatch :batchone
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain, tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain, tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted
 from tokens t, token_definitions td, contracts c, token_medias tm
 where t.token_definition_id = td.id
     and td.contract_id = c.id
@@ -3645,6 +3648,7 @@ func (b *GetTokenByUserTokenIdentifiersIgnoreDisplayableBatchBatchResults) Query
 			&i.TokenDefinition.ContractAddress,
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
 			&i.Contract.ID,
 			&i.Contract.Deleted,
 			&i.Contract.Version,
@@ -3685,7 +3689,7 @@ func (b *GetTokenByUserTokenIdentifiersIgnoreDisplayableBatchBatchResults) Close
 }
 
 const getTokenDefinitionByIdBatch = `-- name: GetTokenDefinitionByIdBatch :batchone
-select id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id from token_definitions where id = $1 and not deleted
+select id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id, is_fxhash from token_definitions where id = $1 and not deleted
 `
 
 type GetTokenDefinitionByIdBatchBatchResults struct {
@@ -3733,6 +3737,7 @@ func (b *GetTokenDefinitionByIdBatchBatchResults) QueryRow(f func(int, TokenDefi
 			&i.ContractAddress,
 			&i.ContractID,
 			&i.TokenMediaID,
+			&i.IsFxhash,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -3837,7 +3842,7 @@ func (b *GetTokensByCollectionIdBatchBatchResults) Close() error {
 }
 
 const getTokensByUserIdBatch = `-- name: GetTokensByUserIdBatch :batchmany
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain
 from tokens t
 join token_definitions td on t.token_definition_id = td.id
 join contracts c on c.id = td.contract_id
@@ -3933,6 +3938,7 @@ func (b *GetTokensByUserIdBatchBatchResults) Query(f func(int, []GetTokensByUser
 					&i.TokenDefinition.ContractAddress,
 					&i.TokenDefinition.ContractID,
 					&i.TokenDefinition.TokenMediaID,
+					&i.TokenDefinition.IsFxhash,
 					&i.Contract.ID,
 					&i.Contract.Deleted,
 					&i.Contract.Version,
@@ -6055,7 +6061,7 @@ token_memberships as (
         and not tokens.deleted
 )
 
-(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from contract_memberships ct
+(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from contract_memberships ct
     join tokens t on t.id = ct.id
     join token_definitions td on t.token_definition_id = td.id
     join users u on u.id = t.owner_user_id
@@ -6074,7 +6080,7 @@ token_memberships as (
 
 union all
 
-(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from token_memberships ct
+(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from token_memberships ct
     join tokens t on t.id = ct.id
     join token_definitions td on t.token_definition_id = td.id
     join users u on u.id = t.owner_user_id
@@ -6190,6 +6196,7 @@ func (b *PaginateTokensByCommunityIDBatchResults) Query(f func(int, []PaginateTo
 					&i.TokenDefinition.ContractAddress,
 					&i.TokenDefinition.ContractID,
 					&i.TokenDefinition.TokenMediaID,
+					&i.TokenDefinition.IsFxhash,
 					&i.Contract.ID,
 					&i.Contract.Deleted,
 					&i.Contract.Version,

--- a/db/gen/coredb/community.sql.go
+++ b/db/gen/coredb/community.sql.go
@@ -51,7 +51,6 @@ func (q *Queries) CountHoldersByCommunityID(ctx context.Context, communityID per
 }
 
 const countPostsByCommunityID = `-- name: CountPostsByCommunityID :one
-
 with community_data as (
     select community_type, contract_id
     from communities
@@ -84,9 +83,6 @@ community_posts as (
 select count(*) from community_posts
 `
 
-// set role to access_rw;
-// create index posts_token_ids_idx on posts using gin (token_ids) where (deleted = false);
-// drop index if exists posts_token_ids_idx;
 func (q *Queries) CountPostsByCommunityID(ctx context.Context, communityID persist.DBID) (int64, error) {
 	row := q.db.QueryRow(ctx, countPostsByCommunityID, communityID)
 	var count int64
@@ -298,7 +294,7 @@ with community_data as (
 ),
 
 community_token_definitions as (
-    select td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id
+    select td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash
     from community_data, token_definitions td
     where community_data.community_type = 0
         and td.contract_id = community_data.contract_id
@@ -306,7 +302,7 @@ community_token_definitions as (
 
     union all
 
-    select td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id
+    select td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash
     from community_data, token_definitions td
         join token_community_memberships on td.id = token_community_memberships.token_definition_id
             and token_community_memberships.community_id = $2

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -621,6 +621,7 @@ type TokenDefinition struct {
 	ContractAddress persist.Address       `db:"contract_address" json:"contract_address"`
 	ContractID      persist.DBID          `db:"contract_id" json:"contract_id"`
 	TokenMediaID    persist.DBID          `db:"token_media_id" json:"token_media_id"`
+	IsFxhash        bool                  `db:"is_fxhash" json:"is_fxhash"`
 }
 
 type TokenMedia struct {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -3292,7 +3292,7 @@ func (q *Queries) GetPostByID(ctx context.Context, id persist.DBID) (Post, error
 }
 
 const getPotentialENSProfileImageByUserId = `-- name: GetPotentialENSProfileImageByUserId :one
-select token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_medias.id, token_medias.created_at, token_medias.last_updated, token_medias.version, token_medias.active, token_medias.media, token_medias.processing_job_id, token_medias.deleted, wallets.id, wallets.created_at, wallets.last_updated, wallets.deleted, wallets.version, wallets.address, wallets.wallet_type, wallets.chain, wallets.l1_chain
+select token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, token_medias.id, token_medias.created_at, token_medias.last_updated, token_medias.version, token_medias.active, token_medias.media, token_medias.processing_job_id, token_medias.deleted, wallets.id, wallets.created_at, wallets.last_updated, wallets.deleted, wallets.version, wallets.address, wallets.wallet_type, wallets.chain, wallets.l1_chain
 from token_definitions, tokens, users, token_medias, wallets, unnest(tokens.owned_by_wallets) tw(id)
 where token_definitions.contract_address = $1
     and token_definitions.chain = $2
@@ -3343,6 +3343,7 @@ func (q *Queries) GetPotentialENSProfileImageByUserId(ctx context.Context, arg G
 		&i.TokenDefinition.ContractAddress,
 		&i.TokenDefinition.ContractID,
 		&i.TokenDefinition.TokenMediaID,
+		&i.TokenDefinition.IsFxhash,
 		&i.TokenMedia.ID,
 		&i.TokenMedia.CreatedAt,
 		&i.TokenMedia.LastUpdated,
@@ -3860,7 +3861,7 @@ func (q *Queries) GetSocialsByUserID(ctx context.Context, id persist.DBID) (pers
 }
 
 const getTokenById = `-- name: GetTokenById :one
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash
 from tokens t
 join token_definitions td on t.token_definition_id = td.id
 where t.id = $1 and t.displayable and t.deleted = false and td.deleted = false
@@ -3907,12 +3908,13 @@ func (q *Queries) GetTokenById(ctx context.Context, id persist.DBID) (GetTokenBy
 		&i.TokenDefinition.ContractAddress,
 		&i.TokenDefinition.ContractID,
 		&i.TokenDefinition.TokenMediaID,
+		&i.TokenDefinition.IsFxhash,
 	)
 	return i, err
 }
 
 const getTokenByUserTokenIdentifiers = `-- name: GetTokenByUserTokenIdentifiers :one
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain
 from tokens t, token_definitions td, contracts c
 where t.token_definition_id = td.id
     and td.contract_id = c.id
@@ -3980,6 +3982,7 @@ func (q *Queries) GetTokenByUserTokenIdentifiers(ctx context.Context, arg GetTok
 		&i.TokenDefinition.ContractAddress,
 		&i.TokenDefinition.ContractID,
 		&i.TokenDefinition.TokenMediaID,
+		&i.TokenDefinition.IsFxhash,
 		&i.Contract.ID,
 		&i.Contract.Deleted,
 		&i.Contract.Version,
@@ -4004,7 +4007,7 @@ func (q *Queries) GetTokenByUserTokenIdentifiers(ctx context.Context, arg GetTok
 }
 
 const getTokenDefinitionById = `-- name: GetTokenDefinitionById :one
-select id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id from token_definitions where id = $1 and not deleted
+select id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id, is_fxhash from token_definitions where id = $1 and not deleted
 `
 
 func (q *Queries) GetTokenDefinitionById(ctx context.Context, id persist.DBID) (TokenDefinition, error) {
@@ -4026,12 +4029,13 @@ func (q *Queries) GetTokenDefinitionById(ctx context.Context, id persist.DBID) (
 		&i.ContractAddress,
 		&i.ContractID,
 		&i.TokenMediaID,
+		&i.IsFxhash,
 	)
 	return i, err
 }
 
 const getTokenDefinitionByTokenDbid = `-- name: GetTokenDefinitionByTokenDbid :one
-select token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id
+select token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash
 from token_definitions, tokens
 where token_definitions.id = tokens.token_definition_id
     and tokens.id = $1
@@ -4058,12 +4062,13 @@ func (q *Queries) GetTokenDefinitionByTokenDbid(ctx context.Context, id persist.
 		&i.ContractAddress,
 		&i.ContractID,
 		&i.TokenMediaID,
+		&i.IsFxhash,
 	)
 	return i, err
 }
 
 const getTokenDefinitionByTokenIdentifiers = `-- name: GetTokenDefinitionByTokenIdentifiers :one
-select id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id
+select id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id, is_fxhash
 from token_definitions
 where (chain, contract_address, token_id) = ($1, $2, $3) and not deleted
 `
@@ -4093,12 +4098,13 @@ func (q *Queries) GetTokenDefinitionByTokenIdentifiers(ctx context.Context, arg 
 		&i.ContractAddress,
 		&i.ContractID,
 		&i.TokenMediaID,
+		&i.IsFxhash,
 	)
 	return i, err
 }
 
 const getTokenFullDetailsByContractId = `-- name: GetTokenFullDetailsByContractId :many
-select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
+select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
 from tokens
 join token_definitions on tokens.token_definition_id = token_definitions.id
 join contracts on token_definitions.contract_id = contracts.id
@@ -4154,6 +4160,7 @@ func (q *Queries) GetTokenFullDetailsByContractId(ctx context.Context, id persis
 			&i.TokenDefinition.ContractAddress,
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
 			&i.Contract.ID,
 			&i.Contract.Deleted,
 			&i.Contract.Version,
@@ -4185,7 +4192,7 @@ func (q *Queries) GetTokenFullDetailsByContractId(ctx context.Context, id persis
 }
 
 const getTokenFullDetailsByUserId = `-- name: GetTokenFullDetailsByUserId :many
-select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
+select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
 from tokens
 join token_definitions on tokens.token_definition_id = token_definitions.id
 join contracts on token_definitions.contract_id = contracts.id
@@ -4241,6 +4248,7 @@ func (q *Queries) GetTokenFullDetailsByUserId(ctx context.Context, ownerUserID p
 			&i.TokenDefinition.ContractAddress,
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
 			&i.Contract.ID,
 			&i.Contract.Deleted,
 			&i.Contract.Version,
@@ -4272,7 +4280,7 @@ func (q *Queries) GetTokenFullDetailsByUserId(ctx context.Context, ownerUserID p
 }
 
 const getTokenFullDetailsByUserTokenIdentifiers = `-- name: GetTokenFullDetailsByUserTokenIdentifiers :one
-select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
+select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
 from tokens
 join token_definitions on tokens.token_definition_id = token_definitions.id
 join contracts on token_definitions.contract_id = contracts.id
@@ -4339,6 +4347,7 @@ func (q *Queries) GetTokenFullDetailsByUserTokenIdentifiers(ctx context.Context,
 		&i.TokenDefinition.ContractAddress,
 		&i.TokenDefinition.ContractID,
 		&i.TokenDefinition.TokenMediaID,
+		&i.TokenDefinition.IsFxhash,
 		&i.Contract.ID,
 		&i.Contract.Deleted,
 		&i.Contract.Version,
@@ -4363,7 +4372,7 @@ func (q *Queries) GetTokenFullDetailsByUserTokenIdentifiers(ctx context.Context,
 }
 
 const getTokensByContractIdPaginate = `-- name: GetTokensByContractIdPaginate :many
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain, u.id, u.deleted, u.version, u.last_updated, u.created_at, u.username, u.username_idempotent, u.wallets, u.bio, u.traits, u.universal, u.notification_settings, u.email_verified, u.email_unsubscriptions, u.featured_gallery, u.primary_wallet_id, u.user_experiences, u.profile_image_id from tokens t
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain, u.id, u.deleted, u.version, u.last_updated, u.created_at, u.username, u.username_idempotent, u.wallets, u.bio, u.traits, u.universal, u.notification_settings, u.email_verified, u.email_unsubscriptions, u.featured_gallery, u.primary_wallet_id, u.user_experiences, u.profile_image_id from tokens t
     join token_definitions td on t.token_definition_id = td.id
     join users u on u.id = t.owner_user_id
     join contracts c on t.contract_id = c.id
@@ -4453,6 +4462,7 @@ func (q *Queries) GetTokensByContractIdPaginate(ctx context.Context, arg GetToke
 			&i.TokenDefinition.ContractAddress,
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
 			&i.Contract.ID,
 			&i.Contract.Deleted,
 			&i.Contract.Version,
@@ -7103,7 +7113,7 @@ where token_id = $3
     and contract_id = $4
     and chain = $5
     and deleted = false
-returning id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id
+returning id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id, is_fxhash
 `
 
 type UpdateTokenMetadataFieldsByTokenIdentifiersParams struct {
@@ -7139,6 +7149,7 @@ func (q *Queries) UpdateTokenMetadataFieldsByTokenIdentifiers(ctx context.Contex
 		&i.ContractAddress,
 		&i.ContractID,
 		&i.TokenMediaID,
+		&i.IsFxhash,
 	)
 	return i, err
 }

--- a/db/migrations/core/000141_add_is_fxhash.up.sql
+++ b/db/migrations/core/000141_add_is_fxhash.up.sql
@@ -1,0 +1,22 @@
+alter table token_definitions add column if not exists is_fxhash boolean not null default false;
+
+update token_definitions set is_fxhash = true
+from (
+	select td.id
+	from token_definitions td
+	join contracts c on td.contract_id = c.id
+	where 
+	-- tezos fxhash contracts
+	(c.chain = 4 and c.address in (
+		'KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE',
+		'KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi',
+		'KT1EfsNuqwLAWDd3o4pvfUx1CAh5GMdTrRvr',
+		'KT1GtbuswcNMGhHF2TSuH1Yfaqn16do8Qtva',
+		'KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton',
+		'KT19xbD2xn6A81an18S35oKtnkFNr9CVwY5m'
+	))
+	or
+	-- eth fxhash contracts
+	(c.chain = 0 and c.symbol = 'FXGEN')
+) fxhash_tokens
+where fxhash_tokens.id = token_definitions.id;

--- a/db/queries/core/token_gallery.sql
+++ b/db/queries/core/token_gallery.sql
@@ -16,6 +16,7 @@ with token_definitions_insert as (
     , contract_address
     , contract_id
     , metadata
+    , is_fxhash
   ) (
     select unnest(@definition_dbid::varchar[]) as id
       , now()
@@ -31,6 +32,7 @@ with token_definitions_insert as (
       , unnest(@definition_contract_address::varchar[]) as contract_address
       , unnest(@definition_contract_id::varchar[]) as contract_id
       , unnest(@definition_metadata::jsonb[]) as metadata
+      , unnest(@definition_is_fxhash::boolean[]) as is_fxhash
   )
   on conflict (chain, contract_id, token_id) where deleted = false
   do update set
@@ -42,6 +44,7 @@ with token_definitions_insert as (
     , fallback_media = excluded.fallback_media
     , contract_address = excluded.contract_address
     , metadata = excluded.metadata
+    , is_fxhash = excluded.is_fxhash
   returning *
 )
 , tokens_insert as (

--- a/emails/send.go
+++ b/emails/send.go
@@ -141,7 +141,7 @@ func adminSendNotificationEmail(queries *coredb.Queries, s *sendgrid.Client) gin
 func sendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, r *redis.Cache) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		l, _ := r.Get(ctx, "send-notification-emails")
-		if l != nil && len(l) > 0 {
+		if len(l) > 0 {
 			logger.For(ctx).Infof("notification emails already being sent")
 			return
 		}
@@ -315,7 +315,7 @@ func sendDigestEmails(queries *coredb.Queries, loaders *dataloader.Loaders, s *s
 		ctx.Set("auth.auth_error", nil)
 
 		l, _ := r.Get(ctx, "send-digest-emails")
-		if l != nil && len(l) > 0 {
+		if len(l) > 0 {
 			logger.For(ctx).Infof("digest emails already being sent")
 			return
 		}

--- a/emails/send.go
+++ b/emails/send.go
@@ -141,7 +141,7 @@ func adminSendNotificationEmail(queries *coredb.Queries, s *sendgrid.Client) gin
 func sendNotificationEmails(queries *coredb.Queries, s *sendgrid.Client, r *redis.Cache) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		l, _ := r.Get(ctx, "send-notification-emails")
-		if len(l) > 0 {
+		if l != nil && len(l) > 0 {
 			logger.For(ctx).Infof("notification emails already being sent")
 			return
 		}
@@ -315,7 +315,7 @@ func sendDigestEmails(queries *coredb.Queries, loaders *dataloader.Loaders, s *s
 		ctx.Set("auth.auth_error", nil)
 
 		l, _ := r.Get(ctx, "send-digest-emails")
-		if len(l) > 0 {
+		if l != nil && len(l) > 0 {
 			logger.For(ctx).Infof("digest emails already being sent")
 			return
 		}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2723,15 +2723,10 @@ func (r *queryResolver) PostComposerDraftDetails(ctx context.Context, input mode
 		return nil, err
 	}
 
-	c, err := publicapi.For(ctx).Contract.GetContractByID(ctx, td.ContractID)
-	if err != nil {
-		return nil, err
-	}
-
 	highDef := false
 
 	return model.PostComposerDraftDetailsPayload{
-		Media:            resolveTokenMedia(ctx, td, *c, media, highDef),
+		Media:            resolveTokenMedia(ctx, td, media, highDef),
 		TokenName:        util.ToPointer(td.Name.String),
 		TokenDescription: util.ToPointer(td.Description.String),
 		Community:        nil, // handled by dedicated resolver
@@ -3072,11 +3067,6 @@ func (r *tokenResolver) Media(ctx context.Context, obj *model.Token) (model.Medi
 		return nil, err
 	}
 
-	contract, err := publicapi.For(ctx).Contract.GetContractByID(ctx, td.ContractID)
-	if err != nil {
-		return nil, err
-	}
-
 	var media coredb.TokenMedia
 
 	if td.TokenMediaID != "" {
@@ -3086,7 +3076,7 @@ func (r *tokenResolver) Media(ctx context.Context, obj *model.Token) (model.Medi
 		}
 	}
 
-	return resolveTokenMedia(ctx, td, *contract, media, highDef), err
+	return resolveTokenMedia(ctx, td, media, highDef), err
 }
 
 // TokenType is the resolver for the tokenType field.
@@ -3190,12 +3180,7 @@ func (r *tokenDefinitionResolver) Media(ctx context.Context, obj *model.TokenDef
 		}
 	}
 
-	contract, err := publicapi.For(ctx).Contract.GetContractByID(ctx, obj.HelperTokenDefinitionData.Definition.ContractID)
-	if err != nil {
-		return nil, err
-	}
-
-	return resolveTokenMedia(ctx, obj.HelperTokenDefinitionData.Definition, *contract, media, false), nil
+	return resolveTokenMedia(ctx, obj.HelperTokenDefinitionData.Definition, media, false), nil
 }
 
 // Contract is the resolver for the contract field.

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2723,10 +2723,15 @@ func (r *queryResolver) PostComposerDraftDetails(ctx context.Context, input mode
 		return nil, err
 	}
 
+	c, err := publicapi.For(ctx).Contract.GetContractByID(ctx, td.ContractID)
+	if err != nil {
+		return nil, err
+	}
+
 	highDef := false
 
 	return model.PostComposerDraftDetailsPayload{
-		Media:            resolveTokenMedia(ctx, td, media, highDef),
+		Media:            resolveTokenMedia(ctx, td, *c, media, highDef),
 		TokenName:        util.ToPointer(td.Name.String),
 		TokenDescription: util.ToPointer(td.Description.String),
 		Community:        nil, // handled by dedicated resolver
@@ -3067,6 +3072,11 @@ func (r *tokenResolver) Media(ctx context.Context, obj *model.Token) (model.Medi
 		return nil, err
 	}
 
+	contract, err := publicapi.For(ctx).Contract.GetContractByID(ctx, td.ContractID)
+	if err != nil {
+		return nil, err
+	}
+
 	var media coredb.TokenMedia
 
 	if td.TokenMediaID != "" {
@@ -3076,7 +3086,7 @@ func (r *tokenResolver) Media(ctx context.Context, obj *model.Token) (model.Medi
 		}
 	}
 
-	return resolveTokenMedia(ctx, td, media, highDef), err
+	return resolveTokenMedia(ctx, td, *contract, media, highDef), err
 }
 
 // TokenType is the resolver for the tokenType field.
@@ -3180,7 +3190,12 @@ func (r *tokenDefinitionResolver) Media(ctx context.Context, obj *model.TokenDef
 		}
 	}
 
-	return resolveTokenMedia(ctx, obj.HelperTokenDefinitionData.Definition, media, false), nil
+	contract, err := publicapi.For(ctx).Contract.GetContractByID(ctx, obj.HelperTokenDefinitionData.Definition.ContractID)
+	if err != nil {
+		return nil, err
+	}
+
+	return resolveTokenMedia(ctx, obj.HelperTokenDefinitionData.Definition, *contract, media, false), nil
 }
 
 // Contract is the resolver for the contract field.

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/mediamapper"
 	"github.com/mikeydub/go-gallery/service/notifications"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/service/rpc/arweave"
 	"github.com/mikeydub/go-gallery/service/rpc/ipfs"
 	"github.com/mikeydub/go-gallery/service/socialauth"
 	"github.com/mikeydub/go-gallery/service/twitter"
@@ -2313,15 +2314,15 @@ func mediaToModel(ctx context.Context, tokenMedia db.TokenMedia, fallback persis
 	// Rewrite fallback IPFS and Arweave URLs to HTTP
 	if fallbackURL := fallback.ImageURL.String(); ipfs.IsIpfsURL(fallbackURL) {
 		fallback.ImageURL = persist.NullString(ipfs.BestGatewayNodeFrom(fallbackURL, isFxHash))
-	} else if strings.HasPrefix(fallbackURL, "ar://") {
-		fallback.ImageURL = persist.NullString(fmt.Sprintf("https://arweave.net/%s", util.GetURIPath(fallbackURL, false)))
+	} else if arweave.IsArweaveURL(fallbackURL) {
+		fallback.ImageURL = persist.NullString(arweave.BestGatewayNodeFrom(fallbackURL))
 	}
 
 	// Rewrite media IPFS and Arweave URLs to HTTP
 	if mediaURL := tokenMedia.Media.MediaURL.String(); ipfs.IsIpfsURL(mediaURL) {
 		tokenMedia.Media.MediaURL = persist.NullString(ipfs.BestGatewayNodeFrom(mediaURL, isFxHash))
-	} else if strings.HasPrefix(mediaURL, "ar://") {
-		tokenMedia.Media.MediaURL = persist.NullString(fmt.Sprintf("https://arweave.net/%s", util.GetURIPath(mediaURL, false)))
+	} else if arweave.IsArweaveURL(mediaURL) {
+		tokenMedia.Media.MediaURL = persist.NullString(arweave.BestGatewayNodeFrom(mediaURL))
 	}
 
 	fallbackMedia := getFallbackMedia(ctx, fallback)

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -24,7 +24,6 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/debugtools"
 	"github.com/mikeydub/go-gallery/graphql/model"
-	"github.com/mikeydub/go-gallery/platform"
 	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/emails"
@@ -2278,12 +2277,10 @@ func pageInfoToModel(ctx context.Context, pageInfo publicapi.PageInfo) *model.Pa
 	}
 }
 
-func resolveTokenMedia(ctx context.Context, td db.TokenDefinition, c db.Contract, tokenMedia db.TokenMedia, highDef bool) model.MediaSubtype {
-	isFxHash := platform.IsFxhash(td, c)
-
+func resolveTokenMedia(ctx context.Context, td db.TokenDefinition, tokenMedia db.TokenMedia, highDef bool) model.MediaSubtype {
 	// Media is found and is active.
 	if tokenMedia.ID != "" && tokenMedia.Active {
-		return mediaToModel(ctx, tokenMedia, td.FallbackMedia, highDef, isFxHash)
+		return mediaToModel(ctx, tokenMedia, td.FallbackMedia, highDef, td.IsFxhash)
 	}
 
 	// If there is no media for a token, assume that the token is still being synced.
@@ -2297,7 +2294,7 @@ func resolveTokenMedia(ctx context.Context, td db.TokenDefinition, c db.Contract
 				tokenMedia.Media.MediaType = persist.MediaTypeInvalid
 			}
 		}
-		return mediaToModel(ctx, tokenMedia, td.FallbackMedia, highDef, isFxHash)
+		return mediaToModel(ctx, tokenMedia, td.FallbackMedia, highDef, td.IsFxhash)
 	}
 
 	// If the media isn't valid, check if its still up for processing. If so, set the media as syncing.
@@ -2307,7 +2304,7 @@ func resolveTokenMedia(ctx context.Context, td db.TokenDefinition, c db.Contract
 		}
 	}
 
-	return mediaToModel(ctx, tokenMedia, td.FallbackMedia, highDef, isFxHash)
+	return mediaToModel(ctx, tokenMedia, td.FallbackMedia, highDef, td.IsFxhash)
 }
 
 func mediaToModel(ctx context.Context, tokenMedia db.TokenMedia, fallback persist.FallbackMedia, highDef bool, isFxHash bool) model.MediaSubtype {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -2318,7 +2318,6 @@ func mediaToModel(ctx context.Context, tokenMedia db.TokenMedia, fallback persis
 	}
 
 	// Rewrite media IPFS and Arweave URLs to HTTP
-	// Temporarily re-write URLs using the infura gateway node to a more reliable one
 	if mediaURL := tokenMedia.Media.MediaURL.String(); ipfs.IsIpfsURL(mediaURL) {
 		tokenMedia.Media.MediaURL = persist.NullString(ipfs.BestGatewayNodeFrom(mediaURL, isFxHash))
 	} else if strings.HasPrefix(mediaURL, "ar://") {

--- a/indexer/core.go
+++ b/indexer/core.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/rpc"
+	"github.com/mikeydub/go-gallery/service/rpc/arweave"
 	"github.com/mikeydub/go-gallery/service/rpc/ipfs"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/service/task"
@@ -58,7 +59,7 @@ func coreInit(fromBlock, toBlock *uint64, quietLogs, enableRPC bool) (*gin.Engin
 	tClient := task.NewClient(context.Background())
 	ethClient := rpc.NewEthSocketClient()
 	ipfsClient := ipfs.NewShell()
-	arweaveClient := rpc.NewArweaveClient()
+	arweaveClient := arweave.NewClient()
 
 	if env.GetString("ENV") == "production" || enableRPC {
 		rpcEnabled = true
@@ -96,7 +97,7 @@ func coreInitServer(quietLogs, enableRPC bool) *gin.Engine {
 	tClient := task.NewClient(context.Background())
 	ethClient := rpc.NewEthSocketClient()
 	ipfsClient := ipfs.NewShell()
-	arweaveClient := rpc.NewArweaveClient()
+	arweaveClient := arweave.NewClient()
 
 	if env.GetString("ENV") == "production" || enableRPC {
 		rpcEnabled = true

--- a/indexer/t__utils_test.go
+++ b/indexer/t__utils_test.go
@@ -266,16 +266,6 @@ var expectedResults expectedTokenResults = expectedTokenResults{
 	},
 }
 
-func expectedTokensForAddress(address persist.EthereumAddress) int {
-	count := 0
-	for _, token := range expectedResults {
-		if token.OwnerAddress == address {
-			count++
-		}
-	}
-	return count
-}
-
 func expectedContracts() []persist.EthereumAddress {
 	contracts := make([]persist.EthereumAddress, 0, len(expectedResults))
 	seen := map[persist.EthereumAddress]struct{}{}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -1,0 +1,97 @@
+package platform
+
+import (
+	"net/url"
+	"strings"
+
+	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/util"
+)
+
+var (
+	ProhibitionContract    = persist.NewContractIdentifiers("0x47a91457a3a1f700097199fd63c039c4784384ab", persist.ChainArbitrum)
+	EnsContract            = persist.NewContractIdentifiers("0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85", persist.ChainETH)
+	FxHashGentkV1Contract  = persist.NewContractIdentifiers("KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE", persist.ChainTezos)
+	FxHash2GentkV2Contract = persist.NewContractIdentifiers("KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi", persist.ChainTezos)
+	FxHash3GentkV3Contract = persist.NewContractIdentifiers("KT1EfsNuqwLAWDd3o4pvfUx1CAh5GMdTrRvr", persist.ChainTezos)
+	FxHashArticlesContract = persist.NewContractIdentifiers("KT1GtbuswcNMGhHF2TSuH1Yfaqn16do8Qtva", persist.ChainTezos)
+	HicEtNuncContract      = persist.NewContractIdentifiers("KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton", persist.ChainTezos)
+	ObjktContract          = persist.NewContractIdentifiers("KT19xbD2xn6A81an18S35oKtnkFNr9CVwY5m", persist.ChainTezos)
+)
+
+var FxHashContracts = []persist.ContractIdentifiers{
+	FxHashGentkV1Contract,
+	FxHash2GentkV2Contract,
+	FxHash3GentkV3Contract,
+	FxHashArticlesContract,
+}
+
+var HicEtNuncContracts = []persist.ContractIdentifiers{
+	HicEtNuncContract,
+	ObjktContract,
+}
+
+func IsEns(chain persist.Chain, address persist.Address) bool {
+	return persist.NewContractIdentifiers(address, chain) == EnsContract
+}
+
+func IsProhibition(chain persist.Chain, address persist.Address) bool {
+	return persist.NewContractIdentifiers(address, chain) == ProhibitionContract
+}
+
+func IsHicEtNunc(chain persist.Chain, address persist.Address) bool {
+	return util.Contains(HicEtNuncContracts, persist.NewContractIdentifiers(address, chain))
+}
+
+func IsFxhash(td db.TokenDefinition, c db.Contract) bool {
+	if td.Chain == persist.ChainTezos {
+		return IsFxhashTezos(td.Chain, td.ContractAddress)
+	}
+	if td.Chain == persist.ChainETH {
+		return IsFxhashEth(td.Chain, td.ContractAddress, c.Symbol.String, td.Metadata)
+	}
+	return false
+}
+
+func IsFxhashTezos(chain persist.Chain, address persist.Address) bool {
+	return util.Contains(FxHashContracts, persist.NewContractIdentifiers(address, chain))
+}
+
+func IsFxhashEth(chain persist.Chain, address persist.Address, contractSymbol string, tokenMetadata persist.TokenMetadata) bool {
+	if chain == persist.ChainETH {
+		// fxhash contracts on eth are deployed with "FXGEN" as the contract symbol
+		if strings.ToLower(contractSymbol) == "fxgen" {
+			return true
+		}
+		// check if the external_url has fxhash as the domain
+		if u, ok := tokenMetadata["external_url"].(string); ok {
+			parsed, _ := url.Parse(u)
+			if chain == persist.ChainETH && strings.HasPrefix(parsed.Hostname(), "fxhash") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func IsFxhashSignedTezos(chain persist.Chain, address persist.Address, tokenName string) bool {
+	return !IsFxhashTezos(chain, address) || tokenName != "[WAITING TO BE SIGNED]"
+}
+
+func IsFxhashSignedEth(chain persist.Chain, address persist.Address, contractSymbol string, tokenMetadata persist.TokenMetadata) bool {
+	return !IsFxhashEth(chain, address, contractSymbol, tokenMetadata) || (tokenMetadata["authenticityHash"] != "" && tokenMetadata["authenticityHash"] != nil)
+}
+
+func IsFxhashSigned(td db.TokenDefinition, c db.Contract, m persist.TokenMetadata) bool {
+	if !IsFxhash(td, c) {
+		return true
+	}
+	if td.Chain == persist.ChainTezos {
+		return IsFxhashSignedTezos(td.Chain, td.ContractAddress, td.Name.String)
+	}
+	if td.Chain == persist.ChainETH {
+		return IsFxhashSignedEth(td.Chain, td.ContractAddress, c.Symbol.String, m)
+	}
+	return true
+}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -92,7 +92,7 @@ func KeywordsFor(td db.TokenDefinition) ([]string, []string) {
 	}
 
 	if td.IsFxhash {
-		imgK := append([]string{"displayUri", "artifactUri", "image", "uri"}, imgK...)
+		imgK := append([]string{"displayUri", "artifactUri", "image", "thumbnailUri", "uri"}, imgK...)
 		animK := append([]string{"artifactUri", "displayUri"}, animK...)
 		return imgK, animK
 	}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -95,3 +95,21 @@ func IsFxhashSigned(td db.TokenDefinition, c db.Contract, m persist.TokenMetadat
 	}
 	return true
 }
+
+// KeywordsFor returns the fields in a token's metadata that should be used to download assets from
+func KeywordsFor(td db.TokenDefinition, c db.Contract) ([]string, []string) {
+	imgK, animK := td.Chain.BaseKeywords()
+
+	if IsHicEtNunc(td.Chain, td.ContractAddress) {
+		imgK = append([]string{"artifactUri", "displayUri", "image"}, imgK...)
+		return imgK, animK
+	}
+
+	if IsFxhash(td, c) {
+		imgK := append([]string{"displayUri", "artifactUri", "image", "uri"}, imgK...)
+		animK := append([]string{"artifactUri", "displayUri"}, animK...)
+		return imgK, animK
+	}
+
+	return imgK, animK
+}

--- a/publicapi/pagination_test.go
+++ b/publicapi/pagination_test.go
@@ -278,12 +278,7 @@ func TestMain(t *testing.T) {
 			expected := []string{"a", "b", "c", "d", "e"}
 			first := 5
 
-			ret, _, err := p.paginate(nil, nil, &first, nil)
-
-			actual := make([]string, len(ret))
-			for i, v := range ret {
-				actual[i] = v
-			}
+			actual, _, err := p.paginate(nil, nil, &first, nil)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)
@@ -307,12 +302,7 @@ func TestMain(t *testing.T) {
 			expected := []string{"a", "b", "c", "d", "e"}
 			last := 5
 
-			ret, _, err := p.paginate(nil, nil, nil, &last)
-
-			actual := make([]string, len(ret))
-			for i, v := range ret {
-				actual[i] = v
-			}
+			actual, _, err := p.paginate(nil, nil, nil, &last)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, actual)

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -1769,14 +1769,14 @@ func uriFromRecord(ctx context.Context, mc *multichain.Provider, r eth.AvatarRec
 	case eth.EnsIpfsRecord:
 		return standardizeURI(u.URL), nil
 	case eth.EnsTokenRecord:
-		uri, err = uriFromENSTokenRecord(ctx, mc, u)
+		uri, err = uriFromEnsTokenRecord(ctx, mc, u)
 		return standardizeURI(uri), err
 	default:
 		return "", eth.ErrUnknownEnsAvatarURI
 	}
 }
 
-func uriFromENSTokenRecord(ctx context.Context, mc *multichain.Provider, r eth.EnsTokenRecord) (string, error) {
+func uriFromEnsTokenRecord(ctx context.Context, mc *multichain.Provider, r eth.EnsTokenRecord) (string, error) {
 	chain, contractAddr, _, tokenID, err := eth.TokenInfoFor(r)
 	if err != nil {
 		return "", err
@@ -1788,9 +1788,9 @@ func uriFromENSTokenRecord(ctx context.Context, mc *multichain.Provider, r eth.E
 		return "", err
 	}
 
-	imgKeys, animKeys := chain.BaseKeywords()
+	imgK, animK := chain.BaseKeywords()
 
-	imageURL, _, err := media.FindImageAndAnimationURLs(ctx, metadata, imgKeys, animKeys)
+	imageURL, _, err := media.FindImageAndAnimationURLs(ctx, metadata, imgK, animK)
 	if err != nil {
 		if errors.Is(err, media.ErrNoMediaURLs) {
 			return "", nil

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -1769,14 +1769,14 @@ func uriFromRecord(ctx context.Context, mc *multichain.Provider, r eth.AvatarRec
 	case eth.EnsIpfsRecord:
 		return standardizeURI(u.URL), nil
 	case eth.EnsTokenRecord:
-		uri, err = uriFromTokenRecord(ctx, mc, u)
+		uri, err = uriFromENSTokenRecord(ctx, mc, u)
 		return standardizeURI(uri), err
 	default:
 		return "", eth.ErrUnknownEnsAvatarURI
 	}
 }
 
-func uriFromTokenRecord(ctx context.Context, mc *multichain.Provider, r eth.EnsTokenRecord) (string, error) {
+func uriFromENSTokenRecord(ctx context.Context, mc *multichain.Provider, r eth.EnsTokenRecord) (string, error) {
 	chain, contractAddr, _, tokenID, err := eth.TokenInfoFor(r)
 	if err != nil {
 		return "", err
@@ -1788,7 +1788,9 @@ func uriFromTokenRecord(ctx context.Context, mc *multichain.Provider, r eth.EnsT
 		return "", err
 	}
 
-	imageURL, _, err := media.FindImageAndAnimationURLs(ctx, chain, contractAddr, metadata)
+	imgKeys, animKeys := chain.BaseKeywords()
+
+	imageURL, _, err := media.FindImageAndAnimationURLs(ctx, metadata, imgKeys, animKeys)
 	if err != nil {
 		if errors.Is(err, media.ErrNoMediaURLs) {
 			return "", nil

--- a/server/inject.go
+++ b/server/inject.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/platform"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/multichain/alchemy"
 	"github.com/mikeydub/go-gallery/service/multichain/eth"
@@ -454,7 +455,8 @@ func tezosFallbackProvider(e envInit, httpClient *http.Client) multichain.SyncWi
 
 func tezosTokenEvalFunc() func(multichain.ChainAgnosticToken) bool {
 	return func(t multichain.ChainAgnosticToken) bool {
-		return tezos.IsFxHashSigned(t.ContractAddress, t.Descriptors.Name) && tezos.ContainsTezosKeywords(t)
+		return platform.IsFxhashSignedTezos(persist.ChainTezos, t.ContractAddress, t.Descriptors.Name) &&
+			tezos.ContainsTezosKeywords(t)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
-	"github.com/mikeydub/go-gallery/publicapi"
+	// "github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
@@ -58,9 +58,10 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
-	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	router := CoreInit(ctx, c, provider, recommender, p)
+	// XXX recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
+	// XXX p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	// XXX router := CoreInit(ctx, c, provider, recommender, p)
+	router := CoreInit(ctx, c, provider, nil, nil)
 	http.Handle("/", router)
 }
 
@@ -130,8 +131,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	authRefreshCache := redis.NewCache(redis.AuthTokenForceRefreshCache)
 	tokenManageCache := redis.NewCache(redis.TokenManageCache)
 
-	recommender.Loop(ctx, time.NewTicker(time.Hour))
-	p.Loop(ctx, time.NewTicker(time.Minute*15))
+	// XXX recommender.Loop(ctx, time.NewTicker(time.Hour))
+	// XXX p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, c.MagicLinkClient, recommender, p)
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/wire"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/platform"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/multichain/alchemy"
 	"github.com/mikeydub/go-gallery/service/multichain/eth"
@@ -416,7 +417,7 @@ func newMultichainSet(
 
 func tezosTokenEvalFunc() func(multichain.ChainAgnosticToken) bool {
 	return func(t multichain.ChainAgnosticToken) bool {
-		return tezos.IsFxHashSigned(t.ContractAddress, t.Descriptors.Name) && tezos.ContainsTezosKeywords(t)
+		return platform.IsFxhashSignedTezos(persist.ChainTezos, t.ContractAddress, t.Descriptors.Name) && tezos.ContainsTezosKeywords(t)
 	}
 }
 

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mikeydub/go-gallery/platform"
 	"github.com/mikeydub/go-gallery/service/logger"
-	"github.com/mikeydub/go-gallery/service/multichain/tezos"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/mikeydub/go-gallery/service/rpc/ipfs"
@@ -330,10 +330,10 @@ func predictTrueURLs(ctx context.Context, curImg ImageURL, curV AnimationURL) (I
 
 func keywordsForToken(contract persist.Address, chain persist.Chain) ([]string, []string) {
 	switch {
-	case tezos.IsHicEtNunc(contract):
+	case platform.IsHicEtNunc(chain, contract):
 		_, anim := chain.BaseKeywords()
 		return []string{"artifactUri", "displayUri", "image"}, anim
-	case tezos.IsFxHash(contract):
+	case platform.IsFxhashTezos(chain, contract):
 		return []string{"displayUri", "artifactUri", "image", "uri"}, []string{"artifactUri", "displayUri"}
 	default:
 		return chain.BaseKeywords()

--- a/service/media/media.go
+++ b/service/media/media.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
+	"github.com/mikeydub/go-gallery/service/rpc/arweave"
 	"github.com/mikeydub/go-gallery/service/rpc/ipfs"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
@@ -135,8 +135,7 @@ func PredictMediaType(ctx context.Context, url string) (persist.MediaType, strin
 
 			return MediaFromContentType(ctl.contentType), ctl.contentType, &ctl.length, nil
 		case persist.URITypeArweave:
-			path := util.GetURIPath(asURI.String(), false)
-			url = fmt.Sprintf("https://arweave.net/%s", path)
+			url = arweave.BestGatewayNodeFrom(asURI.String())
 			fallthrough
 		case persist.URITypeHTTP, persist.URITypeIPFSAPI, persist.URITypeArweaveGateway:
 			header, err := rpc.GetHTTPHeaders(ctx, url)

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -1339,12 +1339,11 @@ metadatas:
 
 			for _, fieldRequest := range requestedFields {
 				if !fieldRequest.MatchesFilter(metadata.Metadata) {
-					logger.For(ctx).Infof("metadata %+v does not match field request %+v", metadata, fieldRequest)
+					logger.For(ctx).Infof("metadata does not match field request %+v", fieldRequest)
 					prioritiesEncountered = append(prioritiesEncountered, metadata.Priority)
 					continue metadatas
 				}
 			}
-			logger.For(ctx).Infof("got metadata %+v", metadata)
 			if lowestIntNotInList(prioritiesEncountered, len(metadataFetchers)) == metadata.Priority {
 				// short circuit if we've found the highest priority metadata
 				return metadata.Metadata, nil
@@ -1739,12 +1738,14 @@ func chainTokensToUpsertableTokenDefinitions(ctx context.Context, chainTokens []
 				externalURL := util.FirstNonEmptyString(definition.ExternalUrl.String, token.ExternalURL)
 				fallbackMedia, _ := util.FindFirst([]persist.FallbackMedia{definition.FallbackMedia, token.FallbackMedia}, func(m persist.FallbackMedia) bool { return m.IsServable() })
 				metadata, _ := util.FindFirst([]persist.TokenMetadata{definition.Metadata, token.TokenMetadata}, func(m persist.TokenMetadata) bool { return len(m) > 0 })
+				isFxhash := definition.IsFxhash || platform.IsFxhash(contractLookup[contractIdentifiers])
 
 				definition.Name = util.ToNullString(name, true)
 				definition.Description = util.ToNullString(description, true)
 				definition.ExternalUrl = util.ToNullString(externalURL, true)
 				definition.FallbackMedia = fallbackMedia
 				definition.Metadata = metadata
+				definition.IsFxhash = isFxhash
 				definitions[tokenIdentifiers] = definition
 			}
 		}

--- a/service/multichain/operation/operation.go
+++ b/service/multichain/operation/operation.go
@@ -143,6 +143,7 @@ func BulkUpsert(ctx context.Context, q *db.Queries, tokens []UpsertToken, defini
 		appendJSONB(&params.DefinitionMetadata, d.Metadata, &errors)
 		params.DefinitionContractAddress = append(params.DefinitionContractAddress, d.ContractAddress.String())
 		params.DefinitionContractID = append(params.DefinitionContractID, d.ContractID.String())
+		params.DefinitionIsFxhash = append(params.DefinitionIsFxhash, d.IsFxhash)
 		// Defer error checking until now to keep the code above from being
 		// littered with multiline "if" statements
 		if len(errors) > 0 {

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -26,35 +26,6 @@ import (
 	"github.com/mikeydub/go-gallery/util/retry"
 )
 
-const (
-	hicEtNunc = "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton"
-	objktCom  = "KT19xbD2xn6A81an18S35oKtnkFNr9CVwY5m"
-	fxHash    = "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE"
-	fxHash2   = "KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi"
-	fxHash3   = "KT1EfsNuqwLAWDd3o4pvfUx1CAh5GMdTrRvr"
-	fxHash4   = "KT1GtbuswcNMGhHF2TSuH1Yfaqn16do8Qtva"
-)
-
-var hicContracts = []persist.Address{
-	persist.Address(hicEtNunc),
-	persist.Address(objktCom),
-}
-
-var fxContracts = []persist.Address{
-	persist.Address(fxHash),
-	persist.Address(fxHash2),
-	persist.Address(fxHash3),
-	persist.Address(fxHash4),
-}
-
-func IsHicEtNunc(contract persist.Address) bool {
-	return util.Contains(hicContracts, contract)
-}
-
-func IsFxHash(contract persist.Address) bool {
-	return util.Contains(fxContracts, contract)
-}
-
 const pageSize = 1000
 
 const tezDomainsApiURL = "https://api.tezos.domains/graphql"
@@ -1064,15 +1035,6 @@ func (b balance) ToBigInt() *big.Int {
 		panic(fmt.Sprintf("failed to convert tokenID to int: %s", b))
 	}
 	return asInt
-}
-
-// IsFxHashSigned returns false if the token is an unsigned FxHash token (metadata hasn't yet been uploaded to the FxHash contract).
-// It's possible for tzkt to index a token before FxHash signs a token which results in the API returning placeholder metadata.
-// This seems to happen infrequently, but there are a few cases where the token is never updated with the signed metadata
-// (either because of tzkt failing to update the metadata, or FxHash never signing the token). If it's the former, we want to
-// fallback to an alternative provider in case there might be usable metadata elsewhere.
-func IsFxHashSigned(contract persist.Address, tokenName string) bool {
-	return !IsFxHash(contract) || tokenName != "[WAITING TO BE SIGNED]"
 }
 
 // ContainsTezosKeywords returns true if the token's metadata has at least one non-empty Tezos keyword.

--- a/service/rpc/arweave/arweave.go
+++ b/service/rpc/arweave/arweave.go
@@ -1,0 +1,1 @@
+package arweave

--- a/service/rpc/arweave/arweave.go
+++ b/service/rpc/arweave/arweave.go
@@ -1,1 +1,33 @@
 package arweave
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/everFinance/goar"
+
+	"github.com/mikeydub/go-gallery/util"
+)
+
+const ArweaveHost = "https://arweave.net"
+
+func NewClient() *goar.Client { return goar.NewClient(ArweaveHost) }
+
+func IsArweaveURL(u string) bool {
+	return strings.HasPrefix(u, "ar://") || strings.HasPrefix(u, "arweave://")
+}
+
+func BestGatewayNodeFrom(u string) string {
+	if !IsArweaveURL(u) {
+		return u
+	}
+	return DefaultGatewayFrom(u)
+}
+
+func DefaultGatewayFrom(u string) string {
+	return pathURL(ArweaveHost, util.GetURIPath(u, false))
+}
+
+func pathURL(host, uri string) string {
+	return fmt.Sprintf("%s/%s", host, uri)
+}

--- a/service/rpc/arweave/arweave.go
+++ b/service/rpc/arweave/arweave.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 
 	"github.com/everFinance/goar"
-
-	"github.com/mikeydub/go-gallery/util"
 )
 
 const ArweaveHost = "https://arweave.net"
@@ -25,7 +23,14 @@ func BestGatewayNodeFrom(u string) string {
 }
 
 func DefaultGatewayFrom(u string) string {
-	return pathURL(ArweaveHost, util.GetURIPath(u, false))
+	return pathURL(ArweaveHost, uriFrom(u))
+}
+
+func uriFrom(u string) string {
+	u = strings.TrimSpace(u)
+	u = strings.TrimPrefix(u, "arweave://")
+	u = strings.TrimPrefix(u, "ar://")
+	return u
 }
 
 func pathURL(host, uri string) string {

--- a/service/rpc/ipfs/ipfs.go
+++ b/service/rpc/ipfs/ipfs.go
@@ -202,7 +202,7 @@ func DefaultGatewayFrom(ipfsURL string) string {
 
 // PathGatewayFrom is a helper function that rewrites an IPFS URI to an IPFS gateway URL
 func PathGatewayFrom(gatewayHost, ipfsURL string) string {
-	return pathURL(gatewayHost, util.GetURIPath(ipfsURL, false))
+	return pathURL(gatewayHost, uriFrom(ipfsURL))
 }
 
 func IsIpfsURL(ipfsURL string) bool {
@@ -234,6 +234,17 @@ type authTransport struct {
 func (t authTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.SetBasicAuth(t.ProjectID, t.ProjectSecret)
 	return t.RoundTripper.RoundTrip(r)
+}
+
+func uriFrom(u string) string {
+	u = strings.TrimSpace(u)
+	u = strings.TrimPrefix(u, "ipfs://")
+	u = strings.TrimPrefix(u, "https://")
+	pathIdx := strings.Index(u, "/ipfs/")
+	if pathIdx != -1 {
+		u = u[pathIdx+6:] // len("/ipfs/") == 6
+	}
+	return u
 }
 
 // pathURL returns the gateway URL in path resolution sytle

--- a/service/rpc/onchfs/onchfs.go
+++ b/service/rpc/onchfs/onchfs.go
@@ -1,13 +1,33 @@
 package onchfs
 
 import (
+	"fmt"
 	"strings"
 )
+
+const FxhashGateway = "https://onchfs.fxhash2.xyz"
 
 func IsOnchfsURL(u string) bool {
 	return strings.HasPrefix(u, "onchfs://")
 }
 
 func BestGatewayNodeFrom(u string) string {
-	panic("not implemented")
+	if !IsOnchfsURL(u) {
+		return u
+	}
+	return DefaultGatewayFrom(u)
+}
+
+func DefaultGatewayFrom(u string) string {
+	return fmt.Sprintf("%s/%s", FxhashGateway, uriFrom(u))
+}
+
+func uriFrom(u string) string {
+	u = strings.TrimSpace(u)
+	u = strings.TrimPrefix(u, "onchfs://")
+	return u
+}
+
+func pathURL(host, uri string) string {
+	return fmt.Sprintf("%s/%s", host, uri)
 }

--- a/service/rpc/onchfs/onchfs.go
+++ b/service/rpc/onchfs/onchfs.go
@@ -1,1 +1,13 @@
 package onchfs
+
+import (
+	"strings"
+)
+
+func IsOnchfsURL(u string) bool {
+	return strings.HasPrefix(u, "onchfs://")
+}
+
+func BestGatewayNodeFrom(u string) string {
+	panic("not implemented")
+}

--- a/service/rpc/onchfs/onchfs.go
+++ b/service/rpc/onchfs/onchfs.go
@@ -1,0 +1,1 @@
+package onchfs

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -443,11 +443,11 @@ func remapMedia(media persist.Media) persist.Media {
 	return media
 }
 
-func findImageAndAnimationURLs(ctx context.Context, contractAddress persist.Address, chain persist.Chain, metadata persist.TokenMetadata, pMeta *persist.PipelineMetadata) (media.ImageURL, media.AnimationURL, error) {
+func findImageAndAnimationURLs(ctx context.Context, metadata persist.TokenMetadata, imgKeywords, animKeywords []string, pMeta *persist.PipelineMetadata) (media.ImageURL, media.AnimationURL, error) {
 	traceCallback, ctx := persist.TrackStepStatus(ctx, &pMeta.MediaURLsRetrieval, "MediaURLsRetrieval")
 	defer traceCallback()
 
-	imgURL, vURL, err := media.FindImageAndAnimationURLs(ctx, chain, contractAddress, metadata)
+	imgURL, vURL, err := media.FindImageAndAnimationURLs(ctx, metadata, imgKeywords, animKeywords)
 	if err != nil {
 		persist.FailStep(&pMeta.MediaURLsRetrieval)
 	}

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -421,28 +421,6 @@ func getHTMLDimensions(ctx context.Context, url string) (persist.Dimensions, err
 
 }
 
-func remapPaths(mediaURL string) string {
-	switch persist.TokenURI(mediaURL).Type() {
-	case persist.URITypeIPFS, persist.URITypeIPFSAPI:
-		return ipfs.PathGatewayFrom(env.GetString("IPFS_URL"), mediaURL)
-	case persist.URITypeArweave:
-		path := util.GetURIPath(mediaURL, false)
-		return fmt.Sprintf("https://arweave.net/%s", path)
-	default:
-		return mediaURL
-	}
-
-}
-
-func remapMedia(media persist.Media) persist.Media {
-	media.MediaURL = persist.NullString(remapPaths(strings.TrimSpace(media.MediaURL.String())))
-	media.ThumbnailURL = persist.NullString(remapPaths(strings.TrimSpace(media.ThumbnailURL.String())))
-	if !persist.TokenURI(media.ThumbnailURL).IsRenderable() {
-		media.ThumbnailURL = persist.NullString("")
-	}
-	return media
-}
-
 func findImageAndAnimationURLs(ctx context.Context, metadata persist.TokenMetadata, imgKeywords, animKeywords []string, pMeta *persist.PipelineMetadata) (media.ImageURL, media.AnimationURL, error) {
 	traceCallback, ctx := persist.TrackStepStatus(ctx, &pMeta.MediaURLsRetrieval, "MediaURLsRetrieval")
 	defer traceCallback()

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -31,7 +31,6 @@ import (
 	shell "github.com/ipfs/go-ipfs-api"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
-	"github.com/mikeydub/go-gallery/service/rpc/ipfs"
 	"github.com/mikeydub/go-gallery/util"
 )
 
@@ -360,7 +359,6 @@ func getHTMLMedia(pCtx context.Context, tids persist.TokenIdentifiers, tokenBuck
 			}
 		}
 	}
-	res = remapMedia(res)
 
 	dimensions, err := getHTMLDimensions(pCtx, res.MediaURL.String())
 	if err != nil {

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -128,6 +128,12 @@ func (pOpts) WithRequireProhibitionimage(c db.Contract) PipelineOption {
 	}
 }
 
+func (pOpts) WithIsFxhash() PipelineOption {
+	return func(j *tokenProcessingJob) {
+		j.isFxhash = true
+	}
+}
+
 func (pOpts) WithRequireFxHashSigned(td db.TokenDefinition, c db.Contract) PipelineOption {
 	return func(j *tokenProcessingJob) {
 		if platform.IsFxhash(td, c) {
@@ -250,10 +256,10 @@ func rewriteURLs(u string, isFxhash bool) string {
 	if ipfs.IsIpfsURL(u) {
 		return ipfs.BestGatewayNodeFrom(u, isFxhash)
 	}
-	if arweave.IsArweave(u) {
+	if arweave.IsArweaveURL(u) {
 		return arweave.BestGatewayNodeFrom(u)
 	}
-	if onchfs.IsOnchfs(u) {
+	if onchfs.IsOnchfsURL(u) {
 		return onchfs.BestGatewayNodeFrom(u)
 	}
 	return u

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -22,9 +22,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/multichain/opensea"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/rpc/arweave"
-	"github.com/mikeydub/go-gallery/service/rpc/ipfs"
-	"github.com/mikeydub/go-gallery/service/rpc/onchfs"
+	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/mikeydub/go-gallery/service/tracing"
 	"github.com/mikeydub/go-gallery/util"
 )
@@ -252,25 +250,12 @@ func (tpj *tokenProcessingJob) createErrFromResults(animResult cacheResult, imgR
 	return wrapWithBadTokenErr(animResult.err)
 }
 
-func rewriteURLs(u string, isFxhash bool) string {
-	if ipfs.IsIpfsURL(u) {
-		return ipfs.BestGatewayNodeFrom(u, isFxhash)
-	}
-	if arweave.IsArweaveURL(u) {
-		return arweave.BestGatewayNodeFrom(u)
-	}
-	if onchfs.IsOnchfsURL(u) {
-		return onchfs.BestGatewayNodeFrom(u)
-	}
-	return u
-}
-
 func (tpj *tokenProcessingJob) urlsToDownload(ctx context.Context, metadata persist.TokenMetadata) (imgURL media.ImageURL, pfpURL media.ImageURL, animURL media.AnimationURL, err error) {
 	pfpURL = findProfileImageURL(metadata, tpj.profileImageKey)
 	imgURL, animURL, err = findImageAndAnimationURLs(ctx, metadata, tpj.imgKeywords, tpj.animKeywords, tpj.pipelineMetadata)
-	imgURL = media.ImageURL(rewriteURLs(string(imgURL), tpj.isFxhash))
-	pfpURL = media.ImageURL(rewriteURLs(string(pfpURL), tpj.isFxhash))
-	animURL = media.AnimationURL(rewriteURLs(string(animURL), tpj.isFxhash))
+	imgURL = media.ImageURL(rpc.RewriteURIToHTTP(string(imgURL), tpj.isFxhash))
+	pfpURL = media.ImageURL(rpc.RewriteURIToHTTP(string(pfpURL), tpj.isFxhash))
+	animURL = media.AnimationURL(rpc.RewriteURIToHTTP(string(animURL), tpj.isFxhash))
 	return imgURL, pfpURL, animURL, err
 }
 

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/api/googleapi"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/platform"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/metric"
@@ -111,7 +112,7 @@ func (pOpts) WithRequireImage() PipelineOption {
 
 func (pOpts) WithRequireProhibitionimage(c db.Contract) PipelineOption {
 	return func(j *tokenProcessingJob) {
-		if isProhibition(c) {
+		if platform.IsProhibition(c.Chain, c.Address) {
 			j.requireImage = true
 		}
 	}
@@ -119,9 +120,9 @@ func (pOpts) WithRequireProhibitionimage(c db.Contract) PipelineOption {
 
 func (pOpts) WithRequireFxHashSigned(td db.TokenDefinition, c db.Contract) PipelineOption {
 	return func(j *tokenProcessingJob) {
-		if isFxHash(td, c) {
+		if platform.IsFxhash(td, c) {
 			j.requireFxHashSigned = true
-			j.fxHashIsSignedF = func(m persist.TokenMetadata) bool { return isFxHashSigned(td, c, m) }
+			j.fxHashIsSignedF = func(m persist.TokenMetadata) bool { return platform.IsFxhashSigned(td, c, m) }
 		}
 	}
 }

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -128,15 +128,15 @@ func (pOpts) WithRequireProhibitionimage(c db.Contract) PipelineOption {
 	}
 }
 
-func (pOpts) WithIsFxhash() PipelineOption {
+func (pOpts) WithIsFxhash(isFxhash bool) PipelineOption {
 	return func(j *tokenProcessingJob) {
-		j.isFxhash = true
+		j.isFxhash = isFxhash
 	}
 }
 
 func (pOpts) WithRequireFxHashSigned(td db.TokenDefinition, c db.Contract) PipelineOption {
 	return func(j *tokenProcessingJob) {
-		if platform.IsFxhash(td, c) {
+		if td.IsFxhash {
 			j.isFxhash = true
 			j.requireFxHashSigned = true
 			j.fxHashIsSignedF = func(m persist.TokenMetadata) bool { return platform.IsFxhashSigned(td, c, m) }
@@ -144,9 +144,9 @@ func (pOpts) WithRequireFxHashSigned(td db.TokenDefinition, c db.Contract) Pipel
 	}
 }
 
-func (pOpts) WithKeywords(td db.TokenDefinition, c db.Contract) PipelineOption {
+func (pOpts) WithKeywords(td db.TokenDefinition) PipelineOption {
 	return func(j *tokenProcessingJob) {
-		j.imgKeywords, j.animKeywords = platform.KeywordsFor(td, c)
+		j.imgKeywords, j.animKeywords = platform.KeywordsFor(td)
 	}
 }
 

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -537,6 +537,7 @@ type GoldskyWebhookInput struct {
 		New GoldskyToken1155Holder `json:"new"` // this is what we care about
 	} `json:"data"`
 }
+
 type GoldskyToken1155Holder struct {
 	ID               string `json:"id"`                 // ID in this format "0x{user address}-0x{address}-{token_id}"
 	User             string `json:"user"`               // address in format "\\x{address}"
@@ -865,22 +866,14 @@ func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage
 	}
 	// Runtime options that should be applied to every run
 	runOpts := append([]PipelineOption{}, addContractRunOptions(cID)...)
-	runOpts = append(runOpts, addCauseRunOptions(cause)...)
 	runOpts = append(runOpts, PipelineOpts.WithMetadata(td.Metadata))
 	runOpts = append(runOpts, PipelineOpts.WithKeywords(td))
 	runOpts = append(runOpts, PipelineOpts.WithIsFxhash(td.IsFxhash))
+	runOpts = append(runOpts, PipelineOpts.WithRefreshMetadata())
 	runOpts = append(runOpts, opts...)
 	media, err := tp.ProcessTokenPipeline(ctx, tID, cID, cause, runOpts...)
 	defer closing(err)
 	return media, err
-}
-
-// addCauseRunOptions adds pipeline options for specific types of runs
-func addCauseRunOptions(cause persist.ProcessingCause) (opts []PipelineOption) {
-	if cause == persist.ProcessingCauseRefresh || cause == persist.ProcessingCauseSyncRetry || cause == persist.ProcessingCausePostPreflight {
-		opts = append(opts, PipelineOpts.WithRefreshMetadata())
-	}
-	return opts
 }
 
 // addContractRunOptions adds pipeline options for specific contracts

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -863,10 +863,12 @@ func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage
 	if err != nil {
 		return db.TokenMedia{}, err
 	}
+	// Runtime options that should be applied to every run
 	runOpts := append([]PipelineOption{}, addContractRunOptions(cID)...)
 	runOpts = append(runOpts, addCauseRunOptions(cause)...)
 	runOpts = append(runOpts, PipelineOpts.WithMetadata(td.Metadata))
 	runOpts = append(runOpts, PipelineOpts.WithKeywords(td, c))
+	runOpts = append(runOpts, PipelineOpts.WithIsFxhash())
 	runOpts = append(runOpts, opts...)
 	media, err := tp.ProcessTokenPipeline(ctx, tID, cID, cause, runOpts...)
 	defer closing(err)


### PR DESCRIPTION
**Changes**
* Adds `is_fxhash` to `token_definitions` table
* Adds support for `onchfs://` in media pipeline and in fallbacks
* Better support in pipeline for fxhash assets and in fallbacks
* Pipeline supports configuration at runtime which fields from metadata to download from
* Pipeline now re-maps all URIs of `ar://`, `ipfs://` and `onchfs://` to `https://` to simplify processing