### PR TITLE
Change UserFollowsUsers to UsersFollowUser and enforce ordering

### DIFF
--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -1128,8 +1128,8 @@ func pushFollowEvent(ctx context.Context, followingID, followedID persist.DBID, 
 
 func pushFollowEvents(ctx context.Context, followingID persist.DBID, followedIDs []persist.DBID, refollowed []bool) {
 	followedIDsAsStr := util.MapWithoutError(followedIDs, func(id persist.DBID) string { return id.String() })
-	followsBack, err := For(ctx).User.queries.UserFollowsUsers(ctx, db.UserFollowsUsersParams{
-		Follower:    followingID,
+	followsBack, err := For(ctx).User.queries.UsersFollowUser(ctx, db.UsersFollowUserParams{
+		Followee:    followingID,
 		FollowedIds: followedIDsAsStr,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR fixes an issue where users were being "followed back" instead of being "followed," and also updates the original query to use `generate_subscripts` to ensure that result rows are returned in the same order as supplied parameters.