### PR TITLE
Add support for Privy auth

### DIFF
--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -489,6 +489,15 @@ type Post struct {
 	UserMintUrl sql.NullString   `db:"user_mint_url" json:"user_mint_url"`
 }
 
+type PrivyUser struct {
+	ID          persist.DBID `db:"id" json:"id"`
+	PrivyDid    string       `db:"privy_did" json:"privy_did"`
+	UserID      persist.DBID `db:"user_id" json:"user_id"`
+	CreatedAt   time.Time    `db:"created_at" json:"created_at"`
+	LastUpdated time.Time    `db:"last_updated" json:"last_updated"`
+	Deleted     bool         `db:"deleted" json:"deleted"`
+}
+
 type ProfileImage struct {
 	ID           persist.DBID               `db:"id" json:"id"`
 	UserID       persist.DBID               `db:"user_id" json:"user_id"`

--- a/db/migrations/core/000149_add_privy_users.up.sql
+++ b/db/migrations/core/000149_add_privy_users.up.sql
@@ -1,0 +1,11 @@
+create table privy_users (
+    id varchar(255) primary key,
+    privy_did varchar(255) not null,
+    user_id varchar(255) references users(id),
+    created_at timestamptz not null default current_timestamp,
+    last_updated timestamptz not null default current_timestamp,
+    deleted boolean not null default false
+);
+
+create unique index privy_users_privy_did_idx on privy_users (privy_did) where deleted = false;
+create unique index privy_users_user_id_idx on privy_users (user_id) where deleted = false;

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1977,15 +1977,6 @@ order by case when @paging_forward::bool then (cg.user_id != @relative_to_user_i
          case when not @paging_forward::bool then (cg.user_id != @relative_to_user_id, cg.community_id, -cg.gallery_relevance, cg.gallery_id) end desc
 limit sqlc.arg('limit');
 
-create index community_galleries_community_id_gallery_relevance_test_idx
-    on public.community_galleries (user_id, community_id, gallery_relevance, gallery_id);
-
-
-
-select * from users where username_idempotent = 'robin';
-
-select * from communities where name = 'Art Blocks';
-
 -- name: CountGalleriesDisplayingCommunityIDBatch :batchone
 select count(*) from community_galleries cg
     join galleries g on cg.gallery_id = g.id and not g.deleted and not g.hidden

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1984,3 +1984,16 @@ where cg.community_id = @community_id;
 
 -- name: SetPersonaByUserID :exec
 update users set persona = @persona where id = @user_id and not deleted;
+
+-- name: GetUserByPrivyDID :one
+select u.* from
+    privy_users p
+        join users u on p.user_id = u.id and not u.deleted
+where
+    p.privy_did = @privy_did
+    and not p.deleted;
+
+-- name: SetPrivyDIDForUser :exec
+insert into privy_users (id, user_id, privy_did)
+    values (@id, @user_id, @privy_did)
+    on conflict (user_id) where not deleted do update set privy_did = excluded.privy_did, last_updated = now();

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -9554,6 +9554,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPostComposerDraftDetailsInput,
 		ec.unmarshalInputPostTokensInput,
 		ec.unmarshalInputPreverifyEmailInput,
+		ec.unmarshalInputPrivyAuth,
 		ec.unmarshalInputPublishGalleryInput,
 		ec.unmarshalInputRedeemMerchInput,
 		ec.unmarshalInputReferralPostPreflightInput,
@@ -9685,9 +9686,7 @@ directive @authRequired on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 # Add @basicAuth to any field that should be secured by a basic auth token. For example, some fields
 # should only be usable by Retool, so they'd use @basicAuth(allowed: [Retool]). Other fields might be
 # accessible by both Retool and Monitoring, so they'd use @basicAuth(allowed: [Retool, Monitoring]).
-directive @basicAuth(
-  allowed: [BasicAuthType!]!
-) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @basicAuth(allowed: [BasicAuthType!]!) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @frontendBuildAuth on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
@@ -11557,6 +11556,7 @@ input AuthMechanism {
   debug: DebugAuth
   magicLink: MagicLinkAuth
   oneTimeLoginToken: OneTimeLoginTokenAuth
+  privy: PrivyAuth
 }
 
 input EoaAuth {
@@ -11597,6 +11597,10 @@ input MagicLinkAuth {
 }
 
 input OneTimeLoginTokenAuth {
+  token: String!
+}
+
+input PrivyAuth {
   token: String!
 }
 
@@ -12769,8 +12773,10 @@ type Mutation {
   setPersona(persona: Persona!): SetPersonaPayloadOrError @authRequired
 
   # Retool Specific Mutations
-  addRolesToUser(username: String!, roles: [Role]): AddRolesToUserPayloadOrError @basicAuth(allowed: [Retool])
-  addWalletToUserUnchecked(input: AdminAddWalletInput!): AdminAddWalletPayloadOrError @basicAuth(allowed: [Retool])
+  addRolesToUser(username: String!, roles: [Role]): AddRolesToUserPayloadOrError
+    @basicAuth(allowed: [Retool])
+  addWalletToUserUnchecked(input: AdminAddWalletInput!): AdminAddWalletPayloadOrError
+    @basicAuth(allowed: [Retool])
   revokeRolesFromUser(username: String!, roles: [Role]): RevokeRolesFromUserPayloadOrError
     @basicAuth(allowed: [Retool])
   syncTokensForUsername(username: String!, chains: [Chain!]!): SyncTokensForUsernamePayloadOrError
@@ -12785,7 +12791,8 @@ type Mutation {
   ): SyncCreatedTokensForUsernameAndExistingContractPayloadOrError @basicAuth(allowed: [Retool])
   banUserFromFeed(username: String!, reason: ReportReason!): BanUserFromFeedPayloadOrError
     @basicAuth(allowed: [Retool])
-  unbanUserFromFeed(username: String!): UnbanUserFromFeedPayloadOrError @basicAuth(allowed: [Retool])
+  unbanUserFromFeed(username: String!): UnbanUserFromFeedPayloadOrError
+    @basicAuth(allowed: [Retool])
   mintPremiumCardToWallet(
     input: MintPremiumCardToWalletInput!
   ): MintPremiumCardToWalletPayloadOrError @basicAuth(allowed: [Retool])
@@ -67777,7 +67784,7 @@ func (ec *executionContext) unmarshalInputAuthMechanism(ctx context.Context, obj
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"eoa", "gnosisSafe", "debug", "magicLink", "oneTimeLoginToken"}
+	fieldsInOrder := [...]string{"eoa", "gnosisSafe", "debug", "magicLink", "oneTimeLoginToken", "privy"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -67850,6 +67857,15 @@ func (ec *executionContext) unmarshalInputAuthMechanism(ctx context.Context, obj
 				return it, err
 			}
 			it.OneTimeLoginToken = data
+		case "privy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("privy"))
+			data, err := ec.unmarshalOPrivyAuth2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPrivyAuth(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Privy = data
 		}
 	}
 
@@ -69292,6 +69308,35 @@ func (ec *executionContext) unmarshalInputPreverifyEmailInput(ctx context.Contex
 				return it, err
 			}
 			it.Email = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputPrivyAuth(ctx context.Context, obj interface{}) (model.PrivyAuth, error) {
+	var it model.PrivyAuth
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"token"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "token":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("token"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Token = data
 		}
 	}
 
@@ -92391,6 +92436,14 @@ func (ec *executionContext) marshalOPreviewURLSet2ᚖgithubᚗcomᚋmikeydubᚋg
 		return graphql.Null
 	}
 	return ec._PreviewURLSet(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOPrivyAuth2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐPrivyAuth(ctx context.Context, v interface{}) (*model.PrivyAuth, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputPrivyAuth(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOProfileImage2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐProfileImage(ctx context.Context, sel ast.SelectionSet, v model.ProfileImage) graphql.Marshaler {

--- a/graphql/generated_test.go
+++ b/graphql/generated_test.go
@@ -28,6 +28,7 @@ type AuthMechanism struct {
 	Debug             *DebugAuth             `json:"debug"`
 	MagicLink         *MagicLinkAuth         `json:"magicLink"`
 	OneTimeLoginToken *OneTimeLoginTokenAuth `json:"oneTimeLoginToken"`
+	Privy             *PrivyAuth             `json:"privy"`
 }
 
 // GetEoa returns AuthMechanism.Eoa, and is useful for accessing the field via an interface.
@@ -44,6 +45,9 @@ func (v *AuthMechanism) GetMagicLink() *MagicLinkAuth { return v.MagicLink }
 
 // GetOneTimeLoginToken returns AuthMechanism.OneTimeLoginToken, and is useful for accessing the field via an interface.
 func (v *AuthMechanism) GetOneTimeLoginToken() *OneTimeLoginTokenAuth { return v.OneTimeLoginToken }
+
+// GetPrivy returns AuthMechanism.Privy, and is useful for accessing the field via an interface.
+func (v *AuthMechanism) GetPrivy() *PrivyAuth { return v.Privy }
 
 type Chain string
 
@@ -387,6 +391,13 @@ func (v *PostTokensInput) GetMentions() []MentionInput { return v.Mentions }
 
 // GetMintURL returns PostTokensInput.MintURL, and is useful for accessing the field via an interface.
 func (v *PostTokensInput) GetMintURL() *string { return v.MintURL }
+
+type PrivyAuth struct {
+	Token string `json:"token"`
+}
+
+// GetToken returns PrivyAuth.Token, and is useful for accessing the field via an interface.
+func (v *PrivyAuth) GetToken() string { return v.Token }
 
 type PublishGalleryInput struct {
 	GalleryId persist.DBID `json:"galleryId"`

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -606,6 +606,7 @@ type AuthMechanism struct {
 	Debug             *DebugAuth             `json:"debug"`
 	MagicLink         *MagicLinkAuth         `json:"magicLink"`
 	OneTimeLoginToken *OneTimeLoginTokenAuth `json:"oneTimeLoginToken"`
+	Privy             *PrivyAuth             `json:"privy"`
 }
 
 type AuthNonce struct {
@@ -2039,6 +2040,10 @@ type PreviewURLSet struct {
 	SrcSet     *string `json:"srcSet"`
 	LiveRender *string `json:"liveRender"`
 	Blurhash   *string `json:"blurhash"`
+}
+
+type PrivyAuth struct {
+	Token string `json:"token"`
 }
 
 type PublishGalleryInput struct {

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -209,6 +209,10 @@ func (r *Resolver) authMechanismToAuthenticator(ctx context.Context, m model.Aut
 		return authApi.NewOneTimeLoginTokenAuthenticator(m.OneTimeLoginToken.Token), nil
 	}
 
+	if m.Privy != nil && m.Privy.Token != "" {
+		return authApi.NewPrivyAuthenticator(m.Privy.Token), nil
+	}
+
 	return nil, errNoAuthMechanismFound
 }
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -1891,6 +1891,7 @@ input AuthMechanism {
   debug: DebugAuth
   magicLink: MagicLinkAuth
   oneTimeLoginToken: OneTimeLoginTokenAuth
+  privy: PrivyAuth
 }
 
 input EoaAuth {
@@ -1931,6 +1932,10 @@ input MagicLinkAuth {
 }
 
 input OneTimeLoginTokenAuth {
+  token: String!
+}
+
+input PrivyAuth {
   token: String!
 }
 

--- a/publicapi/auth.go
+++ b/publicapi/auth.go
@@ -3,6 +3,7 @@ package publicapi
 import (
 	"context"
 	"fmt"
+	"github.com/mikeydub/go-gallery/service/auth/privy"
 	"github.com/mikeydub/go-gallery/service/redis"
 	"github.com/mikeydub/go-gallery/util"
 	"time"
@@ -32,6 +33,7 @@ type AuthAPI struct {
 	magicLinkClient    *magicclient.API
 	oneTimeLoginCache  *redis.Cache
 	authRefreshCache   *redis.Cache
+	privyClient        *privy.Client
 }
 
 func (api AuthAPI) NewNonceAuthenticator(chainAddress persist.ChainPubKey, nonce string, signature string, walletType persist.WalletType) auth.Authenticator {
@@ -118,6 +120,10 @@ func (api AuthAPI) NewOneTimeLoginTokenAuthenticator(loginToken string) auth.Aut
 		LoginToken:         loginToken,
 	}
 	return authenticator
+}
+
+func (api AuthAPI) NewPrivyAuthenticator(authToken string) auth.Authenticator {
+	return privy.NewAuthenticator(api.repos.UserRepository, api.queries, api.privyClient, authToken)
 }
 
 func chainAddressPointersToChainAddresses(chainAddresses []*persist.ChainAddress) []persist.ChainAddress {

--- a/publicapi/publicapi.go
+++ b/publicapi/publicapi.go
@@ -2,6 +2,7 @@ package publicapi
 
 import (
 	"context"
+	"github.com/mikeydub/go-gallery/service/auth/privy"
 	"net/http"
 	"time"
 
@@ -68,6 +69,7 @@ func New(ctx context.Context, disableDataloaderCaching bool, repos *postgres.Rep
 	loaders := dataloader.NewLoaders(ctx, queries, disableDataloaderCaching, tracing.DataloaderPreFetchHook, tracing.DataloaderPostFetchHook)
 	validator := validate.WithCustomValidators()
 	tokenManager := tokenmanage.New(ctx, taskClient, tokenManageCache)
+	privyClient := privy.NewPrivyClient(httpClient)
 
 	return &PublicAPI{
 		repos:     repos,
@@ -76,7 +78,7 @@ func New(ctx context.Context, disableDataloaderCaching bool, repos *postgres.Rep
 		validator: validator,
 		APQ:       apq,
 
-		Auth:          &AuthAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient, multiChainProvider: multichainProvider, magicLinkClient: magicClient, oneTimeLoginCache: oneTimeLoginCache, authRefreshCache: authRefreshCache},
+		Auth:          &AuthAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient, multiChainProvider: multichainProvider, magicLinkClient: magicClient, oneTimeLoginCache: oneTimeLoginCache, authRefreshCache: authRefreshCache, privyClient: privyClient},
 		Collection:    &CollectionAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient},
 		Gallery:       &GalleryAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient},
 		User:          &UserAPI{repos: repos, queries: queries, loaders: loaders, validator: validator, ethClient: ethClient, ipfsClient: ipfsClient, arweaveClient: arweaveClient, storageClient: storageClient, multichainProvider: multichainProvider, taskClient: taskClient, cache: socialCache},

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -1900,6 +1900,7 @@ func createNewUserParamsWithAuth(ctx context.Context, authenticator auth.Authent
 		EmailStatus:  persist.EmailVerificationStatusUnverified,
 		ChainAddress: wallet.ChainAddress,
 		WalletType:   wallet.WalletType,
+		PrivyDID:     authResult.PrivyDID,
 	}
 
 	// Override input email with verified email if available

--- a/secrets/dev/backend-env.yaml
+++ b/secrets/dev/backend-env.yaml
@@ -81,6 +81,9 @@ AUTOSOCIAL_POLL_QUEUE: ENC[AES256_GCM,data:5FQ4Ffp8cWbiGfbEEjn1zblBddof7+oTbRAbY
 FARCASTER_APP_ID: ENC[AES256_GCM,data:XbSlxqU=,iv:mk02Jj8h5b91neKQB09co2h9Bx5byESaAnW20bHXfgg=,tag:NZdoEwU6IvBv6FG6ms1WsA==,type:str]
 FARCASTER_MNEMONIC: ENC[AES256_GCM,data:aSpQhaP9KdRgWO8qS+YNPAcbYEMPGqQCLbphk32F7DE0JXreKO8nPLj46tpV7IYBSOOhQJwLoEvIbobCKue/GiwujZQ10wO4LGqzWGnDg9g6HJJBZydSi+hs83zUIwgDEYgNkBgjNEOaAFjHM/8gjJaavyMl3oP7wIWyLm0HVE1SYiWxYn3347qGzrLN4iqzd9vWWICKpImK,iv:36I2Acgj9bS23Pn2QV4PgD/e2sBsqdAGPukCw3EBvkk=,tag:JjiZRn9h5cyYT1N6XmnEUQ==,type:str]
 AUTOSOCIAL_URL: ENC[AES256_GCM,data:4t2yAxgNVw42WqeSzHiXcITANTHSWQIh9TsEGW62xBnhFsizxfbh7UsW,iv:oW4x0ydvjTXk7lkNfhCscY4tYZJhyxXHzIo33C+IMCo=,tag:R3aZ3bDpB/wjbzRPRBgFCg==,type:str]
+PRIVY_APP_ID: ENC[AES256_GCM,data:7571Z6/8N60C4lhlTurLah+v9ph+32wvow==,iv:It9YF/vikymijxDmRw3oPA/gV9iVTsG0/deTltmfgas=,tag:zb97lWpjKcZDZmBS8YTs2g==,type:str]
+PRIVY_APP_SECRET: ENC[AES256_GCM,data:sHr420MonsE9ut5iuaoMc7wG6vbm7M0upNL8bbzobw84XtFpGVO3RhsJm6Moh+YFLid61A5k1SxXMH1WK9b+GncBegrorBzlRaFo7FIjuDROyDOtLDyDAA==,iv:wbJFO41z+GTbMd/yFbjZi0xlUZn+qUpkua2A9jQBbN4=,tag:VX35/8P0VKqvlsxLNPNxtA==,type:str]
+PRIVY_APP_VERIFICATION_PUBLIC_KEY: ENC[AES256_GCM,data:jSJzPxDJ/n6FaMojUpemWMiQp2jBiZlADSlZpmFAB+RglKUU4nY5mfHJ8+af+uvsW8WYgYYmOZJXESlxlIGzqL2I+3k/3fyC7Z3pelhLID9gSajZxaVvvw3P1Qdp77NyRAVHyUyYgutnCHDks5lGQ44ZE9LHaLo7y6serSx3sOl1fhsXzyIdIKVFeU3Ke8MPPGNgjt9lTHaK51haxPSJRweuUvNEkQ19aR4XDZSwcSOa,iv:hAq/BFyZzGEQf9dGoku2BBAn5FwDfEz5D3DHXiu22CY=,tag:ZUE5vTvxYLCEhYJYF23k0Q==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -90,8 +93,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-21T18:49:35Z"
-    mac: ENC[AES256_GCM,data:zsiqMQQODfvAw4jivPEx3g8IcSKS/wa8mvY1GFZZy4tXbCON7qYx2tRi93Wyk00DujB2EyptspZiWovv4W7IOQNjxOPSDc8VUk+rqLcFDWUYwsSKP3vhG1Wzx04UWFnt9N6haFEKXBmBc3CNY81nDjY9EDH/C6JCOpyD0QSHdQ0=,iv:YUFaLrqO6kyFfGjs8LWRstpKxzbGiGjL+H869gm/9kY=,tag:An6lFt2xxK5ysixZNWlCag==,type:str]
+    lastmodified: "2024-02-27T20:30:30Z"
+    mac: ENC[AES256_GCM,data:6k5oeqR8lQHdAfxY+6UoNg2WzUatPN+K/1EFqu+tRD5uINgpyjAmThDjmM0L7egKg8HpFGoODhAD1Fne0CHLCYKQBbyZ+VIuczt9U3RWXrOLQ/o73Ib4F9pwaYgcMRNinGpodGAeau99e2O7+4YAD7Vrw4g0X/CF/dVivuLrzdI=,iv:/pS+yvMDVx0rtANJN/dx1oO+HH+13mEuJtW0HVE3CNE=,tag:6ADc7ps5Gx8jZrDnWMz3kQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/backend-sandbox-env.yaml
+++ b/secrets/dev/backend-sandbox-env.yaml
@@ -77,6 +77,9 @@ AUTOSOCIAL_POLL_QUEUE: ENC[AES256_GCM,data:BYBDm9D2b4a9AdNe7rPfvRqfS3yLykKdLNm2R
 AUTOSOCIAL_QUEUE: ENC[AES256_GCM,data:BPqvzkmmeuzh+HRG5lrcWxgvMXZAxfRPodcONpJmozH1zFjJQSt5udqJcVtt05pZFANg6Co3TnybtDfpiATLjA==,iv:Qvbu6LhYhxfkeBfHZa0tJzEgNE+fUC4uJ9NwLWAJmdY=,tag:f6/U3sEx2A4Uxtk96mefEw==,type:str]
 AUTOSOCIAL_URL: ENC[AES256_GCM,data:humqm2K3s7S7fblBjBu3Q5j/+OdaKP4UnKQaqlKGGKjLuR7VoYNMOMqk,iv:2eqYMCgwsd8UbBPogAhwPrZxOidWtGPeFwlVVfpTd3I=,tag:XFy9uMj8ZvFw8UYqFVH9Vg==,type:str]
 EMAILS_TASK_SECRET: ENC[AES256_GCM,data:c/Zlif9+2peIeDwlbkWpvywEgmIHFsapBoW+exWrpSA=,iv:QHMsIihSqAU82KzWAy6OOpBmCA5coRUfSve38/1Ql6E=,tag:XFUumeDUcIvQBPYb33LFAA==,type:str]
+PRIVY_APP_ID: ENC[AES256_GCM,data:yVrhT1JLk1z6QNI53m2cM8rRRHX+0NBEcQ==,iv:cUCmg96xipIzATF6tV1ZNBUT6M8b9CXq/4ytU5a83ao=,tag:1abohq56ZJBquCU2J6n3pg==,type:str]
+PRIVY_APP_SECRET: ENC[AES256_GCM,data:9l/XZSnAaRfEW/eI92QAHdh5itZ6erhpun3YFHaZqZd7zpYeJzQdZnhe10X9VdyhClgkRYXTdKqH4XhkqMLAyuzJQ27qdntWILGbwEI8iaG3hZb1jWDuCQ==,iv:JyjQwKCKtzRiqSCtCKIjPUvlqBR8jn7DYAVw5F2dDHs=,tag:CGeUyR4wGQBtcONs9f9xWg==,type:str]
+PRIVY_APP_VERIFICATION_PUBLIC_KEY: ENC[AES256_GCM,data:PKS5+N5Ul2TBTVa5RVFI6G6jh3DY7uAzmgSeii6e7UpZlyXznBOie96agmkuavp8HZCKC7GqS8hIIOjLWntP/lTwKg4lU1+uYnRLy1EjRFr39eerujOxHeGBO9pDjQcqJie6bHD7KBKYkmzCrp6ljJTyFOZRqkBOHUhJh8ceDhNEBUFtPXPE0735jSFTroJOfYZgEFtQKiUAQ2zSof8dmkgXwIEm59L+Q8tCusiM9J1C,iv:34TunGYcJFYh+GpHMFRFA3XR7TlpSzdE/4xeOEzR5gk=,tag:CHcsSnAzyLP8BkiA4ls9SA==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -86,8 +89,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-21T18:50:43Z"
-    mac: ENC[AES256_GCM,data:PQhHtlslg9QrZcnfSTU8dcu8zdAqJn3QvzCKICok5+FVKC3oyPihpFIy/2Z2j48zgDwu2vhjkCvLr1mXzQnDYqi4BrBmywEO8Ua61XW2UXBijUw+g2RyvhVEv12b8rI+5LktJ/2W43JyPOAOUHJQKToJhG2JRxzCtcC0mRebZOQ=,iv:oRNusad6z5ZwqfUXN9jWC2O/zLXbvGV6jQjjFFAiQSc=,tag:G3rryUz5Fz0yXs5WL/KrTg==,type:str]
+    lastmodified: "2024-02-27T20:30:38Z"
+    mac: ENC[AES256_GCM,data:KA7hSfxA7tJIci6rmapCJ9PRAYayl2vTXHlcSFQN1GKlIrzseARWPgpxIZs1nKecwfS573fBHLXiv3xGimeWyQWBlfArUyLuMtbxHETrHSiamT70iRQ2A5z9I13EY3LyoPaETnFBpyAISO6LHwCjZOOW5VgvFch9zmR8k/nOn/M=,iv:Xp/pBsxb1Z6+x6E5dBQE4QbeqUu4rp6uvIh3AWYSIKA=,tag:UUxdKDkMS1jBUJD6o0XZNA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -55,6 +55,9 @@ AUTOSOCIAL_POLL_QUEUE: ENC[AES256_GCM,data:KoTHV1WcXWiZl9AH1N9hFbLPKcLJtu6t7VU1A
 FARCASTER_APP_ID: ENC[AES256_GCM,data:CIE5LXA=,iv:6BFb5CbDZX9QCBdhYfRvqd0V85Qr8jw3dEzSjeOYTQY=,tag:GN58N7R0+k/5p7tUI6V2mg==,type:int]
 FARCASTER_MNEMONIC: ENC[AES256_GCM,data:cp/FCHu3vdGXOnwnyba0IqnfQkTfeVlNb/JFVGA/ssz0vKjqTnX5kRae+AfoVn61e8juLzjNEqy8JoT4YyPEkh+Ave9PeoP4CyNNGt2hbLv85kBsn3Y/kpJC7GS+conmptGwl22yfcA/wl2Gmmy8ApAuZzj+1bzK1Saht2YlE4bxLsmDGbnNEs5pmcCHZ2kkkGYLgT0TlXSJ,iv:za1TlWCtqr17ifFd1Wo0PG3h3pID5NgUKhw/0AGQcak=,tag:PjSJ1DmGowh3oPAfUkW/VQ==,type:str]
 FEEDBOT_URL: ENC[AES256_GCM,data:381swg3qLYO6UfGdWz65pwv6dnC3MrD4hrcYHrvfq3lKF/ySAAkH3/IKwg==,iv:n06Bc+VsJZKvV9RZAqxlGL8+EqboXdBOHbR8xqv4G8I=,tag:0ZjRuTOGrR4D+fQ49/2hYw==,type:str]
+PRIVY_APP_ID: ENC[AES256_GCM,data:nSCzZQxh7uv1jKrmQ1ITN2z9MBRrsETLSA==,iv:bG/DVVNC87c41djumk27bjZgKLJsVKiagClhQ5gTcUk=,tag:cIio12thDNIxjSj6SEMG7Q==,type:str]
+PRIVY_APP_SECRET: ENC[AES256_GCM,data:KiPaoRMil8aINYsS8MiwC2iTRT6Qf/kRPcwhb5QHrp1B9eDe1JogQALJpGF23BlDYgVKnxyVC0+FvAq1PXJMKPdMXTaFr4YLnMmgiXpAGYCmHVx9hkr6Rw==,iv:XadFyji5Tthsie0M+Ezp+WBYZEtk2BkVCbs2kJNRGJg=,tag:Jl3ZSj7e68NH4xex50jQIQ==,type:str]
+PRIVY_APP_VERIFICATION_PUBLIC_KEY: ENC[AES256_GCM,data:Qj9y9WDxGqbb2y77bidznNJ2j6lMLh2sNKkyqkFA6z6/KgZOO+SdzdGndOKQ6OO4OK7tPW/giiColeV70p2RS8GEc4ezDjON+xZW3KMudyErWJ1kf77JggPispSgm8UepW8XL4HHcmhRckqUvmVytguQnn3Ilac+tZ583dAtZX43Ydu9a678zB/AYKIhaLzFUvnXQXi9azleLVQpQRbhI185m/H91X5fN/DcN8jrw5JM,iv:si/iWb8FBhvCWI4npSs41wMWFoRFEryGcQSPPxST0No=,tag:Rp3rcU5cn2BrB4PfC4G/bg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -64,8 +67,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-21T18:50:31Z"
-    mac: ENC[AES256_GCM,data:8hpGsKPIXUHb2WOwNtiZ1zUVOGC7tlacVIhWmlVAGfw5ZX21xWbGGTp3HBMTv3wa+X/Yi90b0QAqLKDcWb7SECOpbkOum9vWi0FmloJpyFxxffDszxpvcte9AUqx29aqjEfR0bYCVKQbCFXgtBzvQUq05ZR202Pa2oUf8KfLMGQ=,iv:KAEl982RxTEOMQgmKWoIJTHt7ZWPOlEE7/eAvVCPFeA=,tag:s5LmGfA8KDfsaTINAYCN0Q==,type:str]
+    lastmodified: "2024-02-27T20:31:04Z"
+    mac: ENC[AES256_GCM,data:5m4R8nsbz/lvD9dYASriKY3TpdHtEmkJMaFCBEOrqhRT2BuXwltjkg/EpxA2Rn2A9TkREwCwycciZDJcQZKLt1K0OY1m0SEGfp9F7y2I2z2ptYIciFkw8nsZkXLYye2Vw8lpDtZP3sXT51mxOGqEM2p9K74ArboYydwdjwBTjBQ=,iv:iYsfRQUiI+k6CdEUybVJ3mvQOJCTFbXaEeRTkmbsb2c=,tag:ChLtrlOCRdQ8nCTNeQlPTA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-backend.yaml
+++ b/secrets/local/local/app-local-backend.yaml
@@ -48,6 +48,9 @@ AUTOSOCIAL_POLL_QUEUE: ENC[AES256_GCM,data:lJcSmOd4k8zk09H4tS6LpC3dv9o3xWb4syW7I
 FARCASTER_APP_ID: ENC[AES256_GCM,data:qNkJv38=,iv:4hinorYJ88qkOKLmQ3NlQQAZ9KOFVXzWzd5RVxOxxQQ=,tag:nRVBK692F3TJUDsquEAg1w==,type:int]
 FARCASTER_MNEMONIC: ENC[AES256_GCM,data:q4L4MvXgQUWJSYEbyzIXIW0Ypq6Lf2ewv0eLgdQaslbyrg8PkJ2OCI98eNHimXRJtXwUa3+AA4rWXPf22qua4RZh2qKdIB9Q3jQuP7TXpHVu12RllwIDUsoh7i3pnFQ+mDxZNZQIJgzgyCDFQLI1exaPK+HIFysZ/B11Yul4QocDdxLJtsYzHXhaLTy224/EMDR5t331mDto,iv:bENLEzzg8ueZ8UGkfVg+SOUqERkd8fOTg4CO3aDNXJs=,tag:8Qqmi0G5whF4+VUZdt3ZBQ==,type:str]
 AUTOSOCIAL_URL: ENC[AES256_GCM,data:Jx2v/E4x841LeDjmiUUmTT70IBfJmmzbhmCUTd/aqUM=,iv:n8NkhZosTCwo0AEXuRvQoVvlzBcEdWa1Swa2gWIA8yU=,tag:BH5wARsJ4w31HFkVfMBN7w==,type:str]
+PRIVY_APP_ID: ENC[AES256_GCM,data:0H5ejAYSM+tuTMfIIHDQhs0gq2IMKGTHMw==,iv:li5cC97Prq2x2mMqhrGnDoaRZsLzShYl8FsenrvrObU=,tag:PebG0voKS2UNPcSuzy/GFA==,type:str]
+PRIVY_APP_SECRET: ENC[AES256_GCM,data:8WwOWHpTl/2T/Y+A06VIjVf7pdXZhKjmdc7db7XWd7S7EsNJ5FObtGFkxcwcyTs4lBeN7C/4mzPoD4IFNWAo1eOFIp35tYJs8n7e3OQaB76UfhSS7J2NPg==,iv:XzJbr0gkrGqn6jdNBfDrUPxycZsFZi0SXQ9mb3bimIQ=,tag:mFcwY+LyR9mCWDBeuaWMsw==,type:str]
+PRIVY_APP_VERIFICATION_PUBLIC_KEY: ENC[AES256_GCM,data:qXBYiUJ1jq5EZsaYX+Mt/VqTEgl4ia8eY2cs4NqvMDDwVQCFoYH1mRnyFnNz9WcdPliPbyqz95WeDoljCq7LVSx/dsUcZQCkBpt6aMGZxH+rMcxZhKe5fHSVM/Bwg9hVGxnARBnbPt2GTbZzqSuqiIxkKWn+d1dXpNgkttZhPH/qnslnU8kqWyHXWbBs3IKzk5hnutKsrqjdoC13A4fuadLGFQzDLobM6+eCLHBjJ58R,iv:d+IlgiQ7+XtJ7VVOXOyVPkMaXZKgKD97g0/Rzv7cg+0=,tag:NWcn2JzOz8n7YXs/usZ93g==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -57,8 +60,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-20T22:53:14Z"
-    mac: ENC[AES256_GCM,data:FIp+oOsAFrfpe/hWTV+XjVqp7yTbXOTv+VI/Bk5NHNUUuo5vAhrCi/BKq4kGzvZtzEMqADRqK2Q5huLg9Br9ZHtWdUrarcntV12iPXDZrdctr1DlvhEGlUJKB61cvymDQoSBi63vb39+ZoKxljN+0JcB+ITaJJgPpCIFjQD66/U=,iv:a7srz+vvLzP/LslC+Nf6IrqHCrxBqgvMq/KU5awkVbA=,tag:x/FsRMJDCNoRafTXNxFZGA==,type:str]
+    lastmodified: "2024-02-27T20:51:01Z"
+    mac: ENC[AES256_GCM,data:6bZNvoTuvEqYnMbflqs944/L8teQ6vkXN8KOVDkZvL5Ou12FeW2Fd7fBmFCXPoEi8lpnT5bpHZB87iIWBND8iyOEaVxn/XYwBOr/7bD3jii6JWWZJHRg/DIqEy4DXyf4/QHYgufxA/FlTD708Mb+lPOc01dHJEcuDYNOKc3We4c=,iv:jNmngLR7q1O49RolGZDlpuaOMxXS0k/7FpmkPovc69A=,tag:TGMCLrLlj1VxjSn791Xwbg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/backend-env.yaml
+++ b/secrets/prod/backend-env.yaml
@@ -81,6 +81,9 @@ AUTOSOCIAL_URL: ENC[AES256_GCM,data:1++2NVhPw2K6vfAJO/DYX6w+OeieJQKC7X/+yQOJ655d
 FARCASTER_APP_ID: ENC[AES256_GCM,data:SolNb84=,iv:hNcFyPKsF0V47iiXFr+/NXj8hswPYcDjRuM4Fma9MrU=,tag:R0LNcics4b8l+m8pAPzURg==,type:str]
 FARCASTER_MNEMONIC: ENC[AES256_GCM,data:q+xR6yHx5s14kDORrhrSGvHhYjbftOvuJLtnpuvJFxPx7Vcm20JglxhiR+hOW9EMQxfESVIPZKctCJ77yRySK3S+M7suwDx8xWCL26g/p0Ou+Vm4/gaQNptEIaeLI2jYwD/RC3pFfsewz9cCtMNACmKYGWHt6s9iGxgEDyD5PDG76WmCAlWqxsGaGG3C2s2aiVmeEWrRuXFe,iv:FoyeTEnnKEGYM0tQTgofSuifkWk4hDssPtvNrZCW8SA=,tag:sKH7cFb1SFObGQdK1dgLcQ==,type:str]
 EMAILS_TASK_SECRET: ENC[AES256_GCM,data:C+HWjJa5qu5Rs2xGjqek6tcYI8SnGhdziOSyq54W7Uk=,iv:qcek1g7fyDb3B8mOrDqowoYXGvS6WkAyuN9xABGkZfw=,tag:qvlHiesFIvUe8Il3INXzkQ==,type:str]
+PRIVY_APP_ID: ENC[AES256_GCM,data:UOMjtjHwvJSAUOoDdtEoczuG2xid2ETUgg==,iv:HrxkchGLuTy5Bo6t1HBCxhkKf5H69QnnroXLNGF9k0k=,tag:Fp7Felnzi91xK0EWO3JoIw==,type:str]
+PRIVY_APP_SECRET: ENC[AES256_GCM,data:5/iKvGHDBIA9UR6be2XzudSYIINl5o36AXXIUmn68RU9ZBT/W5inDfPSgXQtg16L053KIkUao66+zWEE8RroJ1RP/sVRMcCeIwg3loFpemIV6S2+7jybEw==,iv:+tdVDN4bEI3DbbXPi82ESaEmJBc9HlGeA6Eh21WTBCU=,tag:WI7HjZ1r/WtX1rhFD5guhA==,type:str]
+PRIVY_APP_VERIFICATION_PUBLIC_KEY: ENC[AES256_GCM,data:Oebjazq3IqOsRJPOdYYu4zjuIT+yBEDHkcKFX+pWQz7ra/NiZwaa4aZXunSBGolTIoPOfA/F9vN1rOhTklin4xHd4sQ3VJ0m3yxrmdbpeBjEnMLguwUBHXvPyNbP6zkAxZ9MMHWsZnW7r4IxikuvReGlX/We1gE19et2QFToU6m46iaF68gChcc7hqy98og52pS+j5xe+qo7KLEEsWzSfLC9H+UUZEEWU7haA4DbWGU6,iv:82pCBuCt+qJXdErVeCScBTmhVEcxYfn4TzApfiOKn8s=,tag:Ps62L8TZk5cbd4jPBFy9jQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -90,8 +93,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-21T18:48:07Z"
-    mac: ENC[AES256_GCM,data:d2Kd8U5qgg136xQQ2Qz21r5rOM7HQKB81eSw4ZtUHARbPFnsL8LY2nRiw8ZpB71+liwFbqEMxB2yETLseW0dCnXJIGwCwC2a5nTWffwtC2BgixNTfIkabYjMB99X7HRNM8U92a+oD6OUcV0YNTHUmy5UaC+ZiQR+27z1an6W9VY=,iv:bZYiRFNBuZqcBPcQr5svkRjzT5TF3HtFBvjqx5Zs60c=,tag:vn9BP7UDT5aHJgg9Hh/gdw==,type:str]
+    lastmodified: "2024-02-27T20:29:55Z"
+    mac: ENC[AES256_GCM,data:DW2SlH6QSSjwERmm161TpUQHLoO8pGzNaVFpeOESNEHoW+DabMjfajI68Y4M1mGPha81RL7aHaCIHhGXVwVGwZwSkasVu/MaDcvPj5YviLhpDy1Ql6AURXTj6GppuMlfNBjmDtM1ha6MUiUzsUMUXm/sSrFddOyjr2O2SeDEwZg=,iv:DIIEkvaFOMWsxi3Ilqj09x00n8DZnkck376WoI2M3CQ=,tag:Cb9HAYVjpN1gedEtZJVD2A==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -102,6 +102,7 @@ type AuthResult struct {
 	User      *persist.User
 	Addresses []AuthenticatedAddress
 	Email     *persist.Email
+	PrivyDID  *string
 }
 
 func (a *AuthResult) GetAuthenticatedAddress(chainAddress persist.ChainAddress) (AuthenticatedAddress, bool) {

--- a/service/auth/privy/privy.go
+++ b/service/auth/privy/privy.go
@@ -1,0 +1,214 @@
+package privy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v4"
+	"github.com/mikeydub/go-gallery/db/gen/coredb"
+	"github.com/mikeydub/go-gallery/env"
+	"github.com/mikeydub/go-gallery/service/auth"
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/service/persist/postgres"
+	"github.com/mikeydub/go-gallery/service/sentry"
+	"github.com/mikeydub/go-gallery/util"
+	"net/http"
+)
+
+const usersURL = "https://auth.privy.io/api/v1/users"
+
+type PrivyAuthenticator struct {
+	userRepo       *postgres.UserRepository
+	queries        *coredb.Queries
+	privyClient    *Client
+	privyAuthToken string
+}
+
+func (a PrivyAuthenticator) GetDescription() string {
+	return fmt.Sprintf("PrivyAuthenticator")
+}
+
+func NewAuthenticator(userRepo *postgres.UserRepository, queries *coredb.Queries, privyClient *Client, privyAuthToken string) PrivyAuthenticator {
+	return PrivyAuthenticator{
+		userRepo:       userRepo,
+		queries:        queries,
+		privyClient:    privyClient,
+		privyAuthToken: privyAuthToken,
+	}
+}
+
+func (a PrivyAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult, error) {
+	privyDID, err := a.privyClient.parseAuthToken(ctx, a.privyAuthToken)
+	if err != nil {
+		return nil, err
+	}
+
+	details, err := a.privyClient.getUserDetails(ctx, privyDID)
+	if err != nil {
+		return nil, err
+	}
+
+	var persistUser *persist.User
+
+	// Look for an existing user, but don't error if there isn't one
+	dbUser, err := a.queries.GetUserByPrivyDID(ctx, privyDID)
+	if err == nil {
+		// Convert the coredb.User to a persist.User via SQL
+		u, err := a.userRepo.GetByID(ctx, dbUser.ID)
+		if err != nil {
+			return nil, err
+		}
+		persistUser = &u
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, err
+	}
+
+	authResult := auth.AuthResult{
+		User:     persistUser,
+		Email:    details.EmailAddress,
+		PrivyDID: util.ToPointer(privyDID),
+	}
+
+	for _, wallet := range details.Wallets {
+		authResult.Addresses = append(authResult.Addresses, auth.AuthenticatedAddress{
+			ChainAddress: wallet,
+			WalletType:   persist.WalletTypeEOA,
+		})
+	}
+
+	return &authResult, nil
+}
+
+func NewPrivyClient(httpClient *http.Client) *Client {
+	appID := env.GetString("PRIVY_APP_ID")
+	appSecret := env.GetString("PRIVY_APP_SECRET")
+	jwtPublicKey := env.GetString("PRIVY_VERIFICATION_PUBLIC_KEY")
+
+	return &Client{
+		httpClient:   httpClient,
+		appID:        appID,
+		appSecret:    appSecret,
+		jwtPublicKey: jwtPublicKey,
+	}
+}
+
+type Client struct {
+	httpClient   *http.Client
+	appID        string
+	appSecret    string
+	jwtPublicKey string
+}
+
+type userResponse struct {
+	ID             string          `json:"id"`
+	CreatedAt      uint64          `json:"created_at"`
+	LinkedAccounts []linkedAccount `json:"linked_accounts"`
+}
+
+type linkedAccount struct {
+	Type             string `json:"type"`
+	Address          string `json:"address"`
+	ChainType        string `json:"chain_type"`
+	ChainID          string `json:"chain_id"`
+	WalletClient     string `json:"wallet_client"`
+	WalletClientType string `json:"wallet_client_type"`
+	ConnectorType    string `json:"connector_type"`
+	VerifiedAt       uint64 `json:"verified_at"`
+}
+
+type privyClaims struct {
+	jwt.RegisteredClaims
+}
+
+// parseAuthToken parses a Privy JWT token and returns the privy DID.
+// See: https://docs.privy.io/guide/server/authorization/verification
+func (c *Client) parseAuthToken(ctx context.Context, token string) (string, error) {
+	privyKeyFunc := func(token *jwt.Token) (interface{}, error) {
+		if token.Method.Alg() != "ES256" {
+			return nil, fmt.Errorf("unexpected JWT signing method=%v", token.Header["alg"])
+		}
+
+		return jwt.ParseECPublicKeyFromPEM([]byte(c.jwtPublicKey))
+	}
+
+	claims := privyClaims{}
+	parsedToken, err := jwt.ParseWithClaims(token, &claims, privyKeyFunc)
+
+	if err != nil || !parsedToken.Valid {
+		return "", auth.ErrInvalidJWT
+	}
+
+	if len(claims.Audience) != 1 || claims.Audience[0] != c.appID {
+		return "", errors.New("audience claim must be your Privy App ID")
+	}
+
+	if claims.Issuer != "privy.io" {
+		return "", errors.New("issuer claim must be 'privy.io'")
+	}
+
+	return claims.Subject, nil
+}
+
+type userDetails struct {
+	EmailAddress *persist.Email
+	Wallets      []persist.ChainAddress
+}
+
+func (c *Client) getUserDetails(ctx context.Context, privyDID string) (userDetails, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/%s", usersURL, privyDID), http.NoBody)
+	if err != nil {
+		return userDetails{}, err
+	}
+
+	req.SetBasicAuth(c.appID, c.appSecret)
+	req.Header.Add("privy-app-id", c.appID)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return userDetails{}, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return userDetails{}, util.GetErrFromResp(resp)
+	}
+
+	var output userResponse
+	err = json.NewDecoder(resp.Body).Decode(&output)
+	if err != nil {
+		return userDetails{}, err
+	}
+
+	details := userDetails{}
+
+	for _, account := range output.LinkedAccounts {
+		if account.Type == "email" {
+			details.EmailAddress = util.ToPointer(persist.Email(account.Address))
+		} else if account.Type == "wallet" {
+			chain, err := privyChainToPersistChain(account.ChainType)
+			if err != nil {
+				err := fmt.Errorf("error parsing Privy chain type: %w", err)
+				logger.For(ctx).Error(err)
+				sentryutil.ReportError(ctx, err)
+				continue
+			}
+			details.Wallets = append(details.Wallets, persist.NewChainAddress(persist.Address(account.Address), chain))
+		}
+	}
+
+	return details, nil
+}
+
+func privyChainToPersistChain(privyChain string) (persist.Chain, error) {
+	// According to Privy docs, "ethereum" is currently the only valid chain_type
+	switch privyChain {
+	case "ethereum":
+		return persist.ChainETH, nil
+	default:
+		return -1, fmt.Errorf("unrecognized chain type: %s", privyChain)
+	}
+}

--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -268,6 +268,17 @@ func (u *UserRepository) Create(pCtx context.Context, pUser persist.CreateUserIn
 		return "", err
 	}
 
+	if pUser.PrivyDID != nil {
+		err := queries.SetPrivyDIDForUser(pCtx, db.SetPrivyDIDForUserParams{
+			ID:       persist.GenerateID(),
+			UserID:   userID,
+			PrivyDid: *pUser.PrivyDID,
+		})
+		if err != nil {
+			return "", err
+		}
+	}
+
 	if pUser.ChainAddress.Address() != "" {
 		_, err = u.createWalletWithTx(pCtx, queries, pUser.ChainAddress, pUser.WalletType, userID)
 		if err != nil {

--- a/service/persist/user.go
+++ b/service/persist/user.go
@@ -95,6 +95,7 @@ type CreateUserInput struct {
 	WalletType                 WalletType
 	Universal                  bool
 	EmailNotificationsSettings EmailUnsubscriptions
+	PrivyDID                   *string
 }
 
 // UserRepository represents the interface for interacting with the persisted state of users


### PR DESCRIPTION
## What's new?

- Added `Privy` as an available auth type in the GraphQL schema
- Added backend support for Privy via a `PrivyAuthenticator` type

## How's it work?
- Frontend:
  - Interacts with the Privy SDK and gets a Privy auth token representing the user's Privy-verified status
- Backend:
  - Receives the token, verifies it via public key, and extracts the user's Privy DID
  - Calls the Privy REST API to get the user's email address and embedded wallet address
  - Uses our existing `Authenticator` architecture to output verified email and wallet addresses
  - Now Privy can be used for anything that requires an authenticated email or wallet address!
  - When a user is created via `PrivyAuthenticator`, they also get added to a new `privy_users` SQL table that stores their Privy DID, at which point the `PrivyAuthenticator` can also output a verified Gallery user ID (e.g. for login purposes)
