### PR TITLE
Stop providers from getting blocked on an abandoned channel

### DIFF
--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -516,7 +516,7 @@ func (p *Provider) SyncCreatedTokensForExistingContract(ctx context.Context, use
 				}
 			case err, ok := <-pageErrCh:
 				if !ok {
-					return
+					continue
 				}
 				errCh <- ErrProviderFailed{Err: err}
 				return


### PR DESCRIPTION
We were running into an issue where a goroutine could return while a provider's result channel was still open. Without a goroutine reading from that channel, any writes to the channel would block the sender, which meant we'd only return one page of token results.

This PR updates the `fanIn` function to ensure it only returns when all results channels are closed.