### PR TITLE
Opensea multichain

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/multichain/indexer"
 	"github.com/mikeydub/go-gallery/service/multichain/opensea"
 	"github.com/mikeydub/go-gallery/service/multichain/poap"
+	"github.com/mikeydub/go-gallery/service/multichain/reservoir"
 	"github.com/mikeydub/go-gallery/service/multichain/tezos"
 	"github.com/mikeydub/go-gallery/service/multichain/tzkt"
 	"github.com/mikeydub/go-gallery/service/multichain/zora"
@@ -112,6 +113,14 @@ func ethProviderSet(envInit, *http.Client) *multichain.EthereumProvider {
 		rpc.NewEthClient,
 		wire.Value(persist.ChainETH),
 		indexer.NewProvider,
+		newOpenseaProvider,
+	)
+	return nil
+}
+
+func newOpenseaProvider(*http.Client, persist.Chain) *opensea.Provider {
+	wire.Build(
+		reservoir.NewProvider,
 		opensea.NewProvider,
 	)
 	return nil
@@ -165,7 +174,7 @@ func optimismProviderSet(*http.Client) *multichain.OptimismProvider {
 	wire.Build(
 		optimismProvidersConfig,
 		wire.Value(persist.ChainOptimism),
-		opensea.NewProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }
@@ -186,7 +195,7 @@ func arbitrumProviderSet(*http.Client) *multichain.ArbitrumProvider {
 	wire.Build(
 		arbitrumProvidersConfig,
 		wire.Value(persist.ChainArbitrum),
-		opensea.NewProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }
@@ -228,7 +237,7 @@ func zoraProviderSet(envInit, *http.Client) *multichain.ZoraProvider {
 		zoraProvidersConfig,
 		wire.Value(persist.ChainZora),
 		zora.NewProvider,
-		opensea.NewProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }
@@ -252,7 +261,7 @@ func baseProviderSet(*http.Client) *multichain.BaseProvider {
 	wire.Build(
 		baseProvidersConfig,
 		wire.Value(persist.ChainBase),
-		opensea.NewProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }
@@ -273,7 +282,7 @@ func polygonProviderSet(*http.Client) *multichain.PolygonProvider {
 	wire.Build(
 		polygonProvidersConfig,
 		wire.Value(persist.ChainPolygon),
-		opensea.NewProvider,
+		newOpenseaProvider,
 	)
 	return nil
 }

--- a/server/inject.go
+++ b/server/inject.go
@@ -131,7 +131,7 @@ func ethProvidersConfig(
 		wire.Bind(new(multichain.TokensContractFetcher), util.ToPointer(reservoirProvider)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(reservoirProvider)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(reservoirProvider)),
-		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(reservoirProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(reservoirProvider)),
 		wire.Bind(new(multichain.ContractRefresher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.ContractsOwnerFetcher), util.ToPointer(indexerProvider)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(openseaProvider)),
@@ -239,7 +239,7 @@ func zoraProviderSet(envInit, *http.Client) *multichain.ZoraProvider {
 func zoraProvidersConfig(zoraProvider *zora.Provider) *multichain.ZoraProvider {
 	wire.Build(
 		wire.Struct(new(multichain.ZoraProvider), "*"),
-		wire.Bind(new(multichain.ContractsFetcher), util.ToPointer(zoraProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensOwnerFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(zoraProvider)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(zoraProvider)),

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -100,7 +100,7 @@ var (
 func ethProvidersConfig(indexerProvider *indexer.Provider, reservoirProvider *reservoir.Provider, openseaProvider *opensea.Provider) *multichain.EthereumProvider {
 	ethereumProvider := &multichain.EthereumProvider{
 		ContractRefresher:                indexerProvider,
-		ContractsFetcher:                 reservoirProvider,
+		ContractFetcher:                  reservoirProvider,
 		ContractsOwnerFetcher:            indexerProvider,
 		TokenDescriptorsFetcher:          openseaProvider,
 		TokenMetadataFetcher:             openseaProvider,
@@ -205,7 +205,7 @@ func zoraProviderSet(serverEnvInit envInit, client *http.Client) *multichain.Zor
 
 func zoraProvidersConfig(zoraProvider *zora.Provider) *multichain.ZoraProvider {
 	multichainZoraProvider := &multichain.ZoraProvider{
-		ContractsFetcher:                 zoraProvider,
+		ContractFetcher:                  zoraProvider,
 		ContractsOwnerFetcher:            zoraProvider,
 		TokenDescriptorsFetcher:          zoraProvider,
 		TokenMetadataFetcher:             zoraProvider,

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/multichain/indexer"
 	"github.com/mikeydub/go-gallery/service/multichain/opensea"
 	"github.com/mikeydub/go-gallery/service/multichain/poap"
+	"github.com/mikeydub/go-gallery/service/multichain/reservoir"
 	"github.com/mikeydub/go-gallery/service/multichain/tezos"
 	"github.com/mikeydub/go-gallery/service/multichain/tzkt"
 	"github.com/mikeydub/go-gallery/service/multichain/zora"
@@ -86,7 +87,7 @@ func ethProviderSet(serverEnvInit envInit, client *http.Client) *multichain.Ethe
 	ethclientClient := rpc.NewEthClient()
 	provider := indexer.NewProvider(client, ethclientClient)
 	chain := _wireChainValue
-	openseaProvider := opensea.NewProvider(client, chain)
+	openseaProvider := newOpenseaProvider(client, chain)
 	ethereumProvider := ethProvidersConfig(provider, openseaProvider)
 	return ethereumProvider
 }
@@ -94,6 +95,12 @@ func ethProviderSet(serverEnvInit envInit, client *http.Client) *multichain.Ethe
 var (
 	_wireChainValue = persist.ChainETH
 )
+
+func newOpenseaProvider(client *http.Client, chain persist.Chain) *opensea.Provider {
+	provider := reservoir.NewProvider(client, chain)
+	openseaProvider := opensea.NewProvider(client, chain, provider)
+	return openseaProvider
+}
 
 func ethProvidersConfig(indexerProvider *indexer.Provider, openseaProvider *opensea.Provider) *multichain.EthereumProvider {
 	ethereumProvider := &multichain.EthereumProvider{
@@ -134,7 +141,7 @@ func tezosProvidersConfig(tezosProvider *tezos.Provider, tzktProvider *tzkt.Prov
 
 func optimismProviderSet(client *http.Client) *multichain.OptimismProvider {
 	chain := _wirePersistChainValue
-	provider := opensea.NewProvider(client, chain)
+	provider := newOpenseaProvider(client, chain)
 	optimismProvider := optimismProvidersConfig(provider)
 	return optimismProvider
 }
@@ -156,7 +163,7 @@ func optimismProvidersConfig(openseaProvider *opensea.Provider) *multichain.Opti
 
 func arbitrumProviderSet(client *http.Client) *multichain.ArbitrumProvider {
 	chain := _wireChainValue2
-	provider := opensea.NewProvider(client, chain)
+	provider := newOpenseaProvider(client, chain)
 	arbitrumProvider := arbitrumProvidersConfig(provider)
 	return arbitrumProvider
 }
@@ -195,7 +202,7 @@ func poapProvidersConfig(poapProvider *poap.Provider) *multichain.PoapProvider {
 
 func zoraProviderSet(serverEnvInit envInit, client *http.Client) *multichain.ZoraProvider {
 	chain := _wireChainValue3
-	provider := opensea.NewProvider(client, chain)
+	provider := newOpenseaProvider(client, chain)
 	zoraProvider := zora.NewProvider(client)
 	multichainZoraProvider := zoraProvidersConfig(provider, zoraProvider)
 	return multichainZoraProvider
@@ -221,7 +228,7 @@ func zoraProvidersConfig(openseaProvider *opensea.Provider, zoraProvider *zora.P
 
 func baseProviderSet(client *http.Client) *multichain.BaseProvider {
 	chain := _wireChainValue4
-	provider := opensea.NewProvider(client, chain)
+	provider := newOpenseaProvider(client, chain)
 	baseProvider := baseProvidersConfig(provider)
 	return baseProvider
 }
@@ -243,7 +250,7 @@ func baseProvidersConfig(openseaProvider *opensea.Provider) *multichain.BaseProv
 
 func polygonProviderSet(client *http.Client) *multichain.PolygonProvider {
 	chain := _wireChainValue5
-	provider := opensea.NewProvider(client, chain)
+	provider := newOpenseaProvider(client, chain)
 	polygonProvider := polygonProvidersConfig(provider)
 	return polygonProvider
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/multichain/indexer"
 	"github.com/mikeydub/go-gallery/service/multichain/opensea"
 	"github.com/mikeydub/go-gallery/service/multichain/poap"
-	"github.com/mikeydub/go-gallery/service/multichain/reservoir"
 	"github.com/mikeydub/go-gallery/service/multichain/tezos"
 	"github.com/mikeydub/go-gallery/service/multichain/tzkt"
 	"github.com/mikeydub/go-gallery/service/multichain/zora"
@@ -87,9 +86,8 @@ func ethProviderSet(serverEnvInit envInit, client *http.Client) *multichain.Ethe
 	ethclientClient := rpc.NewEthClient()
 	provider := indexer.NewProvider(client, ethclientClient)
 	chain := _wireChainValue
-	reservoirProvider := reservoir.NewProvider(client, chain)
 	openseaProvider := opensea.NewProvider(client, chain)
-	ethereumProvider := ethProvidersConfig(provider, reservoirProvider, openseaProvider)
+	ethereumProvider := ethProvidersConfig(provider, openseaProvider)
 	return ethereumProvider
 }
 
@@ -97,17 +95,17 @@ var (
 	_wireChainValue = persist.ChainETH
 )
 
-func ethProvidersConfig(indexerProvider *indexer.Provider, reservoirProvider *reservoir.Provider, openseaProvider *opensea.Provider) *multichain.EthereumProvider {
+func ethProvidersConfig(indexerProvider *indexer.Provider, openseaProvider *opensea.Provider) *multichain.EthereumProvider {
 	ethereumProvider := &multichain.EthereumProvider{
 		ContractRefresher:                indexerProvider,
-		ContractFetcher:                  reservoirProvider,
+		ContractFetcher:                  openseaProvider,
 		ContractsOwnerFetcher:            indexerProvider,
 		TokenDescriptorsFetcher:          openseaProvider,
 		TokenMetadataFetcher:             openseaProvider,
-		TokensContractFetcher:            reservoirProvider,
-		TokensIncrementalContractFetcher: reservoirProvider,
-		TokensIncrementalOwnerFetcher:    reservoirProvider,
-		TokensOwnerFetcher:               reservoirProvider,
+		TokensContractFetcher:            openseaProvider,
+		TokensIncrementalContractFetcher: openseaProvider,
+		TokensIncrementalOwnerFetcher:    openseaProvider,
+		TokensOwnerFetcher:               openseaProvider,
 		Verifier:                         indexerProvider,
 	}
 	return ethereumProvider
@@ -136,9 +134,8 @@ func tezosProvidersConfig(tezosProvider *tezos.Provider, tzktProvider *tzkt.Prov
 
 func optimismProviderSet(client *http.Client) *multichain.OptimismProvider {
 	chain := _wirePersistChainValue
-	provider := reservoir.NewProvider(client, chain)
-	openseaProvider := opensea.NewProvider(client, chain)
-	optimismProvider := optimismProvidersConfig(provider, openseaProvider)
+	provider := opensea.NewProvider(client, chain)
+	optimismProvider := optimismProvidersConfig(provider)
 	return optimismProvider
 }
 
@@ -146,22 +143,21 @@ var (
 	_wirePersistChainValue = persist.ChainOptimism
 )
 
-func optimismProvidersConfig(reservoirProvider *reservoir.Provider, openseaProvider *opensea.Provider) *multichain.OptimismProvider {
+func optimismProvidersConfig(openseaProvider *opensea.Provider) *multichain.OptimismProvider {
 	optimismProvider := &multichain.OptimismProvider{
 		TokenDescriptorsFetcher:       openseaProvider,
 		TokenMetadataFetcher:          openseaProvider,
-		TokensContractFetcher:         reservoirProvider,
-		TokensIncrementalOwnerFetcher: reservoirProvider,
-		TokensOwnerFetcher:            reservoirProvider,
+		TokensContractFetcher:         openseaProvider,
+		TokensIncrementalOwnerFetcher: openseaProvider,
+		TokensOwnerFetcher:            openseaProvider,
 	}
 	return optimismProvider
 }
 
 func arbitrumProviderSet(client *http.Client) *multichain.ArbitrumProvider {
 	chain := _wireChainValue2
-	provider := reservoir.NewProvider(client, chain)
-	openseaProvider := opensea.NewProvider(client, chain)
-	arbitrumProvider := arbitrumProvidersConfig(provider, openseaProvider)
+	provider := opensea.NewProvider(client, chain)
+	arbitrumProvider := arbitrumProvidersConfig(provider)
 	return arbitrumProvider
 }
 
@@ -169,13 +165,13 @@ var (
 	_wireChainValue2 = persist.ChainArbitrum
 )
 
-func arbitrumProvidersConfig(reservoirProvider *reservoir.Provider, openseaProvider *opensea.Provider) *multichain.ArbitrumProvider {
+func arbitrumProvidersConfig(openseaProvider *opensea.Provider) *multichain.ArbitrumProvider {
 	arbitrumProvider := &multichain.ArbitrumProvider{
 		TokenDescriptorsFetcher:       openseaProvider,
 		TokenMetadataFetcher:          openseaProvider,
-		TokensContractFetcher:         reservoirProvider,
-		TokensIncrementalOwnerFetcher: reservoirProvider,
-		TokensOwnerFetcher:            reservoirProvider,
+		TokensContractFetcher:         openseaProvider,
+		TokensIncrementalOwnerFetcher: openseaProvider,
+		TokensOwnerFetcher:            openseaProvider,
 	}
 	return arbitrumProvider
 }
@@ -198,67 +194,71 @@ func poapProvidersConfig(poapProvider *poap.Provider) *multichain.PoapProvider {
 }
 
 func zoraProviderSet(serverEnvInit envInit, client *http.Client) *multichain.ZoraProvider {
-	provider := zora.NewProvider(client)
-	zoraProvider := zoraProvidersConfig(provider)
-	return zoraProvider
+	chain := _wireChainValue3
+	provider := opensea.NewProvider(client, chain)
+	zoraProvider := zora.NewProvider(client)
+	multichainZoraProvider := zoraProvidersConfig(provider, zoraProvider)
+	return multichainZoraProvider
 }
 
-func zoraProvidersConfig(zoraProvider *zora.Provider) *multichain.ZoraProvider {
+var (
+	_wireChainValue3 = persist.ChainZora
+)
+
+func zoraProvidersConfig(openseaProvider *opensea.Provider, zoraProvider *zora.Provider) *multichain.ZoraProvider {
 	multichainZoraProvider := &multichain.ZoraProvider{
-		ContractFetcher:                  zoraProvider,
+		ContractFetcher:                  openseaProvider,
 		ContractsOwnerFetcher:            zoraProvider,
-		TokenDescriptorsFetcher:          zoraProvider,
-		TokenMetadataFetcher:             zoraProvider,
-		TokensContractFetcher:            zoraProvider,
-		TokensIncrementalContractFetcher: zoraProvider,
-		TokensIncrementalOwnerFetcher:    zoraProvider,
-		TokensOwnerFetcher:               zoraProvider,
+		TokenDescriptorsFetcher:          openseaProvider,
+		TokenMetadataFetcher:             openseaProvider,
+		TokensContractFetcher:            openseaProvider,
+		TokensIncrementalContractFetcher: openseaProvider,
+		TokensIncrementalOwnerFetcher:    openseaProvider,
+		TokensOwnerFetcher:               openseaProvider,
 	}
 	return multichainZoraProvider
 }
 
 func baseProviderSet(client *http.Client) *multichain.BaseProvider {
-	chain := _wireChainValue3
-	provider := reservoir.NewProvider(client, chain)
-	openseaProvider := opensea.NewProvider(client, chain)
-	baseProvider := baseProvidersConfig(provider, openseaProvider)
+	chain := _wireChainValue4
+	provider := opensea.NewProvider(client, chain)
+	baseProvider := baseProvidersConfig(provider)
 	return baseProvider
 }
 
 var (
-	_wireChainValue3 = persist.ChainBase
+	_wireChainValue4 = persist.ChainBase
 )
 
-func baseProvidersConfig(reservoirProvider *reservoir.Provider, openseaProvider *opensea.Provider) *multichain.BaseProvider {
+func baseProvidersConfig(openseaProvider *opensea.Provider) *multichain.BaseProvider {
 	baseProvider := &multichain.BaseProvider{
 		TokenDescriptorsFetcher:       openseaProvider,
 		TokenMetadataFetcher:          openseaProvider,
-		TokensContractFetcher:         reservoirProvider,
-		TokensIncrementalOwnerFetcher: reservoirProvider,
-		TokensOwnerFetcher:            reservoirProvider,
+		TokensContractFetcher:         openseaProvider,
+		TokensIncrementalOwnerFetcher: openseaProvider,
+		TokensOwnerFetcher:            openseaProvider,
 	}
 	return baseProvider
 }
 
 func polygonProviderSet(client *http.Client) *multichain.PolygonProvider {
-	chain := _wireChainValue4
-	provider := reservoir.NewProvider(client, chain)
-	openseaProvider := opensea.NewProvider(client, chain)
-	polygonProvider := polygonProvidersConfig(provider, openseaProvider)
+	chain := _wireChainValue5
+	provider := opensea.NewProvider(client, chain)
+	polygonProvider := polygonProvidersConfig(provider)
 	return polygonProvider
 }
 
 var (
-	_wireChainValue4 = persist.ChainPolygon
+	_wireChainValue5 = persist.ChainPolygon
 )
 
-func polygonProvidersConfig(reservoirProvider *reservoir.Provider, openseaProvider *opensea.Provider) *multichain.PolygonProvider {
+func polygonProvidersConfig(openseaProvider *opensea.Provider) *multichain.PolygonProvider {
 	polygonProvider := &multichain.PolygonProvider{
 		TokenDescriptorsFetcher:       openseaProvider,
 		TokenMetadataFetcher:          openseaProvider,
-		TokensContractFetcher:         reservoirProvider,
-		TokensIncrementalOwnerFetcher: reservoirProvider,
-		TokensOwnerFetcher:            reservoirProvider,
+		TokensContractFetcher:         openseaProvider,
+		TokensIncrementalOwnerFetcher: openseaProvider,
+		TokensOwnerFetcher:            openseaProvider,
 	}
 	return polygonProvider
 }

--- a/service/multichain/config.go
+++ b/service/multichain/config.go
@@ -19,7 +19,7 @@ type ChainProvider struct {
 
 type EthereumProvider struct {
 	ContractRefresher
-	ContractsFetcher
+	ContractFetcher
 	ContractsOwnerFetcher
 	TokenDescriptorsFetcher
 	TokenMetadataFetcher
@@ -66,7 +66,7 @@ type PoapProvider struct {
 }
 
 type ZoraProvider struct {
-	ContractsFetcher
+	ContractFetcher
 	ContractsOwnerFetcher
 	TokenDescriptorsFetcher
 	TokenMetadataFetcher

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -181,7 +181,7 @@ type TokensContractFetcher interface {
 	GetTokensByContractAddress(ctx context.Context, contract persist.Address, limit int, offset int) ([]ChainAgnosticToken, ChainAgnosticContract, error)
 }
 
-type ContractsFetcher interface {
+type ContractFetcher interface {
 	GetContractByAddress(ctx context.Context, contract persist.Address) (ChainAgnosticContract, error)
 }
 
@@ -191,7 +191,6 @@ type ContractsOwnerFetcher interface {
 
 // ContractRefresher supports refreshes of a contract
 type ContractRefresher interface {
-	ContractsFetcher
 	RefreshContract(context.Context, persist.Address) error
 }
 
@@ -1038,7 +1037,7 @@ func (p *Provider) RefreshContract(ctx context.Context, ci persist.ContractIdent
 		}
 	}
 
-	if fetcher, ok := p.Chains[ci.Chain].(ContractsFetcher); ok {
+	if fetcher, ok := p.Chains[ci.Chain].(ContractFetcher); ok {
 		c, err := fetcher.GetContractByAddress(ctx, ci.ContractAddress)
 		if err != nil {
 			return err

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -650,52 +650,15 @@ func (p *Provider) processTokensForUsers(ctx context.Context, users map[persist.
 		currentUserTokens[userID] = util.DedupeWithTranslate(append(currentUserTokens[userID], existingTokensForUsers[userID]...), false, func(t op.TokenFullDetails) persist.DBID { return t.Instance.ID })
 	}
 
-	// Sort by the default ordering the frontend uses to displays tokens so that tokens are processed in the same order
-	// The order is created time desc, token name desc, then token DBID desc.
-	sort.Slice(upsertedTokens, func(i, j int) bool {
-		tokenI := upsertedTokens[i]
-		tokenJ := upsertedTokens[j]
-
-		if tokenI.Instance.CreatedAt.After(tokenJ.Instance.CreatedAt) {
-			return true
-		} else if tokenI.Instance.CreatedAt.Before(tokenJ.Instance.CreatedAt) {
-			return false
-		}
-
-		if tokenI.Definition.Name.String > tokenJ.Definition.Name.String {
-			return true
-		} else if tokenI.Definition.Name.String < tokenJ.Definition.Name.String {
-			return false
-		}
-
-		return tokenI.Instance.ID > tokenJ.Instance.ID
-	})
-
-	batches := make([][]persist.DBID, 0)
-
+	ids := make([]persist.DBID, 0, len(upsertedTokens))
 	for _, t := range upsertedTokens {
-		// Submit tokens that are missing media IDs. Tokens that are missing media IDs are new tokens, or tokens that weren't processed for whatever reason.
 		if t.Definition.TokenMediaID == "" {
-			curBatch := len(batches) - 1
-
-			if curBatch == -1 {
-				batches = append(batches, []persist.DBID{})
-				curBatch = 0
-			}
-
-			// Break up into smaller batches so that a batch is handled per request
-			if len(batches[curBatch]) >= 50 {
-				batches = append(batches, make([]persist.DBID, 0, 50))
-				curBatch++
-			}
-
-			batches[curBatch] = append(batches[curBatch], t.Definition.ID)
+			ids = append(ids, t.Definition.ID)
 		}
 	}
 
-	for _, b := range batches {
-		err = p.SubmitTokens(ctx, b)
-		if err != nil {
+	for _, b := range util.ChunkBy(ids, 50) {
+		if err = p.SubmitTokens(ctx, b); err != nil {
 			logger.For(ctx).Errorf("failed to submit batch: %s", err)
 			sentryutil.ReportError(ctx, err)
 		}

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
+	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
 	"github.com/sourcegraph/conc/pool"
@@ -24,6 +25,13 @@ func init() {
 }
 
 var ErrAPIKeyExpired = errors.New("opensea api key expired")
+
+type ErrOpenseaRateLimited struct{ Err error }
+
+func (e ErrOpenseaRateLimited) Unwrap() error { return e.Err }
+func (e ErrOpenseaRateLimited) Error() string {
+	return fmt.Sprintf("rate limited by opensea: %s", e.Err)
+}
 
 var (
 	baseURL, _                        = url.Parse("https://api.opensea.io/api/v2")
@@ -480,7 +488,7 @@ func fetchContractByAddress(ctx context.Context, client *http.Client, chain pers
 	endpoint := mustContractEndpoint(chain, contractAddress)
 	resp, err := retry.RetryRequest(client, mustAuthRequest(ctx, endpoint))
 	if err != nil {
-		return Contract{}, err
+		return Contract{}, wrapRateLimitErr(ctx, err)
 	}
 	defer resp.Body.Close()
 
@@ -500,7 +508,7 @@ func fetchCollectionBySlug(ctx context.Context, client *http.Client, chain persi
 	endpoint := mustCollectionEndpoint(slug)
 	resp, err := retry.RetryRequest(client, mustAuthRequest(ctx, endpoint))
 	if err != nil {
-		return Collection{}, err
+		return Collection{}, wrapRateLimitErr(ctx, err)
 	}
 	defer resp.Body.Close()
 
@@ -673,7 +681,7 @@ func paginateAssetsFilter(ctx context.Context, client *http.Client, req *http.Re
 	for {
 		resp, err := retry.RetryRequest(client, req)
 		if err != nil {
-			outCh <- assetsReceived{Err: err}
+			outCh <- assetsReceived{Err: wrapRateLimitErr(ctx, err)}
 			return
 		}
 
@@ -751,4 +759,14 @@ func mustChainIdentifierFrom(c persist.Chain) string {
 		panic(fmt.Sprintf("unknown chain identifier: %d", c))
 	}
 	return id
+}
+
+func wrapRateLimitErr(ctx context.Context, err error) error {
+	if !util.ErrorIs[retry.ErrOutOfRetries](err) {
+		return err
+	}
+	err = ErrOpenseaRateLimited{err}
+	logger.For(ctx).Error(err)
+	sentryutil.ReportError(ctx, err)
+	return err
 }

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -742,6 +742,7 @@ var chainToIdentifier = map[persist.Chain]string{
 	persist.ChainOptimism: "optimism",
 	persist.ChainArbitrum: "arbitrum",
 	persist.ChainBase:     "base",
+	persist.ChainZora:     "zora",
 }
 
 func mustChainIdentifierFrom(c persist.Chain) string {

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/eth"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
+	"github.com/mikeydub/go-gallery/service/multichain/reservoir"
 	"github.com/mikeydub/go-gallery/service/persist"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/util"
@@ -24,14 +26,20 @@ func init() {
 	env.RegisterValidation("OPENSEA_API_KEY", "required")
 }
 
-var ErrAPIKeyExpired = errors.New("opensea api key expired")
+const (
+	pageSize = 10
+	poolSize = 12
+)
 
-type ErrOpenseaRateLimited struct{ Err error }
-
-func (e ErrOpenseaRateLimited) Unwrap() error { return e.Err }
-func (e ErrOpenseaRateLimited) Error() string {
-	return fmt.Sprintf("rate limited by opensea: %s", e.Err)
+var newRecCh = func() chan multichain.ChainAgnosticTokensAndContracts {
+	return make(chan multichain.ChainAgnosticTokensAndContracts, poolSize)
 }
+
+var newPool = func(ctx context.Context, s int) *pool.ContextPool {
+	return pool.New().WithMaxGoroutines(s).WithContext(ctx)
+}
+
+var ErrAPIKeyExpired = errors.New("opensea api key expired")
 
 var (
 	baseURL, _                        = url.Parse("https://api.opensea.io/api/v2")
@@ -41,6 +49,23 @@ var (
 	getNftsByWalletEndpointTemplate   = fmt.Sprintf("%s/%s", baseURL.String(), "chain/%s/account/%s/nfts")
 	getNftsByContractEndpointTemplate = fmt.Sprintf("%s/%s", baseURL.String(), "chain/%s/contract/%s/nfts")
 )
+
+// Map of chains to OS chain identifiers
+var chainToIdentifier = map[persist.Chain]string{
+	persist.ChainETH:      "ethereum",
+	persist.ChainPolygon:  "matic",
+	persist.ChainOptimism: "optimism",
+	persist.ChainArbitrum: "arbitrum",
+	persist.ChainBase:     "base",
+	persist.ChainZora:     "zora",
+}
+
+type ErrOpenseaRateLimited struct{ Err error }
+
+func (e ErrOpenseaRateLimited) Unwrap() error { return e.Err }
+func (e ErrOpenseaRateLimited) Error() string {
+	return fmt.Sprintf("rate limited by opensea: %s", e.Err)
+}
 
 // Asset is an NFT from OpenSea
 type Asset struct {
@@ -97,14 +122,15 @@ func FetchAssetsForTokenIdentifiers(ctx context.Context, chain persist.Chain, co
 }
 
 type Provider struct {
-	Chain      persist.Chain
-	httpClient *http.Client
+	Chain             persist.Chain
+	httpClient        *http.Client
+	reservoirProvider *reservoir.Provider
 }
 
 // NewProvider creates a new provider for OpenSea
-func NewProvider(httpClient *http.Client, chain persist.Chain) *Provider {
-	mustChainIdentifierFrom(chain) // validate that the chain is supported
-	return &Provider{httpClient: httpClient, Chain: chain}
+func NewProvider(httpClient *http.Client, chain persist.Chain, reservoirProvider *reservoir.Provider) *Provider {
+	mustChainIdentifierFrom(chain)
+	return &Provider{httpClient: httpClient, Chain: chain, reservoirProvider: reservoirProvider}
 }
 
 func (p *Provider) ProviderInfo() multichain.ProviderInfo {
@@ -127,7 +153,7 @@ func (p *Provider) GetTokensByWalletAddress(ctx context.Context, ownerAddress pe
 
 // GetTokensIncrementallyByWalletAddress returns a list of tokens for an address
 func (p *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, ownerAddress persist.Address) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
-	recCh := make(chan multichain.ChainAgnosticTokensAndContracts)
+	recCh := newRecCh()
 	errCh := make(chan error)
 	outCh := make(chan assetsReceived)
 	go func() {
@@ -144,7 +170,7 @@ func (p *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, ow
 
 // GetTokensIncrementallyByWalletAddress returns a list of tokens for a contract address
 func (p *Provider) GetTokensIncrementallyByContractAddress(ctx context.Context, address persist.Address, maxLimit int) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
-	recCh := make(chan multichain.ChainAgnosticTokensAndContracts)
+	recCh := newRecCh()
 	errCh := make(chan error)
 	assetsCh := make(chan assetsReceived)
 	go func() {
@@ -254,138 +280,116 @@ func (p *Provider) GetContractByAddress(ctx context.Context, contractAddress per
 	return contractToChainAgnosticContract(cc.Contract, cc.Collection), nil
 }
 
-func (p *Provider) assetsToTokens(ctx context.Context, ownerAddress persist.Address, outCh <-chan assetsReceived) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
-	seenContracts := &sync.Map{} // Mapping of contract address to contractCollection
-	tokensCh := make(chan multichain.ChainAgnosticToken)
-	contractsCh := make(chan multichain.ChainAgnosticContract)
-	contractLocks := make(map[string]*sync.Mutex)
-	mu := sync.RWMutex{}
+func (p *Provider) assetsToTokens(ctx context.Context, ownerAddress persist.Address, outCh <-chan assetsReceived) (tokens []multichain.ChainAgnosticToken, contracts []multichain.ChainAgnosticContract, err error) {
+	recCh := newRecCh()
 	errCh := make(chan error)
-	wp := pool.New().WithMaxGoroutines(10).WithContext(ctx)
-
 	go func() {
-		defer close(tokensCh)
-		defer close(contractsCh)
-		for a := range outCh {
-			assetsReceived := a
-			if assetsReceived.Err != nil {
-				errCh <- assetsReceived.Err
-				return
-			}
-			for _, n := range assetsReceived.Assets {
-				nft := n
-				wp.Go(func(ctx context.Context) error {
-					return p.streamTokenAndContract(ctx, ownerAddress, nft, tokensCh, contractsCh, seenContracts, contractLocks, &mu)
-				})
-			}
-		}
-		err := wp.Wait()
-		if err != nil {
-			errCh <- err
-		}
+		defer close(recCh)
+		defer close(errCh)
+		p.streamAssetsToTokens(ctx, ownerAddress, outCh, recCh, errCh)
 	}()
 
-	var tokenOpen, contractOpen bool
-	var token multichain.ChainAgnosticToken
-	var contract multichain.ChainAgnosticContract
-
-	resultTokens := make([]multichain.ChainAgnosticToken, 0, len(outCh))
-	resultContracts := make([]multichain.ChainAgnosticContract, 0, len(outCh))
-
-	for {
-		select {
-		case token, tokenOpen = <-tokensCh:
-			if tokenOpen {
-				resultTokens = append(resultTokens, token)
-				continue
-			}
-			if !contractOpen {
-				return resultTokens, resultContracts, nil
-			}
-		case contract, contractOpen = <-contractsCh:
-			if contractOpen {
-				resultContracts = append(resultContracts, contract)
-				continue
-			}
-			if !tokenOpen {
-				return resultTokens, resultContracts, nil
-			}
-		case <-ctx.Done():
-			return nil, nil, ctx.Err()
-		case err := <-errCh:
-			return nil, nil, err
-		}
+	if err = <-errCh; err != nil {
+		return nil, nil, err
 	}
+
+	for page := range recCh {
+		tokens = append(tokens, page.Tokens...)
+		contracts = append(contracts, page.Contracts...)
+	}
+
+	return tokens, contracts, nil
 }
 
-func (p *Provider) streamAssetsToTokens(ctx context.Context, ownerAddress persist.Address, outCh <-chan assetsReceived, recCh chan<- multichain.ChainAgnosticTokensAndContracts, errCh chan<- error) {
-	seenContracts := &sync.Map{}
-	mu := sync.RWMutex{}
-	contractLocks := make(map[string]*sync.Mutex)
-	for a := range outCh {
-		assetsReceived := a
+func (p *Provider) streamAssetsToTokens(
+	ctx context.Context,
+	ownerAddress persist.Address,
+	outCh <-chan assetsReceived,
+	recCh chan<- multichain.ChainAgnosticTokensAndContracts,
+	errCh chan<- error,
+) {
+	contracts := &sync.Map{}                            // used to avoid duplicate contract fetches
+	contractsL := make(map[persist.Address]*sync.Mutex) // contract job locks
+	mu := sync.RWMutex{}                                // manages access to contract locks
+	wp := newPool(ctx, poolSize)                        // pool to process pages
 
-		if assetsReceived.Err != nil {
-			errCh <- assetsReceived.Err
+	for page := range outCh {
+		page := page
+
+		if page.Err != nil {
+			errCh <- page.Err
 			return
 		}
 
-		tokenCh := make(chan multichain.ChainAgnosticToken)
-		contractCh := make(chan multichain.ChainAgnosticContract)
-		innerErrCh := make(chan error)
-
-		go func() {
-			wp := pool.New().WithMaxGoroutines(10).WithContext(ctx)
-			defer close(tokenCh)
-			defer close(contractCh)
-			for _, n := range assetsReceived.Assets {
-				nft := n
-				wp.Go(func(ctx context.Context) error {
-					return p.streamTokenAndContract(ctx, ownerAddress, nft, tokenCh, contractCh, seenContracts, contractLocks, &mu)
-				})
-			}
-			err := wp.Wait()
-			if err != nil {
-				innerErrCh <- err
-			}
-		}()
-
-		var tokenOpen, contractOpen bool
-		var token multichain.ChainAgnosticToken
-		var contract multichain.ChainAgnosticContract
-
-		tokens := make([]multichain.ChainAgnosticToken, 0, len(assetsReceived.Assets))
-		contracts := make([]multichain.ChainAgnosticContract, 0, len(assetsReceived.Assets))
-
-	outer:
-		for {
-			select {
-			case token, tokenOpen = <-tokenCh:
-				if tokenOpen {
-					tokens = append(tokens, token)
-					continue
-				}
-				if !contractOpen {
-					break outer
-				}
-			case contract, contractOpen = <-contractCh:
-				if contractOpen {
-					contracts = append(contracts, contract)
-					continue
-				}
-				if !tokenOpen {
-					break outer
-				}
-			case <-ctx.Done():
-				errCh <- ctx.Err()
-				return
-			case err := <-innerErrCh:
-				errCh <- err
-				return
-			}
+		if len(page.Assets) == 0 {
+			continue
 		}
 
-		recCh <- multichain.ChainAgnosticTokensAndContracts{Tokens: tokens, Contracts: contracts}
+		wp.Go(func(ctx context.Context) error {
+			fallbacks := make([]persist.FallbackMedia, len(page.Assets))
+
+			// inner pool to fetch fallbacks and contracts
+			pagePool := newPool(ctx, 2)
+
+			// fetch fallbacks
+			pagePool.Go(func(ctx context.Context) error {
+				altFallbacks, err := p.fallbackMediaFromAssets(ctx, page.Assets)
+				if err != nil {
+					logger.For(ctx).Errorf("failed to get fallbacks for page: %s", err)
+					sentryutil.ReportError(ctx, err)
+				}
+				if err == nil {
+					fallbacks = altFallbacks
+				}
+				return err
+			})
+
+			// fetch contracts
+			pagePool.Go(func(ctx context.Context) error {
+				addresses := util.MapWithoutError(page.Assets, func(a Asset) persist.Address { return persist.Address(a.Contract) })
+
+				s := len(addresses)
+				if len(addresses) > 8 {
+					s = 8
+				}
+
+				contractPool := newPool(ctx, s)
+				for _, a := range addresses {
+					a := a
+					contractPool.Go(func(ctx context.Context) error { return p.getChainAgnosticContract(ctx, a, contracts, contractsL, &mu) })
+				}
+
+				return contractPool.Wait()
+			})
+
+			if err := pagePool.Wait(); err != nil {
+				return err
+			}
+
+			var out multichain.ChainAgnosticTokensAndContracts
+
+			for i, a := range page.Assets {
+				contract, ok := contracts.Load(persist.Address(a.Contract))
+				if !ok {
+					panic("contract should have been loaded")
+				}
+
+				tokens, err := p.assetToChainAgnosticTokens(ctx, ownerAddress, a, fallbacks[i])
+				if err != nil {
+					return err
+				}
+
+				out.Tokens = append(out.Tokens, tokens...)
+				out.Contracts = append(out.Contracts, contract.(multichain.ChainAgnosticContract))
+			}
+
+			recCh <- out
+			return nil
+		})
+	}
+
+	if err := wp.Wait(); err != nil {
+		errCh <- err
 	}
 }
 
@@ -394,79 +398,84 @@ type contractCollection struct {
 	Collection Collection
 }
 
-func (p *Provider) streamTokenAndContract(ctx context.Context, ownerAddress persist.Address, asset Asset, tokenCh chan<- multichain.ChainAgnosticToken, contractCh chan<- multichain.ChainAgnosticContract, seenContracts *sync.Map, contractLocks map[string]*sync.Mutex, mu *sync.RWMutex) error {
-	// Haven't seen this contract before, so we need to process it
-	if _, ok := seenContracts.Load(asset.Contract); !ok {
-		// If we don't have a lock yet, create one
-		mu.Lock()
-		if _, hasJobLock := contractLocks[asset.Contract]; !hasJobLock {
-			contractLocks[asset.Contract] = &sync.Mutex{}
+func (p *Provider) fallbackMediaFromAssets(ctx context.Context, assets []Asset) ([]persist.FallbackMedia, error) {
+	tIDs := util.MapWithoutError(assets, func(a Asset) persist.TokenIdentifiers {
+		return persist.TokenIdentifiers{TokenID: persist.MustTokenID(a.Identifier),
+			ContractAddress: persist.Address(a.Contract),
+			Chain:           p.Chain,
 		}
-		mu.Unlock()
+	})
+	return p.reservoirProvider.GetFallbackMediaBatch(ctx, tIDs)
+}
 
-		// Acquire a lock for the job
-		mu.RLock()
-		jobMu := contractLocks[asset.Contract]
-		mu.RUnlock()
-
-		// Process the contract
-		var err error
-
-		func() {
-			jobMu.Lock()
-			defer jobMu.Unlock()
-			// Check again if we've seen the contract, since another job may have processed it while we were waiting for the lock
-			var c contractCollection
-			if _, ok := seenContracts.Load(asset.Contract); !ok {
-				c, err = fetchContractCollectionByAddress(ctx, p.httpClient, p.Chain, persist.Address(asset.Contract))
-				if err == nil {
-					contractCh <- contractToChainAgnosticContract(c.Contract, c.Collection)
-					seenContracts.Store(asset.Contract, c)
-				}
-			}
-		}()
-
-		if err != nil {
-			return err
-		}
+func (p *Provider) getChainAgnosticContract(ctx context.Context, address persist.Address, seenContracts *sync.Map, contractLocks map[persist.Address]*sync.Mutex, mu *sync.RWMutex) error {
+	_, ok := seenContracts.Load(address)
+	// already have the contract
+	if ok {
+		return nil
 	}
 
-	cc, _ := seenContracts.Load(asset.Contract)
-	collection := cc.(contractCollection).Collection
+	// If we don't have a lock yet, create one
+	mu.Lock()
+	if _, hasJobLock := contractLocks[address]; !hasJobLock {
+		contractLocks[address] = &sync.Mutex{}
+	}
+	mu.Unlock()
 
-	typ, err := tokenTypeFromAsset(asset)
+	// Acquire a lock for the job
+	mu.RLock()
+	jobMu := contractLocks[address]
+	mu.RUnlock()
+
+	// Process the contract
+	jobMu.Lock()
+	defer jobMu.Unlock()
+
+	// Check again if we've seen the contract, since another job may have processed it while we were waiting for the lock
+	_, ok = seenContracts.Load(address)
+	if ok {
+		return nil
+	}
+
+	c, err := fetchContractCollectionByAddress(ctx, p.httpClient, p.Chain, address)
 	if err != nil {
 		return err
 	}
 
+	seenContracts.Store(address, contractToChainAgnosticContract(c.Contract, c.Collection))
+	return nil
+}
+
+func (p *Provider) assetToChainAgnosticTokens(ctx context.Context, ownerAddress persist.Address, asset Asset, placeholderMedia persist.FallbackMedia) ([]multichain.ChainAgnosticToken, error) {
+	typ, err := tokenTypeFromAsset(asset)
+	if err != nil {
+		return nil, err
+	}
+
 	if ownerAddress != "" {
-		tokenCh <- assetToAgnosticToken(asset, collection, typ, ownerAddress, 1)
-		return nil
+		token := assetToAgnosticToken(asset, typ, ownerAddress, 1, placeholderMedia)
+		return []multichain.ChainAgnosticToken{token}, nil
 	}
 
 	// No input owner address provided. OS doesn't return the owner of the token a few endpoints
 	// like when paginating a contract or a collection. The owner isn't really important for our purposes,
 	// but we'll to add it to the token if its already available.
-	switch typ {
-	case persist.TokenTypeERC721:
-		if numOwners := len(asset.Owners); numOwners == 1 {
-			tokenCh <- assetToAgnosticToken(asset, collection, typ, persist.Address(asset.Owners[0].Address), 1)
-		} else {
-			tokenCh <- assetToAgnosticToken(asset, collection, typ, "", 1)
-		}
-	case persist.TokenTypeERC1155:
-		if numOwners := len(asset.Owners); numOwners > 0 {
-			for _, o := range asset.Owners {
-				tokenCh <- assetToAgnosticToken(asset, collection, typ, persist.Address(o.Address), o.Quantity)
-			}
-		} else {
-			tokenCh <- assetToAgnosticToken(asset, collection, typ, "", 1)
-		}
-	default:
-		return fmt.Errorf("don't know how to handle owners for token type %s", typ)
+
+	if typ == persist.TokenTypeERC721 && len(asset.Owners) == 1 {
+		token := assetToAgnosticToken(asset, typ, persist.Address(asset.Owners[0].Address), 1, placeholderMedia)
+		return []multichain.ChainAgnosticToken{token}, nil
 	}
 
-	return nil
+	if typ == persist.TokenTypeERC1155 && len(asset.Owners) > 0 {
+		tokens := make([]multichain.ChainAgnosticToken, len(asset.Owners))
+		for i, o := range asset.Owners {
+			tokens[i] = assetToAgnosticToken(asset, typ, persist.Address(o.Address), o.Quantity, placeholderMedia)
+		}
+		return tokens, nil
+	}
+
+	token := assetToAgnosticToken(asset, typ, "", 1, placeholderMedia)
+	return []multichain.ChainAgnosticToken{token}, nil
 }
 
 func fetchContractCollectionByAddress(ctx context.Context, client *http.Client, chain persist.Chain, contractAddress persist.Address) (contractCollection, error) {
@@ -545,7 +554,7 @@ func mustNftEndpoint(chain persist.Chain, address persist.Address, tokenID persi
 }
 
 func mustNftsByWalletEndpoint(chain persist.Chain, address persist.Address) *url.URL {
-	s := fmt.Sprintf(getNftsByWalletEndpointTemplate, mustChainIdentifierFrom(persist.ChainETH), address)
+	s := fmt.Sprintf(getNftsByWalletEndpointTemplate, mustChainIdentifierFrom(chain), address)
 	return checkURL(s)
 }
 
@@ -585,14 +594,6 @@ func streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, client *http.C
 	})
 }
 
-type unknownTokenStandard struct {
-	TokenStandard string
-}
-
-func (e unknownTokenStandard) Error() string {
-	return fmt.Sprintf("unknown token standard: %s", e.TokenStandard)
-}
-
 func tokenTypeFromAsset(asset Asset) (persist.TokenType, error) {
 	switch asset.TokenStandard {
 	case "erc721", "cryptopunks":
@@ -600,7 +601,7 @@ func tokenTypeFromAsset(asset Asset) (persist.TokenType, error) {
 	case "erc1155":
 		return persist.TokenTypeERC1155, nil
 	default:
-		return "", unknownTokenStandard{asset.TokenStandard}
+		return "", fmt.Errorf("unknown token standard: %s", asset.TokenStandard)
 	}
 }
 
@@ -619,7 +620,7 @@ func contractToChainAgnosticContract(contract Contract, collection Collection) m
 	}
 }
 
-func assetToAgnosticToken(asset Asset, collection Collection, tokenType persist.TokenType, tokenOwner persist.Address, quantity int) multichain.ChainAgnosticToken {
+func assetToAgnosticToken(asset Asset, tokenType persist.TokenType, tokenOwner persist.Address, quantity int, placeholderMedia persist.FallbackMedia) multichain.ChainAgnosticToken {
 	return multichain.ChainAgnosticToken{
 		TokenType:       tokenType,
 		Descriptors:     multichain.ChainAgnosticTokenDescriptors{Name: asset.Name, Description: asset.Description},
@@ -627,9 +628,9 @@ func assetToAgnosticToken(asset Asset, collection Collection, tokenType persist.
 		TokenID:         persist.MustTokenID(asset.Identifier),
 		OwnerAddress:    tokenOwner,
 		ContractAddress: persist.Address(asset.Contract),
-		ExternalURL:     collection.ProjectURL, // OpenSea doesn't return a token-specific external URL, so we use the collection's project URL
 		TokenMetadata:   metadataFromAsset(asset),
 		Quantity:        persist.HexString(fmt.Sprintf("%x", quantity)),
+		FallbackMedia:   placeholderMedia,
 	}
 }
 
@@ -733,21 +734,12 @@ func setNext(url *url.URL, next string) {
 
 func setPagingParams(url *url.URL) {
 	query := url.Query()
-	query.Set("limit", "200")
+	query.Set("limit", strconv.Itoa(pageSize))
 	url.RawQuery = query.Encode()
 }
 
 func contractNameIsSpam(name string) bool {
 	return strings.HasSuffix(strings.ToLower(name), ".lens-follower")
-}
-
-var chainToIdentifier = map[persist.Chain]string{
-	persist.ChainETH:      "ethereum",
-	persist.ChainPolygon:  "matic",
-	persist.ChainOptimism: "optimism",
-	persist.ChainArbitrum: "arbitrum",
-	persist.ChainBase:     "base",
-	persist.ChainZora:     "zora",
 }
 
 func mustChainIdentifierFrom(c persist.Chain) string {

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -256,7 +256,7 @@ func RetryGetBlockNumber(ctx context.Context, ethClient *ethclient.Client) (uint
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(i)
+		retry.DefaultRetry.Sleep(ctx, i)
 	}
 	return height, err
 }
@@ -275,7 +275,7 @@ func RetryGetLogs(ctx context.Context, ethClient *ethclient.Client, query ethere
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(i)
+		retry.DefaultRetry.Sleep(ctx, i)
 	}
 	return logs, err
 }
@@ -295,7 +295,7 @@ func RetryGetTransaction(ctx context.Context, ethClient *ethclient.Client, txHas
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.Sleep(i)
+		retry.Sleep(ctx, i)
 	}
 	return tx, pending, err
 }
@@ -333,7 +333,7 @@ func RetryGetTokenContractMetadata(ctx context.Context, contractAddress persist.
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(i)
+		retry.DefaultRetry.Sleep(ctx, i)
 	}
 	return metadata, err
 }
@@ -685,7 +685,7 @@ func RetryGetTokenURI(ctx context.Context, tokenType persist.TokenType, contract
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(i)
+		retry.DefaultRetry.Sleep(ctx, i)
 	}
 	return u, err
 }

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -820,3 +820,11 @@ func ErrorAs[T error](e error) (T, bool) {
 	ok := errors.As(e, &t)
 	return t, ok
 }
+
+// ChunkBy splits a slice into chunks of a given size
+func ChunkBy[T any](items []T, chunkSize int) (chunks [][]T) {
+	for chunkSize < len(items) {
+		items, chunks = items[chunkSize:], append(chunks, items[0:chunkSize:chunkSize])
+	}
+	return append(chunks, items)
+}


### PR DESCRIPTION
**Changes**
* Configures chains to use the Opensea provider where possible
* Improves the Opensea provider to better take advantage of incremental syncing:
  * Send channels are buffered so slow pages and slow writes to the DB don't block other pages
  * Each page is now sent to the received channel instead of a single message of all pages
  * Adds `ErrOpenseaRateLimited`, which is an error that gets logged and reported to Sentry when a request fails after too many retries
  * Adds `GetFallbackMediaBatch` to the Reservoir provider - the Opensea provider calls this method to get fallback media for a list of tokens
* Adds logging to `retry.go` that logs what host is doing the rate limiting, and how long the sleep duration is