### PR TITLE
Keep holder status on tokens

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -271,7 +271,7 @@ func (p *Provider) SyncTokensByUserID(ctx context.Context, userID persist.DBID, 
 		wg.Wait()
 	}()
 
-	_, _, _, err = p.replaceHolderTokensForUser(ctx, user, chains, recCh, errCh)
+	_, _, _, err = p.addHolderTokensForUser(ctx, user, chains, recCh, errCh)
 	return err
 }
 


### PR DESCRIPTION
Add new tokens on a user token sync, but don't delete existing holder tokens even if we think they're no longer owned.