### PR TITLE
Jarrel/pipeline metadata retries

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -198,7 +198,7 @@ func ethSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *open
 		ethTokenIdentifierOwnerFetcherInjector,
 		ethTokensIncrementalOwnerFetcherInjector,
 		ethTokensContractFetcherInjector,
-		wrapper.NewPlaceholderWrapper,
+		wrapper.NewFillInWrapper,
 	))
 }
 
@@ -303,7 +303,7 @@ func optimismSyncPipelineInjector(context.Context, *http.Client, persist.Chain, 
 		optimismTokenIdentifierOwnerFetcherInjector,
 		optimismTokensIncrementalOwnerFetcherInjector,
 		optimismTokensContractFetcherInjector,
-		wrapper.NewPlaceholderWrapper,
+		wrapper.NewFillInWrapper,
 	))
 }
 
@@ -378,7 +378,7 @@ func arbitrumSyncPipelineInjector(context.Context, *http.Client, persist.Chain, 
 		arbitrumTokenIdentifierOwnerFetcherInjector,
 		arbitrumTokensIncrementalOwnerFetcherInjector,
 		arbitrumTokensContractFetcherInjector,
-		wrapper.NewPlaceholderWrapper,
+		wrapper.NewFillInWrapper,
 	))
 }
 
@@ -498,7 +498,7 @@ func zoraSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *ope
 		zoraTokenIdentifierOwnerFetcherInjector,
 		zoraTokensIncrementalOwnerFetcherInjector,
 		zoraTokensContractFetcherInjector,
-		wrapper.NewPlaceholderWrapper,
+		wrapper.NewFillInWrapper,
 	))
 }
 
@@ -557,7 +557,7 @@ func baseSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *ope
 		baseTokenIdentifierOwnerFetcherInjector,
 		baseTokensIncrementalOwnerFetcherInjector,
 		baseTokensContractFetcherInjector,
-		wrapper.NewPlaceholderWrapper,
+		wrapper.NewFillInWrapper,
 	))
 }
 
@@ -619,7 +619,7 @@ func polygonSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *
 		polygonTokenIdentifierOwnerFetcherInjector,
 		polygonTokensIncrementalOwnerFetcherInjector,
 		polygonTokensContractFetcherInjector,
-		wrapper.NewPlaceholderWrapper,
+		wrapper.NewFillInWrapper,
 	))
 }
 

--- a/server/inject.go
+++ b/server/inject.go
@@ -296,6 +296,7 @@ func optimismProviderInjector(
 		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -372,6 +373,7 @@ func arbitrumProviderInjector(
 		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -469,6 +471,7 @@ func zoraProviderInjector(
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.ContractsOwnerFetcher), util.ToPointer(zoraProvider)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -553,6 +556,7 @@ func baseProvidersInjector(
 		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -680,6 +684,7 @@ func polygonProvidersInjector(
 		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
 	))
 }
 

--- a/server/inject.go
+++ b/server/inject.go
@@ -189,12 +189,14 @@ func ethProviderInjector(
 		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
 	))
 }
 
-func ethSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *opensea.Provider, *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
 		ethTokenIdentifierOwnerFetcherInjector,
 		ethTokensIncrementalOwnerFetcherInjector,
 		ethTokensContractFetcherInjector,
@@ -297,9 +299,10 @@ func optimismProviderInjector(
 	))
 }
 
-func optimismSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *opensea.Provider, *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
 		optimismTokenIdentifierOwnerFetcherInjector,
 		optimismTokensIncrementalOwnerFetcherInjector,
 		optimismTokensContractFetcherInjector,
@@ -372,9 +375,10 @@ func arbitrumProviderInjector(
 	))
 }
 
-func arbitrumSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *opensea.Provider, *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
 		arbitrumTokenIdentifierOwnerFetcherInjector,
 		arbitrumTokensIncrementalOwnerFetcherInjector,
 		arbitrumTokensContractFetcherInjector,
@@ -492,9 +496,10 @@ func zoraContractFetcherInjector(openseaProvider *opensea.Provider, zoraProvider
 	))
 }
 
-func zoraSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *opensea.Provider, *zora.Provider) *wrapper.SyncPipelineWrapper {
+func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, zoraProvider *zora.Provider) *wrapper.SyncPipelineWrapper {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(zoraProvider)),
 		zoraTokenIdentifierOwnerFetcherInjector,
 		zoraTokensIncrementalOwnerFetcherInjector,
 		zoraTokensContractFetcherInjector,
@@ -551,9 +556,10 @@ func baseProvidersInjector(
 	))
 }
 
-func baseSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *opensea.Provider, *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
 		baseTokenIdentifierOwnerFetcherInjector,
 		baseTokensIncrementalOwnerFetcherInjector,
 		baseTokensContractFetcherInjector,
@@ -613,9 +619,10 @@ func polygonInjector(context.Context, *http.Client) *multichain.PolygonProvider 
 	))
 }
 
-func polygonSyncPipelineInjector(context.Context, *http.Client, persist.Chain, *opensea.Provider, *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
 		polygonTokenIdentifierOwnerFetcherInjector,
 		polygonTokensIncrementalOwnerFetcherInjector,
 		polygonTokensContractFetcherInjector,

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
-	"github.com/mikeydub/go-gallery/publicapi"
+	// "github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/farcaster"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -60,9 +60,10 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
-	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	router := CoreInit(ctx, c, provider, recommender, p)
+	// recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
+	// p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	// router := CoreInit(ctx, c, provider, recommender, p)
+	router := CoreInit(ctx, c, provider, nil, nil)
 	http.Handle("/", router)
 }
 
@@ -134,8 +135,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	tokenManageCache := redis.NewCache(redis.TokenManageCache)
 	oneTimeLoginCache := redis.NewCache(redis.OneTimeLoginCache)
 
-	recommender.Loop(ctx, time.NewTicker(time.Hour))
-	p.Loop(ctx, time.NewTicker(time.Minute*15))
+	// recommender.Loop(ctx, time.NewTicker(time.Hour))
+	// p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, oneTimeLoginCache, c.MagicLinkClient, recommender, p, farcaster.NewNeynarAPI(c.HTTPClient, socialCache))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
-	// "github.com/mikeydub/go-gallery/publicapi"
+	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/farcaster"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -60,10 +60,9 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	// recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
-	// p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	// router := CoreInit(ctx, c, provider, recommender, p)
-	router := CoreInit(ctx, c, provider, nil, nil)
+	recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
+	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	router := CoreInit(ctx, c, provider, recommender, p)
 	http.Handle("/", router)
 }
 
@@ -135,8 +134,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	tokenManageCache := redis.NewCache(redis.TokenManageCache)
 	oneTimeLoginCache := redis.NewCache(redis.OneTimeLoginCache)
 
-	// recommender.Loop(ctx, time.NewTicker(time.Hour))
-	// p.Loop(ctx, time.NewTicker(time.Minute*15))
+	recommender.Loop(ctx, time.NewTicker(time.Hour))
+	p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, oneTimeLoginCache, c.MagicLinkClient, recommender, p, farcaster.NewNeynarAPI(c.HTTPClient, socialCache))
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -129,12 +129,12 @@ func ethSyncPipelineInjector(contextContext context.Context, client *http.Client
 	tokenIdentifierOwnerFetcher := ethTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalOwnerFetcher := ethTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalContractFetcher := ethTokensContractFetcherInjector(provider, alchemyProvider)
-	placeholderWrapper := wrapper.NewPlaceholderWrapper(contextContext, client, chain)
+	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
-		PlaceholderFetcher:               placeholderWrapper,
+		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
 }
@@ -219,12 +219,12 @@ func optimismSyncPipelineInjector(contextContext context.Context, client *http.C
 	tokenIdentifierOwnerFetcher := optimismTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalOwnerFetcher := optimismTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalContractFetcher := optimismTokensContractFetcherInjector(provider, alchemyProvider)
-	placeholderWrapper := wrapper.NewPlaceholderWrapper(contextContext, client, chain)
+	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
-		PlaceholderFetcher:               placeholderWrapper,
+		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
 }
