### PR TITLE
custom subject in digest values overrides

### DIFF
--- a/emails/digest.go
+++ b/emails/digest.go
@@ -39,6 +39,7 @@ var lookbackWindow time.Duration = time.Duration(7 * 24 * time.Hour)
 type DigestValues struct {
 	Date           string           `json:"date"`
 	IntroText      *string          `json:"intro_text"`
+	Subject        *string          `json:"subject"`
 	Posts          IncludedSelected `json:"posts"`
 	Communities    IncludedSelected `json:"communities"`
 	Galleries      IncludedSelected `json:"galleries"`
@@ -63,6 +64,7 @@ type DigestValueOverrides struct {
 	IncludeTopCommunities *bool          `json:"include_top_communities,omitempty"`
 	IncludeTopGalleries   *bool          `json:"include_top_galleries,omitempty"`
 	IntroText             *string        `json:"intro_text,omitempty"`
+	Subject               *string        `json:"subject,omitempty"`
 }
 
 type TokenDigestEntity struct {
@@ -209,6 +211,7 @@ func buildDigestTemplate(ctx context.Context, b *store.BucketStorer, q *db.Queri
 	return DigestValues{
 		Date:           time.Now().Format("2 January 2006"),
 		IntroText:      overrides.IntroText,
+		Subject:        overrides.Subject,
 		PostCount:      postCount,
 		CommunityCount: communityCount,
 		GalleryCount:   galleryCount,

--- a/emails/send.go
+++ b/emails/send.go
@@ -509,6 +509,11 @@ func sendDigestEmailToUser(c context.Context, u coredb.PiiUserView, emailRecipie
 	m := mail.NewV3Mail()
 	m.SetFrom(from)
 	p := mail.NewPersonalization()
+
+	if digestValues.Subject != nil {
+		m.Subject = *digestValues.Subject
+	}
+
 	m.SetTemplateID(env.GetString("SENDGRID_DIGEST_TEMPLATE_ID"))
 	p.DynamicTemplateData = asMap
 	m.AddPersonalizations(p)

--- a/emails/send.go
+++ b/emails/send.go
@@ -512,6 +512,8 @@ func sendDigestEmailToUser(c context.Context, u coredb.PiiUserView, emailRecipie
 
 	if digestValues.Subject != nil {
 		m.Subject = *digestValues.Subject
+		// personalization subject always overrides the mail subject, might as well just set both just in case
+		p.Subject = *digestValues.Subject
 	}
 
 	m.SetTemplateID(env.GetString("SENDGRID_DIGEST_TEMPLATE_ID"))


### PR DESCRIPTION
Changes:

- **Added** a new digest value and override for setting the subject line of the digest email