### PR TITLE
Check CommentID before PostID when determining mentionSource

### DIFF
--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2924,11 +2924,11 @@ func (r *someoneMentionedYouNotificationResolver) MentionSource(ctx context.Cont
 
 // MentionSource is the resolver for the mentionSource field.
 func (r *someoneMentionedYourCommunityNotificationResolver) MentionSource(ctx context.Context, obj *model.SomeoneMentionedYourCommunityNotification) (model.MentionSource, error) {
-	if obj.PostID != nil {
-		return resolvePostByPostID(ctx, *obj.PostID)
-	}
 	if obj.CommentID != nil {
 		return resolveCommentByCommentID(ctx, *obj.CommentID)
+	}
+	if obj.PostID != nil {
+		return resolvePostByPostID(ctx, *obj.PostID)
 	}
 	return nil, fmt.Errorf("invalid mention source")
 }


### PR DESCRIPTION
This fixes a bug where the mentionSource of a SomeoneMentionedYourCommunity notification was incorrectly returning `Post` in cases where the mention is a comment on a post.