### PR TITLE
Use Alchemy as the provider for custom metadata

### DIFF
--- a/server/inject.go
+++ b/server/inject.go
@@ -155,10 +155,10 @@ func multiTokenByTokenIdentifiersFetcherProvider(a tokensByTokenIdentifiersFetch
 	return wrapper.NewMultiProviderWrapper(wrapper.MultiProviderWapperOptions.WithTokenByTokenIdentifiersFetchers(a, b))
 }
 
-func customMetadataHandlersInjector(openseaProvider *opensea.Provider) *multichain.CustomMetadataHandlers {
+func customMetadataHandlersInjector(alchemyProvider *alchemy.Provider) *multichain.CustomMetadataHandlers {
 	panic(wire.Build(
 		multichain.NewCustomMetadataHandlers,
-		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(openseaProvider)),
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(alchemyProvider)),
 		rpc.NewEthClient,
 		ipfs.NewShell,
 		arweave.NewClient,
@@ -549,7 +549,17 @@ func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 		zoraTokensContractFetcherInjector,
 		zoraTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
-		customMetadataHandlersInjector,
+		zoraCustomMetadataHandlersInjector,
+	))
+}
+
+func zoraCustomMetadataHandlersInjector(openseaProvider *opensea.Provider) *multichain.CustomMetadataHandlers {
+	panic(wire.Build(
+		multichain.NewCustomMetadataHandlers,
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(openseaProvider)),
+		rpc.NewEthClient,
+		ipfs.NewShell,
+		arweave.NewClient,
 	))
 }
 

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -86,11 +86,11 @@ func multichainProviderInjector(contextContext context.Context, repositories *po
 	return provider
 }
 
-func customMetadataHandlersInjector(openseaProvider *opensea.Provider) *multichain.CustomMetadataHandlers {
+func customMetadataHandlersInjector(alchemyProvider *alchemy.Provider) *multichain.CustomMetadataHandlers {
 	client := rpc.NewEthClient()
 	shell := ipfs.NewShell()
 	goarClient := arweave.NewClient()
-	customMetadataHandlers := multichain.NewCustomMetadataHandlers(client, shell, goarClient, openseaProvider)
+	customMetadataHandlers := multichain.NewCustomMetadataHandlers(client, shell, goarClient, alchemyProvider)
 	return customMetadataHandlers
 }
 
@@ -134,7 +134,7 @@ func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain
 	tokensIncrementalOwnerFetcher := ethTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
 	tokensIncrementalContractFetcher := ethTokensContractFetcherInjector(openseaProvider, alchemyProvider)
 	tokensByTokenIdentifiersFetcher := ethTokenByTokenIdentifiersFetcherInjector(openseaProvider, alchemyProvider)
-	customMetadataHandlers := customMetadataHandlersInjector(openseaProvider)
+	customMetadataHandlers := customMetadataHandlersInjector(alchemyProvider)
 	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		Chain:                            chain,
@@ -237,7 +237,7 @@ func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 	tokensIncrementalOwnerFetcher := optimismTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
 	tokensIncrementalContractFetcher := optimismTokensContractFetcherInjector(openseaProvider, alchemyProvider)
 	tokensByTokenIdentifiersFetcher := optmismTokenByTokenIdentifiersFetcherInjector(openseaProvider, alchemyProvider)
-	customMetadataHandlers := customMetadataHandlersInjector(openseaProvider)
+	customMetadataHandlers := customMetadataHandlersInjector(alchemyProvider)
 	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		Chain:                            chain,
@@ -315,7 +315,7 @@ func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 	tokensIncrementalOwnerFetcher := arbitrumTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
 	tokensIncrementalContractFetcher := arbitrumTokensContractFetcherInjector(openseaProvider, alchemyProvider)
 	tokensByTokenIdentifiersFetcher := arbitrumTokenByTokenIdentifiersFetcherInjector(openseaProvider, alchemyProvider)
-	customMetadataHandlers := customMetadataHandlersInjector(openseaProvider)
+	customMetadataHandlers := customMetadataHandlersInjector(alchemyProvider)
 	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		Chain:                            chain,
@@ -427,7 +427,7 @@ func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 	tokensIncrementalOwnerFetcher := zoraTokensIncrementalOwnerFetcherInjector(openseaProvider, zoraProvider)
 	tokensIncrementalContractFetcher := zoraTokensContractFetcherInjector(openseaProvider, zoraProvider)
 	tokensByTokenIdentifiersFetcher := zoraTokenByTokenIdentifiersFetcherInjector(openseaProvider, zoraProvider)
-	customMetadataHandlers := customMetadataHandlersInjector(openseaProvider)
+	customMetadataHandlers := zoraCustomMetadataHandlersInjector(openseaProvider)
 	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		Chain:                            chain,
@@ -440,6 +440,14 @@ func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 		FillInWrapper:                    fillInWrapper,
 	}
 	return syncPipelineWrapper