@@ -284,12 +284,12 @@ func arbitrumSyncPipelineInjector(contextContext context.Context, client *http.C
 	tokenIdentifierOwnerFetcher := arbitrumTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalOwnerFetcher := arbitrumTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalContractFetcher := arbitrumTokensContractFetcherInjector(provider, alchemyProvider)
-	placeholderWrapper := wrapper.NewPlaceholderWrapper(contextContext, client, chain)
+	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
-		PlaceholderFetcher:               placeholderWrapper,
+		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
 }
@@ -383,12 +383,12 @@ func zoraSyncPipelineInjector(contextContext context.Context, client *http.Clien
 	tokenIdentifierOwnerFetcher := zoraTokenIdentifierOwnerFetcherInjector(provider, zoraProvider)
 	tokensIncrementalOwnerFetcher := zoraTokensIncrementalOwnerFetcherInjector(provider, zoraProvider)
 	tokensIncrementalContractFetcher := zoraTokensContractFetcherInjector(provider, zoraProvider)
-	placeholderWrapper := wrapper.NewPlaceholderWrapper(contextContext, client, chain)
+	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
-		PlaceholderFetcher:               placeholderWrapper,
+		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
 }
@@ -438,12 +438,12 @@ func baseSyncPipelineInjector(contextContext context.Context, client *http.Clien
 	tokenIdentifierOwnerFetcher := baseTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalOwnerFetcher := baseTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalContractFetcher := baseTokensContractFetcherInjector(provider, alchemyProvider)
-	placeholderWrapper := wrapper.NewPlaceholderWrapper(contextContext, client, chain)
+	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
-		PlaceholderFetcher:               placeholderWrapper,
+		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
 }
@@ -492,12 +492,12 @@ func polygonSyncPipelineInjector(contextContext context.Context, client *http.Cl
 	tokenIdentifierOwnerFetcher := polygonTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalOwnerFetcher := polygonTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
 	tokensIncrementalContractFetcher := polygonTokensContractFetcherInjector(provider, alchemyProvider)
-	placeholderWrapper := wrapper.NewPlaceholderWrapper(contextContext, client, chain)
+	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
-		PlaceholderFetcher:               placeholderWrapper,
+		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -120,20 +120,22 @@ func ethProviderInjector(ctx context.Context, indexerProvider *indexer.Provider,
 		TokensIncrementalContractFetcher: syncPipeline,
 		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
+		TokenMetadataBatcher:             syncPipeline,
 		Verifier:                         indexerProvider,
 	}
 	return ethereumProvider
 }
 
-func ethSyncPipelineInjector(contextContext context.Context, client *http.Client, chain persist.Chain, provider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
-	tokenIdentifierOwnerFetcher := ethTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalOwnerFetcher := ethTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalContractFetcher := ethTokensContractFetcherInjector(provider, alchemyProvider)
-	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
+func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+	tokenIdentifierOwnerFetcher := ethTokenIdentifierOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := ethTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := ethTokensContractFetcherInjector(openseaProvider, alchemyProvider)
+	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
+		TokenMetadataBatcher:             alchemyProvider,
 		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
@@ -215,15 +217,16 @@ func optimismProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDe
 	return optimismProvider
 }
 
-func optimismSyncPipelineInjector(contextContext context.Context, client *http.Client, chain persist.Chain, provider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
-	tokenIdentifierOwnerFetcher := optimismTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalOwnerFetcher := optimismTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalContractFetcher := optimismTokensContractFetcherInjector(provider, alchemyProvider)
-	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
+func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+	tokenIdentifierOwnerFetcher := optimismTokenIdentifierOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := optimismTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := optimismTokensContractFetcherInjector(openseaProvider, alchemyProvider)
+	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
+		TokenMetadataBatcher:             alchemyProvider,
 		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
@@ -280,15 +283,16 @@ func arbitrumProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDe
 	return arbitrumProvider
 }
 
-func arbitrumSyncPipelineInjector(contextContext context.Context, client *http.Client, chain persist.Chain, provider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
-	tokenIdentifierOwnerFetcher := arbitrumTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalOwnerFetcher := arbitrumTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalContractFetcher := arbitrumTokensContractFetcherInjector(provider, alchemyProvider)
-	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
+func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+	tokenIdentifierOwnerFetcher := arbitrumTokenIdentifierOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := arbitrumTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := arbitrumTokensContractFetcherInjector(openseaProvider, alchemyProvider)
+	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
+		TokenMetadataBatcher:             alchemyProvider,
 		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
@@ -379,15 +383,16 @@ func zoraContractFetcherInjector(openseaProvider *opensea.Provider, zoraProvider
 	return contractFetcher
 }
 
-func zoraSyncPipelineInjector(contextContext context.Context, client *http.Client, chain persist.Chain, provider *opensea.Provider, zoraProvider *zora.Provider) *wrapper.SyncPipelineWrapper {
-	tokenIdentifierOwnerFetcher := zoraTokenIdentifierOwnerFetcherInjector(provider, zoraProvider)
-	tokensIncrementalOwnerFetcher := zoraTokensIncrementalOwnerFetcherInjector(provider, zoraProvider)
-	tokensIncrementalContractFetcher := zoraTokensContractFetcherInjector(provider, zoraProvider)
-	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
+func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, zoraProvider *zora.Provider) *wrapper.SyncPipelineWrapper {
+	tokenIdentifierOwnerFetcher := zoraTokenIdentifierOwnerFetcherInjector(openseaProvider, zoraProvider)
+	tokensIncrementalOwnerFetcher := zoraTokensIncrementalOwnerFetcherInjector(openseaProvider, zoraProvider)
+	tokensIncrementalContractFetcher := zoraTokensContractFetcherInjector(openseaProvider, zoraProvider)
+	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
+		TokenMetadataBatcher:             zoraProvider,
 		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
@@ -434,15 +439,16 @@ func baseProvidersInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDescr
 	return baseProvider
 }
 
-func baseSyncPipelineInjector(contextContext context.Context, client *http.Client, chain persist.Chain, provider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
-	tokenIdentifierOwnerFetcher := baseTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalOwnerFetcher := baseTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalContractFetcher := baseTokensContractFetcherInjector(provider, alchemyProvider)
-	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
+func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+	tokenIdentifierOwnerFetcher := baseTokenIdentifierOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := baseTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := baseTokensContractFetcherInjector(openseaProvider, alchemyProvider)
+	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
+		TokenMetadataBatcher:             alchemyProvider,
 		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
@@ -488,15 +494,16 @@ var (
 	_wireChainValue5 = persist.ChainPolygon
 )
 
-func polygonSyncPipelineInjector(contextContext context.Context, client *http.Client, chain persist.Chain, provider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
-	tokenIdentifierOwnerFetcher := polygonTokenIdentifierOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalOwnerFetcher := polygonTokensIncrementalOwnerFetcherInjector(provider, alchemyProvider)
-	tokensIncrementalContractFetcher := polygonTokensContractFetcherInjector(provider, alchemyProvider)
-	fillInWrapper := wrapper.NewFillInWrapper(contextContext, client, chain)
+func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+	tokenIdentifierOwnerFetcher := polygonTokenIdentifierOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := polygonTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := polygonTokensContractFetcherInjector(openseaProvider, alchemyProvider)
+	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
+		TokenMetadataBatcher:             alchemyProvider,
 		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -213,6 +213,7 @@ func optimismProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDe
 		TokensIncrementalContractFetcher: syncPipeline,
 		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
+		TokenMetadataBatcher:             syncPipeline,
 	}
 	return optimismProvider
 }
@@ -279,6 +280,7 @@ func arbitrumProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDe
 		TokensIncrementalContractFetcher: syncPipeline,
 		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
+		TokenMetadataBatcher:             syncPipeline,
 	}
 	return arbitrumProvider
 }
@@ -364,6 +366,7 @@ func zoraProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, zoraProvide
 		TokensIncrementalContractFetcher: syncPipeline,
 		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
+		TokenMetadataBatcher:             syncPipeline,
 	}
 	return multichainZoraProvider
 }
@@ -435,6 +438,7 @@ func baseProvidersInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDescr
 		TokensIncrementalContractFetcher: syncPipeline,
 		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
+		TokenMetadataBatcher:             syncPipeline,
 	}
 	return baseProvider
 }
@@ -541,6 +545,7 @@ func polygonProvidersInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDe
 		TokensIncrementalContractFetcher: syncPipeline,
 		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
