### PR TITLE
Add community-based mint links and overrides

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -1202,7 +1202,7 @@ func (b *GetCommentByCommentIDBatchBatchResults) Close() error {
 }
 
 const getCommunitiesByTokenDefinitionID = `-- name: GetCommunitiesByTokenDefinitionID :batchmany
-select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url from communities
+select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url, communities.mint_url, communities.override_mint_url from communities
     join token_definitions on token_definitions.contract_id = communities.contract_id
     where community_type = 0
         and token_definitions.id = $1
@@ -1211,7 +1211,7 @@ select communities.id, communities.version, communities.community_type, communit
 
 union all
 
-select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url from communities
+select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url, communities.mint_url, communities.override_mint_url from communities
     join token_community_memberships on token_community_memberships.community_id = communities.id
     where community_type != 0
         and token_community_memberships.token_definition_id = $1
@@ -1277,6 +1277,8 @@ func (b *GetCommunitiesByTokenDefinitionIDBatchResults) Query(f func(int, []Comm
 					&i.Deleted,
 					&i.WebsiteUrl,
 					&i.OverrideWebsiteUrl,
+					&i.MintUrl,
+					&i.OverrideMintUrl,
 				); err != nil {
 					return err
 				}
@@ -1296,7 +1298,7 @@ func (b *GetCommunitiesByTokenDefinitionIDBatchResults) Close() error {
 }
 
 const getCommunityByIDBatch = `-- name: GetCommunityByIDBatch :batchone
-select id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url from communities
+select id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url, mint_url, override_mint_url from communities
     where id = $1
         and not deleted
 `
@@ -1352,6 +1354,8 @@ func (b *GetCommunityByIDBatchBatchResults) QueryRow(f func(int, Community, erro
 			&i.Deleted,
 			&i.WebsiteUrl,
 			&i.OverrideWebsiteUrl,
+			&i.MintUrl,
+			&i.OverrideMintUrl,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -1365,7 +1369,7 @@ func (b *GetCommunityByIDBatchBatchResults) Close() error {
 }
 
 const getCommunityByKey = `-- name: GetCommunityByKey :batchone
-select id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url from communities
+select id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url, mint_url, override_mint_url from communities
     where $1 = community_type
         and $2 = key1
         and $3 = key2
@@ -1437,6 +1441,8 @@ func (b *GetCommunityByKeyBatchResults) QueryRow(f func(int, Community, error)) 
 			&i.Deleted,
 			&i.WebsiteUrl,
 			&i.OverrideWebsiteUrl,
+			&i.MintUrl,
+			&i.OverrideMintUrl,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -3319,7 +3325,7 @@ func (b *GetProfileImageByIdBatchBatchResults) Close() error {
 }
 
 const getSharedCommunitiesBatchPaginate = `-- name: GetSharedCommunitiesBatchPaginate :batchmany
-select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url, a.displayed as displayed_by_user_a, b.displayed as displayed_by_user_b, a.owned_count
+select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url, communities.mint_url, communities.override_mint_url, a.displayed as displayed_by_user_a, b.displayed as displayed_by_user_b, a.owned_count
 from owned_communities a, owned_communities b, communities
 left join contracts on communities.contract_id = contracts.id
 left join marketplace_contracts on communities.contract_id = marketplace_contracts.contract_id
@@ -3449,6 +3455,8 @@ func (b *GetSharedCommunitiesBatchPaginateBatchResults) Query(f func(int, []GetS
 					&i.Community.Deleted,
 					&i.Community.WebsiteUrl,
 					&i.Community.OverrideWebsiteUrl,
+					&i.Community.MintUrl,
+					&i.Community.OverrideMintUrl,
 					&i.DisplayedByUserA,
 					&i.DisplayedByUserB,
 					&i.OwnedCount,

--- a/db/gen/coredb/community.sql.go
+++ b/db/gen/coredb/community.sql.go
@@ -147,7 +147,7 @@ with keys as (
          , unnest ($5::varchar[]) as key4
          , generate_subscripts($1::varchar[], 1) as batch_key_index
 )
-select k.batch_key_index, c.id, c.version, c.community_type, c.key1, c.key2, c.key3, c.key4, c.name, c.override_name, c.description, c.override_description, c.profile_image_url, c.override_profile_image_url, c.badge_url, c.override_badge_url, c.contract_id, c.created_at, c.last_updated, c.deleted, c.website_url, c.override_website_url from keys k
+select k.batch_key_index, c.id, c.version, c.community_type, c.key1, c.key2, c.key3, c.key4, c.name, c.override_name, c.description, c.override_description, c.profile_image_url, c.override_profile_image_url, c.badge_url, c.override_badge_url, c.contract_id, c.created_at, c.last_updated, c.deleted, c.website_url, c.override_website_url, c.mint_url, c.override_mint_url from keys k
     join communities c on
         k.type = c.community_type
         and k.key1 = c.key1
@@ -210,6 +210,8 @@ func (q *Queries) GetCommunitiesByKeys(ctx context.Context, arg GetCommunitiesBy
 			&i.Community.Deleted,
 			&i.Community.WebsiteUrl,
 			&i.Community.OverrideWebsiteUrl,
+			&i.Community.MintUrl,
+			&i.Community.OverrideMintUrl,
 		); err != nil {
 			return nil, err
 		}
@@ -222,7 +224,7 @@ func (q *Queries) GetCommunitiesByKeys(ctx context.Context, arg GetCommunitiesBy
 }
 
 const getCommunityByID = `-- name: GetCommunityByID :one
