### PR TITLE
Allow GIFs for Gallery preview images

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -2356,7 +2356,7 @@ where
 	and not tm.deleted
 	and (
 		tm.media->>'thumbnail_url' is not null
-		or (tm.media->>'media_type' = 'image' and tm.media->>'media_url' is not null)
+		or ((tm.media->>'media_type' = 'image' or tm.media->>'media_type' = 'gif') and tm.media->>'media_url' is not null)
 	)
 order by array_position(g.collections, c.id) , array_position(c.nfts, t.id)
 limit 4

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1160,7 +1160,7 @@ where
 	and not tm.deleted
 	and (
 		tm.media->>'thumbnail_url' is not null
-		or (tm.media->>'media_type' = 'image' and tm.media->>'media_url' is not null)
+		or ((tm.media->>'media_type' = 'image' or tm.media->>'media_type' = 'gif') and tm.media->>'media_url' is not null)
 	)
 order by array_position(g.collections, c.id) , array_position(c.nfts, t.id)
 limit 4;


### PR DESCRIPTION
## What's new?

This PR includes media with `MediaTypeGIF` in the set of tokens that can be used for a Gallery preview when `thumbnail_url` is missing but `media_url` is present. Prior to this, only `MediaTypeImage` was included.