### PR TITLE
Ensure custom handlers are used

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
-	"github.com/mikeydub/go-gallery/service/media"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/multichain/alchemy"
 	"github.com/mikeydub/go-gallery/service/multichain/indexer"
@@ -60,14 +59,6 @@ func NewMultichainProvider(ctx context.Context, envFunc func()) (*multichain.Pro
 	return nil, nil
 }
 
-// customMetadataHandlerSet is a wire provider set for initializing custom metadata handlers
-var customMetadataHandlerSet = wire.NewSet(
-	rpc.NewEthClient,
-	ipfs.NewShell,
-	arweave.NewClient,
-	media.NewCustomMetadataHandlers,
-)
-
 // dbConnSet is a wire provider set for initializing a postgres connection
 var dbConnSet = wire.NewSet(
 	newPqClient,
@@ -101,7 +92,6 @@ func multichainProviderInjector(context.Context, *postgres.Repositories, *db.Que
 		tokenmanage.New,
 		task.NewClient,
 		newProviderLookup,
-		customMetadataHandlerSet,
 	)
 	return nil
 }
@@ -165,6 +155,16 @@ func multiTokenByTokenIdentifiersFetcherProvider(a tokensByTokenIdentifiersFetch
 	return wrapper.NewMultiProviderWrapper(wrapper.MultiProviderWapperOptions.WithTokenByTokenIdentifiersFetchers(a, b))
 }
 
+func customMetadataHandlersInjector(openseaProvider *opensea.Provider) *multichain.CustomMetadataHandlers {
+	panic(wire.Build(
+		multichain.NewCustomMetadataHandlers,
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(openseaProvider)),
+		rpc.NewEthClient,
+		ipfs.NewShell,
+		arweave.NewClient,
+	))
+}
+
 func ethInjector(envInit, context.Context, *http.Client) *multichain.EthereumProvider {
 	panic(wire.Build(
 		rpc.NewEthClient,
@@ -210,6 +210,7 @@ func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain
 		ethTokensContractFetcherInjector,
 		ethTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
+		customMetadataHandlersInjector,
 	))
 }
 
@@ -327,6 +328,7 @@ func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 		optimismTokensContractFetcherInjector,
 		optmismTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
+		customMetadataHandlersInjector,
 	))
 }
 
@@ -414,6 +416,7 @@ func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 		arbitrumTokensContractFetcherInjector,
 		arbitrumTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
+		customMetadataHandlersInjector,
 	))
 }
 
@@ -546,6 +549,7 @@ func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 		zoraTokensContractFetcherInjector,
 		zoraTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
+		customMetadataHandlersInjector,
 	))
 }
 
@@ -617,6 +621,7 @@ func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 		baseTokensContractFetcherInjector,
 		baseTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
+		customMetadataHandlersInjector,
 	))
 }
 
@@ -689,6 +694,7 @@ func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, c
 		polygonTokensContractFetcherInjector,
 		polygonTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
+		customMetadataHandlersInjector,
 	))
 }
 

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -632,7 +632,7 @@ func (d *Provider) GetOwnedTokensByContract(ctx context.Context, contractAddress
 	return cTokens, cContracts[0], nil
 }
 
-func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []persist.TokenIdentifiers) ([]persist.TokenMetadata, error) {
+func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []multichain.ChainAgnosticIdentifiers) ([]persist.TokenMetadata, error) {
 	type tokenRequest struct {
 		ContractAddress string `json:"contractAddress"`
 		TokenID         string `json:"tokenId"`
@@ -663,7 +663,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 	}
 
 	// alchemy doesn't return tokens in the same order as the input
-	lookup := make(map[persist.TokenIdentifiers]persist.TokenMetadata)
+	lookup := make(map[multichain.ChainAgnosticIdentifiers]persist.TokenMetadata)
 
 	for i, c := range chunks {
 		batchID := i + 1
@@ -710,7 +710,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 		}
 
 		for _, m := range batchResp {
-			tID := persist.NewTokenIdentifiers(persist.Address(m.Contract.Address), persist.MustTokenID(m.Id.TokenId), d.chain)
+			tID := multichain.ChainAgnosticIdentifiers{ContractAddress: persist.Address(m.Contract.Address), TokenID: persist.MustTokenID(m.Id.TokenId)}
 			lookup[tID] = alchemyMetadataToMetadata(m.Metadata)
 		}
 	}

