### PR TITLE
Deprecate mint links to mint dot fun

### DIFF
--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -3351,15 +3351,17 @@ func (r *tokenDefinitionResolver) MintURL(ctx context.Context, obj *model.TokenD
 
 	var mintURL string
 
+	tokenID := obj.HelperTokenDefinitionData.Definition.TokenID.Base10String()
+
 	if contract.Address != "" && !contract.IsProviderMarkedSpam {
 		if contract.Chain == persist.ChainZora {
-			mintURL = fmt.Sprintf("https://zora.co/collect/zora:%s/%s", contract.Address, obj.HelperTokenDefinitionData.Definition.TokenID.Base10String())
+			mintURL = fmt.Sprintf("https://zora.co/collect/zora:%s/%s", contract.Address, tokenID)
 		} else if contract.Chain == persist.ChainBase {
-			mintURL = fmt.Sprintf("https://mint.fun/base/%s", contract.Address)
+			mintURL = fmt.Sprintf("https://zora.co/collect/base:%s/%s", contract.Address, tokenID)
 		} else if contract.Chain == persist.ChainOptimism {
-			mintURL = fmt.Sprintf("https://mint.fun/op/%s", contract.Address)
+			mintURL = fmt.Sprintf("https://zora.co/collect/oeth:%s/%s", contract.Address, tokenID)
 		} else if contract.Chain == persist.ChainETH {
-			mintURL = fmt.Sprintf("https://mint.fun/ethereum/%s", contract.Address)
+			mintURL = fmt.Sprintf("https://zora.co/collect/eth:%s/%s", contract.Address, tokenID)
 		}
 	}
 

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1990,11 +1990,11 @@ func contractToModel(ctx context.Context, contract db.Contract) *model.Contract 
 		if contract.Chain == persist.ChainZora {
 			mintURL = fmt.Sprintf("https://zora.co/collect/zora:%s", contract.Address)
 		} else if contract.Chain == persist.ChainBase {
-			mintURL = fmt.Sprintf("https://mint.fun/base/%s", contract.Address)
+			mintURL = fmt.Sprintf("https://zora.co/collect/base:%s", contract.Address)
 		} else if contract.Chain == persist.ChainOptimism {
-			mintURL = fmt.Sprintf("https://mint.fun/op/%s", contract.Address)
+			mintURL = fmt.Sprintf("https://zora.co/collect/oeth:%s", contract.Address)
 		} else if contract.Chain == persist.ChainETH {
-			mintURL = fmt.Sprintf("https://mint.fun/ethereum/%s", contract.Address)
+			mintURL = fmt.Sprintf("https://zora.co/collect/eth:%s", contract.Address)
 		}
 	}
 


### PR DESCRIPTION
Mint.fun is pivoting to meme.market, and Zora's cross-chain indexing has improved. We should default to suggesting Zora.

Example working URLs per chain:
- ETH mainnet (long token ID): https://zora.co/collect/eth:0x7a15b36cb834aea88553de69077d3777460d73ac/5280336779268220421569573059971679349075200194886069432279714075018412552596
- Base: https://zora.co/collect/base:0xa25aed810f763e1d0dfc13f463bb55e4ad2f4653/1
- Optimism: https://zora.co/collect/oeth:0x76af3c60f83f4b03f532d8af6daa6d75b0b985c8/8

In the future, we should enable minting within our own app through something like Reservoir.