### PR TITLE
Use opensea as source

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -113,8 +113,36 @@ func ethProviderSet(envInit, *http.Client) *multichain.EthereumProvider {
 		rpc.NewEthClient,
 		wire.Value(persist.ChainETH),
 		indexer.NewProvider,
+		newReservoirProvider,
+		newOpenseaProvider,
+	)
+	return nil
+}
+
+func newInfoerContractFetcher(openseaProvider *opensea.Provider) multichain.InfoerContractFetcher {
+	wire.Bind(new(multichain.InfoerContractFetcher), util.ToPointer(openseaProvider))
+	return nil
+}
+
+func newTokenByIdentifiersFetcher(reservoirProvider *reservoir.Provider) multichain.TokenByIdentifiersFetcher {
+	wire.Bind(new(multichain.TokenByIdentifiersFetcher), util.ToPointer(reservoirProvider))
+	return nil
+}
+
+func newOpenseaProvider(c *http.Client, chain persist.Chain) *opensea.Provider {
+	wire.Build(
 		reservoir.NewProvider,
+		newTokenByIdentifiersFetcher,
+		opensea.NewProviderAltFallbackMedia,
+	)
+	return nil
+}
+
+func newReservoirProvider(c *http.Client, chain persist.Chain) *reservoir.Provider {
+	wire.Build(
 		opensea.NewProvider,
+		newInfoerContractFetcher,
+		reservoir.NewProviderAltContractFetcher,
 	)
 	return nil
 }