+}
+
+func zoraCustomMetadataHandlersInjector(openseaProvider *opensea.Provider) *multichain.CustomMetadataHandlers {
+	client := rpc.NewEthClient()
+	shell := ipfs.NewShell()
+	goarClient := arweave.NewClient()
+	customMetadataHandlers := multichain.NewCustomMetadataHandlers(client, shell, goarClient, openseaProvider)
+	return customMetadataHandlers
 }
 
 func zoraTokensContractFetcherInjector(openseaProvider *opensea.Provider, zoraProvider *zora.Provider) multichain.TokensIncrementalContractFetcher {
@@ -495,7 +503,7 @@ func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 	tokensIncrementalOwnerFetcher := baseTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
 	tokensIncrementalContractFetcher := baseTokensContractFetcherInjector(openseaProvider, alchemyProvider)
 	tokensByTokenIdentifiersFetcher := baseTokenByTokenIdentifiersFetcherInjector(openseaProvider, alchemyProvider)
-	customMetadataHandlers := customMetadataHandlersInjector(openseaProvider)
+	customMetadataHandlers := customMetadataHandlersInjector(alchemyProvider)
 	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		Chain:                            chain,
@@ -560,7 +568,7 @@ func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, c
 	tokensIncrementalOwnerFetcher := polygonTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
 	tokensIncrementalContractFetcher := polygonTokensContractFetcherInjector(openseaProvider, alchemyProvider)
 	tokensByTokenIdentifiersFetcher := polygonTokenByTokenIdentifiersFetcherInjector(openseaProvider, alchemyProvider)
-	customMetadataHandlers := customMetadataHandlersInjector(openseaProvider)
+	customMetadataHandlers := customMetadataHandlersInjector(alchemyProvider)
 	fillInWrapper := wrapper.NewFillInWrapper(ctx, httpClient, chain)
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		Chain:                            chain,

--- a/service/multichain/custom_metadata.go
+++ b/service/multichain/custom_metadata.go
@@ -50,14 +50,14 @@ type CustomMetadataHandlers struct {
 	OpenseaSharedStorefrontHandler metadataHandler
 }
 
-func NewCustomMetadataHandlers(ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, openseaMetadataFetcher TokenMetadataFetcher) *CustomMetadataHandlers {
+func NewCustomMetadataHandlers(ethClient *ethclient.Client, ipfsClient *shell.Shell, arweaveClient *goar.Client, f TokenMetadataFetcher) *CustomMetadataHandlers {
 	return &CustomMetadataHandlers{
 		AutoglyphHandler:               newAutoglyphHandler(ethClient),
 		ColorglyphHandler:              newColorglyphHandler(ethClient),
 		EnsHandler:                     newEnsHandler(),
 		CryptopunkHandler:              newCryptopunkHandler(ethClient),
 		ZoraHandler:                    newZoraHandler(ethClient, ipfsClient, arweaveClient),
-		OpenseaSharedStorefrontHandler: newOpenseaSharedStorefrontHandler(openseaMetadataFetcher),
+		OpenseaSharedStorefrontHandler: newOpenseaSharedStorefrontHandler(f),
 	}
 }
 
@@ -658,15 +658,6 @@ func newOpenseaSharedStorefrontHandler(f TokenMetadataFetcher) metadataHandler {
 		// Opensea uses imgix for image resizing. We add a width query parameter with the
 		// maximum width to get the highest resolution image.
 		if u.Hostname() == "i.seadn.io" {
-			for k := range query {
-				if k == "w" {
-					query.Set("w", "8120")
-					u.RawQuery = query.Encode()
-					m[imgKey] = u.String()
-					return m, nil
-				}
-			}
-			// If there is no width, add it
 			query.Set("w", "8120")
 			u.RawQuery = query.Encode()
 			m[imgKey] = u.String()


### PR DESCRIPTION
Uses Alchemy instead of Opensea for EVM chains (except Zora because Alchemy doesn't support Zora) because of Opensea's low rate limits.