### PR TITLE
Set category for weekly digest

### DIFF
--- a/emails/send.go
+++ b/emails/send.go
@@ -478,6 +478,7 @@ func sendDigestEmailToUser(c context.Context, u coredb.PiiUserView, emailRecipie
 	m.SetTemplateID(env.GetString("SENDGRID_DIGEST_TEMPLATE_ID"))
 	p.DynamicTemplateData = asMap
 	m.AddPersonalizations(p)
+	m.SetCategories([]string{"weekly_digest"})
 	p.AddTos(to)
 
 	response, err := s.Send(m)

--- a/emails/send.go
+++ b/emails/send.go
@@ -478,7 +478,7 @@ func sendDigestEmailToUser(c context.Context, u coredb.PiiUserView, emailRecipie
 	m.SetTemplateID(env.GetString("SENDGRID_DIGEST_TEMPLATE_ID"))
 	p.DynamicTemplateData = asMap
 	m.AddPersonalizations(p)
-	m.SetCategories([]string{"weekly_digest"})
+	m.AddCategories([]string{"weekly_digest"})
 	p.AddTos(to)
 
 	response, err := s.Send(m)


### PR DESCRIPTION
## Description
Attempt to set a category for the weekly digest which supposedly will help us see SendGrid stats specifically for the weekly digest email instead of all emails.

Categories doc
https://docs.sendgrid.com/for-developers/sending-email/categories

AddCategories doc
https://github.com/sendgrid/sendgrid-go/blob/574e54c73371f737f02d2dcafc0a5b3f56a2a1e9/helpers/mail/mail_v3.go#L262