### PR TITLE
add the other unsub types

### DIFF
--- a/emails/emails.go
+++ b/emails/emails.go
@@ -92,6 +92,8 @@ func setDefaults() {
 	viper.SetDefault("SENDGRID_DIGEST_TEMPLATE_ID", "d-0b9b6b0b0b5e4b6e9b0b0b5e4b6e9b0b")
 	viper.SetDefault("SENDGRID_UNSUBSCRIBE_NOTIFICATIONS_GROUP_ID", 20676)
 	viper.SetDefault("SENDGRID_UNSUBSCRIBE_DIGEST_GROUP_ID", 46079)
+	viper.SetDefault("SENDGRID_UNSUBSCRIBE_MARKETING_GROUP_ID", 22420)
+	viper.SetDefault("SENDGRID_UNSUBSCRIBE_MEMBERS_CLUB_GROUP_ID", 22419)
 	viper.SetDefault("SCHEDULER_AUDIENCE", "")
 	viper.SetDefault("GOOGLE_CLOUD_PROJECT", "gallery-dev-322005")
 	viper.SetDefault("ADMIN_PASS", "admin")

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -469,6 +469,8 @@ type ComplexityRoot struct {
 	EmailNotificationSettings struct {
 		UnsubscribedFromAll           func(childComplexity int) int
 		UnsubscribedFromDigest        func(childComplexity int) int
+		UnsubscribedFromMarketing     func(childComplexity int) int
+		UnsubscribedFromMembersClub   func(childComplexity int) int
 		UnsubscribedFromNotifications func(childComplexity int) int
 	}
 
@@ -3618,6 +3620,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.EmailNotificationSettings.UnsubscribedFromDigest(childComplexity), true
+
+	case "EmailNotificationSettings.unsubscribedFromMarketing":
+		if e.complexity.EmailNotificationSettings.UnsubscribedFromMarketing == nil {
+			break
+		}
+
+		return e.complexity.EmailNotificationSettings.UnsubscribedFromMarketing(childComplexity), true
+
+	case "EmailNotificationSettings.unsubscribedFromMembersClub":
+		if e.complexity.EmailNotificationSettings.UnsubscribedFromMembersClub == nil {
+			break
+		}
+
+		return e.complexity.EmailNotificationSettings.UnsubscribedFromMembersClub(childComplexity), true
 
 	case "EmailNotificationSettings.unsubscribedFromNotifications":
 		if e.complexity.EmailNotificationSettings.UnsubscribedFromNotifications == nil {
@@ -10532,6 +10548,8 @@ enum EmailUnsubscriptionType {
   All
   Notifications
   Digest
+  Marketing
+  MembersClub
 }
 
 type UserEmail {
@@ -10544,12 +10562,16 @@ type EmailNotificationSettings {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
   unsubscribedFromDigest: Boolean!
+  unsubscribedFromMarketing: Boolean
+  unsubscribedFromMembersClub: Boolean # TODO make this required once frontend is updated
 }
 
 input UpdateEmailNotificationSettingsInput {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
   unsubscribedFromDigest: Boolean!
+  unsubscribedFromMarketing: Boolean
+  unsubscribedFromMembersClub: Boolean
 }
 
 input UnsubscribeFromEmailTypeInput {
@@ -26401,6 +26423,88 @@ func (ec *executionContext) _EmailNotificationSettings_unsubscribedFromDigest(ct
 }
 
 func (ec *executionContext) fieldContext_EmailNotificationSettings_unsubscribedFromDigest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "EmailNotificationSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _EmailNotificationSettings_unsubscribedFromMarketing(ctx context.Context, field graphql.CollectedField, obj *model.EmailNotificationSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_EmailNotificationSettings_unsubscribedFromMarketing(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UnsubscribedFromMarketing, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_EmailNotificationSettings_unsubscribedFromMarketing(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "EmailNotificationSettings",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _EmailNotificationSettings_unsubscribedFromMembersClub(ctx context.Context, field graphql.CollectedField, obj *model.EmailNotificationSettings) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_EmailNotificationSettings_unsubscribedFromMembersClub(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UnsubscribedFromMembersClub, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_EmailNotificationSettings_unsubscribedFromMembersClub(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "EmailNotificationSettings",
 		Field:      field,
@@ -63434,6 +63538,10 @@ func (ec *executionContext) fieldContext_UserEmail_emailNotificationSettings(ctx
 				return ec.fieldContext_EmailNotificationSettings_unsubscribedFromNotifications(ctx, field)
 			case "unsubscribedFromDigest":
 				return ec.fieldContext_EmailNotificationSettings_unsubscribedFromDigest(ctx, field)
+			case "unsubscribedFromMarketing":
+				return ec.fieldContext_EmailNotificationSettings_unsubscribedFromMarketing(ctx, field)
+			case "unsubscribedFromMembersClub":
+				return ec.fieldContext_EmailNotificationSettings_unsubscribedFromMembersClub(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type EmailNotificationSettings", field.Name)
 		},
@@ -70107,7 +70215,7 @@ func (ec *executionContext) unmarshalInputUpdateEmailNotificationSettingsInput(c
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"unsubscribedFromAll", "unsubscribedFromNotifications", "unsubscribedFromDigest"}
+	fieldsInOrder := [...]string{"unsubscribedFromAll", "unsubscribedFromNotifications", "unsubscribedFromDigest", "unsubscribedFromMarketing", "unsubscribedFromMembersClub"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -70141,6 +70249,24 @@ func (ec *executionContext) unmarshalInputUpdateEmailNotificationSettingsInput(c
 				return it, err
 			}
 			it.UnsubscribedFromDigest = data
+		case "unsubscribedFromMarketing":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("unsubscribedFromMarketing"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UnsubscribedFromMarketing = data
+		case "unsubscribedFromMembersClub":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("unsubscribedFromMembersClub"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UnsubscribedFromMembersClub = data
 		}
 	}
 
@@ -77834,6 +77960,14 @@ func (ec *executionContext) _EmailNotificationSettings(ctx context.Context, sel 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "unsubscribedFromMarketing":
+
+			out.Values[i] = ec._EmailNotificationSettings_unsubscribedFromMarketing(ctx, field, obj)
+
+		case "unsubscribedFromMembersClub":
+
+			out.Values[i] = ec._EmailNotificationSettings_unsubscribedFromMembersClub(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1021,9 +1021,11 @@ type DisconnectSocialAccountPayload struct {
 func (DisconnectSocialAccountPayload) IsDisconnectSocialAccountPayloadOrError() {}
 
 type EmailNotificationSettings struct {
-	UnsubscribedFromAll           bool `json:"unsubscribedFromAll"`
-	UnsubscribedFromNotifications bool `json:"unsubscribedFromNotifications"`
-	UnsubscribedFromDigest        bool `json:"unsubscribedFromDigest"`
+	UnsubscribedFromAll           bool  `json:"unsubscribedFromAll"`
+	UnsubscribedFromNotifications bool  `json:"unsubscribedFromNotifications"`
+	UnsubscribedFromDigest        bool  `json:"unsubscribedFromDigest"`
+	UnsubscribedFromMarketing     *bool `json:"unsubscribedFromMarketing"`
+	UnsubscribedFromMembersClub   *bool `json:"unsubscribedFromMembersClub"`
 }
 
 type EnsProfileImage struct {
@@ -2758,9 +2760,11 @@ type UpdateEmailInput struct {
 }
 
 type UpdateEmailNotificationSettingsInput struct {
-	UnsubscribedFromAll           bool `json:"unsubscribedFromAll"`
-	UnsubscribedFromNotifications bool `json:"unsubscribedFromNotifications"`
-	UnsubscribedFromDigest        bool `json:"unsubscribedFromDigest"`
+	UnsubscribedFromAll           bool  `json:"unsubscribedFromAll"`
+	UnsubscribedFromNotifications bool  `json:"unsubscribedFromNotifications"`
+	UnsubscribedFromDigest        bool  `json:"unsubscribedFromDigest"`
+	UnsubscribedFromMarketing     *bool `json:"unsubscribedFromMarketing"`
+	UnsubscribedFromMembersClub   *bool `json:"unsubscribedFromMembersClub"`
 }
 
 type UpdateEmailNotificationSettingsPayload struct {
@@ -3054,17 +3058,21 @@ const (
 	EmailUnsubscriptionTypeAll           EmailUnsubscriptionType = "All"
 	EmailUnsubscriptionTypeNotifications EmailUnsubscriptionType = "Notifications"
 	EmailUnsubscriptionTypeDigest        EmailUnsubscriptionType = "Digest"
+	EmailUnsubscriptionTypeMarketing     EmailUnsubscriptionType = "Marketing"
+	EmailUnsubscriptionTypeMembersClub   EmailUnsubscriptionType = "MembersClub"
 )
 
 var AllEmailUnsubscriptionType = []EmailUnsubscriptionType{
 	EmailUnsubscriptionTypeAll,
 	EmailUnsubscriptionTypeNotifications,
 	EmailUnsubscriptionTypeDigest,
+	EmailUnsubscriptionTypeMarketing,
+	EmailUnsubscriptionTypeMembersClub,
 }
 
 func (e EmailUnsubscriptionType) IsValid() bool {
 	switch e {
-	case EmailUnsubscriptionTypeAll, EmailUnsubscriptionTypeNotifications, EmailUnsubscriptionTypeDigest:
+	case EmailUnsubscriptionTypeAll, EmailUnsubscriptionTypeNotifications, EmailUnsubscriptionTypeDigest, EmailUnsubscriptionTypeMarketing, EmailUnsubscriptionTypeMembersClub:
 		return true
 	}
 	return false

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -599,6 +599,8 @@ func userWithPIIToEmailModel(user *db.PiiUserView) *model.UserEmail {
 			UnsubscribedFromAll:           user.EmailUnsubscriptions.All.Bool(),
 			UnsubscribedFromNotifications: user.EmailUnsubscriptions.Notifications.Bool(),
 			UnsubscribedFromDigest:        user.EmailUnsubscriptions.Digest.Bool(),
+			UnsubscribedFromMarketing:     user.EmailUnsubscriptions.Marketing.BoolPointer(),
+			UnsubscribedFromMembersClub:   user.EmailUnsubscriptions.MembersClub.BoolPointer(),
 		},
 	}
 
@@ -1420,6 +1422,8 @@ func updateUserEmailNotificationSettings(ctx context.Context, input model.Update
 		All:           persist.NullBool(input.UnsubscribedFromAll),
 		Notifications: persist.NullBool(input.UnsubscribedFromNotifications),
 		Digest:        persist.NullBool(input.UnsubscribedFromDigest),
+		Marketing:     persist.NullBool(util.FromPointer(input.UnsubscribedFromMarketing)),
+		MembersClub:   persist.NullBool(util.FromPointer(input.UnsubscribedFromMembersClub)),
 	})
 	if err != nil {
 		return nil, err

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -867,6 +867,8 @@ enum EmailUnsubscriptionType {
   All
   Notifications
   Digest
+  Marketing
+  MembersClub
 }
 
 type UserEmail {
@@ -879,12 +881,16 @@ type EmailNotificationSettings {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
   unsubscribedFromDigest: Boolean!
+  unsubscribedFromMarketing: Boolean
+  unsubscribedFromMembersClub: Boolean # TODO make this required once frontend is updated
 }
 
 input UpdateEmailNotificationSettingsInput {
   unsubscribedFromAll: Boolean!
   unsubscribedFromNotifications: Boolean!
   unsubscribedFromDigest: Boolean!
+  unsubscribedFromMarketing: Boolean
+  unsubscribedFromMembersClub: Boolean
 }
 
 input UnsubscribeFromEmailTypeInput {

--- a/service/persist/email.go
+++ b/service/persist/email.go
@@ -20,6 +20,8 @@ const (
 	EmailTypeNotifications EmailType = "notifications"
 	EmailTypeAdmin         EmailType = "admin"
 	EmailTypeDigest        EmailType = "digest"
+	EmailTypeMarketing     EmailType = "marketing"
+	EmailTypeMembersClub   EmailType = "members_club"
 )
 
 const (
@@ -33,6 +35,8 @@ type EmailUnsubscriptions struct {
 	All           NullBool `json:"all"`
 	Notifications NullBool `json:"notifications"`
 	Digest        NullBool `json:"digest"`
+	Marketing     NullBool `json:"marketing"`
+	MembersClub   NullBool `json:"members_club"`
 }
 
 func (e EmailUnsubscriptions) Value() (driver.Value, error) {


### PR DESCRIPTION
Changes:

- **Added** the other unsubscription groups to the email handlers and graphQL resolvers


Like the previous time we added new unsub groups, I left the fields nullable in gql for backwards compat, once the frontend starts using the new fields directly we should make them non-nullable