### PR TITLE
get sendgrid unsubscriptions to sync

### DIFF
--- a/emails/handler.go
+++ b/emails/handler.go
@@ -39,7 +39,8 @@ func handlersInitServer(router *gin.Engine, loaders *dataloader.Loaders, q *core
 	verificationLimiter := limiters.NewKeyRateLimiter(limiterCtx, limiterCache, "verification", 1, time.Second*5)
 	sendGroup.POST("/verification", middleware.IPRateLimited(verificationLimiter), sendVerificationEmail(loaders, q, s))
 
-	router.POST("/subscriptions", updateSubscriptions(q))
+	router.POST("/unsubscriptions", updateUnsubscriptions(q))
+	router.GET("/unsubscriptions", getUnsubscriptions(q))
 	router.POST("/unsubscribe", unsubscribe(q))
 	router.POST("/resubscribe", resubscribe(q))
 

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1020,9 +1020,9 @@ type DisconnectSocialAccountPayload struct {
 func (DisconnectSocialAccountPayload) IsDisconnectSocialAccountPayloadOrError() {}
 
 type EmailNotificationSettings struct {
-	UnsubscribedFromAll           bool  `json:"unsubscribedFromAll"`
-	UnsubscribedFromNotifications bool  `json:"unsubscribedFromNotifications"`
-	UnsubscribedFromDigest        *bool `json:"unsubscribedFromDigest"`
+	UnsubscribedFromAll           bool `json:"unsubscribedFromAll"`
+	UnsubscribedFromNotifications bool `json:"unsubscribedFromNotifications"`
+	UnsubscribedFromDigest        bool `json:"unsubscribedFromDigest"`
 }
 
 type EnsProfileImage struct {
@@ -2753,9 +2753,9 @@ type UpdateEmailInput struct {
 }
 
 type UpdateEmailNotificationSettingsInput struct {
-	UnsubscribedFromAll           bool  `json:"unsubscribedFromAll"`
-	UnsubscribedFromNotifications bool  `json:"unsubscribedFromNotifications"`
-	UnsubscribedFromDigest        *bool `json:"unsubscribedFromDigest"`
+	UnsubscribedFromAll           bool `json:"unsubscribedFromAll"`
+	UnsubscribedFromNotifications bool `json:"unsubscribedFromNotifications"`
+	UnsubscribedFromDigest        bool `json:"unsubscribedFromDigest"`
 }
 
 type UpdateEmailNotificationSettingsPayload struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -3407,7 +3407,8 @@ func (r *userCreatedFeedEventDataResolver) Owner(ctx context.Context, obj *model
 func (r *userEmailResolver) EmailNotificationSettings(ctx context.Context, obj *model.UserEmail) (*model.EmailNotificationSettings, error) {
 	unsubs, err := publicapi.For(ctx).User.GetCurrentUserEmailNotificationSettings(ctx)
 	if err != nil {
-		return nil, err
+		logger.For(ctx).Errorf("error getting email notification settings from email service: %s", err)
+		return obj.EmailNotificationSettings, nil
 	}
 
 	return &model.EmailNotificationSettings{

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -3403,6 +3403,20 @@ func (r *userCreatedFeedEventDataResolver) Owner(ctx context.Context, obj *model
 	return resolveGalleryUserByUserID(ctx, obj.Owner.Dbid)
 }
 
+// EmailNotificationSettings is the resolver for the emailNotificationSettings field.
+func (r *userEmailResolver) EmailNotificationSettings(ctx context.Context, obj *model.UserEmail) (*model.EmailNotificationSettings, error) {
+	unsubs, err := publicapi.For(ctx).User.GetCurrentUserEmailNotificationSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.EmailNotificationSettings{
+		UnsubscribedFromAll:           unsubs.All.Bool(),
+		UnsubscribedFromNotifications: unsubs.Notifications.Bool(),
+		UnsubscribedFromDigest:        unsubs.Digest.Bool(),
+	}, nil
+}
+
 // Owner is the resolver for the owner field.
 func (r *userFollowedUsersFeedEventDataResolver) Owner(ctx context.Context, obj *model.UserFollowedUsersFeedEventData) (*model.GalleryUser, error) {
 	return resolveGalleryUserByUserID(ctx, obj.Owner.Dbid)
@@ -3788,6 +3802,9 @@ func (r *Resolver) UserCreatedFeedEventData() generated.UserCreatedFeedEventData
 	return &userCreatedFeedEventDataResolver{r}
 }
 
+// UserEmail returns generated.UserEmailResolver implementation.
+func (r *Resolver) UserEmail() generated.UserEmailResolver { return &userEmailResolver{r} }
+
 // UserFollowedUsersFeedEventData returns generated.UserFollowedUsersFeedEventDataResolver implementation.
 func (r *Resolver) UserFollowedUsersFeedEventData() generated.UserFollowedUsersFeedEventDataResolver {
 	return &userFollowedUsersFeedEventDataResolver{r}
@@ -3870,6 +3887,7 @@ type tokensAddedToCollectionFeedEventDataResolver struct{ *Resolver }
 type unfollowUserPayloadResolver struct{ *Resolver }
 type updateCollectionTokensPayloadResolver struct{ *Resolver }
 type userCreatedFeedEventDataResolver struct{ *Resolver }
+type userEmailResolver struct{ *Resolver }
 type userFollowedUsersFeedEventDataResolver struct{ *Resolver }
 type viewerResolver struct{ *Resolver }
 type walletResolver struct{ *Resolver }

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -594,7 +594,7 @@ func userWithPIIToEmailModel(user *db.PiiUserView) *model.UserEmail {
 		EmailNotificationSettings: &model.EmailNotificationSettings{
 			UnsubscribedFromAll:           user.EmailUnsubscriptions.All.Bool(),
 			UnsubscribedFromNotifications: user.EmailUnsubscriptions.Notifications.Bool(),
-			UnsubscribedFromDigest:        user.EmailUnsubscriptions.Digest.BoolPointer(),
+			UnsubscribedFromDigest:        user.EmailUnsubscriptions.Digest.Bool(),
 		},
 	}
 
@@ -1415,7 +1415,7 @@ func updateUserEmailNotificationSettings(ctx context.Context, input model.Update
 	err := publicapi.For(ctx).User.UpdateUserEmailNotificationSettings(ctx, persist.EmailUnsubscriptions{
 		All:           persist.NullBool(input.UnsubscribedFromAll),
 		Notifications: persist.NullBool(input.UnsubscribedFromNotifications),
-		Digest:        persist.NullBool(util.FromPointer(input.UnsubscribedFromDigest)),
+		Digest:        persist.NullBool(input.UnsubscribedFromDigest),
 	})
 	if err != nil {
 		return nil, err

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -864,19 +864,19 @@ enum EmailUnsubscriptionType {
 type UserEmail {
   email: Email
   verificationStatus: EmailVerificationStatus
-  emailNotificationSettings: EmailNotificationSettings
+  emailNotificationSettings: EmailNotificationSettings @goField(forceResolver: true)
 }
 
 type EmailNotificationSettings {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
-  unsubscribedFromDigest: Boolean # TODO make this non-nullable
+  unsubscribedFromDigest: Boolean!
 }
 
 input UpdateEmailNotificationSettingsInput {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
-  unsubscribedFromDigest: Boolean # TODO make this non-nullable
+  unsubscribedFromDigest: Boolean!
 }
 
 input UnsubscribeFromEmailTypeInput {

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -729,6 +729,19 @@ func (api UserAPI) UpdateUserEmailNotificationSettings(ctx context.Context, sett
 
 }
 
+func (api UserAPI) GetCurrentUserEmailNotificationSettings(ctx context.Context) (persist.EmailUnsubscriptions, error) {
+
+	userID, err := getAuthenticatedUserID(ctx)
+	if err != nil {
+		return persist.EmailUnsubscriptions{}, err
+	}
+
+	// update unsubscriptions
+
+	return emails.GetCurrentUnsubscriptionsByUserID(ctx, userID)
+
+}
+
 func (api UserAPI) ResendEmailVerification(ctx context.Context) error {
 
 	userID, err := getAuthenticatedUserID(ctx)


### PR DESCRIPTION
Changes:

- **Added** a new get handler for the email service that will query sendgrid for what a user it is currently unsubscribed to. It will also sync what we have stored in the database for that user, using SendGrid as the source of truth. This is better than using us as the source of truth because unsubscribe links in emails do not connect to gallery. If a user clicks that link it will unsubscribe them on sendgrid but not in our database. By syncing with sendgrid first we ensure accuracy.

Note:

- It was in my TODO that there needs to be a gql mutation for updating subscription statuses. That already exists and has for a while: 
```
updateEmailNotificationSettings(
    input: UpdateEmailNotificationSettingsInput!
  ): UpdateEmailNotificationSettingsPayloadOrError @authRequired
  ```