### PR TITLE
Don't convert UserNotFound errors to EmailUnverified

### DIFF
--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -250,9 +250,6 @@ func (e MagicLinkAuthenticator) Authenticate(pCtx context.Context) (*AuthResult,
 
 	user, err := e.UserRepo.GetByVerifiedEmail(pCtx, authedEmail)
 	if err != nil {
-		if util.ErrorIs[persist.ErrUserNotFound](err) {
-			return &authResult, ErrEmailUnverified
-		}
 		return &authResult, err
 	}
 


### PR DESCRIPTION
Callers of the MagicLinkAuthenticator expect ErrUserNotFound errors as a signal that a user can be created. When I refactored this, I changed ErrUserNotFound to ErrEmailUnverified, but that broke the existing flow.
