### PR TITLE
Add a background color to GIF -> MP4 conversions

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -118,6 +118,9 @@ models:
   ReportReason:
     model:
       - github.com/mikeydub/go-gallery/service/persist.ReportReason
+  DarkMode:
+    model:
+      - github.com/mikeydub/go-gallery/service/persist.DarkMode
 directives:
   goGqlId:
     skip_runtime: true

--- a/graphql/model/models.go
+++ b/graphql/model/models.go
@@ -218,8 +218,10 @@ type HelperPostData struct {
 }
 
 type HelperPostComposerDraftDetailsPayloadData struct {
-	Token      persist.TokenIdentifiers
-	ContractID persist.DBID
+	Token           persist.TokenIdentifiers
+	TokenDefinition db.TokenDefinition
+	TokenMedia      db.TokenMedia
+	ContractID      persist.DBID
 }
 
 type ErrInvalidIDFormat struct {

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -439,7 +439,7 @@ type TokenDefinition implements Node @goEmbedHelper {
   dbid: DBID!
   creationTime: Time
   lastUpdated: Time
-  media: MediaSubtype @goField(forceResolver: true)
+  media(darkMode: DarkMode): MediaSubtype @goField(forceResolver: true)
   tokenType: TokenType
   contract: Contract @goField(forceResolver: true)
   chain: Chain
@@ -478,7 +478,7 @@ type Token implements Node @goEmbedHelper {
   viewerAdmire: Admire @goField(forceResolver: true)
 
   # The following fields will be deprecated and removed in the future.
-  media: MediaSubtype
+  media(darkMode: DarkMode): MediaSubtype
     @goField(forceResolver: true)
     @deprecated(reason: "Use definition.media instead")
   tokenType: TokenType
@@ -1387,7 +1387,7 @@ input PostComposerDraftDetailsInput {
 }
 
 type PostComposerDraftDetailsPayload @goEmbedHelper {
-  media: MediaSubtype
+  media(darkMode: DarkMode): MediaSubtype @goField(forceResolver: true)
   community: Community @goField(forceResolver: true)
   tokenName: String
   tokenDescription: String
@@ -2304,6 +2304,11 @@ enum Platform {
   Web
   Mobile
   All
+}
+
+enum DarkMode {
+  Disabled
+  Enabled
 }
 
 type GalleryAnnouncementNotification implements Notification & Node {

--- a/service/mediamapper/mediamapper.go
+++ b/service/mediamapper/mediamapper.go
@@ -172,6 +172,14 @@ func WithFormatAuto() Option {
 	}
 }
 
+// WithBackgroundColor will set the background color of the media.
+// See https://docs.imgix.com/apis/rendering#colors for valid parameter values.
+func WithBackgroundColor(color string) Option {
+	return func(params *[]imgix.IxParam) {
+		*params = append(*params, imgix.Param("bg", color))
+	}
+}
+
 func (u *MediaMapper) GetThumbnailImageUrl(sourceUrl string, options ...Option) string {
 	return u.buildPreviewImageUrl(sourceUrl, thumbnailWidth, u.thumbnailUrlParams, options...)
 }

--- a/service/persist/persist.go
+++ b/service/persist/persist.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"unicode"
 
@@ -272,4 +273,37 @@ func ToJSONB(v any) (pgtype.JSONB, error) {
 	ret := pgtype.JSONB{}
 	err = ret.Set(byt)
 	return ret, err
+}
+
+type DarkMode int
+
+const (
+	DarkModeDisabled DarkMode = iota
+	DarkModeEnabled
+)
+
+// UnmarshalGQL implements the graphql.Unmarshaler interface
+func (d *DarkMode) UnmarshalGQL(v interface{}) error {
+	n, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("darkMode must be a string")
+	}
+
+	switch strings.ToLower(n) {
+	case "disabled":
+		*d = DarkModeDisabled
+	case "enabled":
+		*d = DarkModeEnabled
+	}
+	return nil
+}
+
+// MarshalGQL implements the graphql.Marshaler interface
+func (d DarkMode) MarshalGQL(w io.Writer) {
+	switch d {
+	case DarkModeDisabled:
+		w.Write([]byte(`"Disabled"`))
+	case DarkModeEnabled:
+		w.Write([]byte(`"Enabled"`))
+	}
 }


### PR DESCRIPTION
GIFs support transparency, but MP4s don't. Up to this point, the GIFs we've converted to MP4 would default to a black background, but that looks odd outside of dark mode. This PR defaults converted MP4s to an off-white background, and optionally allows a `DarkMode` flag to choose a black background where applicable.