### PR TITLE
Fix feed index error

### DIFF
--- a/db/gen/coredb/recommend.sql.go
+++ b/db/gen/coredb/recommend.sql.go
@@ -107,7 +107,6 @@ join t4 using(id)
 join posts p on feed_entity_scores.id = p.id and not p.deleted
 left join feed_blocklist fb on p.actor_id = fb.user_id and not fb.deleted and fb.active
 where (fb.user_id is null or $1 = fb.user_id)
-order by (t4.group_number, random() > 0.5) desc
 `
 
 type GetFeedEntityScoresParams struct {

--- a/db/queries/core/recommend.sql
+++ b/db/queries/core/recommend.sql
@@ -90,5 +90,4 @@ from t2 feed_entity_scores
 join t4 using(id)
 join posts p on feed_entity_scores.id = p.id and not p.deleted
 left join feed_blocklist fb on p.actor_id = fb.user_id and not fb.deleted and fb.active
-where (fb.user_id is null or @viewer_id = fb.user_id)
-order by (t4.group_number, random() > 0.5) desc;
+where (fb.user_id is null or @viewer_id = fb.user_id);

--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -831,11 +831,12 @@ func (api FeedAPI) ForYouFeed(ctx context.Context, before, after *string, first,
 				blendedRank[idx] = (blendedRank[idx] + score) * 0.5
 			} else {
 				combined = append(combined, e)
+				engagementRank = append(engagementRank, 0)
+				// New posts tend to have no engagement, so don't over penalize it by halving it
 				blendedRank = append(blendedRank, score)
 			}
 		}
 
-		// Score based on the average of the two rankings
 		interleaved := api.scoreFeedEntities(ctx, feedOpts.FetchSize, combined, func(i int) float64 {
 			if combined[i].Post.ActorID == viewerID {
 				return engagementRank[i]


### PR DESCRIPTION
Fixes index error because a post could be present in `topNByEngagement` but not `topNByPersonalization`.