### PR TITLE
Fix query escape

### DIFF
--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -531,7 +531,7 @@ func GetDataFromURIAsReader(ctx context.Context, turi persist.TokenURI, mediaTyp
 			// query unescape asString first
 			if needsUnescape(asString) {
 				escaped, err := url.QueryUnescape(asString)
-				if err == nil {
+				if err != nil {
 					logger.For(ctx).Warnf("error unescaping uri: %s", err)
 				} else {
 					asString = escaped


### PR DESCRIPTION
We were using the errored string because of a flipped error check.