-select id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url from communities
+select id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url, mint_url, override_mint_url from communities
     where id = $1
         and not deleted
 `
@@ -252,6 +254,8 @@ func (q *Queries) GetCommunityByID(ctx context.Context, id persist.DBID) (Commun
 		&i.Deleted,
 		&i.WebsiteUrl,
 		&i.OverrideWebsiteUrl,
+		&i.MintUrl,
+		&i.OverrideMintUrl,
 	)
 	return i, err
 }
@@ -367,7 +371,7 @@ on conflict (community_type, key1, key2, key3, key4) where not deleted
                 , contract_id = coalesce(nullif(excluded.contract_id, ''), nullif(communities.contract_id, ''))
                 , last_updated = now()
                 , deleted = excluded.deleted
-returning id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url
+returning id, version, community_type, key1, key2, key3, key4, name, override_name, description, override_description, profile_image_url, override_profile_image_url, badge_url, override_badge_url, contract_id, created_at, last_updated, deleted, website_url, override_website_url, mint_url, override_mint_url
 `
 
 type UpsertCommunitiesParams struct {
@@ -431,6 +435,8 @@ func (q *Queries) UpsertCommunities(ctx context.Context, arg UpsertCommunitiesPa
 			&i.Deleted,
 			&i.WebsiteUrl,
 			&i.OverrideWebsiteUrl,
+			&i.MintUrl,
+			&i.OverrideMintUrl,
 		); err != nil {
 			return nil, err
 		}

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -86,6 +86,8 @@ type Community struct {
 	Deleted                 bool                  `db:"deleted" json:"deleted"`
 	WebsiteUrl              sql.NullString        `db:"website_url" json:"website_url"`
 	OverrideWebsiteUrl      sql.NullString        `db:"override_website_url" json:"override_website_url"`
+	MintUrl                 sql.NullString        `db:"mint_url" json:"mint_url"`
+	OverrideMintUrl         sql.NullString        `db:"override_mint_url" json:"override_mint_url"`
 }
 
 type CommunityContractProvider struct {

--- a/db/gen/coredb/search.sql.go
+++ b/db/gen/coredb/search.sql.go
@@ -21,7 +21,7 @@ community_key_weights as (
     select $5::float4 / 1000000000 as poap_weight,
            $6::float4 / 1000000000 as provider_weight
 )
-select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url from communities left join community_relevance on community_relevance.id = communities.id,
+select communities.id, communities.version, communities.community_type, communities.key1, communities.key2, communities.key3, communities.key4, communities.name, communities.override_name, communities.description, communities.override_description, communities.profile_image_url, communities.override_profile_image_url, communities.badge_url, communities.override_badge_url, communities.contract_id, communities.created_at, communities.last_updated, communities.deleted, communities.website_url, communities.override_website_url, communities.mint_url, communities.override_mint_url from communities left join community_relevance on community_relevance.id = communities.id,
      to_tsquery('simple', websearch_to_tsquery('simple', $1)::text || ':*') simple_partial_query,
      websearch_to_tsquery('simple', $1) simple_full_query,
      websearch_to_tsquery('english', $1) english_full_query,
@@ -90,6 +90,8 @@ func (q *Queries) SearchCommunities(ctx context.Context, arg SearchCommunitiesPa
 			&i.Deleted,
 			&i.WebsiteUrl,
 			&i.OverrideWebsiteUrl,
+			&i.MintUrl,
+			&i.OverrideMintUrl,
 		); err != nil {
 			return nil, err
 		}

--- a/db/migrations/core/000151_community_mint_url.up.sql
+++ b/db/migrations/core/000151_community_mint_url.up.sql
@@ -1,0 +1,2 @@
+alter table communities add column if not exists mint_url text;
+alter table communities add column if not exists override_mint_url text;


### PR DESCRIPTION
## What's new?

- The `communities` table now has `mint_url` and `override_mint_url` fields.
  - `mint_url` would be populated by a provider, though none currently use it
  - `override_mint_url` lets us manually set a mint URL for a community

- `Community.mintURL` and `TokenDefinition.mintURL` fields now check the `communities` table columns before guessing a chain-based mint URL