+		TokenMetadataBatcher:             syncPipeline,
 	}
 	return polygonProvider
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -172,7 +172,7 @@ func ethTokenDescriptorsFetcherInjector(openseaProvider *opensea.Provider, alche
 }
 
 func tezosInjector(serverEnvInit envInit, client *http.Client) *multichain.TezosProvider {
-	provider := tezos.NewProvider(client)
+	provider := tezos.NewProvider()
 	tzktProvider := tzkt.NewProvider(client)
 	tezosProvider := tezosProviderInjector(provider, tzktProvider)
 	return tezosProvider

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -662,7 +662,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 		return nil, err
 	}
 
-	// alchemy unfortunately doesn't return tokens in the same order as the input so we need to create a lookup
+	// alchemy doesn't return tokens in the same order as the input
 	lookup := make(map[persist.TokenIdentifiers]persist.TokenMetadata)
 
 	for i, c := range chunks {
@@ -684,7 +684,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 		logger.For(ctx).Infof("handling metadata batch=%d of %d", batchID, len(chunks))
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(byt))
 		if err != nil {
-			return metadatas, err
+			return nil, err
 		}
 
 		resp, err := d.httpClient.Do(req)
@@ -706,7 +706,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 		err = util.UnmarshallBody(&batchResp, resp.Body)
 		if err != nil {
 			logger.For(ctx).Errorf("failed to read alchemy metadata batch=%d body: %s", batchID, err)
-			return metadatas, err
+			return nil, err
 		}
 
 		if len(batchResp) != len(c) {

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -709,11 +709,6 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 			return nil, err
 		}
 
-		if len(batchResp) != len(c) {
-			panic(fmt.Sprintf("expected response to be equal in length to batch=%d; got %d; expected %d", batchID, len(batchResp), len(c)))
-		}
-
-		// alchemy doesn't return data in the same order as the input, so we need to create a lookup
 		for _, m := range batchResp {
 			tID := persist.NewTokenIdentifiers(persist.Address(m.Contract.Address), persist.MustTokenID(m.Id.TokenId), d.chain)
 			lookup[tID] = alchemyMetadataToMetadata(m.Metadata)
@@ -724,7 +719,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 		metadatas[i] = lookup[tID]
 	}
 
-	logger.For(ctx).Info("finished alchemy metadata batch")
+	logger.For(ctx).Infof("finished alchemy metadata batch of %d tokens", len(tIDs))
 	return metadatas, nil
 }
 

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -631,6 +631,10 @@ func (d *Provider) GetOwnedTokensByContract(ctx context.Context, contractAddress
 	return cTokens, cContracts[0], nil
 }
 
+func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []persist.TokenIdentifiers) ([]persist.TokenMetadata, error) {
+	panic("not implemented")
+}
+
 func alchemyTokensToChainAgnosticTokensForOwner(owner persist.EthereumAddress, tokens []Token) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract) {
 	chainAgnosticTokens := make([]multichain.ChainAgnosticToken, 0, len(tokens))
 	chainAgnosticContracts := make([]multichain.ChainAgnosticContract, 0, len(tokens))

--- a/service/multichain/config.go
+++ b/service/multichain/config.go
@@ -26,6 +26,7 @@ type EthereumProvider struct {
 	TokensIncrementalContractFetcher
 	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
+	TokenMetadataBatcher
 	Verifier
 }
 

--- a/service/multichain/config.go
+++ b/service/multichain/config.go
@@ -46,6 +46,7 @@ type OptimismProvider struct {
 	TokensIncrementalContractFetcher
 	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
+	TokenMetadataBatcher
 }
 
 type ArbitrumProvider struct {
@@ -54,6 +55,7 @@ type ArbitrumProvider struct {
 	TokensIncrementalContractFetcher
 	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
+	TokenMetadataBatcher
 }
 
 type PoapProvider struct {
@@ -71,6 +73,7 @@ type ZoraProvider struct {
 	TokensIncrementalContractFetcher
 	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
+	TokenMetadataBatcher
 }
 
 type BaseProvider struct {
@@ -79,6 +82,7 @@ type BaseProvider struct {
 	TokensIncrementalContractFetcher
 	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
+	TokenMetadataBatcher
 }
 
 type PolygonProvider struct {
@@ -87,4 +91,5 @@ type PolygonProvider struct {
 	TokensIncrementalContractFetcher
 	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
+	TokenMetadataBatcher
 }

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -171,6 +171,10 @@ type TokenMetadataFetcher interface {
 	GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti ChainAgnosticIdentifiers) (persist.TokenMetadata, error)
 }
 
+type TokenMetadataBatcher interface {
+	GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []persist.TokenIdentifiers) ([]persist.TokenMetadata, error)
+}
+
 type TokenDescriptorsFetcher interface {
 	GetTokenDescriptorsByTokenIdentifiers(ctx context.Context, ti ChainAgnosticIdentifiers) (ChainAgnosticTokenDescriptors, ChainAgnosticContractDescriptors, error)
 }

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -897,8 +897,7 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 		return err
 	}
 
-	// url := fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL"))
-	url := fmt.Sprintf("%s/media/process/token", "http://localhost:6500")
+	url := fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL"))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -897,7 +897,8 @@ func (p *Provider) RefreshToken(ctx context.Context, ti persist.TokenIdentifiers
 		return err
 	}
 
-	url := fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL"))
+	// url := fmt.Sprintf("%s/media/process/token", env.GetString("TOKEN_PROCESSING_URL"))
+	url := fmt.Sprintf("%s/media/process/token", "http://localhost:6500")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -714,7 +714,7 @@ func paginateAssetsFilter(ctx context.Context, client *http.Client, req *http.Re
 				}
 				return
 			}