--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -24,81 +24,111 @@ var (
 // Specifically, SyncPipelineWrapper searches every applicable provider to find tokens and
 // fills missing token fields with data from a supplemental provider.
 type SyncPipelineWrapper struct {
+	Chain                            persist.Chain
 	TokenIdentifierOwnerFetcher      multichain.TokenIdentifierOwnerFetcher
 	TokensIncrementalOwnerFetcher    multichain.TokensIncrementalOwnerFetcher
 	TokensIncrementalContractFetcher multichain.TokensIncrementalContractFetcher
 	TokenMetadataBatcher             multichain.TokenMetadataBatcher
 	TokensByTokenIdentifiersFetcher  multichain.TokensByTokenIdentifiersFetcher
+	CustomMetadataWrapper            *multichain.CustomMetadataHandlers
 	FillInWrapper                    *FillInWrapper
 }
 
 func NewSyncPipelineWrapper(
 	ctx context.Context,
+	chain persist.Chain,
 	tokenIdentifierOwnerFetcher multichain.TokenIdentifierOwnerFetcher,
 	tokensIncrementalOwnerFetcher multichain.TokensIncrementalOwnerFetcher,
 	tokensIncrementalContractFetcher multichain.TokensIncrementalContractFetcher,
 	tokenMetadataBatcher multichain.TokenMetadataBatcher,
 	fillInWrapper *FillInWrapper,
+	customMetadataHandlers *multichain.CustomMetadataHandlers,
 ) *SyncPipelineWrapper {
 	return &SyncPipelineWrapper{
+		Chain:                            chain,
 		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
 		TokenMetadataBatcher:             tokenMetadataBatcher,
 		FillInWrapper:                    fillInWrapper,
+		CustomMetadataWrapper:            customMetadataHandlers,
 	}
 }
 
 func (w SyncPipelineWrapper) GetTokenByTokenIdentifiersAndOwner(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, address persist.Address) (t multichain.ChainAgnosticToken, c multichain.ChainAgnosticContract, err error) {
 	t, c, err = w.TokenIdentifierOwnerFetcher.GetTokenByTokenIdentifiersAndOwner(ctx, ti, address)
+	t = w.CustomMetadataWrapper.AddToToken(ctx, w.Chain, t)
 	t = w.FillInWrapper.AddToToken(ctx, t)
 	return t, c, err
 }
 
 func (w SyncPipelineWrapper) GetTokensIncrementallyByWalletAddress(ctx context.Context, address persist.Address) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
 	recCh, errCh := w.TokensIncrementalOwnerFetcher.GetTokensIncrementallyByWalletAddress(ctx, address)
+	recCh, errCh = w.CustomMetadataWrapper.AddToPage(ctx, w.Chain, recCh, errCh)
 	recCh, errCh = w.FillInWrapper.AddToPage(ctx, recCh, errCh)
 	return recCh, errCh
 }
 
 func (w SyncPipelineWrapper) GetTokensIncrementallyByContractAddress(ctx context.Context, address persist.Address, maxLimit int) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
 	recCh, errCh := w.TokensIncrementalContractFetcher.GetTokensIncrementallyByContractAddress(ctx, address, maxLimit)
+	recCh, errCh = w.CustomMetadataWrapper.AddToPage(ctx, w.Chain, recCh, errCh)
 	recCh, errCh = w.FillInWrapper.AddToPage(ctx, recCh, errCh)
 	return recCh, errCh
 }
 
 func (w SyncPipelineWrapper) GetTokensByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
 	t, c, err := w.TokensByTokenIdentifiersFetcher.GetTokensByTokenIdentifiers(ctx, ti)
-	if err != nil {
-		return nil, multichain.ChainAgnosticContract{}, err
-	}
+	t = w.CustomMetadataWrapper.LoadAll(ctx, w.Chain, t)
 	t = w.FillInWrapper.LoadAll(t)
-	return t, c, nil
+	return t, c, err
 }
 
