### PR TITLE
Speed up community tokens query for contract communities

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -6038,35 +6038,19 @@ func (b *PaginateRepliesByCommentIDBatchBatchResults) Close() error {
 
 const paginateTokensByCommunityID = `-- name: PaginateTokensByCommunityID :batchmany
 with community_data as (
-    select community_type, contract_id
+    select id as community_id, community_type, contract_id
     from communities
     where communities.id = $1 and not deleted
-),
-
-contract_memberships as (
-    select tokens.id
-    from community_data, tokens
-    where community_data.community_type = 0
-      and tokens.contract_id = community_data.contract_id
-      and not tokens.deleted
-),
-
-token_memberships as (
-    select tokens.id
-    from community_data, tokens
-        join token_community_memberships on tokens.token_definition_id = token_community_memberships.token_definition_id
-            and token_community_memberships.community_id = $1
-            and not token_community_memberships.deleted
-    where community_data.community_type != 0
-        and not tokens.deleted
+    limit 1
 )
 
-(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from contract_memberships ct
-    join tokens t on t.id = ct.id
+(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from community_data cd
+    join tokens t on t.contract_id = cd.contract_id
     join token_definitions td on t.token_definition_id = td.id
     join users u on u.id = t.owner_user_id
     join contracts c on t.contract_id = c.id
-    where t.displayable
+where cd.community_type = 0
+    and t.displayable
     and t.deleted = false
     and c.deleted = false
     and td.deleted = false
@@ -6074,18 +6058,21 @@ token_memberships as (
     and u.universal = false
     and (t.created_at,t.id) < ($2::timestamptz, $3)
     and (t.created_at,t.id) > ($4::timestamptz, $5)
-    order by case when $6::bool then (t.created_at,t.id) end asc,
-             case when not $6::bool then (t.created_at,t.id) end desc
-    limit $7)
+order by case when $6::bool then (t.created_at,t.id) end asc,
+         case when not $6::bool then (t.created_at,t.id) end desc
+limit $7)
 
 union all
 
-(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from token_memberships ct
-    join tokens t on t.id = ct.id
-    join token_definitions td on t.token_definition_id = td.id
+(select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain from community_data cd, token_community_memberships tcm
+    join tokens t on t.token_definition_id = tcm.token_definition_id
+    join token_definitions td on td.id = t.token_definition_id
     join users u on u.id = t.owner_user_id
     join contracts c on t.contract_id = c.id
-    where t.displayable
+where cd.community_type != 0
+    and tcm.community_id = cd.community_id
+    and t.displayable
+    and tcm.deleted = false
     and t.deleted = false
     and c.deleted = false
     and td.deleted = false
@@ -6093,9 +6080,9 @@ union all
     and u.universal = false
     and (t.created_at,t.id) < ($2::timestamptz, $3)
     and (t.created_at,t.id) > ($4::timestamptz, $5)
-    order by case when $6::bool then (t.created_at,t.id) end asc,
-             case when not $6::bool then (t.created_at,t.id) end desc
-    limit $7)
+order by case when $6::bool then (t.created_at,t.id) end asc,
+         case when not $6::bool then (t.created_at,t.id) end desc
+limit $7)
 `
 
 type PaginateTokensByCommunityIDBatchResults struct {

--- a/db/gen/coredb/community.sql.go
+++ b/db/gen/coredb/community.sql.go
@@ -92,45 +92,50 @@ func (q *Queries) CountPostsByCommunityID(ctx context.Context, communityID persi
 
 const countTokensByCommunityID = `-- name: CountTokensByCommunityID :one
 with community_data as (
-    select community_type, contract_id
+    select id as community_id, community_type, contract_id
     from communities
     where communities.id = $1 and not deleted
-),
+    limit 1
+)
 
-community_tokens as (
-    select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable
-    from community_data, tokens
-    where community_data.community_type = 0
-        and tokens.contract_id = community_data.contract_id
-        and not tokens.deleted
+select sum(u.count) from (
+    (select count(t.*) from community_data cd
+        join tokens t on t.contract_id = cd.contract_id
+        join token_definitions td on t.token_definition_id = td.id
+        join users u on u.id = t.owner_user_id
+        join contracts c on t.contract_id = c.id
+    where cd.community_type = 0
+        and t.displayable
+        and t.deleted = false
+        and c.deleted = false
+        and td.deleted = false
+        and u.deleted = false
+        and u.universal = false)
 
     union all
 
-    select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable
-    from community_data, tokens
-        join token_community_memberships on tokens.token_definition_id = token_community_memberships.token_definition_id
-            and token_community_memberships.community_id = $1
-            and not token_community_memberships.deleted
-    where community_data.community_type != 0
-        and not tokens.deleted
-)
-
-select count(t.*) from community_tokens t
-    join token_definitions td on t.token_definition_id = td.id
-    join users u on u.id = t.owner_user_id
-    join contracts c on t.contract_id = c.id
-    where t.displayable
-    and t.deleted = false
-    and c.deleted = false
-    and td.deleted = false
-    and u.universal = false
+    (select count(t.*) from community_data cd, token_community_memberships tcm
+        join tokens t on t.token_definition_id = tcm.token_definition_id
+        join token_definitions td on td.id = t.token_definition_id
+        join users u on u.id = t.owner_user_id
+        join contracts c on t.contract_id = c.id
+    where cd.community_type != 0
+        and tcm.community_id = cd.community_id
+        and t.displayable
+        and tcm.deleted = false
+        and t.deleted = false
+        and c.deleted = false
+        and td.deleted = false
+        and u.deleted = false
+        and u.universal = false)
+) u
 `
 
 func (q *Queries) CountTokensByCommunityID(ctx context.Context, communityID persist.DBID) (int64, error) {
 	row := q.db.QueryRow(ctx, countTokensByCommunityID, communityID)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
+	var sum int64
+	err := row.Scan(&sum)
+	return sum, err
 }
 
 const getCommunitiesByKeys = `-- name: GetCommunitiesByKeys :many

--- a/db/queries/core/community.sql
+++ b/db/queries/core/community.sql
@@ -306,27 +306,10 @@ select count(distinct u.id) from users u, community_tokens t
 
 -- name: PaginateTokensByCommunityID :batchmany
 with community_data as (
-    select community_type, contract_id
+    select id as community_id, community_type, contract_id
     from communities
     where communities.id = @community_id and not deleted
-),
-
-contract_memberships as (
-    select tokens.id
-    from community_data, tokens
-    where community_data.community_type = 0
-      and tokens.contract_id = community_data.contract_id
-      and not tokens.deleted
-),
-
-token_memberships as (
-    select tokens.id
-    from community_data, tokens
-        join token_community_memberships on tokens.token_definition_id = token_community_memberships.token_definition_id
-            and token_community_memberships.community_id = @community_id
-            and not token_community_memberships.deleted
-    where community_data.community_type != 0
-        and not tokens.deleted
+    limit 1
 )
 
 -- At present, a community is either entirely token-based or contract-based, so only
@@ -336,12 +319,13 @@ token_memberships as (
 -- select + join on the results of that union, but that prevented the query planner from
 -- using indexes correctly (since the referenced tables might be indexed, but the union
 -- of results is not). The current method is verbose and brittle, but it's fast!
-(select sqlc.embed(t), sqlc.embed(td), sqlc.embed(c) from contract_memberships ct
-    join tokens t on t.id = ct.id
+(select sqlc.embed(t), sqlc.embed(td), sqlc.embed(c) from community_data cd
+    join tokens t on t.contract_id = cd.contract_id
     join token_definitions td on t.token_definition_id = td.id
     join users u on u.id = t.owner_user_id
     join contracts c on t.contract_id = c.id
-    where t.displayable
+where cd.community_type = 0
+    and t.displayable
     and t.deleted = false
     and c.deleted = false
     and td.deleted = false
@@ -349,18 +333,21 @@ token_memberships as (
     and u.universal = false
     and (t.created_at,t.id) < (@cur_before_time::timestamptz, @cur_before_id)
     and (t.created_at,t.id) > (@cur_after_time::timestamptz, @cur_after_id)
-    order by case when @paging_forward::bool then (t.created_at,t.id) end asc,
-             case when not @paging_forward::bool then (t.created_at,t.id) end desc
-    limit sqlc.arg('limit'))
+order by case when @paging_forward::bool then (t.created_at,t.id) end asc,
+         case when not @paging_forward::bool then (t.created_at,t.id) end desc
+limit sqlc.arg('limit'))
 
 union all
 
-(select sqlc.embed(t), sqlc.embed(td), sqlc.embed(c) from token_memberships ct
-    join tokens t on t.id = ct.id
-    join token_definitions td on t.token_definition_id = td.id
+(select sqlc.embed(t), sqlc.embed(td), sqlc.embed(c) from community_data cd, token_community_memberships tcm
+    join tokens t on t.token_definition_id = tcm.token_definition_id
+    join token_definitions td on td.id = t.token_definition_id
     join users u on u.id = t.owner_user_id
     join contracts c on t.contract_id = c.id
-    where t.displayable
+where cd.community_type != 0
+    and tcm.community_id = cd.community_id
+    and t.displayable
+    and tcm.deleted = false
     and t.deleted = false
     and c.deleted = false
     and td.deleted = false
@@ -368,44 +355,49 @@ union all
     and u.universal = false
     and (t.created_at,t.id) < (@cur_before_time::timestamptz, @cur_before_id)
     and (t.created_at,t.id) > (@cur_after_time::timestamptz, @cur_after_id)
-    order by case when @paging_forward::bool then (t.created_at,t.id) end asc,
-             case when not @paging_forward::bool then (t.created_at,t.id) end desc
-    limit sqlc.arg('limit'));
+order by case when @paging_forward::bool then (t.created_at,t.id) end asc,
+         case when not @paging_forward::bool then (t.created_at,t.id) end desc
+limit sqlc.arg('limit'));
 
 -- name: CountTokensByCommunityID :one
 with community_data as (
-    select community_type, contract_id
+    select id as community_id, community_type, contract_id
     from communities
     where communities.id = @community_id and not deleted
-),
+    limit 1
+)
 
-community_tokens as (
-    select tokens.*
-    from community_data, tokens
-    where community_data.community_type = 0
-        and tokens.contract_id = community_data.contract_id
-        and not tokens.deleted
+select sum(u.count) from (
+    (select count(t.*) from community_data cd
+        join tokens t on t.contract_id = cd.contract_id
+        join token_definitions td on t.token_definition_id = td.id
+        join users u on u.id = t.owner_user_id
+        join contracts c on t.contract_id = c.id
+    where cd.community_type = 0
+        and t.displayable
+        and t.deleted = false
+        and c.deleted = false
+        and td.deleted = false
+        and u.deleted = false
+        and u.universal = false)
 
     union all
 
-    select tokens.*
-    from community_data, tokens
-        join token_community_memberships on tokens.token_definition_id = token_community_memberships.token_definition_id
-            and token_community_memberships.community_id = @community_id
-            and not token_community_memberships.deleted
-    where community_data.community_type != 0
-        and not tokens.deleted
-)
-
-select count(t.*) from community_tokens t
-    join token_definitions td on t.token_definition_id = td.id
-    join users u on u.id = t.owner_user_id
-    join contracts c on t.contract_id = c.id
-    where t.displayable
-    and t.deleted = false
-    and c.deleted = false
-    and td.deleted = false
-    and u.universal = false;
+    (select count(t.*) from community_data cd, token_community_memberships tcm
+        join tokens t on t.token_definition_id = tcm.token_definition_id
+        join token_definitions td on td.id = t.token_definition_id
+        join users u on u.id = t.owner_user_id
+        join contracts c on t.contract_id = c.id
+    where cd.community_type != 0
+        and tcm.community_id = cd.community_id
+        and t.displayable
+        and tcm.deleted = false
+        and t.deleted = false
+        and c.deleted = false
+        and td.deleted = false
+        and u.deleted = false
+        and u.universal = false)
+) u;
 
 -- name: UpsertCommunityCreators :many
 with entries as (


### PR DESCRIPTION
This is (another) reworked version of the "tokens for community" query, featuring even less clever code reuse, more copy/pasting of boilerplate, and better performance when looking up the tokens in a contract-based community.