-			logger.For(ctx).Infof("got target tokens from page=%dfrom opensea", pages)
+			logger.For(ctx).Infof("got target tokens from page=%d from opensea", pages)
 			outCh <- assetsReceived{Assets: []Asset{page.NFT}}
 			return
 		}

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -295,10 +295,9 @@ func (p *Provider) streamAssetsToTokens(
 	recCh chan<- multichain.ChainAgnosticTokensAndContracts,
 	errCh chan<- error,
 ) {
-	cachedContracts := &sync.Map{}                           // used to avoid duplicate contract fetches
-	contractsL := make(map[persist.Address]*sync.Mutex)      // contract job locks
-	contractToCollection := make(map[persist.Address]string) // lookup of contract address to collection slug
-	mu := sync.RWMutex{}                                     // manages access to contract locks
+	cachedContracts := &sync.Map{}                      // used to avoid duplicate contract fetches
+	contractsL := make(map[persist.Address]*sync.Mutex) // contract job locks
+	mu := sync.RWMutex{}                                // manages access to contract locks
 
 	for page := range outCh {
 		page := page
@@ -320,10 +319,8 @@ func (p *Provider) streamAssetsToTokens(
 		for i, asset := range page.Assets {
 			addr := persist.Address(asset.Contract)
 			addresses[i] = addr
-			contractToCollection[addr] = asset.Collection
-
 			wp.Go(func(context.Context) error {
-				return p.getChainAgnosticContract(ctx, addr, contractToCollection[addr], cachedContracts, contractsL, &mu)
+				return p.getChainAgnosticContract(ctx, addr, asset.Collection, cachedContracts, contractsL, &mu)
 			})
 		}
 

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 const (
-	pageSize = 50
+	pageSize = 100
 	poolSize = 12
 )
 

--- a/service/multichain/tezos/tezos.go
+++ b/service/multichain/tezos/tezos.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"net/http"
 	"strings"
 
 	tezospkg "blockwatch.cc/tzgo/tezos"
-	mgql "github.com/machinebox/graphql"
 	"golang.org/x/crypto/blake2b"
 
 	"github.com/mikeydub/go-gallery/service/auth"
@@ -35,14 +33,10 @@ func ToAddress(address persist.Address) (persist.Address, error) {
 	return persist.Address(key.Address().String()), nil
 }
 
-type Provider struct {
-	tzDomainsGQL *mgql.Client
-}
+type Provider struct{}
 
-func NewProvider(httpClient *http.Client) *Provider {
-	return &Provider{
-		tzDomainsGQL: mgql.NewClient(tezDomainsApiURL, mgql.WithHTTPClient(httpClient)),
-	}
+func NewProvider() *Provider {
+	return &Provider{}
 }
 
 // VerifySignature will verify a signature using the ed25519 algorithm

--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -71,7 +71,7 @@ func (w SyncPipelineWrapper) GetTokenMetadataByTokenIdentifiersBatch(ctx context
 	}
 
 	if len(metadatas) != len(tIDs) {
-		panic(fmt.Sprintf("expected length to the the same: %d %d", len(metadatas), len(tIDs)))
+		panic(fmt.Sprintf("expected length to the the same; expected=%d; got=%d", len(tIDs), len(metadatas)))
 	}
 
 	// Convert metadatas to tokens so they can be passed to FillInWrapper
@@ -268,8 +268,7 @@ func fanIn(ctx context.Context, recCh chan<- multichain.ChainAgnosticTokensAndCo
 // FillInWrapper is a service for adding missing data to tokens.
 // Batching pattern adapted from dataloaden (https://github.com/vektah/dataloaden)
 type FillInWrapper struct {
-	chain persist.Chain
-	// May want to use an interface instread so it can be used for other chains
+	chain             persist.Chain
 	reservoirProvider *reservoir.Provider
 	ctx               context.Context
 	mu                sync.Mutex
@@ -376,11 +375,13 @@ func (w *FillInWrapper) addTokenToBatch(t multichain.ChainAgnosticToken) func() 
 	}
 
 	w.mu.Lock()
+
 	if w.batch == nil {
 		w.batch = &batch{done: make(chan struct{})}
 	}
 	b := w.batch
 	pos := b.addToBatch(w, ti)
+
 	w.mu.Unlock()
 
 	return func() multichain.ChainAgnosticToken {

--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -321,9 +321,7 @@ func (w *FillInWrapper) LoadMetadataAll(tokens []multichain.ChainAgnosticToken) 
 	thunks := make([]func(multichain.ChainAgnosticToken) multichain.ChainAgnosticToken, len(tokens))
 	for i, t := range tokens {
 		if hasMediaURLs(t.TokenMetadata, w.chain) {
-			thunks = append(thunks, func(multichain.ChainAgnosticToken) multichain.ChainAgnosticToken {
-				return t
-			})
+			thunks[i] = func(multichain.ChainAgnosticToken) multichain.ChainAgnosticToken { return t }
 			continue
 		}
 		thunks[i] = w.addTokenToBatch(t)

--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -188,7 +188,7 @@ func (m MultiProviderWrapper) GetTokensIncrementallyByContractAddress(ctx contex
 }
 
 func (m MultiProviderWrapper) GetTokensIncrementallyByWalletAddress(ctx context.Context, address persist.Address) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
-	recCh := make(chan multichain.ChainAgnosticTokensAndContracts, 2*10)
+	recCh := make(chan multichain.ChainAgnosticTokensAndContracts)
 	errCh := make(chan error, 2)
 	resultA, errA := m.TokensIncrementalOwnerFetchers[0].GetTokensIncrementallyByWalletAddress(ctx, address)
 	resultB, errB := m.TokensIncrementalOwnerFetchers[1].GetTokensIncrementallyByWalletAddress(ctx, address)

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -308,11 +308,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 	metadatas := make([]persist.TokenMetadata, len(tIDs))
 
 	req := graphql.NewRequest(`query tokenBatch($tokens: [TokenInput!], $limit: Int!) {
-   tokens(
-     networks: [ { network: ZORA chain: ZORA_MAINNET } ],
-     pagination: {limit: $limit}
-     where: { tokens: $tokens }
-   ) {
+   tokens( networks: [ { network: ZORA chain: ZORA_MAINNET } ], pagination: {limit: $limit} where: { tokens: $tokens } ) {
      nodes { token { tokenId collectionAddress metadata } }
      pageInfo { limit hasNextPage endCursor }
    }
@@ -374,7 +370,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 		metadatas[i] = lookup[tID]
 	}
 
-	logger.For(ctx).Info("finished zora metadata batch")
+	logger.For(ctx).Infof("finished zora metadata batch of %d tokens", len(tIDs))
 	return metadatas, nil
 }
 

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -296,6 +296,10 @@ func (d *Provider) GetContractsByOwnerAddress(ctx context.Context, addr persist.
 	return result, nil
 }
 
+func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []persist.TokenIdentifiers) ([]persist.TokenMetadata, error) {
+	panic("not implemented")
+}
+
 const maxLimit = 1000
 
 func (d *Provider) getTokens(ctx context.Context, url string, recCh chan<- multichain.ChainAgnosticTokensAndContracts, balance bool) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/machinebox/graphql"
+
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/media"
@@ -18,13 +19,17 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 )
 
-var zoraRESTURL = "https://api.zora.co/discover"
-var goldskyURL = "https://api.goldsky.com/api/public/project_clhk16b61ay9t49vm6ntn4mkz/subgraphs/zora-create-zora-mainnet/stable/gn"
+const (
+	zoraRESTURL = "https://api.zora.co/discover"
+	zoraGraphQL = "https://api.zora.co/graphql"
+	goldskyURL  = "https://api.goldsky.com/api/public/project_clhk16b61ay9t49vm6ntn4mkz/subgraphs/zora-create-zora-mainnet/stable/gn"
+)
 
 // Provider is an the struct for retrieving data from the zora blockchain
 type Provider struct {
 	httpClient *http.Client
-	ggql       *graphql.Client
+	goldskyQL  *graphql.Client
+	zoraQL     *graphql.Client
 }
 
 type tokenID string
@@ -127,7 +132,8 @@ func NewProvider(httpClient *http.Client) *Provider {
 	}
 
 	return &Provider{
-		ggql:       graphql.NewClient(goldskyURL, graphql.WithHTTPClient(httpClient)),
+		goldskyQL:  graphql.NewClient(goldskyURL, graphql.WithHTTPClient(httpClient)),
+		zoraQL:     graphql.NewClient(zoraGraphQL, graphql.WithHTTPClient(httpClient)),
 		httpClient: zoraClient,
 	}
 }
@@ -270,7 +276,7 @@ func (d *Provider) GetContractsByOwnerAddress(ctx context.Context, addr persist.
 	req.Var("creator", addr.String())
 
 	resp := getZoraCreateContractsResponse{}
-	err := d.ggql.Run(ctx, req, &resp)
+	err := d.goldskyQL.Run(ctx, req, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +303,79 @@ func (d *Provider) GetContractsByOwnerAddress(ctx context.Context, addr persist.
 }
 
 func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []persist.TokenIdentifiers) ([]persist.TokenMetadata, error) {
-	panic("not implemented")
+	chunkSize := 50
+	chunks := util.ChunkBy(tIDs, chunkSize)
+	metadatas := make([]persist.TokenMetadata, len(tIDs))
+
+	req := graphql.NewRequest(`query tokenBatch($tokens: [TokenInput!], $limit: Int!) {
+   tokens(
+     networks: [ { network: ZORA chain: ZORA_MAINNET } ],
+     pagination: {limit: $limit}
+     where: { tokens: $tokens }
+   ) {
+     nodes { token { tokenId collectionAddress metadata } }
+     pageInfo { limit hasNextPage endCursor }
+   }
+ }`)
+
+	type tokenInput struct {
+		Address string `json:"address"`
+		TokenID string `json:"tokenId"`
+	}
+
+	type tokenBatchResponse struct {
+		Tokens struct {
+			Nodes []struct {
+				Token struct {
+					TokenID           string         `json:"tokenId"`
+					CollectionAddress string         `json:"collectionAddress"`
+					Metadata          map[string]any `json:"metadata"`
+				} `json:"token"`
+			} `json:"nodes"`
+		} `json:"tokens"`
+	}
+
+	// zora doesn't return tokens in the same order as the input
+	lookup := make(map[persist.TokenIdentifiers]persist.TokenMetadata)
+
+	for i, chunk := range chunks {
+		batchID := i + 1
+
+		tokenQuery := make([]tokenInput, len(chunk))
+
+		for j, token := range chunk {
+			tokenQuery[j] = tokenInput{
+				Address: token.ContractAddress.String(),
+				TokenID: token.TokenID.Base10String(),
+			}
+		}
+
+		req.Var("limit", chunkSize)
+		req.Var("tokens", tokenQuery)
+
+		logger.For(ctx).Infof("handling metadata batch=%d of %d", batchID, len(chunks))
+
+		var batchResp tokenBatchResponse
+
+		err := d.zoraQL.Run(ctx, req, &batchResp)
+
+		if err != nil {
+			logger.For(ctx).Errorf("error handling zora batch=%d request: %s", batchID, err)
+			return nil, err
+		}
+
+		for _, token := range batchResp.Tokens.Nodes {
+			tID := persist.NewTokenIdentifiers(persist.Address(token.Token.CollectionAddress), persist.MustTokenID(token.Token.TokenID), persist.ChainZora)
+			lookup[tID] = persist.TokenMetadata(token.Token.Metadata)
+		}
+	}
+
+	for i, tID := range tIDs {
+		metadatas[i] = lookup[tID]
+	}
+
+	logger.For(ctx).Info("finished zora metadata batch")
+	return metadatas, nil
 }
 
 const maxLimit = 1000

--- a/service/tokenmanage/tokenmanage.go
+++ b/service/tokenmanage/tokenmanage.go
@@ -37,6 +37,7 @@ func (e ErrContractPaused) Error() string {
 	return fmt.Sprintf("processing for chain=%d; contract=%s is paused", e.Chain, e.Contract)
 }
 
+// ErrContractFlaking indicates that runs of this contract are frequently failing
 type ErrContractFlaking struct {
 	Chain    persist.Chain
 	Contract persist.Address

--- a/service/tokenmanage/tokenmanage.go
+++ b/service/tokenmanage/tokenmanage.go
@@ -47,7 +47,7 @@ type ErrContractFlaking struct {
 
 func (e ErrContractFlaking) Unwrap() error { return e.Err }
 func (e ErrContractFlaking) Error() string {
-	return fmt.Sprintf("processing of chain=%d; contract=%s is paused for %s because of too many errors; last error: %s", e.Chain, e.Contract, e.Duration, e.Err)
+	return fmt.Sprintf("runs of chain=%d; contract=%s are paused for %s because of too many failures; last error: %s", e.Chain, e.Contract, e.Duration, e.Err)
 }
 
 type Manager struct {

--- a/service/tokenmanage/tokenmanage.go
+++ b/service/tokenmanage/tokenmanage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/platform"
 	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/metric"
@@ -47,47 +48,51 @@ type ErrContractFlaking struct {
 
 func (e ErrContractFlaking) Unwrap() error { return e.Err }
 func (e ErrContractFlaking) Error() string {
-	return fmt.Sprintf("runs of chain=%d; contract=%s are paused for %s because of too many failures; last error: %s", e.Chain, e.Contract, e.Duration, e.Err)
+	return fmt.Sprintf("runs of chain=%d; contract=%s are paused for %s because of too many failed runs; last error: %s", e.Chain, e.Contract, e.Duration, e.Err)
 }
 
 type Manager struct {
-	cache           *redis.Cache
-	processRegistry *registry
+	ProcessRegistry *Registry
 	taskClient      *task.Client
 	throttle        *throttle.Locker
 	errorCounter    *limiters.KeyRateLimiter
-	numRetryF       NumRetryF
-	delayF          TaskDelayF
+	enableRetries   bool
+	markTokenRan    func(db.TokenDefinition) (time.Duration, error)
 	metricReporter  metric.MetricReporter
 }
 
 func New(ctx context.Context, taskClient *task.Client, cache *redis.Cache) *Manager {
+	slowRetry := limiters.NewKeyRateLimiter(ctx, cache, "retrySlow", 1, 5*time.Minute)
+	fastRetry := limiters.NewKeyRateLimiter(ctx, cache, "retryFast", 1, 30*time.Second)
+
+	markTokenRan := func(td db.TokenDefinition) (time.Duration, error) {
+		if shareToGalleryEnabled(td) {
+			_, delay, err := fastRetry.ForKey(ctx, td.ID.String())
+			return delay, err
+		}
+		_, delay, err := slowRetry.ForKey(ctx, td.ID.String())
+		return delay, err
+	}
+
 	return &Manager{
-		cache:           cache,
-		processRegistry: &registry{cache},
+		ProcessRegistry: &Registry{cache},
 		taskClient:      taskClient,
 		throttle:        throttle.NewThrottleLocker(cache, 30*time.Minute),
 		metricReporter:  metric.NewLogMetricReporter(),
 		errorCounter:    limiters.NewKeyRateLimiter(ctx, cache, "errorCount", 100, 3*time.Hour),
+		markTokenRan:    markTokenRan,
 	}
 }
 
-// NumRetryF returns the max number of times a token can be retried
-type NumRetryF func() int
-
-// TaskDelayF returns the delay period between retries
-type TaskDelayF func() (time.Duration, error)
-
-func NewWithRetries(ctx context.Context, taskClient *task.Client, cache *redis.Cache, numRetryF NumRetryF, delayF TaskDelayF) *Manager {
+func NewWithRetries(ctx context.Context, taskClient *task.Client, cache *redis.Cache) *Manager {
 	m := New(ctx, taskClient, cache)
-	m.numRetryF = numRetryF
-	m.delayF = delayF
+	m.enableRetries = true
 	return m
 }
 
 // Processing returns true if the token is processing or enqueued.
 func (m Manager) Processing(ctx context.Context, tDefID persist.DBID) bool {
-	p, _ := m.processRegistry.processing(ctx, tDefID)
+	p, _ := m.ProcessRegistry.processing(ctx, tDefID)
 	return p
 }
 
@@ -96,28 +101,28 @@ func (m Manager) SubmitBatch(ctx context.Context, tDefIDs []persist.DBID) error 
 	if len(tDefIDs) == 0 {
 		return nil
 	}
-	m.processRegistry.setManyEnqueue(ctx, tDefIDs)
+	m.ProcessRegistry.setManyEnqueue(ctx, tDefIDs)
 	message := task.TokenProcessingBatchMessage{BatchID: persist.GenerateID(), TokenDefinitionIDs: tDefIDs}
 	logger.For(ctx).WithField("batchID", message.BatchID).Infof("enqueued batch: %s (size=%d)", message.BatchID, len(tDefIDs))
 	return m.taskClient.CreateTaskForTokenProcessing(ctx, message)
 }
 
 // IsPaused returns true if runs of this token are paused.
-func (m Manager) Paused(ctx context.Context, tID persist.TokenIdentifiers) bool {
-	p, _ := m.processRegistry.pausedContract(ctx, tID.Chain, tID.ContractAddress)
+func (m Manager) Paused(ctx context.Context, td db.TokenDefinition) bool {
+	p, _ := m.ProcessRegistry.pausedContract(ctx, td.Chain, td.ContractAddress)
 	return p
 }
 
 // StartProcessing marks a token as processing. It returns a callback that must be called when work on the token is finished in order to mark
 // it as finished. If withRetry is true, the callback will attempt to reenqueue the token if an error is passed. attemps is ignored when MaxRetries
 // is set to the default value of 0.
-func (m Manager) StartProcessing(ctx context.Context, tDefID persist.DBID, tID persist.TokenIdentifiers, attempts int, cause persist.ProcessingCause) (func(db.TokenMedia, error) error, error) {
-	if m.Paused(ctx, tID) {
-		recordPipelinePaused(ctx, m.metricReporter, tID.Chain, tID.ContractAddress, cause)
-		return nil, ErrContractPaused{Chain: tID.Chain, Contract: tID.ContractAddress}
+func (m Manager) StartProcessing(ctx context.Context, td db.TokenDefinition, attempts int, cause persist.ProcessingCause) (func(db.TokenMedia, error) error, error) {
+	if m.Paused(ctx, td) {
+		recordPipelinePaused(ctx, m.metricReporter, td.Chain, td.ContractAddress, cause)
+		return nil, ErrContractPaused{Chain: td.Chain, Contract: td.ContractAddress}
 	}
 
-	err := m.throttle.Lock(ctx, "lock:"+tDefID.String())
+	err := m.throttle.Lock(ctx, "lock:"+td.ID.String())
 	if err != nil {
 		return nil, err
 	}
@@ -128,11 +133,11 @@ func (m Manager) StartProcessing(ctx context.Context, tDefID persist.DBID, tID p
 
 	go func() {
 		defer tick.Stop()
-		m.processRegistry.keepAlive(ctx, tDefID)
+		m.ProcessRegistry.keepAlive(ctx, td.ID)
 		for {
 			select {
 			case <-tick.C:
-				m.processRegistry.keepAlive(ctx, tDefID)
+				m.ProcessRegistry.keepAlive(ctx, td.ID)
 			case <-stop:
 				close(done)
 				return
@@ -145,27 +150,39 @@ func (m Manager) StartProcessing(ctx context.Context, tDefID persist.DBID, tID p
 	callback := func(tm db.TokenMedia, err error) error {
 		close(stop)
 		<-done
-		m.recordError(ctx, tID, err)
-		m.tryRetry(ctx, tDefID, tID, err, attempts)
-		m.throttle.Unlock(ctx, "lock:"+tDefID.String())
-		recordPipelineResults(ctx, m.metricReporter, tID.Chain, tm.Media.MediaType, err, time.Since(start), cause)
+		m.markTokenRan(td) // mark that the token ran so if an error occured tryRetry delays the next run appropriately
+		m.recordError(ctx, td, err)
+		m.tryRetry(ctx, td, err, attempts)
+		m.throttle.Unlock(ctx, "lock:"+td.ID.String())
+		recordMetrics(ctx, m.metricReporter, td.Chain, tm.Media.MediaType, err, time.Since(start), cause)
 		return nil
 	}
 
 	return callback, err
 }
 
-func (m Manager) recordError(ctx context.Context, tID persist.TokenIdentifiers, err error) {
+func shareToGalleryEnabled(td db.TokenDefinition) bool {
+	return platform.IsProhibition(td.Chain, td.ContractAddress) || td.IsFxhash
+}
+
+func maxRetriesFor(td db.TokenDefinition) int {
+	if shareToGalleryEnabled(td) {
+		return 24
+	}
+	return 2
+}
+
+func (m Manager) recordError(ctx context.Context, td db.TokenDefinition, err error) {
 	// Don't penalize non-token related errors e.g. errors related to the pipeline
 	if err == nil || !util.ErrorIs[ErrBadToken](err) {
 		return
 	}
 
-	if paused, _ := m.processRegistry.pausedContract(ctx, tID.Chain, tID.ContractAddress); paused {
+	if paused, _ := m.ProcessRegistry.pausedContract(ctx, td.Chain, td.ContractAddress); paused {
 		return
 	}
 
-	canRetry, _, err := m.errorCounter.ForKey(ctx, fmt.Sprintf("%d:%s", tID.Chain, tID.ContractAddress))
+	canRetry, _, err := m.errorCounter.ForKey(ctx, fmt.Sprintf("%d:%s", td.Chain, td.ContractAddress))
 	if err != nil {
 		logger.For(ctx).Errorf("failed to track error: %s", err)
 		sentryutil.ReportError(ctx, err)
@@ -175,7 +192,7 @@ func (m Manager) recordError(ctx context.Context, tID persist.TokenIdentifiers, 
 		return
 	}
 
-	nowFlaky, err := m.processRegistry.pauseContract(ctx, tID.Chain, tID.ContractAddress, time.Hour*3)
+	nowFlaky, err := m.ProcessRegistry.pauseContract(ctx, td.Chain, td.ContractAddress, time.Hour*3)
 	if err != nil {
 		logger.For(ctx).Errorf("failed to pause contract:%s", err)
 		sentryutil.ReportError(ctx, err)
@@ -183,78 +200,78 @@ func (m Manager) recordError(ctx context.Context, tID persist.TokenIdentifiers, 
 	}
 
 	if nowFlaky {
-		err := ErrContractFlaking{Chain: tID.Chain, Contract: tID.ContractAddress, Err: err, Duration: time.Hour * 3}
+		err := ErrContractFlaking{Chain: td.Chain, Contract: td.ContractAddress, Err: err, Duration: time.Hour * 3}
 		logger.For(ctx).Warnf(err.Error())
 		sentryutil.ReportError(ctx, err)
 	}
 }
 
-func (m Manager) tryRetry(ctx context.Context, tDefID persist.DBID, tID persist.TokenIdentifiers, err error, attempts int) error {
+func (m Manager) tryRetry(ctx context.Context, td db.TokenDefinition, err error, attempts int) error {
 	// Only retry intermittent errors related to the token e.g. missing metadata
 	if !util.ErrorIs[ErrBadToken](err) {
-		m.processRegistry.finish(ctx, tDefID)
+		m.ProcessRegistry.finish(ctx, td.ID)
 		return nil
 	}
 
-	if m.Paused(ctx, tID) {
-		m.processRegistry.finish(ctx, tDefID)
+	if m.Paused(ctx, td) {
+		m.ProcessRegistry.finish(ctx, td.ID)
 		return nil
 	}
 
-	if err == nil || m.numRetryF == nil || attempts >= m.numRetryF() {
-		m.processRegistry.finish(ctx, tDefID)
+	if err == nil || !m.enableRetries || attempts >= maxRetriesFor(td) {
+		m.ProcessRegistry.finish(ctx, td.ID)
 		return nil
 	}
 
-	delay, err := m.delayF()
+	delay, err := m.markTokenRan(td)
 	if err != nil {
 		logger.For(ctx).Errorf("failed to get retry delay, not retrying: %s", err)
-		m.processRegistry.finish(ctx, tDefID)
+		m.ProcessRegistry.finish(ctx, td.ID)
 		return err
 	}
 
-	m.processRegistry.setEnqueue(ctx, tDefID)
-	message := task.TokenProcessingTokenMessage{TokenDefinitionID: tDefID, Attempts: attempts + 1}
+	m.ProcessRegistry.setEnqueue(ctx, td.ID)
+	message := task.TokenProcessingTokenMessage{TokenDefinitionID: td.ID, Attempts: attempts + 1}
 	return m.taskClient.CreateTaskForTokenTokenProcessing(ctx, message, delay)
 }
 
-// registry handles the storing of object state managed by Manager
-type registry struct{ c *redis.Cache }
+// Registry handles the storing of object state managed by Manager
+type Registry struct{ Cache *redis.Cache }
 
-func (r registry) processing(ctx context.Context, tDefID persist.DBID) (bool, error) {
-	_, err := r.c.Get(ctx, processingKey(tDefID))
+func (r Registry) processing(ctx context.Context, tDefID persist.DBID) (bool, error) {
+	_, err := r.Cache.Get(ctx, processingKey(tDefID))
 	return err == nil, err
 }
 
-func (r registry) finish(ctx context.Context, tDefID persist.DBID) error {
-	return r.c.Delete(ctx, processingKey(tDefID))
+func (r Registry) finish(ctx context.Context, tDefID persist.DBID) error {
+	return r.Cache.Delete(ctx, processingKey(tDefID))
 }
 
-func (r registry) setEnqueue(ctx context.Context, tDefID persist.DBID) error {
+func (r Registry) setEnqueue(ctx context.Context, tDefID persist.DBID) error {
 	return r.setManyEnqueue(ctx, []persist.DBID{tDefID})
 }
 
-func (r registry) setManyEnqueue(ctx context.Context, tDefIDs []persist.DBID) error {
+func (r Registry) setManyEnqueue(ctx context.Context, tDefIDs []persist.DBID) error {
 	keyValues := make(map[string]any, len(tDefIDs))
 	for _, id := range tDefIDs {
 		keyValues[processingKey(id)] = []byte("enqueued")
 	}
-	return r.c.MSetWithTTL(ctx, keyValues, time.Hour)
+	return r.Cache.MSetWithTTL(ctx, keyValues, time.Hour)
 }
 
-func (r registry) pausedContract(ctx context.Context, chain persist.Chain, address persist.Address) (bool, error) {
-	_, err := r.c.Get(ctx, pauseContractKey(chain, address))
+func (r Registry) pausedContract(ctx context.Context, chain persist.Chain, address persist.Address) (bool, error) {
+	_, err := r.Cache.Get(ctx, pauseContractKey(chain, address))
 	return err == nil, err
 }
 
-func (r registry) pauseContract(ctx context.Context, chain persist.Chain, address persist.Address, ttl time.Duration) (bool, error) {
+func (r Registry) pauseContract(ctx context.Context, chain persist.Chain, address persist.Address, ttl time.Duration) (bool, error) {
 	b := make([]byte, 64)
 	binary.BigEndian.PutUint64(b, uint64(time.Now().UnixMilli()))
-	return r.c.SetNX(ctx, pauseContractKey(chain, address), b, ttl)
+	return r.Cache.SetNX(ctx, pauseContractKey(chain, address), b, ttl)
 }
 
-func (r registry) keepAlive(ctx context.Context, tDefID persist.DBID) error {
-	return r.c.Set(ctx, processingKey(tDefID), []byte("processing"), time.Minute)
+func (r Registry) keepAlive(ctx context.Context, tDefID persist.DBID) error {
+	return r.Cache.Set(ctx, processingKey(tDefID), []byte("processing"), time.Minute)
 }
 
 func processingKey(id persist.DBID) string { return "inflight:" + id.String() }
@@ -303,7 +320,7 @@ func recordPipelinePaused(ctx context.Context, mr metric.MetricReporter, chain p
 	)...)
 }
 
-func recordPipelineResults(ctx context.Context, mr metric.MetricReporter, chain persist.Chain, mediaType persist.MediaType, err error, d time.Duration, cause persist.ProcessingCause) {
+func recordMetrics(ctx context.Context, mr metric.MetricReporter, chain persist.Chain, mediaType persist.MediaType, err error, d time.Duration, cause persist.ProcessingCause) {
 	baseOpts := append([]any{}, metric.LogOptions.WithTags(map[string]string{
 		"chain":      fmt.Sprintf("%d", chain),
 		"mediaType":  mediaType.String(),

--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	"github.com/mikeydub/go-gallery/service/redis"
@@ -19,16 +20,19 @@ import (
 )
 
 func handlersInitServer(ctx context.Context, router *gin.Engine, tp *tokenProcessor, mc *multichain.Provider, repos *postgres.Repositories, throttler *throttle.Locker, taskClient *task.Client, tokenManageCache *redis.Cache) *gin.Engine {
+	fastRetryLimit := limiters.NewKeyRateLimiter(ctx, tokenManageCache, "retryFast", 2, 1*time.Minute)
+	slowRetryLimit := limiters.NewKeyRateLimiter(ctx, tokenManageCache, "retrySlow", 1, 5*time.Minute)
+
 	mediaGroup := router.Group("/media")
 	mediaGroup.POST("/process", func(c *gin.Context) {
 		if hub := sentryutil.SentryHubFromContext(c); hub != nil {
 			hub.Scope().AddEventProcessor(sentryutil.SpanFilterEventProcessor(c, 1000, 1*time.Millisecond, 8, true))
 		}
-		processBatch(tp, mc.Queries, taskClient, tokenManageCache)(c)
+		processBatch(tp, mc.Queries, taskClient, tokenManageCache, fastRetryLimit, slowRetryLimit)(c)
 	})
 	mediaGroup.POST("/process/token", processMediaForTokenIdentifiers(tp, mc.Queries, tokenmanage.New(ctx, taskClient, tokenManageCache)))
-	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, taskClient, tokenManageCache))
-	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, mc, repos.UserRepository, taskClient, tokenManageCache))
+	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, taskClient, tokenManageCache, fastRetryLimit, slowRetryLimit))
+	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, mc, repos.UserRepository, taskClient, tokenManageCache, fastRetryLimit, slowRetryLimit))
 
 	authOpts := middleware.BasicAuthOptionBuilder{}
 	ownersGroup := router.Group("/owners")

--- a/tokenprocessing/metadata.go
+++ b/tokenprocessing/metadata.go
@@ -36,8 +36,9 @@ func (m *MetadataFinder) add(ctx context.Context, t persist.TokenIdentifiers) fu
 
 	if m.batch == nil {
 		m.batch = &batch{
-			tokens: make(map[persist.Chain][]persist.TokenIdentifiers),
-			done:   make(chan struct{}),
+			tokens:  make(map[persist.Chain][]persist.TokenIdentifiers),
+			results: make(map[persist.Chain][]persist.TokenMetadata),
+			done:    make(chan struct{}),
 		}
 	}
 
@@ -106,4 +107,5 @@ func (b *batch) end(m *MetadataFinder) {
 		}
 		b.results[c] = metadata
 	}
+	close(b.done)
 }

--- a/tokenprocessing/metadata.go
+++ b/tokenprocessing/metadata.go
@@ -1,0 +1,109 @@
+package tokenprocessing
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/multichain"
+	"github.com/mikeydub/go-gallery/service/persist"
+)
+
+// MetadataFinder is a service for fetching metadata for a token
+// Batching pattern adapted from dataloaden (https://github.com/vektah/dataloaden)
+type MetadataFinder struct {
+	mc       *multichain.Provider
+	ctx      context.Context
+	mu       sync.Mutex
+	batch    *batch
+	wait     time.Duration
+	maxBatch int
+}
+
+func (m *MetadataFinder) GetMetadata(ctx context.Context, t persist.TokenIdentifiers) (persist.TokenMetadata, error) {
+	return m.add(ctx, t)()
+}
+
+func (m *MetadataFinder) add(ctx context.Context, t persist.TokenIdentifiers) func() (persist.TokenMetadata, error) {
+	if _, ok := m.mc.Chains[t.Chain].(multichain.TokenMetadataBatcher); !ok {
+		return func() (persist.TokenMetadata, error) {
+			return m.mc.GetTokenMetadataByTokenIdentifiers(ctx, t.ContractAddress, t.TokenID, t.Chain)
+		}
+	}
+
+	m.mu.Lock()
+
+	if m.batch == nil {
+		m.batch = &batch{
+			tokens: make(map[persist.Chain][]persist.TokenIdentifiers),
+			done:   make(chan struct{}),
+		}
+	}
+
+	b := m.batch
+	pos := b.addToBatch(m, t)
+
+	m.mu.Unlock()
+
+	return func() (persist.TokenMetadata, error) {
+		<-b.done
+		if err := b.errors[t.Chain]; err != nil {
+			return persist.TokenMetadata{}, err
+		}
+		return b.results[t.Chain][pos], nil
+	}
+}
+
+type batch struct {
+	total   int
+	tokens  map[persist.Chain][]persist.TokenIdentifiers
+	done    chan struct{}
+	closing bool
+	errors  map[persist.Chain]error
+	results map[persist.Chain][]persist.TokenMetadata
+}
+
+func (b *batch) addToBatch(m *MetadataFinder, t persist.TokenIdentifiers) int {
+	tot := b.total
+	b.tokens[t.Chain] = append(b.tokens[t.Chain], t)
+	b.total++
+	if tot == 0 {
+		go b.startTimer(m)
+	}
+	if m.maxBatch != 0 && tot >= m.maxBatch-1 {
+		if !b.closing {
+			b.closing = true
+			m.batch = nil
+			go b.end(m)
+		}
+	}
+	return len(b.tokens[t.Chain]) - 1
+}
+
+func (b *batch) startTimer(m *MetadataFinder) {
+	time.Sleep(m.wait)
+	m.mu.Lock()
+
+	// we must have hit a batch limit and are already finalizing this batch
+	if b.closing {
+		m.mu.Unlock()
+		return
+	}
+
+	m.batch = nil
+	m.mu.Unlock()
+
+	b.end(m)
+}
+
+func (b *batch) end(m *MetadataFinder) {
+	for c, t := range b.tokens {
+		metadata, err := m.mc.Chains[c].(multichain.TokenMetadataBatcher).GetTokenMetadataByTokenIdentifiersBatch(m.ctx, t)
+		if err != nil {
+			logger.For(m.ctx).Errorf("failed to load batch of metadata for chain=%d: %s", c, err)
+			continue
+		}
+		b.results[c] = metadata
+	}
+}

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -255,9 +255,6 @@ func (tpj *tokenProcessingJob) urlsToDownload(ctx context.Context, metadata pers
 }
 
 func (tpj *tokenProcessingJob) createMediaForToken(ctx context.Context) (persist.Media, persist.TokenMetadata, error) {
-	traceCallback, ctx := persist.TrackStepStatus(ctx, &tpj.pipelineMetadata.CreateMedia, "CreateMedia")
-	defer traceCallback()
-
 	var (
 		imgURL     media.ImageURL
 		pfpURL     media.ImageURL
@@ -414,6 +411,9 @@ func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, p
 		"requireSigned": requireSigned,
 	})
 
+	traceCallback, ctx := persist.TrackStepStatus(ctx, &tpj.pipelineMetadata.CreateMedia, "CreateMedia")
+	defer traceCallback()
+
 	imgResult, pfpResult, animResult := tpj.cacheMediaFromOriginalURLs(ctx, imgURL, pfpURL, animURL)
 
 	if (!requireImg && animResult.IsSuccess()) || imgResult.IsSuccess() {
@@ -435,7 +435,7 @@ func (tpj *tokenProcessingJob) cacheMediaFromURLs(ctx context.Context, imgURL, p
 		return createMediaFromResults(ctx, tpj, animResult, imgResult, pfpResult), err
 	}
 
-	traceCallback, ctx := persist.TrackStepStatus(ctx, &tpj.pipelineMetadata.NothingCachedWithErrors, "NothingCachedWithErrors")
+	traceCallback, ctx = persist.TrackStepStatus(ctx, &tpj.pipelineMetadata.NothingCachedWithErrors, "NothingCachedWithErrors")
 	defer traceCallback()
 
 	// At this point we don't have a way to make media so we return an error

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -17,7 +17,6 @@ import (
 	"github.com/mikeydub/go-gallery/platform"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/media"
-	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/rpc"
 	"github.com/mikeydub/go-gallery/service/tokenmanage"
@@ -26,24 +25,24 @@ import (
 )
 
 type tokenProcessor struct {
-	queries       *db.Queries
-	httpClient    *http.Client
-	mc            *multichain.Provider
-	ipfsClient    *shell.Shell
-	arweaveClient *goar.Client
-	stg           *storage.Client
-	tokenBucket   string
+	queries        *db.Queries
+	httpClient     *http.Client
+	metadataFinder *MetadataFinder
+	ipfsClient     *shell.Shell
+	arweaveClient  *goar.Client
+	stg            *storage.Client
+	tokenBucket    string
 }
 
-func NewTokenProcessor(queries *db.Queries, httpClient *http.Client, mc *multichain.Provider, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, tokenBucket string) *tokenProcessor {
+func NewTokenProcessor(queries *db.Queries, httpClient *http.Client, metadataFinder *MetadataFinder, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client, tokenBucket string) *tokenProcessor {
 	return &tokenProcessor{
-		queries:       queries,
-		mc:            mc,
-		httpClient:    httpClient,
-		ipfsClient:    ipfsClient,
-		arweaveClient: arweaveClient,
-		stg:           stg,
-		tokenBucket:   tokenBucket,
+		queries:        queries,
+		metadataFinder: metadataFinder,
+		httpClient:     httpClient,
+		ipfsClient:     ipfsClient,
+		arweaveClient:  arweaveClient,
+		stg:            stg,
+		tokenBucket:    tokenBucket,
 	}
 }
 
@@ -279,7 +278,7 @@ func (tpj *tokenProcessingJob) createMediaForToken(ctx context.Context) (persist
 		metadataCallback, ctx := persist.TrackStepStatus(ctx, &tpj.pipelineMetadata.MetadataRetrieval, "MetadataRetrieval")
 		defer metadataCallback()
 
-		metadata, err = tpj.tp.mc.GetTokenMetadataByTokenIdentifiers(ctx, tpj.contract.ContractAddress, tpj.token.TokenID, tpj.token.Chain)
+		metadata, err = tpj.tp.metadataFinder.GetMetadata(ctx, tpj.token)
 		if err != nil {
 			return
 		}

--- a/tokenprocessing/reprocess.go
+++ b/tokenprocessing/reprocess.go
@@ -1,7 +1,0 @@
-package tokenprocessing
-
-const FullReprocessQuery = `left join token_medias on tokens.token_media_id = token_medias.id where tokens.deleted = false and (tokens.token_media_id is null or token_medias.active = false)`
-
-const MissingThumbnailQuery = `left join token_medias on tokens.token_media_id = token_medias.id where tokens.deleted = false and token_medias.active = true and token_medias.media->>'media_type' = 'html' and (token_medias.media->>'thumbnail_url' is null or token_medias.media->>'thumbnail_url' = '')`
-
-const SVGQuery = `left join token_medias on tokens.token_media_id = token_medias.id where tokens.deleted = false and token_medias.active = true and token_medias.media->>'media_type' = 'svg'`

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -66,7 +66,7 @@ func CoreInitServer(ctx context.Context, clients *server.Clients, mc *multichain
 	logger.For(nil).Info("Registering handlers...")
 
 	t := newThrottler()
-	metadataFetcher := MetadataFinder{mc: mc, ctx: ctx, wait: 3 * time.Second, maxBatch: 100}
+	metadataFetcher := MetadataFinder{mc: mc, ctx: ctx, wait: 5 * time.Second, maxBatch: 100}
 	tp := NewTokenProcessor(clients.Queries, clients.HTTPClient, &metadataFetcher, clients.IPFSClient, clients.ArweaveClient, clients.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
 
 	return handlersInitServer(ctx, router, tp, mc, clients.Repos, t, clients.TaskClient, redis.NewCache(redis.TokenManageCache))

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -66,7 +66,7 @@ func CoreInitServer(ctx context.Context, clients *server.Clients, mc *multichain
 	logger.For(nil).Info("Registering handlers...")
 
 	t := newThrottler()
-	metadataFetcher := MetadataFinder{mc: mc, ctx: ctx, wait: 3 * time.Second, maxBatch: 10}
+	metadataFetcher := MetadataFinder{mc: mc, ctx: ctx, wait: 3 * time.Second, maxBatch: 100}
 	tp := NewTokenProcessor(clients.Queries, clients.HTTPClient, &metadataFetcher, clients.IPFSClient, clients.ArweaveClient, clients.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
 
 	return handlersInitServer(ctx, router, tp, mc, clients.Repos, t, clients.TaskClient, redis.NewCache(redis.TokenManageCache))

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -66,7 +66,8 @@ func CoreInitServer(ctx context.Context, clients *server.Clients, mc *multichain
 	logger.For(nil).Info("Registering handlers...")
 
 	t := newThrottler()
-	tp := NewTokenProcessor(clients.Queries, clients.HTTPClient, mc, clients.IPFSClient, clients.ArweaveClient, clients.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
+	metadataFetcher := MetadataFinder{mc: mc, ctx: ctx, wait: 3 * time.Second, maxBatch: 10}
+	tp := NewTokenProcessor(clients.Queries, clients.HTTPClient, &metadataFetcher, clients.IPFSClient, clients.ArweaveClient, clients.StorageClient, env.GetString("GCLOUD_TOKEN_CONTENT_BUCKET"))
 
 	return handlersInitServer(ctx, router, tp, mc, clients.Repos, t, clients.TaskClient, redis.NewCache(redis.TokenManageCache))
 }

--- a/util/response.go
+++ b/util/response.go
@@ -83,7 +83,7 @@ func BodyAsError(res *http.Response) error {
 	}
 
 	if len(body) == 0 {
-		return fmt.Errorf("empty body")
+		return fmt.Errorf("empty response body")
 	}
 
 	// Otherwise, return the entire body as an error


### PR DESCRIPTION
**Changes**
* Renames `PlaceholderWrapper` to `FillInWrapper` - `FillInWrapper` uses Reservoir to fill in missing metadata and placeholder images not obtained from the first set of providers
* Adds `MetadataFinder` to tokenprocessing - `MetadataFinder` is a service that batches metadata requests from running pipelines and uses bulk API endpoints of providers to be more conservative on request. Missing metadata is filled in by `FillInWrapper`
  * Adds `GetTokenMetadataByTokenIdentifiersBatch` to the Alchemy provider which gets used by `MetadataFinder`
  * Adds `GetTokenMetadataByTokenIdentifiersBatch` to the Zora provider which gets used by `MetadataFinder`
* Updates `tokenmanage` to be more conservative on retries
  * Retries are now delayed by 5 minutes for not-Share-to-Gallery enabled contracts
  * Only errors related to the token e.g. `ErrBadToken` errors are retried instead of all errors
  * Default number of retries reduced from 4 to 2
* Opensea provider page size increased from 50 to 100