### PR TITLE
Make underlying retry limiter a singleton

### DIFF
--- a/service/limiters/rate.go
+++ b/service/limiters/rate.go
@@ -75,6 +75,7 @@ func (i *KeyRateLimiter) ForKey(ctx context.Context, key string) (bool, time.Dur
 	w, err := bucket.(*limiters.TokenBucket).Limit(ctx)
 	if err == limiters.ErrLimitExhausted {
 		return false, w, nil
+	} else if err == redislock.ErrNotObtained {
 	} else if err != nil {
 		// The limiter failed. This error should be logged and examined.
 		rateErr := fmt.Errorf("rate limiting err: %s", err)

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -12,17 +12,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sourcegraph/conc/pool"
 
 	"github.com/mikeydub/go-gallery/env"
 	"github.com/mikeydub/go-gallery/service/eth"
-	"github.com/mikeydub/go-gallery/service/limiters"
 	"github.com/mikeydub/go-gallery/service/logger"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/mikeydub/go-gallery/service/redis"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
@@ -107,11 +104,9 @@ type Provider struct {
 }
 
 // NewProvider creates a new provider for OpenSea
-func NewProvider(ctx context.Context, httpClient *http.Client, chain persist.Chain) (*Provider, func()) {
+func NewProvider(ctx context.Context, httpClient *http.Client, chain persist.Chain, l retry.Limiter) (*Provider, func()) {
 	mustChainIdentifierFrom(chain)
-	cache := redis.NewCache(redis.TokenManageCache)
-	limiter := limiters.NewKeyRateLimiter(ctx, cache, "retryer:opensea", 500, time.Minute)
-	r, cleanup := retry.New(limiter, httpClient)
+	r, cleanup := retry.New(l, httpClient)
 	return &Provider{Chain: chain, r: r}, cleanup
 }
 

--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
 	"github.com/mikeydub/go-gallery/util"
+	"github.com/mikeydub/go-gallery/util/retry"
 )
 
 var (
@@ -337,8 +338,8 @@ type FillInWrapper struct {
 	resultCache       sync.Map
 }
 
-func NewFillInWrapper(ctx context.Context, httpClient *http.Client, chain persist.Chain) (*FillInWrapper, func()) {
-	r, cleanup := reservoir.NewProvider(ctx, httpClient, chain)
+func NewFillInWrapper(ctx context.Context, httpClient *http.Client, chain persist.Chain, l retry.Limiter) (*FillInWrapper, func()) {
+	r, cleanup := reservoir.NewProvider(ctx, httpClient, chain, l)
 	return &FillInWrapper{
 		chain:             chain,
 		reservoirProvider: r,


### PR DESCRIPTION
Errors arise when trying to obtain a lock on a Redis key with several instances of a limiter (even though all point to the same redis cache and try to obtain the same key) during a many-chain sync. Passing a limiter to the constructor instead of instantiating a limiter in the constructor fixed the issue. I'm not sure why this is the case, though.