### PR TITLE
Multichain - Handle OS missing contracts

### DIFF
--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -232,6 +232,7 @@ func (d *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, ad
 
 	go func() {
 		defer close(rec)
+		defer close(errChan)
 	outer:
 		for {
 			select {
@@ -280,6 +281,7 @@ func (d *Provider) GetTokensIncrementallyByContractAddress(ctx context.Context, 
 
 	go func() {
 		defer close(rec)
+		defer close(errChan)
 		for {
 			select {
 			case err := <-subErrChan:

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -300,7 +300,7 @@ func (d *Provider) GetTokensIncrementallyByContractAddress(ctx context.Context, 
 					return
 				}
 				if len(cContracts) == 0 {
-					errChan <- fmt.Errorf("no contract found for contract address %s", addr)
+					errChan <- multichain.ErrProviderContractNotFound{Contract: addr, Chain: d.chain}
 					return
 				}
 				rec <- multichain.ChainAgnosticTokensAndContracts{
@@ -503,8 +503,9 @@ func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddre
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
+
 	if len(cContracts) == 0 {
-		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("no contract found for contract address %s", contractAddress)
+		return nil, multichain.ChainAgnosticContract{}, multichain.ErrProviderContractNotFound{Contract: contractAddress, Chain: d.chain}
 	}
 
 	return cTokens, cContracts[0], nil

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -106,12 +106,21 @@ func (t ChainAgnosticIdentifiers) String() string {
 	return fmt.Sprintf("token(address=%s; id=%s)", t.ContractAddress, t.TokenID)
 }
 
-type ErrProviderFailed struct {
-	Err error
-}
+type ErrProviderFailed struct{ Err error }
 
 func (e ErrProviderFailed) Unwrap() error { return e.Err }
 func (e ErrProviderFailed) Error() string { return fmt.Sprintf("calling provider failed: %s", e.Err) }
+
+type ErrProviderContractNotFound struct {
+	Contract persist.Address
+	Chain    persist.Chain
+	Err      error
+}
+
+func (e ErrProviderContractNotFound) Unwrap() error { return e.Err }
+func (e ErrProviderContractNotFound) Error() string {
+	return fmt.Sprintf("provider did not find contract: %s", e.Contract.String())
+}
 
 type communityInfo interface {
 	GetKey() persist.CommunityKey


### PR DESCRIPTION
Fixes bug where creator syncs would fail because OS doesn't have a contract but Alchemy does. Rather than exiting on the first error from OS, multichain now checks if the contract is available from one other provider.