@@ -127,11 +155,11 @@ func ethProvidersConfig(
 	wire.Build(
 		wire.Struct(new(multichain.EthereumProvider), "*"),
 		wire.Bind(new(multichain.Verifier), util.ToPointer(indexerProvider)),
-		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(reservoirProvider)),
-		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(reservoirProvider)),
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(reservoirProvider)),
-		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(reservoirProvider)),
-		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(reservoirProvider)),
+		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(openseaProvider)),
+		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(openseaProvider)),
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(openseaProvider)),
+		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(openseaProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(openseaProvider)),
 		wire.Bind(new(multichain.ContractRefresher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.ContractsOwnerFetcher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(openseaProvider)),
@@ -168,8 +196,8 @@ func optimismProviderSet(*http.Client) *multichain.OptimismProvider {
 	wire.Build(
 		optimismProvidersConfig,
 		wire.Value(persist.ChainOptimism),
-		reservoir.NewProvider,
-		opensea.NewProvider,
+		newReservoirProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }
@@ -190,8 +218,8 @@ func arbitrumProviderSet(*http.Client) *multichain.ArbitrumProvider {
 	wire.Build(
 		arbitrumProvidersConfig,
 		wire.Value(persist.ChainArbitrum),
-		reservoir.NewProvider,
-		opensea.NewProvider,
+		newReservoirProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }
@@ -239,7 +267,7 @@ func zoraProviderSet(envInit, *http.Client) *multichain.ZoraProvider {
 func zoraProvidersConfig(zoraProvider *zora.Provider) *multichain.ZoraProvider {
 	wire.Build(
 		wire.Struct(new(multichain.ZoraProvider), "*"),
-		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(zoraProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(zoraProvider)),
@@ -255,8 +283,8 @@ func baseProviderSet(*http.Client) *multichain.BaseProvider {
 	wire.Build(
 		baseProvidersConfig,
 		wire.Value(persist.ChainBase),
-		reservoir.NewProvider,
-		opensea.NewProvider,
+		newReservoirProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }
@@ -277,8 +305,8 @@ func polygonProviderSet(*http.Client) *multichain.PolygonProvider {
 	wire.Build(
 		polygonProvidersConfig,
 		wire.Value(persist.ChainPolygon),
-		reservoir.NewProvider,
-		opensea.NewProvider,
+		newReservoirProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }

--- a/service/multichain/config.go
+++ b/service/multichain/config.go
@@ -19,7 +19,7 @@ type ChainProvider struct {
 
 type EthereumProvider struct {
 	ContractRefresher
-	ContractsFetcher
+	ContractFetcher
 	ContractsOwnerFetcher
 	TokenDescriptorsFetcher
 	TokenMetadataFetcher
@@ -66,7 +66,7 @@ type PoapProvider struct {
 }
 
 type ZoraProvider struct {
-	ContractsFetcher
+	ContractFetcher
 	ContractsOwnerFetcher
 	TokenDescriptorsFetcher
 	TokenMetadataFetcher

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -91,12 +91,21 @@ func FetchAssetsForTokenIdentifiers(ctx context.Context, chain persist.Chain, co
 type Provider struct {
 	Chain      persist.Chain
 	httpClient *http.Client
+	// Used to get fallback media because OS doesn't have fallbacks
+	tFetcher multichain.TokenByIdentifiersFetcher
 }
 
 // NewProvider creates a new provider for OpenSea
 func NewProvider(httpClient *http.Client, chain persist.Chain) *Provider {
 	mustChainIdentifierFrom(chain) // validate that the chain is supported
 	return &Provider{httpClient: httpClient, Chain: chain}
+}
+
+// NewProviderAltFallbackMedia configures the provider with a fetcher used to get fallback media
+func NewProviderAltFallbackMedia(httpClient *http.Client, chain persist.Chain, tFetcher multichain.TokenByIdentifiersFetcher) *Provider {
+	p := NewProvider(httpClient, chain)
+	p.tFetcher = tFetcher
+	return p
 }
 
 func (p *Provider) ProviderInfo() multichain.ProviderInfo {
@@ -267,7 +276,10 @@ func (p *Provider) assetsToTokens(ctx context.Context, ownerAddress persist.Addr
 			for _, n := range assetsReceived.Assets {
 				nft := n
 				wp.Go(func(ctx context.Context) error {
-					return p.streamTokenAndContract(ctx, ownerAddress, nft, tokensCh, contractsCh, seenContracts, contractLocks, &mu)
+					return p.streamContract(ctx, nft.Contract, contractsCh, seenContracts, contractLocks, &mu)
+				})
+				wp.Go(func(ctx context.Context) error {
+					return p.streamToken(ctx, ownerAddress, nft, tokensCh)
 				})
 			}
 		}
@@ -335,7 +347,10 @@ func (p *Provider) streamAssetsToTokens(ctx context.Context, ownerAddress persis
 			for _, n := range assetsReceived.Assets {
 				nft := n
 				wp.Go(func(ctx context.Context) error {
-					return p.streamTokenAndContract(ctx, ownerAddress, nft, innerTokenReceived, innerContractReceived, seenContracts, contractLocks, &mu)
+					return p.streamContract(ctx, nft.Contract, innerContractReceived, seenContracts, contractLocks, &mu)
+				})
+				wp.Go(func(ctx context.Context) error {
+					return p.streamToken(ctx, ownerAddress, nft, innerTokenReceived)
 				})
 			}
 			err := wp.Wait()
@@ -389,19 +404,26 @@ type contractCollection struct {
 	Collection Collection
 }
 
-func (p *Provider) streamTokenAndContract(ctx context.Context, ownerAddress persist.Address, asset Asset, tokenCh chan<- multichain.ChainAgnosticToken, contractCh chan<- multichain.ChainAgnosticContract, seenContracts *sync.Map, contractLocks map[string]*sync.Mutex, mu *sync.RWMutex) error {
+func (p *Provider) streamContract(
+	ctx context.Context,
+	contractAddress string,
+	contractCh chan<- multichain.ChainAgnosticContract,
+	seenContracts *sync.Map,
+	contractLocks map[string]*sync.Mutex,
+	mu *sync.RWMutex,
+) error {
 	// Haven't seen this contract before, so we need to process it
-	if _, ok := seenContracts.Load(asset.Contract); !ok {
+	if _, ok := seenContracts.Load(contractAddress); !ok {
 		// If we don't have a lock yet, create one
 		mu.Lock()
-		if _, hasJobLock := contractLocks[asset.Contract]; !hasJobLock {
-			contractLocks[asset.Contract] = &sync.Mutex{}
+		if _, hasJobLock := contractLocks[contractAddress]; !hasJobLock {
+			contractLocks[contractAddress] = &sync.Mutex{}
 		}
 		mu.Unlock()
 
 		// Acquire a lock for the job
 		mu.RLock()
-		jobMu := contractLocks[asset.Contract]
+		jobMu := contractLocks[contractAddress]
 		mu.RUnlock()
 
 		// Process the contract
@@ -412,50 +434,49 @@ func (p *Provider) streamTokenAndContract(ctx context.Context, ownerAddress pers
 			defer jobMu.Unlock()
 			// Check again if we've seen the contract, since another job may have processed it while we were waiting for the lock
 			var c contractCollection
-			if _, ok := seenContracts.Load(asset.Contract); !ok {
-				c, err = fetchContractCollectionByAddress(ctx, p.httpClient, p.Chain, persist.Address(asset.Contract))
+			if _, ok := seenContracts.Load(contractAddress); !ok {
+				c, err = fetchContractCollectionByAddress(ctx, p.httpClient, p.Chain, persist.Address(contractAddress))
 				if err == nil {
 					contractCh <- contractToChainAgnosticContract(c.Contract, c.Collection)
-					seenContracts.Store(asset.Contract, c)
+					seenContracts.Store(contractAddress, c)
 				}
 			}
 		}()
-
 		if err != nil {
 			return err
 		}
 	}
+	return nil
+}
 
-	cc, _ := seenContracts.Load(asset.Contract)
-	collection := cc.(contractCollection).Collection
-
+func (p *Provider) streamToken(ctx context.Context, ownerAddress persist.Address, asset Asset, tokenCh chan<- multichain.ChainAgnosticToken) error {
 	typ, err := tokenTypeFromAsset(asset)
 	if err != nil {
 		return err
 	}
 
 	if ownerAddress != "" {
-		tokenCh <- assetToAgnosticToken(asset, collection, typ, ownerAddress, 1)
+		tokenCh <- assetToAgnosticToken(ctx, asset, typ, ownerAddress, 1, p.tFetcher)
 		return nil
 	}
 
-	// No input owner address provided. OS doesn't return the owner of the token a few endpoints
-	// like when paginating a contract or a collection. The owner isn't really important for our purposes,
+	// No input owner address provided. OS doesn't return the owner of the token for a few endpoints
+	// like when paging through a contract or collection. The owner isn't really important for our purposes,
 	// but we'll to add it to the token if its already available.
 	switch typ {
 	case persist.TokenTypeERC721:
 		if numOwners := len(asset.Owners); numOwners == 1 {
-			tokenCh <- assetToAgnosticToken(asset, collection, typ, persist.Address(asset.Owners[0].Address), 1)
+			tokenCh <- assetToAgnosticToken(ctx, asset, typ, persist.Address(asset.Owners[0].Address), 1, p.tFetcher)
 		} else {
-			tokenCh <- assetToAgnosticToken(asset, collection, typ, "", 1)
+			tokenCh <- assetToAgnosticToken(ctx, asset, typ, "", 1, p.tFetcher)
 		}
 	case persist.TokenTypeERC1155:
 		if numOwners := len(asset.Owners); numOwners > 0 {
 			for _, o := range asset.Owners {
-				tokenCh <- assetToAgnosticToken(asset, collection, typ, persist.Address(o.Address), o.Quantity)
+				tokenCh <- assetToAgnosticToken(ctx, asset, typ, persist.Address(o.Address), o.Quantity, p.tFetcher)
 			}
 		} else {
-			tokenCh <- assetToAgnosticToken(asset, collection, typ, "", 1)
+			tokenCh <- assetToAgnosticToken(ctx, asset, typ, "", 1, p.tFetcher)
 		}
 	default:
 		return fmt.Errorf("don't know how to handle owners for token type %s", typ)
@@ -614,18 +635,28 @@ func contractToChainAgnosticContract(contract Contract, collection Collection) m
 	}
 }
 
-func assetToAgnosticToken(asset Asset, collection Collection, tokenType persist.TokenType, tokenOwner persist.Address, quantity int) multichain.ChainAgnosticToken {
-	return multichain.ChainAgnosticToken{
+func assetToAgnosticToken(ctx context.Context, asset Asset, tokenType persist.TokenType, tokenOwner persist.Address, quantity int, tFetcher multichain.TokenByIdentifiersFetcher) multichain.ChainAgnosticToken {
+	t := multichain.ChainAgnosticToken{
 		TokenType:       tokenType,
 		Descriptors:     multichain.ChainAgnosticTokenDescriptors{Name: asset.Name, Description: asset.Description},
 		TokenURI:        persist.TokenURI(asset.MetadataURL),
 		TokenID:         persist.MustTokenID(asset.Identifier),
 		OwnerAddress:    tokenOwner,
 		ContractAddress: persist.Address(asset.Contract),
-		ExternalURL:     collection.ProjectURL, // OpenSea doesn't return a token-specific external URL, so we use the collection's project URL
 		TokenMetadata:   metadataFromAsset(asset),
 		Quantity:        persist.HexString(fmt.Sprintf("%x", quantity)),
 	}
+
+	if tFetcher != nil {
+		tID := multichain.ChainAgnosticIdentifiers{ContractAddress: t.ContractAddress, TokenID: t.TokenID}
+		if alt, _, err := tFetcher.GetTokenByTokenIdentifiers(ctx, tID); err != nil {
+			logger.For(ctx).Warnf("failed to get fallback media: %s", err)
+		} else {
+			t.FallbackMedia = alt.FallbackMedia
+		}
+	}
+
+	return t
 }
 
 func metadataFromAsset(asset Asset) persist.TokenMetadata {


### PR DESCRIPTION
**Changes**
* Uses opensea as the primary source for EVM chains except zora
* Opensea provider calls reservoir provider to get fallback media
* Wraps rate limit errors from Opensea and reports to Sentry