### PR TITLE
Add improved rate limiter and set Alchemy as the primary

### DIFF
--- a/publicapi/feed.go
+++ b/publicapi/feed.go
@@ -279,9 +279,9 @@ func (api FeedAPI) ReferralPostToken(ctx context.Context, t persist.TokenIdentif
 	} else {
 		// The token is not synced, so we need to find it
 		synced, err := api.multichainProvider.SyncTokenByUserWalletsAndTokenIdentifiersRetry(ctx, userID, t, retry.Retry{
-			Base:  2,
-			Cap:   4,
-			Tries: 4,
+			MinWait:    2,
+			MaxWait:    4,
+			MaxRetries: 4,
 		})
 		if err != nil {
 			return "", err

--- a/secrets/local/local/app-local-indexer-server.yaml
+++ b/secrets/local/local/app-local-indexer-server.yaml
@@ -1,8 +1,8 @@
 #ENC[AES256_GCM,data:8zgEEHBLWgSSWwbZjxNVCM3FvmLR9gPdgA0WefIPzIsoWioeTUoVVILBDkAMPtF/aw==,iv:E2rtefZaRAEkqiJZN3cc0hr/cUk1HF79IINmR+O73Gc=,tag:Ufi4/EEqzkxbvq8ksTLYig==,type:comment]
-RPC_URL: ENC[AES256_GCM,data:8SV7/oeQByiURXDR/qMlbl2/PU0Zxb2Sy9Apwunsn8ZbpjVgPnpqjmJgYaH802EYl0J6LoLydmKg3NAr+3rB9uvk1P41,iv:1MimQ5FOtPD7EBepPycCz0UYaSVbv3ox6j8g9tUV8CE=,tag:05XtWhvd/ZK9NUNf6S9Jpg==,type:str]
+RPC_URL: ENC[AES256_GCM,data:5wvrWfg4kHA/vSHbEBQTPuUJgHu0IMmrHah894Wh0cPfOvmLRo+YhHhf9Z9OeKa+uZYVQY88KBUHFq+CmcRIJu1H0A==,iv:UD/9JWGZgCBISbhmda72gxdUP8ApT7MoeQAu+Lb6eLc=,tag:HV9haJAMTcRpLEG6gnLYow==,type:str]
 IMGIX_API_KEY: ENC[AES256_GCM,data:xeBmuCi2hcY6akGUqRyotYmQV4+un1k56GmWRa5pVbQToAzAkHkwEINUeevu02xVbvIzHqaGBPne5KHib1zTuPtd9Q==,iv:pVNrkQtCmPppoxoo8O5jNxMDPpvThpdV3c2ZaIkfbCk=,tag:lFWyC8N+5IN6FL2XhWARuA==,type:str]
 IPFS_PROJECT_ID: ENC[AES256_GCM,data:gBkA5TZiWdk59RVjZ8cDi/xTg9DCZ8TIsSBM,iv:o0Oamk/i/CDkxTXxSG5Fp5awZqIPpCgXc2217XBaaGQ=,tag:AQE3sWkHmKKgkQI4fFtang==,type:str]
-ALCHEMY_API_URL: ENC[AES256_GCM,data:z2csIf/wJatB/zq9gwCbAXTr2UGDF+soFQQa2Fm//TNP/jDiFFct7BIsMZoVvBkWgdortDO0NvUdO21j+hhkBmIjTlK4Brn7xQ==,iv:Z8T4zp/WXsRmEQpAB6JMhhBqrqIaaEem+bHiR+vYMQY=,tag:CydL9fKpXsUK3BnysEifXg==,type:str]
+ALCHEMY_API_URL: ENC[AES256_GCM,data:7TotMkl1896tcF3N6ohmrOC+x2Bu3Lu/cbtzKTjJXg81Nf77wzFrbeNTnO8XWJJI5im32NP/pNHvait9JddsgcTy9WKZ,iv:6Uch/+cGRXs8RJoKrASar1i7rB8/B53NVwWhxDrMcoM=,tag:r3kfdzZZwH6DxUNjt9+7kQ==,type:str]
 IPFS_PROJECT_SECRET: ENC[AES256_GCM,data:dqdtL+KL0Kfb1ahqNLECV+Bt6brdHTYsg+krCxKdKU0=,iv:yZCgCU05kJRhqUbv+BpHKu7MWxYH4AIuk1wkSbh/Sxw=,tag:hffGpFBC70NGTaSS6ntSwQ==,type:str]
 sops:
     kms: []
@@ -13,8 +13,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2023-04-06T23:21:42Z"
-    mac: ENC[AES256_GCM,data:cLDdzarclp79+6eDm2PUqCJcIOg3YZhGjhHvPWZdJ8i19XUfvQi4fAxH4nDOAR0sCm7ImpKMBGw/oJ++t49JGVis5h0NXxl9SdFVlQ4ZhTGli+8ulySKIajHZhXhw4+yUXdBHgGg6B9ozfePgXanPZnf4KM85qhUZVsr/IcjyJM=,iv:GqeByxia1aHI7PU4T08qWTyyJAxcuvxnCXdGR/unN3Y=,tag:uV6zAOTIrDPF28goGnm3qg==,type:str]
+    lastmodified: "2024-03-07T19:11:24Z"
+    mac: ENC[AES256_GCM,data:Epdln4NfTkvYcr3dk8ULT9fnL0ivQ+b+nXthGWK/ne3/FJU0CwfmEGLKt9G7ctbUG0nU31+X4QuIPV47PE5Qs5FBi7kF6MG5klnOf5GngGkDuNOXpSo1Fw6WOE7lqjRAFT5jabN12K7EX8vWhIcKKzqRlqRQuPuCWQ0VLnJQPDM=,iv:e1GL4ppivXyl4ms+ipQ4IKT6N0TlTJGwOJSQUH2HSa8=,tag:XyqUBW1xwLjO6jXE15+Zcg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/server/inject.go
+++ b/server/inject.go
@@ -165,7 +165,7 @@ func customMetadataHandlersInjector(alchemyProvider *alchemy.Provider) *multicha
 	))
 }
 
-func ethInjector(envInit, context.Context, *http.Client) *multichain.EthereumProvider {
+func ethInjector(envInit, context.Context, *http.Client) (*multichain.EthereumProvider, func()) {
 	panic(wire.Build(
 		rpc.NewEthClient,
 		wire.Value(persist.ChainETH),
@@ -201,12 +201,13 @@ func ethProviderInjector(
 	))
 }
 
-func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) (*wrapper.SyncPipelineWrapper, func()) {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
 		ethTokenIdentifierOwnerFetcherInjector,
-		ethTokensIncrementalOwnerFetcherInjector,
+		// ethTokensIncrementalOwnerFetcherInjector,
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(alchemyProvider)),
 		ethTokensContractFetcherInjector,
 		ethTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
@@ -292,7 +293,7 @@ func tezosProviderInjector(tezosProvider *tezos.Provider, tzktProvider *tzkt.Pro
 	))
 }
 
-func optimismInjector(context.Context, *http.Client) *multichain.OptimismProvider {
+func optimismInjector(context.Context, *http.Client) (*multichain.OptimismProvider, func()) {
 	panic(wire.Build(
 		wire.Value(persist.ChainOptimism),
 		optimismProviderInjector,
@@ -319,7 +320,7 @@ func optimismProviderInjector(
 	))
 }
 
-func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) (*wrapper.SyncPipelineWrapper, func()) {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
@@ -380,7 +381,7 @@ func optmismTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Prov
 	))
 }
 
-func arbitrumInjector(context.Context, *http.Client) *multichain.ArbitrumProvider {
+func arbitrumInjector(context.Context, *http.Client) (*multichain.ArbitrumProvider, func()) {
 	panic(wire.Build(
 		arbitrumProviderInjector,
 		wire.Value(persist.ChainArbitrum),
@@ -407,7 +408,7 @@ func arbitrumProviderInjector(
 	))
 }
 
-func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) (*wrapper.SyncPipelineWrapper, func()) {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
@@ -485,7 +486,7 @@ func poapProviderInjector(poapProvider *poap.Provider) *multichain.PoapProvider 
 	))
 }
 
-func zoraInjector(envInit, context.Context, *http.Client) *multichain.ZoraProvider {
+func zoraInjector(envInit, context.Context, *http.Client) (*multichain.ZoraProvider, func()) {
 	panic(wire.Build(
 		zoraProviderInjector,
 		wire.Value(persist.ChainZora),
@@ -540,7 +541,7 @@ func zoraContractFetcherInjector(openseaProvider *opensea.Provider, zoraProvider
 	))
 }
 
-func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, zoraProvider *zora.Provider) *wrapper.SyncPipelineWrapper {
+func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, zoraProvider *zora.Provider) (*wrapper.SyncPipelineWrapper, func()) {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(zoraProvider)),
@@ -595,7 +596,7 @@ func zoraTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provide
 	))
 }
 
-func baseInjector(context.Context, *http.Client) *multichain.BaseProvider {
+func baseInjector(context.Context, *http.Client) (*multichain.BaseProvider, func()) {
 	panic(wire.Build(
 		baseProvidersInjector,
 		wire.Value(persist.ChainBase),
@@ -622,7 +623,7 @@ func baseProvidersInjector(
 	))
 }
 
-func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) (*wrapper.SyncPipelineWrapper, func()) {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
@@ -683,7 +684,7 @@ func baseTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provide
 	))
 }
 
