### PR TITLE
Don't try to disconnect a random connection if nothing is connected

### DIFF
--- a/opensea-streamer/main.go
+++ b/opensea-streamer/main.go
@@ -307,6 +307,10 @@ func (m *connectionManager) disconnectRandomConnection() {
 		connectionIDs = append(connectionIDs, id)
 	}
 
+	if len(connectionIDs) == 0 {
+		return
+	}
+	
 	randomID := connectionIDs[rand.Intn(len(connectionIDs))]
 	logger.For(m.ctx).Infof("disconnecting random connection (id=%d)", randomID)
 	m.requestStateChange(randomID, Connecting)


### PR DESCRIPTION
This fixes an infrequent panic where we'd try to pick a random number with an invalid argument (0)
