### PR TITLE
Add Farcaster friend finder

### DIFF
--- a/db/migrations/core/000152_add_farcaster_fid_idx.up.sql
+++ b/db/migrations/core/000152_add_farcaster_fid_idx.up.sql
@@ -1,0 +1,2 @@
+/* {% require_sudo %} */
+create index for_users_farcaster_fid_idx on pii.for_users(((pii_socials -> 'farcaster'::text) ->> 'id'::text) text_ops);

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1274,6 +1274,14 @@ update pii.for_users set pii_socials = @socials where user_id = @user_id;
 -- name: UpdateEventCaptionByGroup :exec
 update events set caption = @caption where group_id = @group_id and deleted = false;
 
+-- name: GetFarcasterConnections :many
+select u.*
+from (select unnest(@fids::varchar[]) fid) farcaster
+join pii.for_users p on p.pii_socials->'Farcaster'->>'id' = farcaster.fid
+join users u on u.id = p.user_id
+left join follows f on f.follower = @user_id and u.id = f.followee
+where not u.deleted and not u.deleted; -- and f.id is null;
+
 -- this query will take in enoug info to create a sort of fake table of social accounts matching them up to users in gallery with twitter connected.
 -- it will also go and search for whether the specified user follows any of the users returned
 -- name: GetSocialConnectionsPaginate :many

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -1763,17 +1763,18 @@ type ComplexityRoot struct {
 	}
 
 	Viewer struct {
-		Email                func(childComplexity int) int
-		Feed                 func(childComplexity int, before *string, after *string, first *int, last *int, includePosts bool) int
-		ID                   func(childComplexity int) int
-		NotificationSettings func(childComplexity int) int
-		Notifications        func(childComplexity int, before *string, after *string, first *int, last *int) int
-		Persona              func(childComplexity int) int
-		SocialAccounts       func(childComplexity int) int
-		SuggestedUsers       func(childComplexity int, before *string, after *string, first *int, last *int) int
-		User                 func(childComplexity int) int
-		UserExperiences      func(childComplexity int) int
-		ViewerGalleries      func(childComplexity int) int
+		Email                   func(childComplexity int) int
+		Feed                    func(childComplexity int, before *string, after *string, first *int, last *int, includePosts bool) int
+		ID                      func(childComplexity int) int
+		NotificationSettings    func(childComplexity int) int
+		Notifications           func(childComplexity int, before *string, after *string, first *int, last *int) int
+		Persona                 func(childComplexity int) int
+		SocialAccounts          func(childComplexity int) int
+		SuggestedUsers          func(childComplexity int, before *string, after *string, first *int, last *int) int
+		SuggestedUsersFarcaster func(childComplexity int, before *string, after *string, first *int, last *int) int
+		User                    func(childComplexity int) int
+		UserExperiences         func(childComplexity int) int
+		ViewerGalleries         func(childComplexity int) int
 	}
 
 	ViewerGallery struct {
@@ -2259,6 +2260,7 @@ type ViewerResolver interface {
 	UserExperiences(ctx context.Context, obj *model.Viewer) ([]*model.UserExperience, error)
 	Persona(ctx context.Context, obj *model.Viewer) (*persist.Persona, error)
 	SuggestedUsers(ctx context.Context, obj *model.Viewer, before *string, after *string, first *int, last *int) (*model.UsersConnection, error)
+	SuggestedUsersFarcaster(ctx context.Context, obj *model.Viewer, before *string, after *string, first *int, last *int) (*model.UsersConnection, error)
 }
 type WalletResolver interface {
 	Tokens(ctx context.Context, obj *model.Wallet) ([]*model.Token, error)
@@ -9395,6 +9397,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Viewer.SuggestedUsers(childComplexity, args["before"].(*string), args["after"].(*string), args["first"].(*int), args["last"].(*int)), true
 
+	case "Viewer.suggestedUsersFarcaster":
+		if e.complexity.Viewer.SuggestedUsersFarcaster == nil {
+			break
+		}
+
+		args, err := ec.field_Viewer_suggestedUsersFarcaster_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Viewer.SuggestedUsersFarcaster(childComplexity, args["before"].(*string), args["after"].(*string), args["first"].(*int), args["last"].(*int)), true
+
 	case "Viewer.user":
 		if e.complexity.Viewer.User == nil {
 			break
@@ -10504,6 +10518,8 @@ type Viewer implements Node @goGqlId(fields: ["userId"]) @goEmbedHelper {
   userExperiences: [UserExperience!] @goField(forceResolver: true)
   persona: Persona @goField(forceResolver: true)
   suggestedUsers(before: String, after: String, first: Int, last: Int): UsersConnection
+    @goField(forceResolver: true)
+  suggestedUsersFarcaster(before: String, after: String, first: Int, last: Int): UsersConnection
     @goField(forceResolver: true)
 }
 
@@ -16593,6 +16609,48 @@ func (ec *executionContext) field_Viewer_notifications_args(ctx context.Context,
 	return args, nil
 }
 
+func (ec *executionContext) field_Viewer_suggestedUsersFarcaster_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["before"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("before"))
+		arg0, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["before"] = arg0
+	var arg1 *string
+	if tmp, ok := rawArgs["after"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("after"))
+		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["after"] = arg1
+	var arg2 *int
+	if tmp, ok := rawArgs["first"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("first"))
+		arg2, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["first"] = arg2
+	var arg3 *int
+	if tmp, ok := rawArgs["last"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("last"))
+		arg3, err = ec.unmarshalOInt2ᚖint(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["last"] = arg3
+	return args, nil
+}
+
 func (ec *executionContext) field_Viewer_suggestedUsers_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -16731,6 +16789,8 @@ func (ec *executionContext) fieldContext_AddUserWalletPayload_viewer(ctx context
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -17189,6 +17249,8 @@ func (ec *executionContext) fieldContext_AdmireCommentPayload_viewer(ctx context
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -17378,6 +17440,8 @@ func (ec *executionContext) fieldContext_AdmireFeedEventPayload_viewer(ctx conte
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -17561,6 +17625,8 @@ func (ec *executionContext) fieldContext_AdmirePostPayload_viewer(ctx context.Co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -17752,6 +17818,8 @@ func (ec *executionContext) fieldContext_AdmireTokenPayload_viewer(ctx context.C
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -22521,6 +22589,8 @@ func (ec *executionContext) fieldContext_CommentOnFeedEventPayload_viewer(ctx co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -22787,6 +22857,8 @@ func (ec *executionContext) fieldContext_CommentOnPostPayload_viewer(ctx context
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -24965,6 +25037,8 @@ func (ec *executionContext) fieldContext_ConnectSocialAccountPayload_viewer(ctx 
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -25966,6 +26040,8 @@ func (ec *executionContext) fieldContext_CreateUserPayload_viewer(ctx context.Co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -26274,6 +26350,8 @@ func (ec *executionContext) fieldContext_DisconnectSocialAccountPayload_viewer(c
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -29756,6 +29834,8 @@ func (ec *executionContext) fieldContext_FollowAllOnboardingRecommendationsPaylo
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -29821,6 +29901,8 @@ func (ec *executionContext) fieldContext_FollowAllSocialConnectionsPayload_viewe
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -30018,6 +30100,8 @@ func (ec *executionContext) fieldContext_FollowUserPayload_viewer(ctx context.Co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -35941,6 +36025,8 @@ func (ec *executionContext) fieldContext_LoginPayload_viewer(ctx context.Context
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -36006,6 +36092,8 @@ func (ec *executionContext) fieldContext_LogoutPayload_viewer(ctx context.Contex
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -49239,6 +49327,8 @@ func (ec *executionContext) fieldContext_RegisterUserPushTokenPayload_viewer(ctx
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -49304,6 +49394,8 @@ func (ec *executionContext) fieldContext_RemoveAdmirePayload_viewer(ctx context.
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -49544,6 +49636,8 @@ func (ec *executionContext) fieldContext_RemoveCommentPayload_viewer(ctx context
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -49743,6 +49837,8 @@ func (ec *executionContext) fieldContext_RemoveProfileImagePayload_viewer(ctx co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -49808,6 +49904,8 @@ func (ec *executionContext) fieldContext_RemoveUserWalletsPayload_viewer(ctx con
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -49917,6 +50015,8 @@ func (ec *executionContext) fieldContext_ResendVerificationEmailPayload_viewer(c
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -50208,6 +50308,8 @@ func (ec *executionContext) fieldContext_SetPersonaPayload_viewer(ctx context.Co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -50273,6 +50375,8 @@ func (ec *executionContext) fieldContext_SetProfileImagePayload_viewer(ctx conte
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -56259,6 +56363,8 @@ func (ec *executionContext) fieldContext_SyncCreatedTokensForExistingContractPay
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -56324,6 +56430,8 @@ func (ec *executionContext) fieldContext_SyncCreatedTokensForNewContractsPayload
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -56521,6 +56629,8 @@ func (ec *executionContext) fieldContext_SyncTokensPayload_viewer(ctx context.Co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -61345,6 +61455,8 @@ func (ec *executionContext) fieldContext_UnfollowUserPayload_viewer(ctx context.
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -61779,6 +61891,8 @@ func (ec *executionContext) fieldContext_UnregisterUserPushTokenPayload_viewer(c
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -61844,6 +61958,8 @@ func (ec *executionContext) fieldContext_UnsubscribeFromEmailTypePayload_viewer(
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62155,6 +62271,8 @@ func (ec *executionContext) fieldContext_UpdateEmailNotificationSettingsPayload_
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62220,6 +62338,8 @@ func (ec *executionContext) fieldContext_UpdateEmailPayload_viewer(ctx context.C
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62285,6 +62405,8 @@ func (ec *executionContext) fieldContext_UpdateFeaturedGalleryPayload_viewer(ctx
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62533,6 +62655,8 @@ func (ec *executionContext) fieldContext_UpdateGalleryOrderPayload_viewer(ctx co
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62659,6 +62783,8 @@ func (ec *executionContext) fieldContext_UpdatePrimaryWalletPayload_viewer(ctx c
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62724,6 +62850,8 @@ func (ec *executionContext) fieldContext_UpdateSocialAccountDisplayedPayload_vie
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62892,6 +63020,8 @@ func (ec *executionContext) fieldContext_UpdateUserExperiencePayload_viewer(ctx 
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -62957,6 +63087,8 @@ func (ec *executionContext) fieldContext_UpdateUserInfoPayload_viewer(ctx contex
 				return ec.fieldContext_Viewer_persona(ctx, field)
 			case "suggestedUsers":
 				return ec.fieldContext_Viewer_suggestedUsers(ctx, field)
+			case "suggestedUsersFarcaster":
+				return ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Viewer", field.Name)
 		},
@@ -65236,6 +65368,64 @@ func (ec *executionContext) fieldContext_Viewer_suggestedUsers(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Viewer_suggestedUsers_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Viewer_suggestedUsersFarcaster(ctx context.Context, field graphql.CollectedField, obj *model.Viewer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Viewer_suggestedUsersFarcaster(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Viewer().SuggestedUsersFarcaster(rctx, obj, fc.Args["before"].(*string), fc.Args["after"].(*string), fc.Args["first"].(*int), fc.Args["last"].(*int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.UsersConnection)
+	fc.Result = res
+	return ec.marshalOUsersConnection2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐUsersConnection(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Viewer_suggestedUsersFarcaster(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Viewer",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "edges":
+				return ec.fieldContext_UsersConnection_edges(ctx, field)
+			case "pageInfo":
+				return ec.fieldContext_UsersConnection_pageInfo(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UsersConnection", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Viewer_suggestedUsersFarcaster_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -87686,6 +87876,23 @@ func (ec *executionContext) _Viewer(ctx context.Context, sel ast.SelectionSet, o
 					}
 				}()
 				res = ec._Viewer_suggestedUsers(ctx, field, obj)
+				return res
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return innerFunc(ctx)
+
+			})
+		case "suggestedUsersFarcaster":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Viewer_suggestedUsersFarcaster(ctx, field, obj)
 				return res
 			}
 

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -3006,11 +3006,12 @@ type Viewer struct {
 	Email           *UserEmail       `json:"email"`
 	// Returns a list of notifications in reverse chronological order.
 	// Seen notifications come after unseen notifications
-	Notifications        *NotificationsConnection `json:"notifications"`
-	NotificationSettings *NotificationSettings    `json:"notificationSettings"`
-	UserExperiences      []*UserExperience        `json:"userExperiences"`
-	Persona              *persist.Persona         `json:"persona"`
-	SuggestedUsers       *UsersConnection         `json:"suggestedUsers"`
+	Notifications           *NotificationsConnection `json:"notifications"`
+	NotificationSettings    *NotificationSettings    `json:"notificationSettings"`
+	UserExperiences         []*UserExperience        `json:"userExperiences"`
+	Persona                 *persist.Persona         `json:"persona"`
+	SuggestedUsers          *UsersConnection         `json:"suggestedUsers"`
+	SuggestedUsersFarcaster *UsersConnection         `json:"suggestedUsersFarcaster"`
 }
 
 func (Viewer) IsNode()          {}

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -3524,7 +3524,18 @@ func (r *viewerResolver) SuggestedUsers(ctx context.Context, obj *model.Viewer, 
 	if err != nil {
 		return nil, err
 	}
+	return &model.UsersConnection{
+		Edges:    usersToEdges(ctx, users),
+		PageInfo: pageInfoToModel(ctx, pageInfo),
+	}, nil
+}
 
+// SuggestedUsersFarcaster is the resolver for the suggestedUsersFarcaster field.
+func (r *viewerResolver) SuggestedUsersFarcaster(ctx context.Context, obj *model.Viewer, before *string, after *string, first *int, last *int) (*model.UsersConnection, error) {
+	users, pageInfo, err := publicapi.For(ctx).User.GetSuggestedUsersFarcaster(ctx, before, after, first, last)
+	if err != nil {
+		return nil, err
+	}
 	return &model.UsersConnection{
 		Edges:    usersToEdges(ctx, users),
 		PageInfo: pageInfoToModel(ctx, pageInfo),

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -840,6 +840,8 @@ type Viewer implements Node @goGqlId(fields: ["userId"]) @goEmbedHelper {
   persona: Persona @goField(forceResolver: true)
   suggestedUsers(before: String, after: String, first: Int, last: Int): UsersConnection
     @goField(forceResolver: true)
+  suggestedUsersFarcaster(before: String, after: String, first: Int, last: Int): UsersConnection
+    @goField(forceResolver: true)
 }
 
 type NotificationSettings {

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:qRvTTA==,iv:ftUAzGsWSjyIchN5oj4hRvJQ5Ps4wnSR4PqSSHuO/jE=,tag:cUavfGuTwPrKojDbtHgbxA==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:3fBozA==,iv:7SxrdfVlrXmteelDhDUs0cuMDzHvgp/jqETJwyHYdgA=,tag:xr3b3Jh+rF9nFtyMfZqZPg==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:FIh7tKrzvT00UdHfclTPCm4adfNrRZpXvdceLk20IgE=,iv:Zb2HzxUwX6+fy4/YKXzS879WVK3HsAb9T7OvkIdCXHg=,tag:MPTmDKDbUwEd0daI4RBn6w==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:OdBqWwRMhe1wMi/f/DRdV9AgLEfLIal3r/+moHwT4SY=,iv:flJVXjnwkEFjSOe+yaWLJvctOFm/iMDQ8ySkRtR1zMA=,tag:cpnOyfpVLtCybB495IMTTw==,type:str]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:7iuBV6YRagS0PIz2nPsNDU80es3bCFX5oLYt2qJ49l8=,iv:QWsHE0j4aE0os8+qU7Guu/KgUKYS5sb4D7MU4r2HGJg=,tag:U/SnrYyvr70Z4ew5Aym41A==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -67,8 +67,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-03-01T22:53:26Z"
-    mac: ENC[AES256_GCM,data:VcnoKk/dQcTSSrBUsgzuL6/8C+18EPNUm6/oMLjQkNDdSLs042diLI8vzII7vcGVlNeZQ8mJJUVYH874l1hjAj3tOorOMF/YpF0Du2qG7SLW+7voC6mpAjs3irifwp1jr/gNeWL59pZO7WnLwLx6umOegf/AUDnmhTHLixZH4JA=,iv:XEVZWXv9F2WswvJC06dVNeTOfJdNaOulPmVDRlTBVD4=,tag:IHi+Ae4JSvJ6SalAxl77fg==,type:str]
+    lastmodified: "2024-02-27T20:31:04Z"
+    mac: ENC[AES256_GCM,data:5m4R8nsbz/lvD9dYASriKY3TpdHtEmkJMaFCBEOrqhRT2BuXwltjkg/EpxA2Rn2A9TkREwCwycciZDJcQZKLt1K0OY1m0SEGfp9F7y2I2z2ptYIciFkw8nsZkXLYye2Vw8lpDtZP3sXT51mxOGqEM2p9K74ArboYydwdjwBTjBQ=,iv:iYsfRQUiI+k6CdEUybVJ3mvQOJCTFbXaEeRTkmbsb2c=,tag:ChLtrlOCRdQ8nCTNeQlPTA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-backend.yaml
+++ b/secrets/dev/local/app-dev-backend.yaml
@@ -2,9 +2,9 @@
 IMGIX_SECRET: ENC[AES256_GCM,data:aC5LTs4wMT53mZbqMMXS2g==,iv:i5JUhAZrTUBJsFzl+hO3bHTfgk0HdHqV495cqWYayjE=,tag:KdqDnWX6ZoweWb1D6vGPyw==,type:str]
 POAP_API_KEY: ENC[AES256_GCM,data:rQ8r6aPyXPooVQ4MQqb/nLfSVJ+TnqgmFuN0Kuas6mlLHpnB6aJl5hcw+ARz4QqSrTeh3HbBZRi3b0J8nRbRzIX3+XBZrm55KVneddf9prpg0tmMk3v9fTImNQ9jOFmRELgkdeK8RmJ4/UxW/yv4NoEKSci69aniOWunmisiQFE=,iv:siuMZWQ2pFewJel88VhzaCsQg/F0SqY+5KI1iFmHk/U=,tag:MdVKmMlqs2eobdODrSG3rg==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:eAU6TQcSb/aF,iv:gO4IhubyeUoUuw0miYBspGghqSAuoylw3fIPQC3rNaw=,tag:j56Ez77af5YWri10VdghuQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:3fBozA==,iv:7SxrdfVlrXmteelDhDUs0cuMDzHvgp/jqETJwyHYdgA=,tag:xr3b3Jh+rF9nFtyMfZqZPg==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:qRvTTA==,iv:ftUAzGsWSjyIchN5oj4hRvJQ5Ps4wnSR4PqSSHuO/jE=,tag:cUavfGuTwPrKojDbtHgbxA==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:an9PImH6/EWmIX9O0gmc,iv:haEZ62nGMJoHORV8lzFfXkpaJ2x99HNG8ro876eL1fQ=,tag:BB655iMRl8ymyTOk0lWEvw==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:OdBqWwRMhe1wMi/f/DRdV9AgLEfLIal3r/+moHwT4SY=,iv:flJVXjnwkEFjSOe+yaWLJvctOFm/iMDQ8ySkRtR1zMA=,tag:cpnOyfpVLtCybB495IMTTw==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:FIh7tKrzvT00UdHfclTPCm4adfNrRZpXvdceLk20IgE=,iv:Zb2HzxUwX6+fy4/YKXzS879WVK3HsAb9T7OvkIdCXHg=,tag:MPTmDKDbUwEd0daI4RBn6w==,type:str]
 POAP_AUTH_TOKEN: ENC[AES256_GCM,data:D6LxgHAER69SK4lcotytqmRIdjKvKVT+gITI1mJiKZf44u5Fc/CPcmzOacmTyD4QM7DSQtOZScA4ATUKbx1GChjIfs1joTs7H3HVb1JIvl2JgutA0a6F8h9qVWTaWpslmfidCjmfHwYzWGZsDHMhTmGUNqcIYbfUrQy7SA/YR8e/Sa4g4JUcxkMh8KpyX7fovj4ehlZdgOlC2wvnkqzXPIm6jjkwlPhIp8RDmDdDhLtLr9DohUheZzeUt3eZr2O0RbFTx0vBw2tn5NhbQci+ZrHmx5OfUHopjopHqELZHor2YNP8iH3GRKmfcsLCwAkN8akN1BEOK6Yqxc8J+kBvxkys9ErH05J0L1Isv5j0wptp4Lx7WuP5ihm9KZHOKCmsfQM/I6YS3NS4irisAyRIK8HyrFCnGfHmv1OXjmyYxX6sIubci7OBo2JwAhivc99PcScVb/sJhSUepzf95gXG9Vf3mfFWYzovGZPjq9qGa7jD2p2HrvRTLldLXnyXWgyxJclb1INjs7F38QSSd/tOXvjow1A0w+K8lQ7xgA82REC7+sMjHJbaOvMmMbSaQVB04m8n1b1pRlOWcJloFCWdGnztGTWU2UxQjWe4k0omOhGBL1J7JypoosBuxr92Wzo4h2T4jn+uUZBVcDbLbdHtsnvTkOWit3siWRDauCOFIz/lAofxCpmEcDZNyXlVDfvryAYnnSSsbo+bN8xfDZMYMEN8u8wml+R41ani5KFuZV2NOHFNrprMVS3V3tMqCy980b98JQDH8GMMdbClhhJe/FTQv01VDbnKKtaiFQKo3TwLgS70E35N50h9vBiUbZ5AGekeMthx3MSBRvG0SFTGSLYcJBJXmA5TYMCo3aD11rg8xTXPv0Wm8qLn00UgoOnnmcfTEzk5uhi/hCdVEjjQsO6SdRRc5mK+pZsgJNyS5s8EhQ355MAkwtGd6dMTAIAU4tDJoJWQ2zMuAPlXJLmv/6VSZYGSmokAg045skjbR7mGEqYana66gtDdxKxUcovlOJBIm5Au3zOmSxsdvkvIQIluxA==,iv:bydsdTKwyvwKGrg/HlLON//DBADWvA6Yj3KolhyKta0=,tag:aSv4oz8+3H+RJsXsWJO9ww==,type:str]
 OPENSEA_API_KEY: ENC[AES256_GCM,data:7iuBV6YRagS0PIz2nPsNDU80es3bCFX5oLYt2qJ49l8=,iv:QWsHE0j4aE0os8+qU7Guu/KgUKYS5sb4D7MU4r2HGJg=,tag:U/SnrYyvr70Z4ew5Aym41A==,type:str]
 TEZOS_API_URL: ENC[AES256_GCM,data:rRX5EW2nMUI+Dc+cH/dKLIqDGQ==,iv:x+I39Zw2MuliHE/XXWEpIsXrcPALl3FGeBKlTnQWb1o=,tag:BwINanQuhCI2mwaNcYjVKw==,type:str]
@@ -67,8 +67,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-27T20:31:04Z"
-    mac: ENC[AES256_GCM,data:5m4R8nsbz/lvD9dYASriKY3TpdHtEmkJMaFCBEOrqhRT2BuXwltjkg/EpxA2Rn2A9TkREwCwycciZDJcQZKLt1K0OY1m0SEGfp9F7y2I2z2ptYIciFkw8nsZkXLYye2Vw8lpDtZP3sXT51mxOGqEM2p9K74ArboYydwdjwBTjBQ=,iv:iYsfRQUiI+k6CdEUybVJ3mvQOJCTFbXaEeRTkmbsb2c=,tag:ChLtrlOCRdQ8nCTNeQlPTA==,type:str]
+    lastmodified: "2024-03-01T22:53:26Z"
+    mac: ENC[AES256_GCM,data:VcnoKk/dQcTSSrBUsgzuL6/8C+18EPNUm6/oMLjQkNDdSLs042diLI8vzII7vcGVlNeZQ8mJJUVYH874l1hjAj3tOorOMF/YpF0Du2qG7SLW+7voC6mpAjs3irifwp1jr/gNeWL59pZO7WnLwLx6umOegf/AUDnmhTHLixZH4JA=,iv:XEVZWXv9F2WswvJC06dVNeTOfJdNaOulPmVDRlTBVD4=,tag:IHi+Ae4JSvJ6SalAxl77fg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
-	"github.com/mikeydub/go-gallery/publicapi"
+	// "github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/farcaster"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -60,9 +60,10 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
-	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	router := CoreInit(ctx, c, provider, recommender, p)
+	// recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
+	// p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	// router := CoreInit(ctx, c, provider, recommender, p)
+	router := CoreInit(ctx, c, provider, nil, nil)
 	http.Handle("/", router)
 }
 
@@ -134,8 +135,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	tokenManageCache := redis.NewCache(redis.TokenManageCache)
 	oneTimeLoginCache := redis.NewCache(redis.OneTimeLoginCache)
 
-	recommender.Loop(ctx, time.NewTicker(time.Hour))
-	p.Loop(ctx, time.NewTicker(time.Minute*15))
+	// recommender.Loop(ctx, time.NewTicker(time.Hour))
+	// p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, oneTimeLoginCache, c.MagicLinkClient, recommender, p, farcaster.NewNeynarAPI(c.HTTPClient, socialCache))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
-	// "github.com/mikeydub/go-gallery/publicapi"
+	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/farcaster"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -60,10 +60,9 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	// recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
-	// p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	// router := CoreInit(ctx, c, provider, recommender, p)
-	router := CoreInit(ctx, c, provider, nil, nil)
+	recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
+	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	router := CoreInit(ctx, c, provider, recommender, p)
 	http.Handle("/", router)
 }
 
@@ -135,8 +134,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	tokenManageCache := redis.NewCache(redis.TokenManageCache)
 	oneTimeLoginCache := redis.NewCache(redis.OneTimeLoginCache)
 
-	// recommender.Loop(ctx, time.NewTicker(time.Hour))
-	// p.Loop(ctx, time.NewTicker(time.Minute*15))
+	recommender.Loop(ctx, time.NewTicker(time.Hour))
+	p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, oneTimeLoginCache, c.MagicLinkClient, recommender, p, farcaster.NewNeynarAPI(c.HTTPClient, socialCache))
 }


### PR DESCRIPTION
**Changes**
* Adds a new field, `suggestedUsersFarcaster`, to the `Viewer` type that returns users you follow on Farcaster that you don't follow on Gallery:
```graphql
type Viewer {
  suggestedUsersFarcaster(before: String, after: String, first: Int, last: Int): UsersConnection
}
```
* The order of users is based on the  average rank of the their tokens displayed and the number of posts they made
* Adds pagination to `neynar.FollowingByUserID` - previously only returned the first 25 users
* Adds index to `pii.for_users` to find a user by Farcaster FID quickly