-func polygonInjector(context.Context, *http.Client) *multichain.PolygonProvider {
+func polygonInjector(context.Context, *http.Client) (*multichain.PolygonProvider, func()) {
 	panic(wire.Build(
 		polygonProvidersInjector,
 		wire.Value(persist.ChainPolygon),
@@ -695,7 +696,7 @@ func polygonInjector(context.Context, *http.Client) *multichain.PolygonProvider 
 	))
 }
 
-func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) *wrapper.SyncPipelineWrapper {
+func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) (*wrapper.SyncPipelineWrapper, func()) {
 	panic(wire.Build(
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),

--- a/server/inject.go
+++ b/server/inject.go
@@ -206,8 +206,7 @@ func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain
 		wire.Struct(new(wrapper.SyncPipelineWrapper), "*"),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(alchemyProvider)),
 		ethTokenIdentifierOwnerFetcherInjector,
-		// ethTokensIncrementalOwnerFetcherInjector,
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(alchemyProvider)),
+		ethTokensIncrementalOwnerFetcherInjector,
 		ethTokensContractFetcherInjector,
 		ethTokenByTokenIdentifiersFetcherInjector,
 		wrapper.NewFillInWrapper,
@@ -218,56 +217,56 @@ func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain
 func ethTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalContractFetcherProvider,
