### PR TITLE
Fix wrapper cache func

### DIFF
--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -370,7 +370,14 @@ func (w *FillInWrapper) addTokenToBatch(t multichain.ChainAgnosticToken) func() 
 
 	if v, ok := w.resultCache.Load(ti); ok {
 		return func() multichain.ChainAgnosticToken {
-			return v.(multichain.ChainAgnosticToken)
+			f := v.(multichain.ChainAgnosticToken)
+			if !t.FallbackMedia.IsServable() {
+				t.FallbackMedia = f.FallbackMedia
+			}
+			if !hasMediaURLs(t.TokenMetadata, w.chain) {
+				t.TokenMetadata = f.TokenMetadata
+			}
+			return t
 		}
 	}
 

--- a/service/tokenmanage/tokenmanage.go
+++ b/service/tokenmanage/tokenmanage.go
@@ -172,9 +172,9 @@ func maxRetriesFor(td db.TokenDefinition) int {
 	return 2
 }
 
-func (m Manager) recordError(ctx context.Context, td db.TokenDefinition, err error) {
+func (m Manager) recordError(ctx context.Context, td db.TokenDefinition, originalErr error) {
 	// Don't penalize non-token related errors e.g. errors related to the pipeline
-	if err == nil || !util.ErrorIs[ErrBadToken](err) {
+	if originalErr == nil || !util.ErrorIs[ErrBadToken](originalErr) {
 		return
 	}
 
@@ -200,7 +200,7 @@ func (m Manager) recordError(ctx context.Context, td db.TokenDefinition, err err
 	}
 
 	if nowFlaky {
-		err := ErrContractFlaking{Chain: td.Chain, Contract: td.ContractAddress, Err: err, Duration: time.Hour * 3}
+		err := ErrContractFlaking{Chain: td.Chain, Contract: td.ContractAddress, Err: originalErr, Duration: time.Hour * 3}
 		logger.For(ctx).Warnf(err.Error())
 		sentryutil.ReportError(ctx, err)
 	}


### PR DESCRIPTION
The `FillInWrapper` cache func was returning the entire token, but we only want to use select fields instead of the entire token.