-func (w SyncPipelineWrapper) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []persist.TokenIdentifiers) ([]persist.TokenMetadata, error) {
-	metadatas, err := w.TokenMetadataBatcher.GetTokenMetadataByTokenIdentifiersBatch(ctx, tIDs)
-	if err != nil {
-		logger.For(ctx).Errorf("error fetching metadata for batch: %s", err)
-		sentryutil.ReportError(ctx, err)
+func (w SyncPipelineWrapper) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []multichain.ChainAgnosticIdentifiers) ([]persist.TokenMetadata, error) {
+	ret := make([]persist.TokenMetadata, len(tIDs))
+	noCustomHandlerBatch := make([]multichain.ChainAgnosticIdentifiers, 0, len(tIDs))
+	noCustomHandlerResultIdxToInputIdx := make(map[int]int)
+
+	// Separate tokens that have custom metadata handlers from those that don't
+	for i, tID := range tIDs {
+		t := multichain.ChainAgnosticIdentifiers{ContractAddress: tID.ContractAddress, TokenID: tID.TokenID}
+		metadata := w.CustomMetadataWrapper.Load(ctx, w.Chain, t)
+		if len(metadata) > 0 {
+			ret[i] = metadata
+			continue
+		}
+		pos := len(noCustomHandlerBatch)
+		noCustomHandlerBatch = append(noCustomHandlerBatch, tID)
+		noCustomHandlerResultIdxToInputIdx[pos] = i
 	}
 
-	if len(metadatas) != len(tIDs) {
-		panic(fmt.Sprintf("expected length to the the same; expected=%d; got=%d", len(tIDs), len(metadatas)))
-	}
-
-	// Convert metadatas to tokens so they can be passed to FillInWrapper
-	asTokens := make([]multichain.ChainAgnosticToken, len(metadatas))
-	for i, m := range metadatas {
-		asTokens[i] = multichain.ChainAgnosticToken{
-			TokenID:         tIDs[i].TokenID,
-			ContractAddress: tIDs[i].ContractAddress,
-			TokenMetadata:   m,
+	// Fetch metadata for tokens that don't have custom metadata handlers
+	if len(noCustomHandlerBatch) > 0 {
+		batchMetadata, err := w.TokenMetadataBatcher.GetTokenMetadataByTokenIdentifiersBatch(ctx, noCustomHandlerBatch)
+		if err != nil {
+			logger.For(ctx).Errorf("error fetching metadata for batch: %s", err)
+			sentryutil.ReportError(ctx, err)
+		} else {
+			if len(batchMetadata) != len(noCustomHandlerBatch) {
+				panic(fmt.Sprintf("expected length to the the same; expected=%d; got=%d", len(noCustomHandlerBatch), len(batchMetadata)))
+			}
+			for i := range batchMetadata {
+				ret[noCustomHandlerResultIdxToInputIdx[i]] = batchMetadata[i]
+			}
 		}
 	}
 
-	metadatas = w.FillInWrapper.LoadMetadataAll(asTokens)
-	return metadatas, nil
+	// Convert metadata to tokens to fill in missing data
+	asTokens := make([]multichain.ChainAgnosticToken, len(tIDs))
+	for i, tID := range tIDs {
+		asTokens[i] = multichain.ChainAgnosticToken{
+			ContractAddress: tID.ContractAddress,
+			TokenID:         tID.TokenID,
+			TokenMetadata:   ret[i],
+		}
+	}
+
+	ret = w.FillInWrapper.LoadMetadataAll(asTokens)
+	return ret, nil
 }
 
 // MultiProviderWrapperOpts configures options for the MultiProviderWrapper
@@ -339,7 +369,6 @@ func (w *FillInWrapper) AddToPage(ctx context.Context, recCh <-chan multichain.C
 			case err, ok := <-errIn:
 				if ok {
 					errOut <- err
-					return
 				}
 			case <-ctx.Done():
 				errOut <- ctx.Err()
@@ -347,7 +376,7 @@ func (w *FillInWrapper) AddToPage(ctx context.Context, recCh <-chan multichain.C
 			}
 		}
 	}()
-	logger.For(ctx).Info("closing out channel")
+	logger.For(ctx).Info("finished filling in page")
 	return outCh, errOut
 }
 
@@ -371,7 +400,10 @@ func (w *FillInWrapper) LoadMetadataAll(tokens []multichain.ChainAgnosticToken) 
 	for i, t := range tokens {
 		t := t
 		if hasMediaURLs(t.TokenMetadata, w.chain) {
-			thunks[i] = func() multichain.ChainAgnosticToken { return t }
+			thunks[i] = func() multichain.ChainAgnosticToken {
+				w.cacheTokenResult(t)
+				return t
+			}
 		} else {
 			thunks[i] = w.addTokenToBatch(t)
 		}
@@ -390,7 +422,10 @@ func (w *FillInWrapper) LoadFallbackAll(tokens []multichain.ChainAgnosticToken) 
 	for i, t := range tokens {
 		t := t
 		if t.FallbackMedia.IsServable() {
-			thunks[i] = func() multichain.ChainAgnosticToken { return t }
+			thunks[i] = func() multichain.ChainAgnosticToken {
+				w.cacheTokenResult(t)
+				return t
+			}
 		} else {
 			thunks[i] = w.addTokenToBatch(t)
 		}
@@ -418,17 +453,21 @@ func (w *FillInWrapper) addPage(p multichain.ChainAgnosticTokensAndContracts) fu
 
 func (w *FillInWrapper) addToken(t multichain.ChainAgnosticToken) func() multichain.ChainAgnosticToken {
 	if hasMediaURLs(t.TokenMetadata, w.chain) && t.FallbackMedia.IsServable() {
-		return func() multichain.ChainAgnosticToken { return t }
+		return func() multichain.ChainAgnosticToken {
+			w.cacheTokenResult(t)
+			return t
+		}
 	}
 	return w.addTokenToBatch(t)
 }
 
+func (w *FillInWrapper) cacheTokenResult(t multichain.ChainAgnosticToken) {
+	tID := persist.NewTokenIdentifiers(t.ContractAddress, t.TokenID, w.chain)
+	w.resultCache.Store(tID, t)
+}
+
 func (w *FillInWrapper) addTokenToBatch(t multichain.ChainAgnosticToken) func() multichain.ChainAgnosticToken {
-	ti := persist.TokenIdentifiers{
-		TokenID:         t.TokenID,
-		ContractAddress: t.ContractAddress,
-		Chain:           w.chain,
-	}
+	ti := multichain.ChainAgnosticIdentifiers{ContractAddress: t.ContractAddress, TokenID: t.TokenID}
 
 	if v, ok := w.resultCache.Load(ti); ok {
 		return func() multichain.ChainAgnosticToken {
@@ -474,14 +513,14 @@ func hasMediaURLs(metadata persist.TokenMetadata, chain persist.Chain) bool {
 }
 
 type batch struct {
-	tokens  []persist.TokenIdentifiers
+	tokens  []multichain.ChainAgnosticIdentifiers
 	errors  []error
 	results []multichain.ChainAgnosticToken
 	closing bool
 	done    chan struct{}
 }
 
-func (b *batch) addToBatch(w *FillInWrapper, t persist.TokenIdentifiers) int {
+func (b *batch) addToBatch(w *FillInWrapper, t multichain.ChainAgnosticIdentifiers) int {
 	pos := len(b.tokens)
 	b.tokens = append(b.tokens, t)
 	if pos == 0 {

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -302,7 +302,7 @@ func (d *Provider) GetContractsByOwnerAddress(ctx context.Context, addr persist.
 	return result, nil
 }
 
-func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []persist.TokenIdentifiers) ([]persist.TokenMetadata, error) {
+func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []multichain.ChainAgnosticIdentifiers) ([]persist.TokenMetadata, error) {
 	chunkSize := 50
 	chunks := util.ChunkBy(tIDs, chunkSize)
 	metadatas := make([]persist.TokenMetadata, len(tIDs))
@@ -332,7 +332,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 	}
 
 	// zora doesn't return tokens in the same order as the input
-	lookup := make(map[persist.TokenIdentifiers]persist.TokenMetadata)
+	lookup := make(map[multichain.ChainAgnosticIdentifiers]persist.TokenMetadata)
 
 	for i, chunk := range chunks {
 		batchID := i + 1
@@ -360,9 +360,9 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 			return nil, err
 		}
 
-		for _, token := range batchResp.Tokens.Nodes {
-			tID := persist.NewTokenIdentifiers(persist.Address(token.Token.CollectionAddress), persist.MustTokenID(token.Token.TokenID), persist.ChainZora)
-			lookup[tID] = persist.TokenMetadata(token.Token.Metadata)
+		for _, t := range batchResp.Tokens.Nodes {
+			tID := multichain.ChainAgnosticIdentifiers{ContractAddress: persist.Address(t.Token.CollectionAddress), TokenID: persist.MustTokenID(t.Token.TokenID)}
+			lookup[tID] = persist.TokenMetadata(t.Token.Metadata)
 		}
 	}
 


### PR DESCRIPTION
Changes
* Ensures custom metadata handlers are called for tokens pulled from a sync
* Adds workaround for fetching ENS metadata for tokenIDs stored in decimal in the DB
* Adds custom metadata handler for Opensea shared storefront NFTs that increases the width of the image asset
* `FillInWrapper` now caches already valid tokens so that the same tokens received from a separate provider can re-use its data 