-		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func ethTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
 	panic(wire.Build(
 		multiTokenIdentifierOwnerFetcherProvider,
-		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func ethTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalOwnerFetcherProvider,
-		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func ethContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.ContractFetcher {
 	panic(wire.Build(
 		multiContractFetcherProvider,
-		wire.Bind(new(contractFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(contractFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(contractFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(contractFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func ethTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
 	panic(wire.Build(
 		multiTokenMetadataFetcherProvider,
-		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func ethTokenDescriptorsFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
 	panic(wire.Build(
 		multiTokenDescriptorsFetcherProvider,
-		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func ethTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
 	panic(wire.Build(
 		multiTokenByTokenIdentifiersFetcherProvider,
-		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
@@ -336,48 +335,48 @@ func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 func optimismTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalContractFetcherProvider,
-		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func optimismTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
 	panic(wire.Build(
 		multiTokenIdentifierOwnerFetcherProvider,
-		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func optimismTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalOwnerFetcherProvider,
-		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func optimismTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
 	panic(wire.Build(
 		multiTokenMetadataFetcherProvider,
-		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func optimisimTokenDescriptorsFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
 	panic(wire.Build(
 		multiTokenDescriptorsFetcherProvider,
-		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func optmismTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
 	panic(wire.Build(
 		multiTokenByTokenIdentifiersFetcherProvider,
-		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
@@ -424,48 +423,48 @@ func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 func arbitrumTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
 	panic(wire.Build(
 		multiTokenMetadataFetcherProvider,
-		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func arbitrumTokenDescriptorsFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
 	panic(wire.Build(
 		multiTokenDescriptorsFetcherProvider,
-		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func arbitrumTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalContractFetcherProvider,
-		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func arbitrumTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
 	panic(wire.Build(
 		multiTokenIdentifierOwnerFetcherProvider,
-		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func arbitrumTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalOwnerFetcherProvider,
-		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func arbitrumTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
 	panic(wire.Build(
 		multiTokenByTokenIdentifiersFetcherProvider,
-		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
@@ -639,48 +638,48 @@ func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 func baseTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
 	panic(wire.Build(
 		multiTokenMetadataFetcherProvider,
-		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func baseTokenDescriptorFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
 	panic(wire.Build(
 		multiTokenDescriptorsFetcherProvider,
-		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func baseTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalContractFetcherProvider,
-		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func baseTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
 	panic(wire.Build(
 		multiTokenIdentifierOwnerFetcherProvider,
-		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func baseTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalOwnerFetcherProvider,
-		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func baseTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
 	panic(wire.Build(
 		multiTokenByTokenIdentifiersFetcherProvider,
-		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
@@ -712,40 +711,40 @@ func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, c
 func polygonTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
 	panic(wire.Build(
 		multiTokenMetadataFetcherProvider,
-		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenMetadataFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func polygonTokenDescriptorFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
 	panic(wire.Build(
 		multiTokenDescriptorsFetcherProvider,
-		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenDescriptorsFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func polygonTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalContractFetcherProvider,
-		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalContractFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func polygonTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
 	panic(wire.Build(
 		multiTokenIdentifierOwnerFetcherProvider,
-		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokenIdentifierOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
 func polygonTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
 	panic(wire.Build(
 		multiTokensIncrementalOwnerFetcherProvider,
-		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensIncrementalOwnerFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 
@@ -767,8 +766,8 @@ func polygonProvidersInjector(
 func polygonTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
 	panic(wire.Build(
 		multiTokenByTokenIdentifiersFetcherProvider,
-		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(openseaProvider)),
-		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherA), util.ToPointer(alchemyProvider)),
+		wire.Bind(new(tokensByTokenIdentifiersFetcherB), util.ToPointer(openseaProvider)),
 	))
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
-	// "github.com/mikeydub/go-gallery/publicapi"
+	"github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/farcaster"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -60,10 +60,9 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	// recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
-	// p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	// router := CoreInit(ctx, c, provider, recommender, p)
-	router := CoreInit(ctx, c, provider, nil, nil)
+	recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
+	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	router := CoreInit(ctx, c, provider, recommender, p)
 	http.Handle("/", router)
 }
 
@@ -136,8 +135,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	oneTimeLoginCache := redis.NewCache(redis.OneTimeLoginCache)
 	neynar := farcaster.NewNeynarAPI(c.HTTPClient, socialCache, c.Queries)
 
-	// recommender.Loop(ctx, time.NewTicker(time.Hour))
-	// p.Loop(ctx, time.NewTicker(time.Minute*15))
+	recommender.Loop(ctx, time.NewTicker(time.Hour))
+	p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, oneTimeLoginCache, c.MagicLinkClient, recommender, p, neynar)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,7 @@ import (
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/middleware"
-	"github.com/mikeydub/go-gallery/publicapi"
+	// "github.com/mikeydub/go-gallery/publicapi"
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/farcaster"
 	"github.com/mikeydub/go-gallery/service/logger"
@@ -60,9 +60,10 @@ func Init() {
 	ctx := context.Background()
 	c := ClientInit(ctx)
 	provider, _ := NewMultichainProvider(ctx, SetDefaults)
-	recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
-	p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
-	router := CoreInit(ctx, c, provider, recommender, p)
+	// recommender := recommend.NewRecommender(c.Queries, publicapi.GetOnboardingUserRecommendationsBootstrap(c.Queries))
+	// p := userpref.NewPersonalization(ctx, c.Queries, c.StorageClient)
+	// router := CoreInit(ctx, c, provider, recommender, p)
+	router := CoreInit(ctx, c, provider, nil, nil)
 	http.Handle("/", router)
 }
 
@@ -135,8 +136,8 @@ func CoreInit(ctx context.Context, c *Clients, provider *multichain.Provider, re
 	oneTimeLoginCache := redis.NewCache(redis.OneTimeLoginCache)
 	neynar := farcaster.NewNeynarAPI(c.HTTPClient, socialCache, c.Queries)
 
-	recommender.Loop(ctx, time.NewTicker(time.Hour))
-	p.Loop(ctx, time.NewTicker(time.Minute*15))
+	// recommender.Loop(ctx, time.NewTicker(time.Hour))
+	// p.Loop(ctx, time.NewTicker(time.Minute*15))
 
 	return handlersInit(router, c.Repos, c.Queries, c.HTTPClient, c.EthClient, c.IPFSClient, c.ArweaveClient, c.StorageClient, provider, newThrottler(), c.TaskClient, c.PubSubClient, lock, c.SecretClient, graphqlAPQCache, feedCache, socialCache, authRefreshCache, tokenManageCache, oneTimeLoginCache, c.MagicLinkClient, recommender, p, neynar)
 }

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -140,6 +140,7 @@ func ethProviderInjector(ctx context.Context, indexerProvider *indexer.Provider,
 
 func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain persist.Chain, openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) (*wrapper.SyncPipelineWrapper, func()) {
 	tokenIdentifierOwnerFetcher := ethTokenIdentifierOwnerFetcherInjector(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := ethTokensIncrementalOwnerFetcherInjector(openseaProvider, alchemyProvider)
 	tokensIncrementalContractFetcher := ethTokensContractFetcherInjector(openseaProvider, alchemyProvider)
 	tokensByTokenIdentifiersFetcher := ethTokenByTokenIdentifiersFetcherInjector(openseaProvider, alchemyProvider)
 	customMetadataHandlers := customMetadataHandlersInjector(alchemyProvider)
@@ -147,7 +148,7 @@ func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain
 	syncPipelineWrapper := &wrapper.SyncPipelineWrapper{
 		Chain:                            chain,
 		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
-		TokensIncrementalOwnerFetcher:    alchemyProvider,
+		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
 		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
 		TokenMetadataBatcher:             alchemyProvider,
 		TokensByTokenIdentifiersFetcher:  tokensByTokenIdentifiersFetcher,
@@ -160,37 +161,37 @@ func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain
 }
 
 func ethTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
-	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalContractFetcher
 }
 
 func ethTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
-	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenIdentifierOwnerFetcher
 }
 
 func ethTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
-	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalOwnerFetcher
 }
 
 func ethContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.ContractFetcher {
-	contractFetcher := multiContractFetcherProvider(openseaProvider, alchemyProvider)
+	contractFetcher := multiContractFetcherProvider(alchemyProvider, openseaProvider)
 	return contractFetcher
 }
 
 func ethTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
-	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(openseaProvider, alchemyProvider)
+	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenMetadataFetcher
 }
 
 func ethTokenDescriptorsFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
-	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(openseaProvider, alchemyProvider)
+	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenDescriptorsFetcher
 }
 
 func ethTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
-	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(openseaProvider, alchemyProvider)
+	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensByTokenIdentifiersFetcher
 }
 
@@ -268,32 +269,32 @@ func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 }
 
 func optimismTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
-	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalContractFetcher
 }
 
 func optimismTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
-	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenIdentifierOwnerFetcher
 }
 
 func optimismTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
-	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalOwnerFetcher
 }
 
 func optimismTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
-	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(openseaProvider, alchemyProvider)
+	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenMetadataFetcher
 }
 
 func optimisimTokenDescriptorsFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
-	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(openseaProvider, alchemyProvider)
+	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenDescriptorsFetcher
 }
 
 func optmismTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
-	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(openseaProvider, alchemyProvider)
+	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensByTokenIdentifiersFetcher
 }
 
@@ -351,32 +352,32 @@ func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 }
 
 func arbitrumTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
-	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(openseaProvider, alchemyProvider)
+	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenMetadataFetcher
 }
 
 func arbitrumTokenDescriptorsFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
-	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(openseaProvider, alchemyProvider)
+	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenDescriptorsFetcher
 }
 
 func arbitrumTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
-	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalContractFetcher
 }
 
 func arbitrumTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
-	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenIdentifierOwnerFetcher
 }
 
 func arbitrumTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
-	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalOwnerFetcher
 }
 
 func arbitrumTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
-	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(openseaProvider, alchemyProvider)
+	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensByTokenIdentifiersFetcher
 }
 
@@ -549,32 +550,32 @@ func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 }
 
 func baseTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
-	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(openseaProvider, alchemyProvider)
+	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenMetadataFetcher
 }
 
 func baseTokenDescriptorFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
-	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(openseaProvider, alchemyProvider)
+	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenDescriptorsFetcher
 }
 
 func baseTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
-	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalContractFetcher
 }
 
 func baseTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
-	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenIdentifierOwnerFetcher
 }
 
 func baseTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
-	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalOwnerFetcher
 }
 
 func baseTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
-	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(openseaProvider, alchemyProvider)
+	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensByTokenIdentifiersFetcher
 }
 
@@ -619,27 +620,27 @@ func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, c
 }
 
 func polygonTokenMetadataFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenMetadataFetcher {
-	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(openseaProvider, alchemyProvider)
+	tokenMetadataFetcher := multiTokenMetadataFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenMetadataFetcher
 }
 
 func polygonTokenDescriptorFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenDescriptorsFetcher {
-	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(openseaProvider, alchemyProvider)
+	tokenDescriptorsFetcher := multiTokenDescriptorsFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenDescriptorsFetcher
 }
 
 func polygonTokensContractFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalContractFetcher {
-	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalContractFetcher := multiTokensIncrementalContractFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalContractFetcher
 }
 
 func polygonTokenIdentifierOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokenIdentifierOwnerFetcher {
-	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokenIdentifierOwnerFetcher := multiTokenIdentifierOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokenIdentifierOwnerFetcher
 }
 
 func polygonTokensIncrementalOwnerFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensIncrementalOwnerFetcher {
-	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(openseaProvider, alchemyProvider)
+	tokensIncrementalOwnerFetcher := multiTokensIncrementalOwnerFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensIncrementalOwnerFetcher
 }
 
@@ -657,7 +658,7 @@ func polygonProvidersInjector(syncPipeline *wrapper.SyncPipelineWrapper, tokenDe
 }
 
 func polygonTokenByTokenIdentifiersFetcherInjector(openseaProvider *opensea.Provider, alchemyProvider *alchemy.Provider) multichain.TokensByTokenIdentifiersFetcher {
-	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(openseaProvider, alchemyProvider)
+	tokensByTokenIdentifiersFetcher := multiTokenByTokenIdentifiersFetcherProvider(alchemyProvider, openseaProvider)
 	return tokensByTokenIdentifiersFetcher
 }
 

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -210,7 +210,6 @@ func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Ad
 	u := mustGetNftsEndpoint(d.alchemyAPIURL)
 	setOwner(u, addr)
 	setWithMetadata(u)
-	setExcludeSpamOptionally(u, d.chain)
 	tokens, err := getNFTsPaginate(ctx, u.String(), 100, "pageKey", 0, 0, "", d.httpClient, nil, &getNFTsResponse{})
 	if err != nil {
 		return nil, nil, err
@@ -227,7 +226,6 @@ func (d *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, ad
 	u := mustGetNftsEndpoint(d.alchemyAPIURL)
 	setOwner(u, addr)
 	setWithMetadata(u)
-	setExcludeSpamOptionally(u, d.chain)
 
 	alchemyRec := make(chan []Token)
 	subErrChan := make(chan error)
@@ -277,7 +275,6 @@ func (d *Provider) GetTokensIncrementallyByContractAddress(ctx context.Context, 
 	u := mustGetNftsForCollectionEndpoint(d.alchemyAPIURL)
 	setContractAddress(u, addr)
 	setWithMetadata(u)
-	setExcludeSpamOptionally(u, d.chain)
 
 	alchemyRec := make(chan []Token)
 	subErrChan := make(chan error)
@@ -912,14 +909,6 @@ func setWithMetadata(url *url.URL) {
 	query := url.Query()
 	query.Set("withMetadata", "true")
 	url.RawQuery = query.Encode()
-}
-
-func setExcludeSpamOptionally(url *url.URL, chain persist.Chain) {
-	if chain != persist.ChainPolygon {
-		query := url.Query()
-		query.Set("excludeFilters[]", "SPAM")
-		url.RawQuery = query.Encode()
-	}
 }
 
 func setContractAddress(url *url.URL, address persist.Address) {

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -210,6 +210,7 @@ func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Ad
 	u := mustGetNftsEndpoint(d.alchemyAPIURL)
 	setOwner(u, addr)
 	setWithMetadata(u)
+	setExcludeSpam(u, d.chain)
 	tokens, err := getNFTsPaginate(ctx, u.String(), 100, "pageKey", 0, 0, "", d.httpClient, nil, &getNFTsResponse{})
 	if err != nil {
 		return nil, nil, err
@@ -226,6 +227,7 @@ func (d *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, ad
 	u := mustGetNftsEndpoint(d.alchemyAPIURL)
 	setOwner(u, addr)
 	setWithMetadata(u)
+	setExcludeSpam(u, d.chain)
 
 	alchemyRec := make(chan []Token)
 	subErrChan := make(chan error)
@@ -275,6 +277,7 @@ func (d *Provider) GetTokensIncrementallyByContractAddress(ctx context.Context, 
 	u := mustGetNftsForCollectionEndpoint(d.alchemyAPIURL)
 	setContractAddress(u, addr)
 	setWithMetadata(u)
+	setExcludeSpam(u, d.chain)
 
 	alchemyRec := make(chan []Token)
 	subErrChan := make(chan error)
@@ -909,6 +912,13 @@ func setWithMetadata(url *url.URL) {
 	query := url.Query()
 	query.Set("withMetadata", "true")
 	url.RawQuery = query.Encode()
+}
+
+func setExcludeSpam(url *url.URL, chain persist.Chain) {
+	query := url.Query()
+	query.Set("excludeFilters[]", "SPAM")
+	url.RawQuery = query.Encode()
+
 }
 
 func setContractAddress(url *url.URL, address persist.Address) {

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -20,6 +20,16 @@ import (
 	"github.com/mikeydub/go-gallery/util"
 )
 
+var (
+	getNftsEndpointTemplate                = "%s/getNFTs"
+	getNftsForCollectionEndpointTemplate   = "%s/getNFTsForCollection"
+	getOwnersForCollectionEndpointTemplate = "%s/getOwnersForCollection"
+	getNftMetadataEndpointTemplate         = "%s/getNFTMetadata"
+	getContractMetadataEndpointTemplate    = "%s/getContractMetadata"
+	getOwnersForTokenEndpointTemplate      = "%s/getOwnersForToken"
+	getNftMetadataBatchEndpointTemplate    = "%s/getNFTMetadataBatch"
+)
+
 type TokenURI struct {
 	Gateway string `json:"gateway"`
 	Raw     string `json:"raw"`
@@ -197,11 +207,11 @@ func NewProvider(httpClient *http.Client, chain persist.Chain) *Provider {
 
 // GetTokensByWalletAddress retrieves tokens for a wallet address on the Ethereum Blockchain
 func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Address) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
-	url := fmt.Sprintf("%s/getNFTs?owner=%s&withMetadata=true", d.alchemyAPIURL, addr)
-	if d.chain == persist.ChainPolygon {
-		url += "&excludeFilters[]=SPAM"
-	}
-	tokens, err := getNFTsPaginate(ctx, url, 100, "pageKey", 0, 0, "", d.httpClient, nil, &getNFTsResponse{})
+	u := mustGetNftsEndpoint(d.alchemyAPIURL)
+	setOwner(u, addr)
+	setWithMetadata(u)
+	setExcludeSpamOptionally(u, d.chain)
+	tokens, err := getNFTsPaginate(ctx, u.String(), 100, "pageKey", 0, 0, "", d.httpClient, nil, &getNFTsResponse{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -214,17 +224,17 @@ func (d *Provider) GetTokensByWalletAddress(ctx context.Context, addr persist.Ad
 func (d *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, addr persist.Address) (<-chan multichain.ChainAgnosticTokensAndContracts, <-chan error) {
 	rec := make(chan multichain.ChainAgnosticTokensAndContracts)
 	errChan := make(chan error)
+	u := mustGetNftsEndpoint(d.alchemyAPIURL)
+	setOwner(u, addr)
+	setWithMetadata(u)
+	setExcludeSpamOptionally(u, d.chain)
 
-	url := fmt.Sprintf("%s/getNFTs?owner=%s&withMetadata=true", d.alchemyAPIURL, addr)
-	if d.chain == persist.ChainPolygon {
-		url += "&excludeFilters[]=SPAM"
-	}
 	alchemyRec := make(chan []Token)
 	subErrChan := make(chan error)
 
 	go func() {
 		defer close(alchemyRec)
-		_, err := getNFTsPaginate(ctx, url, 100, "pageKey", 0, 0, "", d.httpClient, alchemyRec, &getNFTsResponse{})
+		_, err := getNFTsPaginate(ctx, u.String(), 100, "pageKey", 0, 0, "", d.httpClient, alchemyRec, &getNFTsResponse{})
 		if err != nil {
 			subErrChan <- err
 			return
@@ -264,16 +274,17 @@ func (d *Provider) GetTokensIncrementallyByContractAddress(ctx context.Context, 
 	rec := make(chan multichain.ChainAgnosticTokensAndContracts)
 	errChan := make(chan error)
 
-	url := fmt.Sprintf("%s/getNFTsForCollection?contractAddress=%s&withMetadata=true", d.alchemyAPIURL, addr)
-	if d.chain == persist.ChainPolygon {
-		url += "&excludeFilters[]=SPAM"
-	}
+	u := mustGetNftsForCollectionEndpoint(d.alchemyAPIURL)
+	setContractAddress(u, addr)
+	setWithMetadata(u)
+	setExcludeSpamOptionally(u, d.chain)
+
 	alchemyRec := make(chan []Token)
 	subErrChan := make(chan error)
 
 	go func() {
 		defer close(alchemyRec)
-		_, err := getNFTsPaginate(ctx, url, 100, "startToken", limit, 0, "", d.httpClient, alchemyRec, &getNFTsForCollectionResponse{})
+		_, err := getNFTsPaginate(ctx, u.String(), 100, "startToken", limit, 0, "", d.httpClient, alchemyRec, &getNFTsForCollectionResponse{})
 		if err != nil {
 			subErrChan <- err
 			return
@@ -399,23 +410,11 @@ func getNFTsPaginate[T tokensPaginated](ctx context.Context, baseURL string, def
 }
 
 func (d *Provider) getOwnersForContract(ctx context.Context, contract persist.EthereumAddress) ([]OwnerWithBalances, error) {
+	u := mustGetOwnersForCollectionEndpoint(d.alchemyAPIURL)
+	setContractAddress(u, persist.Address(contract))
+	setWithTokenBalances(u)
 
-	u := d.alchemyAPIURL + "/getOwnersForCollection"
-
-	parsedURL, err := url.Parse(u)
-	if err != nil {
-		return nil, err
-	}
-
-	q := parsedURL.Query()
-
-	q.Set("contractAddress", contract.String())
-	q.Set("withTokenBalances", "true")
-
-	parsedURL.RawQuery = q.Encode()
-	u = parsedURL.String()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -445,15 +444,21 @@ func (d *Provider) getTokenWithMetadata(ctx context.Context, ti multichain.Chain
 	if timeout == 0 {
 		timeout = (time.Second * 20) / time.Millisecond
 	}
-	url := fmt.Sprintf("%s/getNFTMetadata?contractAddress=%s&tokenId=%s&tokenUriTimeoutInMs=%d&refreshCache=%t", d.alchemyAPIURL, ti.ContractAddress, ti.TokenID.Base10String(), timeout, forceRefresh)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+
+	u := mustGetNftMetadataEndpoint(d.alchemyAPIURL)
+	setContractAddress(u, ti.ContractAddress)
+	setTokenID(u, ti.TokenID)
+	setTokenUriTimeoutInMs(u, timeout)
+	setRefreshCache(u)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
 
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
-		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("failed to get token metadata from alchemy api: %w (url: %s)", err, url)
+		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("failed to get token metadata from alchemy api: %w (url: %s)", err, u.String())
 	}
 
 	defer resp.Body.Close()
@@ -466,12 +471,12 @@ func (d *Provider) getTokenWithMetadata(ctx context.Context, ti multichain.Chain
 	// will have most of the fields empty
 	var token Token
 	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
-		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("failed to decode token metadata response: %w (url: %s)", err, url)
+		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("failed to decode token metadata response: %w (url: %s)", err, u.String())
 	}
 
 	tokens, contracts, err := d.alchemyTokensToChainAgnosticTokens(ctx, []Token{token})
 	if err != nil {
-		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("failed to convert token to chain agnostic token: %w (url: %s)", err, url)
+		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("failed to convert token to chain agnostic token: %w (url: %s)", err, u.String())
 	}
 
 	if len(contracts) == 0 {
@@ -494,8 +499,13 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti mu
 
 // GetTokensByContractAddress retrieves tokens for a contract address on the Ethereum Blockchain
 func (d *Provider) GetTokensByContractAddress(ctx context.Context, contractAddress persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	url := fmt.Sprintf("%s/getNFTsForCollection?contractAddress=%s&withMetadata=true&tokenUriTimeoutInMs=20000", d.alchemyAPIURL, contractAddress)
-	tokens, err := getNFTsPaginate(ctx, url, 100, "startToken", limit, offset, "", d.httpClient, nil, &getNFTsForCollectionResponse{})
+	u := mustGetNftsForCollectionEndpoint(d.alchemyAPIURL)
+	setContractAddress(u, contractAddress)
+	setWithMetadata(u)
+	setWithMetadata(u)
+	setTokenUriTimeoutInMs(u, time.Millisecond*20000)
+
+	tokens, err := getNFTsPaginate(ctx, u.String(), 100, "startToken", limit, offset, "", d.httpClient, nil, &getNFTsForCollectionResponse{})
 	if err != nil {
 		return nil, multichain.ChainAgnosticContract{}, err
 	}
@@ -582,8 +592,10 @@ type GetContractMetadataResponse struct {
 
 // GetContractByAddress retrieves an ethereum contract by address
 func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Address) (multichain.ChainAgnosticContract, error) {
-	url := fmt.Sprintf("%s/getContractMetadata?contractAddress=%s", d.alchemyAPIURL, addr)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	u := mustGetContractMetadataEndpoint(d.alchemyAPIURL)
+	setContractAddress(u, addr)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return multichain.ChainAgnosticContract{}, err
 	}
@@ -617,21 +629,6 @@ func (d *Provider) GetContractByAddress(ctx context.Context, addr persist.Addres
 
 }
 
-func (d *Provider) GetOwnedTokensByContract(ctx context.Context, contractAddress persist.Address, ownerAddress persist.Address, limit, offset int) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	url := fmt.Sprintf("%s/getNFTs?owner=%s&contractAddresses[]=%s&withMetadata=true&orderBy=transferTime", d.alchemyAPIURL, ownerAddress, contractAddress)
-	tokens, err := getNFTsPaginate(ctx, url, 100, "pageKey", limit, offset, "", d.httpClient, nil, &getNFTsResponse{})
-	if err != nil {
-		return nil, multichain.ChainAgnosticContract{}, err
-	}
-
-	cTokens, cContracts := alchemyTokensToChainAgnosticTokensForOwner(persist.EthereumAddress(ownerAddress), tokens)
-
-	if len(cContracts) == 0 {
-		return nil, multichain.ChainAgnosticContract{}, fmt.Errorf("no contract found for contract address %s", contractAddress)
-	}
-	return cTokens, cContracts[0], nil
-}
-
 func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []multichain.ChainAgnosticIdentifiers) ([]persist.TokenMetadata, error) {
 	type tokenRequest struct {
 		ContractAddress string `json:"contractAddress"`
@@ -657,10 +654,7 @@ func (d *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 	chunks := util.ChunkBy(tIDs, chunkSize)
 	metadatas := make([]persist.TokenMetadata, len(tIDs))
 
-	u, err := url.Parse(fmt.Sprintf("%s/getNFTMetadataBatch", d.alchemyAPIURL))
-	if err != nil {
-		return nil, err
-	}
+	u := mustGetNftMetadataBatchEndpoint(d.alchemyAPIURL)
 
 	// alchemy doesn't return tokens in the same order as the input
 	lookup := make(map[multichain.ChainAgnosticIdentifiers]persist.TokenMetadata)
@@ -781,8 +775,11 @@ type ownersResponse struct {
 }
 
 func (d *Provider) getOwnersForToken(ctx context.Context, token Token) ([]persist.EthereumAddress, error) {
-	url := fmt.Sprintf("%s/getOwnersForToken?contractAddress=%s&tokenId=%s", d.alchemyAPIURL, token.Contract.Address, token.ID.TokenID)
-	resp, err := d.httpClient.Get(url)
+	u := mustGetOwnersForTokenEndpoint(d.alchemyAPIURL)
+	setContractAddress(u, persist.Address(token.Contract.Address))
+	setTokenID(u, token.ID.TokenID.ToTokenID())
+
+	resp, err := d.httpClient.Get(u.String())
 	if err != nil {
 		return nil, err
 	}
@@ -860,6 +857,99 @@ func alchemyTokenToChainAgnosticToken(owner persist.EthereumAddress, token Token
 		},
 		IsSpam: &contractSpam,
 	}
+}
+
+func checkURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func mustGetNftsEndpoint(baseURL string) *url.URL {
+	s := fmt.Sprintf(getNftsEndpointTemplate, baseURL)
+	return checkURL(s)
+}
+
+func mustGetNftsForCollectionEndpoint(baseURL string) *url.URL {
+	s := fmt.Sprintf(getNftsForCollectionEndpointTemplate, baseURL)
+	return checkURL(s)
+}
+
+func mustGetOwnersForCollectionEndpoint(baseURL string) *url.URL {
+	s := fmt.Sprintf(getOwnersForCollectionEndpointTemplate, baseURL)
+	return checkURL(s)
+}
+
+func mustGetNftMetadataEndpoint(baseURL string) *url.URL {
+	s := fmt.Sprintf(getNftMetadataEndpointTemplate, baseURL)
+	return checkURL(s)
+}
+
+func mustGetContractMetadataEndpoint(baseURL string) *url.URL {
+	s := fmt.Sprintf(getContractMetadataEndpointTemplate, baseURL)
+	return checkURL(s)
+}
+
+func mustGetOwnersForTokenEndpoint(baseURL string) *url.URL {
+	s := fmt.Sprintf(getOwnersForTokenEndpointTemplate, baseURL)
+	return checkURL(s)
+}
+
+func mustGetNftMetadataBatchEndpoint(baseURL string) *url.URL {
+	s := fmt.Sprintf(getNftMetadataBatchEndpointTemplate, baseURL)
+	return checkURL(s)
+}
+
+func setOwner(url *url.URL, address persist.Address) {
+	query := url.Query()
+	query.Set("owner", address.String())
+	url.RawQuery = query.Encode()
+}
+
+func setWithMetadata(url *url.URL) {
+	query := url.Query()
+	query.Set("withMetadata", "true")
+	url.RawQuery = query.Encode()
+}
+
+func setExcludeSpamOptionally(url *url.URL, chain persist.Chain) {
+	if chain != persist.ChainPolygon {
+		query := url.Query()
+		query.Set("excludeFilters[]", "SPAM")
+		url.RawQuery = query.Encode()
+	}
+}
+
+func setContractAddress(url *url.URL, address persist.Address) {
+	query := url.Query()
+	query.Set("contractAddress", address.String())
+	url.RawQuery = query.Encode()
+}
+
+func setWithTokenBalances(url *url.URL) {
+	query := url.Query()
+	query.Set("withTokenBalances", "true")
+	url.RawQuery = query.Encode()
+}
+
+func setTokenID(url *url.URL, tokenID persist.TokenID) {
+	query := url.Query()
+	query.Set("tokenId", tokenID.Base10String())
+	url.RawQuery = query.Encode()
+}
+
+func setTokenUriTimeoutInMs(url *url.URL, timeout time.Duration) {
+	query := url.Query()
+	query.Set("tokenUriTimeoutInMs", fmt.Sprintf("%d", timeout))
+	url.RawQuery = query.Encode()
+}
+
+func setRefreshCache(url *url.URL) {
+	query := url.Query()
+	query.Set("refreshCache", "true")
+	url.RawQuery = query.Encode()
 }
 
 func contractNameIsSpam(name string) bool {

--- a/service/multichain/custom_metadata.go
+++ b/service/multichain/custom_metadata.go
@@ -93,6 +93,7 @@ func (c *CustomMetadataHandlers) AddToPage(ctx context.Context, chain persist.Ch
 	errOut := make(chan error)
 	go func() {
 		defer close(outCh)
+		defer close(errOut)
 		for {
 			select {
 			case page, ok := <-recCh:

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -98,34 +98,16 @@ type Contract struct {
 	Name            string          `json:"name"`
 }
 
-func FetchAssetsForTokenIdentifiers(ctx context.Context, chain persist.Chain, contractAddress persist.Address, tokenID persist.TokenID) ([]Asset, error) {
-	outCh := make(chan assetsReceived)
-
-	go func() {
-		defer close(outCh)
-		streamAssetsForToken(ctx, http.DefaultClient, chain, contractAddress, tokenID, outCh)
-	}()
-
-	assets := make([]Asset, 0)
-	for a := range outCh {
-		if a.Err != nil {
-			return nil, a.Err
-		}
-		assets = append(assets, a.Assets...)
-	}
-
-	return assets, nil
-}
-
 type Provider struct {
-	Chain      persist.Chain
-	httpClient *http.Client
+	Chain persist.Chain
+	r     *retry.Retryer
 }
 
 // NewProvider creates a new provider for OpenSea
-func NewProvider(httpClient *http.Client, chain persist.Chain) *Provider {
+func NewProvider(ctx context.Context, httpClient *http.Client, chain persist.Chain) (*Provider, func()) {
 	mustChainIdentifierFrom(chain)
-	return &Provider{httpClient: httpClient, Chain: chain}
+	r, cleanup := retry.NewRetryerOpensea(ctx, httpClient)
+	return &Provider{Chain: chain, r: r}, cleanup
 }
 
 // GetTokensByWalletAddress returns a list of tokens for an address
@@ -133,7 +115,7 @@ func (p *Provider) GetTokensByWalletAddress(ctx context.Context, ownerAddress pe
 	outCh := make(chan assetsReceived)
 	go func() {
 		defer close(outCh)
-		streamAssetsForWallet(ctx, p.httpClient, p.Chain, ownerAddress, outCh)
+		streamAssetsForWallet(ctx, p.r, p.Chain, ownerAddress, outCh)
 	}()
 	return p.assetsToTokens(ctx, ownerAddress, outCh)
 }
@@ -145,7 +127,7 @@ func (p *Provider) GetTokensIncrementallyByWalletAddress(ctx context.Context, ow
 	outCh := make(chan assetsReceived, 32)
 	go func() {
 		defer close(outCh)
-		streamAssetsForWallet(ctx, p.httpClient, p.Chain, ownerAddress, outCh)
+		streamAssetsForWallet(ctx, p.r, p.Chain, ownerAddress, outCh)
 	}()
 	go func() {
 		defer close(recCh)
@@ -162,7 +144,7 @@ func (p *Provider) GetTokensIncrementallyByContractAddress(ctx context.Context, 
 	assetsCh := make(chan assetsReceived)
 	go func() {
 		defer close(assetsCh)
-		streamAssetsForContract(ctx, p.httpClient, p.Chain, address, assetsCh)
+		streamAssetsForContract(ctx, p.r, p.Chain, address, assetsCh)
 	}()
 	go func() {
 		defer close(recCh)
@@ -177,7 +159,7 @@ func (p *Provider) GetTokensByContractAddress(ctx context.Context, contractAddre
 	outCh := make(chan assetsReceived)
 	go func() {
 		defer close(outCh)
-		streamAssetsForContract(ctx, p.httpClient, p.Chain, contractAddress, outCh)
+		streamAssetsForContract(ctx, p.r, p.Chain, contractAddress, outCh)
 	}()
 	tokens, contracts, err := p.assetsToTokens(ctx, "", outCh)
 	if err != nil {
@@ -195,7 +177,7 @@ func (p *Provider) GetTokensByTokenIdentifiers(ctx context.Context, ti multichai
 	outCh := make(chan assetsReceived)
 	go func() {
 		defer close(outCh)
-		streamAssetsForToken(ctx, p.httpClient, p.Chain, ti.ContractAddress, ti.TokenID, outCh)
+		streamAssetsForToken(ctx, p.r, p.Chain, ti.ContractAddress, ti.TokenID, outCh)
 	}()
 	tokens, contracts, err := p.assetsToTokens(ctx, "", outCh)
 	if err != nil {
@@ -212,7 +194,7 @@ func (p *Provider) GetTokenByTokenIdentifiersAndOwner(ctx context.Context, ti mu
 	outCh := make(chan assetsReceived)
 	go func() {
 		defer close(outCh)
-		streamAssetsForTokenIdentifiersAndOwner(ctx, p.httpClient, p.Chain, ownerAddress, ti.ContractAddress, ti.TokenID, outCh)
+		streamAssetsForTokenIdentifiersAndOwner(ctx, p.r, p.Chain, ownerAddress, ti.ContractAddress, ti.TokenID, outCh)
 	}()
 
 	tokens, contracts, err := p.assetsToTokens(ctx, ownerAddress, outCh)
@@ -260,7 +242,7 @@ func (p *Provider) GetTokenDescriptorsByTokenIdentifiers(ctx context.Context, ti
 
 // GetContractByAddress returns a contract for a contract address
 func (p *Provider) GetContractByAddress(ctx context.Context, contractAddress persist.Address) (multichain.ChainAgnosticContract, error) {
-	cc, err := fetchContractCollectionByAddress(ctx, p.httpClient, p.Chain, contractAddress)
+	cc, err := fetchContractCollectionByAddress(ctx, p.r, p.Chain, contractAddress)
 	if err != nil {
 		return multichain.ChainAgnosticContract{}, err
 	}
@@ -384,7 +366,7 @@ func (p *Provider) getChainAgnosticContract(ctx context.Context, contractAddress
 		return nil
 	}
 
-	contractCollection, err := fetchContractCollectionByAddress(ctx, p.httpClient, p.Chain, contractAddress)
+	contractCollection, err := fetchContractCollectionByAddress(ctx, p.r, p.Chain, contractAddress)
 	if err != nil {
 		return err
 	}
@@ -425,21 +407,21 @@ func (p *Provider) assetToChainAgnosticTokens(ownerAddress persist.Address, asse
 	return []multichain.ChainAgnosticToken{token}, nil
 }
 
-func fetchContractCollectionByAddress(ctx context.Context, client *http.Client, chain persist.Chain, contractAddress persist.Address) (contractCollection, error) {
-	contract, err := fetchContractByAddress(ctx, client, chain, contractAddress)
+func fetchContractCollectionByAddress(ctx context.Context, r *retry.Retryer, chain persist.Chain, contractAddress persist.Address) (contractCollection, error) {
+	contract, err := fetchContractByAddress(ctx, r, chain, contractAddress)
 	if err != nil {
 		return contractCollection{}, err
 	}
-	collection, err := fetchCollectionBySlug(ctx, client, chain, contract.Collection)
+	collection, err := fetchCollectionBySlug(ctx, r, chain, contract.Collection)
 	if err != nil {
 		return contractCollection{}, err
 	}
 	return contractCollection{contract, collection}, nil
 }
 
-func fetchContractByAddress(ctx context.Context, client *http.Client, chain persist.Chain, contractAddress persist.Address) (contract Contract, err error) {
+func fetchContractByAddress(ctx context.Context, r *retry.Retryer, chain persist.Chain, contractAddress persist.Address) (contract Contract, err error) {
 	endpoint := mustContractEndpoint(chain, contractAddress)
-	resp, err := retry.RetryRequest(client, mustAuthRequest(ctx, endpoint))
+	resp, err := r.Do(mustAuthRequest(ctx, endpoint))
 	if err != nil {
 		return Contract{}, wrapRateLimitErr(ctx, err)
 	}
@@ -457,9 +439,9 @@ func fetchContractByAddress(ctx context.Context, client *http.Client, chain pers
 	return contract, nil
 }
 
-func fetchCollectionBySlug(ctx context.Context, client *http.Client, chain persist.Chain, slug string) (collection Collection, err error) {
+func fetchCollectionBySlug(ctx context.Context, r *retry.Retryer, chain persist.Chain, slug string) (collection Collection, err error) {
 	endpoint := mustCollectionEndpoint(slug)
-	resp, err := retry.RetryRequest(client, mustAuthRequest(ctx, endpoint))
+	resp, err := r.Do(mustAuthRequest(ctx, endpoint))
 	if err != nil {
 		return Collection{}, wrapRateLimitErr(ctx, err)
 	}
@@ -510,28 +492,28 @@ func mustNftsByContractEndpoint(chain persist.Chain, address persist.Address) *u
 	return checkURL(s)
 }
 
-func streamAssetsForToken(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
+func streamAssetsForToken(ctx context.Context, r *retry.Retryer, chain persist.Chain, address persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
 	endpoint := mustNftEndpoint(chain, address, tokenID)
 	setPagingParams(endpoint)
-	paginateAssets(ctx, client, mustAuthRequest(ctx, endpoint), outCh)
+	paginateAssets(ctx, r, mustAuthRequest(ctx, endpoint), outCh)
 }
 
-func streamAssetsForWallet(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, outCh chan assetsReceived) {
+func streamAssetsForWallet(ctx context.Context, r *retry.Retryer, chain persist.Chain, address persist.Address, outCh chan assetsReceived) {
 	endpoint := mustNftsByWalletEndpoint(chain, address)
 	setPagingParams(endpoint)
-	paginateAssets(ctx, client, mustAuthRequest(ctx, endpoint), outCh)
+	paginateAssets(ctx, r, mustAuthRequest(ctx, endpoint), outCh)
 }
 
-func streamAssetsForContract(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, outCh chan assetsReceived) {
+func streamAssetsForContract(ctx context.Context, r *retry.Retryer, chain persist.Chain, address persist.Address, outCh chan assetsReceived) {
 	endpoint := mustNftsByContractEndpoint(chain, address)
 	setPagingParams(endpoint)
-	paginateAssets(ctx, client, mustAuthRequest(ctx, endpoint), outCh)
+	paginateAssets(ctx, r, mustAuthRequest(ctx, endpoint), outCh)
 }
 
-func streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, client *http.Client, chain persist.Chain, ownerAddress, contractAddress persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
+func streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, r *retry.Retryer, chain persist.Chain, ownerAddress, contractAddress persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
 	endpoint := mustNftsByWalletEndpoint(chain, ownerAddress)
 	setPagingParams(endpoint)
-	paginateAssetsFilter(ctx, client, mustAuthRequest(ctx, endpoint), outCh, func(a Asset) bool {
+	paginateAssetsFilter(ctx, r, mustAuthRequest(ctx, endpoint), outCh, func(a Asset) bool {
 		// OS doesn't let you filter by tokenID and owner, so we have to filter for only the token
 		ca := persist.NewChainAddress(persist.Address(a.Contract), chain)
 		if (ca.Address() == contractAddress) && (persist.MustTokenID(a.Identifier) == tokenID) {
@@ -657,16 +639,16 @@ func readErrBody(ctx context.Context, body io.Reader) error {
 	return fmt.Errorf(string(byt))
 }
 
-func paginateAssets(ctx context.Context, client *http.Client, req *http.Request, outCh chan assetsReceived) {
-	paginateAssetsFilter(ctx, client, req, outCh, nil)
+func paginateAssets(ctx context.Context, r *retry.Retryer, req *http.Request, outCh chan assetsReceived) {
+	paginateAssetsFilter(ctx, r, req, outCh, nil)
 }
 
 // paginatesAssetsFilter fetches assets from OpenSea and sends them to outCh. An optional keepAssetFilter can be provided to filter out an asset
 // after it is fetched if keepAssetFilter evaluates to false. This is useful for filtering out assets that can't be filtered natively by the API.
-func paginateAssetsFilter(ctx context.Context, client *http.Client, req *http.Request, outCh chan assetsReceived, keepAssetFilter func(a Asset) bool) {
+func paginateAssetsFilter(ctx context.Context, r *retry.Retryer, req *http.Request, outCh chan assetsReceived, keepAssetFilter func(a Asset) bool) {
 	pages := 0
 	for {
-		resp, err := retry.RetryRequest(client, req)
+		resp, err := r.Do(req)
 		if err != nil {
 			err = wrapRateLimitErr(ctx, err)
 			logger.For(ctx).Errorf("failed to get tokens from opensea: %s", err)
@@ -762,7 +744,7 @@ func mustChainIdentifierFrom(c persist.Chain) string {
 }
 
 func wrapRateLimitErr(ctx context.Context, err error) error {
-	if !util.ErrorIs[retry.ErrOutOfRetries](err) {
+	if !errors.Is(err, retry.ErrOutOfRetries) {
 		return err
 	}
 	err = ErrOpenseaRateLimited{err}

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -333,6 +333,7 @@ func (p *Provider) streamAssetsToTokens(
 			out.Tokens = append(out.Tokens, tokens...)
 			out.Contracts = append(out.Contracts, contract.(multichain.ChainAgnosticContract))
 		}
+
 		recCh <- out
 	}
 }

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -12,14 +12,17 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/eth"
+	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/service/redis"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
@@ -106,7 +109,9 @@ type Provider struct {
 // NewProvider creates a new provider for OpenSea
 func NewProvider(ctx context.Context, httpClient *http.Client, chain persist.Chain) (*Provider, func()) {
 	mustChainIdentifierFrom(chain)
-	r, cleanup := retry.NewRetryerOpensea(ctx, httpClient)
+	cache := redis.NewCache(redis.TokenManageCache)
+	limiter := limiters.NewKeyRateLimiter(ctx, cache, "retryer:opensea", 500, time.Minute)
+	r, cleanup := retry.New(limiter, httpClient)
 	return &Provider{Chain: chain, r: r}, cleanup
 }
 

--- a/service/multichain/reservoir/reservoir.go
+++ b/service/multichain/reservoir/reservoir.go
@@ -128,10 +128,11 @@ type Provider struct {
 	// e.g collection data is available for projects within Art Blocks, but not for the Art Blocks
 	// contract itself. We use another fetcher to get that data.
 	cFetcher multichain.ContractFetcher
+	r        *retry.Retryer
 }
 
 // NewProvider creates a new Reservoir provider
-func NewProvider(httpClient *http.Client, chain persist.Chain) *Provider {
+func NewProvider(ctx context.Context, httpClient *http.Client, chain persist.Chain) (*Provider, func()) {
 	apiURL := map[persist.Chain]string{
 		persist.ChainETH:      ethMainnetBaseURL,
 		persist.ChainOptimism: optimismBaseURL,
@@ -149,19 +150,15 @@ func NewProvider(httpClient *http.Client, chain persist.Chain) *Provider {
 		panic("no reservoir api key set")
 	}
 
+	r, cleanup := retry.NewRetryerReservoir(ctx, httpClient)
+
 	return &Provider{
 		apiURL:     apiURL,
 		apiKey:     apiKey,
 		chain:      chain,
 		httpClient: httpClient,
-	}
-}
-
-// NewProvider creates a new Reservoir provider
-func NewProviderContractFetcher(httpClient *http.Client, chain persist.Chain, cFetcher multichain.ContractFetcher) *Provider {
-	p := NewProvider(httpClient, chain)
-	p.cFetcher = cFetcher
-	return p
+		r:          r,
+	}, cleanup
 }
 
 func (p *Provider) GetTokensByWalletAddress(ctx context.Context, ownerAddress persist.Address) ([]multichain.ChainAgnosticToken, []multichain.ChainAgnosticContract, error) {
@@ -348,9 +345,9 @@ func (p Provider) GetTokensByTokenIdentifiersBatch(ctx context.Context, tIDs []m
 	return ret, errs
 }
 
-func paginateTokens(ctx context.Context, client *http.Client, req *http.Request, outCh chan<- pageResult) {
+func (p *Provider) paginateTokens(ctx context.Context, req *http.Request, outCh chan<- pageResult) {
 	for {
-		resp, err := retry.RetryRequest(client, req)
+		resp, err := p.r.Do(req)
 		if err != nil {
 			outCh <- pageResult{Err: err}
 			return
@@ -391,7 +388,7 @@ func paginateTokens(ctx context.Context, client *http.Client, req *http.Request,
 func (p *Provider) streamAssetsForToken(ctx context.Context, contractAddress persist.Address, tokenID persist.TokenID, outCh chan<- pageResult) {
 	endpoint := mustTokensEndpoint(p.apiURL)
 	setToken(endpoint, contractAddress, tokenID)
-	paginateTokens(ctx, p.httpClient, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
+	p.paginateTokens(ctx, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
 }
 
 func (p *Provider) streamAssetsForTokens(ctx context.Context, tIDs []persist.TokenIdentifiers, outCh chan<- pageResult) {
@@ -402,28 +399,28 @@ func (p *Provider) streamAssetsForTokens(ctx context.Context, tIDs []persist.Tok
 			outCh <- pageResult{Err: err}
 			return
 		}
-		paginateTokens(ctx, p.httpClient, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
+		p.paginateTokens(ctx, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
 	}
 }
 
 func (p *Provider) streamAssetsForWallet(ctx context.Context, addr persist.Address, outCh chan<- pageResult) {
 	endpoint := mustUserTokensEndpoint(p.apiURL, addr)
 	setPagingParams(endpoint, "acquiredAt")
-	paginateTokens(ctx, p.httpClient, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
+	p.paginateTokens(ctx, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
 }
 
 func (p *Provider) streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, ownerAddress, contractAddress persist.Address, tokenID persist.TokenID, outCh chan<- pageResult) {
 	endpoint := mustUserTokensEndpoint(p.apiURL, ownerAddress)
 	setLimit(endpoint, 1)
 	setToken(endpoint, contractAddress, tokenID)
-	paginateTokens(ctx, p.httpClient, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
+	p.paginateTokens(ctx, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
 }
 
 func (p *Provider) streamAssetsForContract(ctx context.Context, contractAddress persist.Address, outCh chan<- pageResult) {
 	endpoint := mustTokensEndpoint(p.apiURL)
 	setCollection(endpoint, contractAddress)
 	setPagingParams(endpoint, "tokenId")
-	paginateTokens(ctx, p.httpClient, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
+	p.paginateTokens(ctx, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
 }
 
 func (p *Provider) fetchCollectionByAddress(ctx context.Context, contractAddress persist.Address) (Collection, error) {

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -1011,7 +1011,7 @@ func NotificationToUserFacingData(ctx context.Context, queries *coredb.Queries, 
 				return nil
 			}, func(err error) bool {
 				return err == errNameNotAvailable
-			}, retry.Retry{Base: 5, Cap: 30, Tries: 3})
+			}, retry.Retry{MinWait: 5, MaxWait: 30, MaxRetries: 3})
 		}
 
 		name := util.TruncateWithEllipsis(td.Name.String, 40)

--- a/service/persist/postgres/postgres.go
+++ b/service/persist/postgres/postgres.go
@@ -92,7 +92,7 @@ func newConnectionParamsFromEnv() connectionParams {
 		port:     env.GetInt("POSTGRES_PORT"),
 
 		// Retry connections by default
-		retry: &retry.Retry{Base: 2, Cap: 4, Tries: 3},
+		retry: &retry.Retry{MinWait: 2, MaxWait: 4, MaxRetries: 3},
 	}
 }
 

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -251,12 +251,12 @@ func GetBlockNumber(ctx context.Context, ethClient *ethclient.Client) (uint64, e
 func RetryGetBlockNumber(ctx context.Context, ethClient *ethclient.Client) (uint64, error) {
 	var height uint64
 	var err error
-	for i := 0; i < retry.DefaultRetry.Tries; i++ {
+	for i := 0; i < retry.DefaultRetry.MaxRetries; i++ {
 		height, err = GetBlockNumber(ctx, ethClient)
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(ctx, i)
+		<-time.After(retry.WaitTime(retry.DefaultRetry.MinWait, retry.DefaultRetry.MaxRetries, i))
 	}
 	return height, err
 }
@@ -270,12 +270,12 @@ func GetLogs(ctx context.Context, ethClient *ethclient.Client, query ethereum.Fi
 func RetryGetLogs(ctx context.Context, ethClient *ethclient.Client, query ethereum.FilterQuery) ([]types.Log, error) {
 	logs := make([]types.Log, 0)
 	var err error
-	for i := 0; i < retry.DefaultRetry.Tries; i++ {
+	for i := 0; i < retry.DefaultRetry.MaxRetries; i++ {
 		logs, err = GetLogs(ctx, ethClient, query)
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(ctx, i)
+		<-time.After(retry.WaitTime(retry.DefaultRetry.MinWait, retry.DefaultRetry.MaxWait, i))
 	}
 	return logs, err
 }
@@ -286,16 +286,16 @@ func GetTransaction(ctx context.Context, ethClient *ethclient.Client, txHash com
 }
 
 // RetryGetTransaction calls GetTransaction with backoff.
-func RetryGetTransaction(ctx context.Context, ethClient *ethclient.Client, txHash common.Hash, retry retry.Retry) (*types.Transaction, bool, error) {
+func RetryGetTransaction(ctx context.Context, ethClient *ethclient.Client, txHash common.Hash, r retry.Retry) (*types.Transaction, bool, error) {
 	var tx *types.Transaction
 	var pending bool
 	var err error
-	for i := 0; i < retry.Tries; i++ {
+	for i := 0; i < r.MaxRetries; i++ {
 		tx, pending, err = GetTransaction(ctx, ethClient, txHash)
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.Sleep(ctx, i)
+		<-time.After(retry.WaitTime(r.MinWait, r.MaxWait, i))
 	}
 	return tx, pending, err
 }
@@ -328,12 +328,12 @@ func GetTokenContractMetadata(ctx context.Context, address persist.EthereumAddre
 func RetryGetTokenContractMetadata(ctx context.Context, contractAddress persist.EthereumAddress, ethClient *ethclient.Client) (*TokenContractMetadata, error) {
 	var metadata *TokenContractMetadata
 	var err error
-	for i := 0; i < retry.DefaultRetry.Tries; i++ {
+	for i := 0; i < retry.DefaultRetry.MaxRetries; i++ {
 		metadata, err = GetTokenContractMetadata(ctx, contractAddress, ethClient)
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(ctx, i)
+		<-time.After(retry.WaitTime(retry.DefaultRetry.MinWait, retry.DefaultRetry.MaxWait, i))
 	}
 	return metadata, err
 }
@@ -680,12 +680,12 @@ func GetTokenURI(ctx context.Context, pTokenType persist.TokenType, pContractAdd
 func RetryGetTokenURI(ctx context.Context, tokenType persist.TokenType, contractAddress persist.EthereumAddress, tokenID persist.TokenID, ethClient *ethclient.Client) (persist.TokenURI, error) {
 	var u persist.TokenURI
 	var err error
-	for i := 0; i < retry.DefaultRetry.Tries; i++ {
+	for i := 0; i < retry.DefaultRetry.MaxRetries; i++ {
 		u, err = GetTokenURI(ctx, tokenType, contractAddress, tokenID, ethClient)
 		if !isRateLimitedError(err) {
 			break
 		}
-		retry.DefaultRetry.Sleep(ctx, i)
+		<-time.After(retry.WaitTime(retry.DefaultRetry.MinWait, retry.DefaultRetry.MaxWait, i))
 	}
 	return u, err
 }

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -85,11 +85,11 @@ func (r *Retryer) do(p pending) (*http.Response, error) {
 		return resp, err
 	}
 	if resp.StatusCode != http.StatusTooManyRequests {
-		logger.For(p.req.Context()).Infof("request successful, waited for %s to submit request to %s", time.Since(p.queuedAt), p.req.Host)
+		logger.For(p.req.Context()).Infof("request to %s was successful, took %s in total", p.req.Host, time.Since(p.queuedAt))
 		return resp, nil
 	}
 	if p.retryCount >= p.r.MaxRetries {
-		logger.For(p.req.Context()).Errorf("ran out of retries, waited for %s to submit request to %s", time.Since(p.queuedAt), p.req.Host)
+		logger.For(p.req.Context()).Errorf("ran out of retries, waited for %s to handle request to %s", time.Since(p.queuedAt), p.req.Host)
 		return resp, ErrOutOfRetries
 	}
 

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -8,56 +8,156 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/service/redis"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/shurcooL/graphql"
 )
 
-var (
-	DefaultRetry = Retry{Base: 4, Cap: 64, Tries: 12}
-)
+var ErrOutOfRetries = fmt.Errorf("tried too many times")
+var DefaultRetry = Retry{MaxWait: 64, MaxRetries: 12}
 
-type ErrOutOfRetries struct {
-	Err   error
-	Retry Retry
-}
-
-func (e ErrOutOfRetries) Error() string {
-	return fmt.Sprintf("retried %d times: last error: %s", e.Retry.Tries, e.Err)
-}
-
-func (e ErrOutOfRetries) Unwrap() error {
-	return e.Err
-}
-
+// Retry is a configuration for retrying requests
 type Retry struct {
-	Base  int // Min amount of time to sleep per iteration
-	Cap   int // Max amount of time to sleep per iteration
-	Tries int // Number of times to retry
+	MinWait    int // Min amount of time to sleep per iteration in seconds
+	MaxWait    int // Max amount of time to sleep per iteration in seconds
+	MaxRetries int // Number of times to retry
 }
 
-func (r *Retry) Sleep(ctx context.Context, i int) {
-	// powerInt returns the base-x exponential of y.
-	powerInt := func(x, y int) int {
-		ret := 1
-		for i := 0; i < y; i++ {
-			ret *= x
-		}
-		return ret
+// NewRetryerReservoir creates a new Retryer with a rate limit configured for Reservoir
+func NewRetryerReservoir(ctx context.Context, c *http.Client) (*Retryer, func()) {
+	cache := redis.NewCache(redis.TokenManageCache)
+	return New(limiters.NewKeyRateLimiter(ctx, cache, "retryer:reservoir", 100000000, time.Minute), c)
+}
+
+// NewRetryerOpensea creates a new Retryer with a rate limit configured for Opensea
+func NewRetryerOpensea(ctx context.Context, c *http.Client) (*Retryer, func()) {
+	cache := redis.NewCache(redis.TokenManageCache)
+	return New(limiters.NewKeyRateLimiter(ctx, cache, "retryer:opensea", 1000, time.Minute), c)
+}
+
+// Retryer protects against rate limits by requiring requests to be sent through it.
+// Retryer checks its underlying rate limiter before sending the request, and if the rate limit is exceeded,
+// it will wait before retrying the request. If the request does get rate limited by the external service even after
+// checking the rate limiter, then Retryer will automatically re-enqueue the request with exponential backoff.
+// Retryer will handle requests in the same order they are received. For retries, the request will be re-enqueued
+// and won't be retried until it is popped off the queue again.
+type Retryer struct {
+	l       *limiters.KeyRateLimiter
+	c       *http.Client
+	q       chan pending
+	closing chan struct{}
+	done    chan struct{}
+}
+
+type pending struct {
+	req        *http.Request
+	done       chan error
+	retryCount int
+	r          Retry
+}
+
+func New(l *limiters.KeyRateLimiter, c *http.Client) (*Retryer, func()) {
+	r := &Retryer{
+		l:       l,
+		c:       c,
+		q:       make(chan pending),
+		closing: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	go r.enqueue()
+	return r, func() {
+		r.closing <- struct{}{}
+		<-r.done
+	}
+}
+
+func (r *Retryer) Do(req *http.Request) (*http.Response, error) {
+	return r.DoRetry(req, DefaultRetry)
+}
+
+func (r *Retryer) DoRetry(req *http.Request, c Retry) (*http.Response, error) {
+	p := pending{req, make(chan error), 0, c}
+	err := r.wait(p)
+	if err != nil {
+		return nil, err
+	}
+	return r.do(p)
+}
+
+func (r *Retryer) wait(p pending) error {
+	r.q <- p
+	return <-p.done
+}
+
+func (r *Retryer) do(p pending) (*http.Response, error) {
+	resp, err := r.c.Do(p.req)
+	if err != nil {
+		return resp, err
+	}
+	// XXX if resp.StatusCode != http.StatusTooManyRequests {
+	// XXX 	return resp, nil
+	// XXX }
+	if p.retryCount >= p.r.MaxRetries {
+		return resp, ErrOutOfRetries
 	}
 
-	// minInt returns the minimum of two ints.
-	minInt := func(x, y int) int {
-		if x < y {
-			return x
-		}
-		return y
-	}
+	// wait for a bit before retrying
+	p.retryCount++
+	wait := WaitTime(p.r.MinWait, p.r.MaxWait, p.retryCount)
+	logger.For(p.req.Context()).Infof("rate limited by %s (attempt=%d/%d); waiting for %s", p.req.Host, p.retryCount, p.r.MaxRetries, wait)
+	<-time.After(wait)
 
-	sleepFor := rand.Intn(minInt(r.Cap, r.Base*powerInt(2, i)))
-	d := time.Duration(sleepFor) * time.Second
-	logger.For(ctx).Infof("retrying in %s", d)
-	time.Sleep(d)
+	// re-enqueue the request
+	p.done = make(chan error)
+	r.wait(p)
+	return r.do(p)
+}
+
+func (r *Retryer) enqueue() {
+	for {
+		select {
+		case pending := <-r.q:
+			ctx := pending.req.Context()
+			waited := time.Duration(0)
+		msgLoop:
+			for {
+				select {
+				case <-ctx.Done():
+					pending.done <- ctx.Err()
+					close(pending.done)
+					break msgLoop
+				default:
+					_, wait, err := r.l.ForKey(ctx, pending.req.Host)
+					if err != nil {
+						pending.done <- err
+						close(pending.done)
+						break msgLoop
+					}
+
+					if wait <= 0 {
+						logger.For(ctx).Infof("retryer consumed token for %s, waited for %s", pending.req.Host, waited)
+						close(pending.done)
+						break msgLoop
+					}
+
+					logger.For(ctx).Infof("out of tokens for %s, waiting for %s", pending.req.Host, wait)
+					waited += wait
+					<-time.After(wait)
+				}
+			}
+		case <-r.closing:
+			logger.For(context.Background()).Infof("stopping retryer, flushing buffered requests")
+			close(r.q)
+			for pending := range r.q {
+				pending.done <- fmt.Errorf("retryer is closing; cancelling request to %s", pending.req.Host)
+				close(pending.done)
+			}
+			close(r.done)
+			return
+		}
+	}
 }
 
 func RetryRequest(c *http.Client, req *http.Request) (*http.Response, error) {
@@ -67,35 +167,34 @@ func RetryRequest(c *http.Client, req *http.Request) (*http.Response, error) {
 func RetryRequestWithRetry(c *http.Client, req *http.Request, r Retry) (*http.Response, error) {
 	var resp *http.Response
 	var err error
-	for i := 0; i < r.Tries; i++ {
+	for i := 0; i < r.MaxRetries; i++ {
 		resp, err = c.Do(req)
 		if err != nil {
 			return resp, err
 		}
-
 		if resp.StatusCode != http.StatusTooManyRequests {
 			return resp, err
 		}
-
-		logger.For(req.Context()).Infof("rate limited by '%s'\n", req.Host)
-		r.Sleep(req.Context(), i)
+		wait := WaitTime(r.MinWait, r.MaxWait, i)
+		logger.For(req.Context()).Infof("rate limited by %s (attempt=%d/%d); waiting for %s", req.Host, i, r.MaxRetries, wait)
+		<-time.After(wait)
 	}
-	return nil, ErrOutOfRetries{Err: err, Retry: r}
+	return nil, ErrOutOfRetries
 }
 
 func RetryQuery(ctx context.Context, c *graphql.Client, query any, vars map[string]any) error {
-	return RetryQueryWithRetry(ctx, c, query, vars, DefaultRetry)
+	return RetryQueryConfig(ctx, c, query, vars, DefaultRetry)
 }
 
-func RetryQueryWithRetry(ctx context.Context, c *graphql.Client, query any, vars map[string]any, r Retry) error {
+func RetryQueryConfig(ctx context.Context, c *graphql.Client, query any, vars map[string]any, r Retry) error {
 	f := func(ctx context.Context) error { return c.Query(ctx, query, vars) }
 	shouldRetry := func(err error) bool { return strings.Contains(err.Error(), "429") }
 	return RetryFunc(ctx, f, shouldRetry, r)
 }
 
-func RetryFunc(ctx context.Context, f func(ctx context.Context) error, shouldRetry func(error) bool, r Retry) error {
+func RetryFunc(ctx context.Context, f func(ctx context.Context) error, shouldRetry func(error) bool, c Retry) error {
 	var err error
-	for i := 0; i < r.Tries; i++ {
+	for i := 0; i < c.MaxRetries; i++ {
 		err = f(ctx)
 		if err == nil {
 			return nil
@@ -105,11 +204,11 @@ func RetryFunc(ctx context.Context, f func(ctx context.Context) error, shouldRet
 			return err
 		}
 
-		if i != r.Tries-1 {
-			r.Sleep(ctx, i)
+		if i != c.MaxRetries-1 {
+			<-time.After(WaitTime(c.MinWait, c.MinWait, i))
 		}
 	}
-	return ErrOutOfRetries{Err: err, Retry: r}
+	return ErrOutOfRetries
 }
 
 func HTTPErrNotFound(err error) bool {
@@ -119,4 +218,27 @@ func HTTPErrNotFound(err error) bool {
 		}
 	}
 	return false
+}
+
+func WaitTime(minWait, maxWait int, tryIteration int) time.Duration {
+	if tryIteration <= 0 {
+		return 0
+	}
+
+	r := 1
+	for i := 0; i < tryIteration; i++ {
+		r *= 2
+	}
+
+	wait := maxWait
+
+	// 1 second plus 10 percent of maxWait
+	rand.Seed(time.Now().UnixNano())
+	jitter := rand.Intn(1 + int(float64(maxWait)*0.1))
+
+	if iterWait := minWait + r + jitter; iterWait < maxWait {
+		wait = iterWait
+	}
+
+	return time.Duration(wait) * time.Second
 }


### PR DESCRIPTION
**Changes**
* Adds a `Retryer` class which buffers requests to an external API to avoid rate limits and handles retries in cases where the limit is exceeded
   * It is currently used in front of calls to Reservoir and Opensea 
* Alchemy is now the primary provider for EVM chains (except Zora which continues to use OS as the primary), with a fallback to OS if Alchemy is missing data
  * Both Alchemy and OS are still used in syncs for EVM chains (except Zora which uses Zora and OS)
* Fixes URL encoding bug in Alchemy provider
* The Opensea custom metadata handler now accepts an optional metadata arg to avoid an extra request to a provider to fetch metadata