### PR TITLE
Community Tokens Refactor: Phase 1

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -3798,10 +3798,10 @@ type GetTokenByUserTokenIdentifiersBatchBatchResults struct {
 }
 
 type GetTokenByUserTokenIdentifiersBatchParams struct {
-	OwnerID         persist.DBID    `db:"owner_id" json:"owner_id"`
-	TokenID         persist.TokenID `db:"token_id" json:"token_id"`
-	Chain           persist.Chain   `db:"chain" json:"chain"`
-	ContractAddress persist.Address `db:"contract_address" json:"contract_address"`
+	OwnerID         persist.DBID       `db:"owner_id" json:"owner_id"`
+	TokenID         persist.HexTokenID `db:"token_id" json:"token_id"`
+	Chain           persist.Chain      `db:"chain" json:"chain"`
+	ContractAddress persist.Address    `db:"contract_address" json:"contract_address"`
 }
 
 type GetTokenByUserTokenIdentifiersBatchRow struct {
@@ -3925,10 +3925,10 @@ type GetTokenByUserTokenIdentifiersIgnoreDisplayableBatchBatchResults struct {
 }
 
 type GetTokenByUserTokenIdentifiersIgnoreDisplayableBatchParams struct {
-	OwnerID         persist.DBID    `db:"owner_id" json:"owner_id"`
-	TokenID         persist.TokenID `db:"token_id" json:"token_id"`
-	Chain           persist.Chain   `db:"chain" json:"chain"`
-	ContractAddress persist.Address `db:"contract_address" json:"contract_address"`
+	OwnerID         persist.DBID       `db:"owner_id" json:"owner_id"`
+	TokenID         persist.HexTokenID `db:"token_id" json:"token_id"`
+	Chain           persist.Chain      `db:"chain" json:"chain"`
+	ContractAddress persist.Address    `db:"contract_address" json:"contract_address"`
 }
 
 type GetTokenByUserTokenIdentifiersIgnoreDisplayableBatchRow struct {

--- a/db/gen/coredb/community.sql.go
+++ b/db/gen/coredb/community.sql.go
@@ -632,7 +632,7 @@ insert into token_community_memberships(id, token_definition_id, community_id, c
 )
 on conflict (community_id, token_definition_id) where not deleted
     do nothing
-returning id, version, token_definition_id, community_id, created_at, last_updated, deleted
+returning id, version, token_definition_id, community_id, created_at, last_updated, deleted, token_id
 `
 
 type UpsertTokenCommunityMembershipsParams struct {
@@ -658,6 +658,7 @@ func (q *Queries) UpsertTokenCommunityMemberships(ctx context.Context, arg Upser
 			&i.CreatedAt,
 			&i.LastUpdated,
 			&i.Deleted,
+			&i.TokenID,
 		); err != nil {
 			return nil, err
 		}

--- a/db/gen/coredb/community.sql.go
+++ b/db/gen/coredb/community.sql.go
@@ -8,6 +8,7 @@ package coredb
 import (
 	"context"
 
+	"github.com/jackc/pgtype"
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
@@ -617,18 +618,19 @@ with memberships as (
     select unnest($1::varchar[]) as id
          , unnest($2::varchar[]) as token_definition_id
          , unnest($3::varchar[]) as community_id
+         , unnest($4::numeric[]) as token_id
          , now() as created_at
          , now() as last_updated
          , false as deleted
 ),
 valid_memberships as (
-    select memberships.id, memberships.token_definition_id, memberships.community_id, memberships.created_at, memberships.last_updated, memberships.deleted
+    select memberships.id, memberships.token_definition_id, memberships.community_id, memberships.token_id, memberships.created_at, memberships.last_updated, memberships.deleted
     from memberships
     join communities on communities.id = memberships.community_id and not communities.deleted
     join token_definitions on token_definitions.id = memberships.token_definition_id and not token_definitions.deleted
 )
-insert into token_community_memberships(id, token_definition_id, community_id, created_at, last_updated, deleted) (
-    select id, token_definition_id, community_id, created_at, last_updated, deleted from valid_memberships
+insert into token_community_memberships(id, token_definition_id, community_id, token_id, created_at, last_updated, deleted) (
+    select id, token_definition_id, community_id, token_id, created_at, last_updated, deleted from valid_memberships
 )
 on conflict (community_id, token_definition_id) where not deleted
     do nothing
@@ -636,13 +638,19 @@ returning id, version, token_definition_id, community_id, created_at, last_updat
 `
 
 type UpsertTokenCommunityMembershipsParams struct {
-	Ids               []string `db:"ids" json:"ids"`
-	TokenDefinitionID []string `db:"token_definition_id" json:"token_definition_id"`
-	CommunityID       []string `db:"community_id" json:"community_id"`
+	Ids               []string         `db:"ids" json:"ids"`
+	TokenDefinitionID []string         `db:"token_definition_id" json:"token_definition_id"`
+	CommunityID       []string         `db:"community_id" json:"community_id"`
+	TokenID           []pgtype.Numeric `db:"token_id" json:"token_id"`
 }
 
 func (q *Queries) UpsertTokenCommunityMemberships(ctx context.Context, arg UpsertTokenCommunityMembershipsParams) ([]TokenCommunityMembership, error) {
-	rows, err := q.db.Query(ctx, upsertTokenCommunityMemberships, arg.Ids, arg.TokenDefinitionID, arg.CommunityID)
+	rows, err := q.db.Query(ctx, upsertTokenCommunityMemberships,
+		arg.Ids,
+		arg.TokenDefinitionID,
+		arg.CommunityID,
+		arg.TokenID,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -344,15 +344,15 @@ type Mention struct {
 }
 
 type Merch struct {
-	ID           persist.DBID    `db:"id" json:"id"`
-	Deleted      bool            `db:"deleted" json:"deleted"`
-	Version      sql.NullInt32   `db:"version" json:"version"`
-	CreatedAt    time.Time       `db:"created_at" json:"created_at"`
-	LastUpdated  time.Time       `db:"last_updated" json:"last_updated"`
-	TokenID      persist.TokenID `db:"token_id" json:"token_id"`
-	ObjectType   int32           `db:"object_type" json:"object_type"`
-	DiscountCode sql.NullString  `db:"discount_code" json:"discount_code"`
-	Redeemed     bool            `db:"redeemed" json:"redeemed"`
+	ID           persist.DBID       `db:"id" json:"id"`
+	Deleted      bool               `db:"deleted" json:"deleted"`
+	Version      sql.NullInt32      `db:"version" json:"version"`
+	CreatedAt    time.Time          `db:"created_at" json:"created_at"`
+	LastUpdated  time.Time          `db:"last_updated" json:"last_updated"`
+	TokenID      persist.HexTokenID `db:"token_id" json:"token_id"`
+	ObjectType   int32              `db:"object_type" json:"object_type"`
+	DiscountCode sql.NullString     `db:"discount_code" json:"discount_code"`
+	Redeemed     bool               `db:"redeemed" json:"redeemed"`
 }
 
 type MigrationValidation struct {
@@ -638,7 +638,7 @@ type TokenDefinition struct {
 	Name            sql.NullString        `db:"name" json:"name"`
 	Description     sql.NullString        `db:"description" json:"description"`
 	TokenType       persist.TokenType     `db:"token_type" json:"token_type"`
-	TokenID         persist.TokenID       `db:"token_id" json:"token_id"`
+	TokenID         persist.HexTokenID    `db:"token_id" json:"token_id"`
 	ExternalUrl     sql.NullString        `db:"external_url" json:"external_url"`
 	Chain           persist.Chain         `db:"chain" json:"chain"`
 	Metadata        persist.TokenMetadata `db:"metadata" json:"metadata"`

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -621,13 +621,14 @@ type Token struct {
 }
 
 type TokenCommunityMembership struct {
-	ID                persist.DBID `db:"id" json:"id"`
-	Version           int32        `db:"version" json:"version"`
-	TokenDefinitionID persist.DBID `db:"token_definition_id" json:"token_definition_id"`
-	CommunityID       persist.DBID `db:"community_id" json:"community_id"`
-	CreatedAt         time.Time    `db:"created_at" json:"created_at"`
-	LastUpdated       time.Time    `db:"last_updated" json:"last_updated"`
-	Deleted           bool         `db:"deleted" json:"deleted"`
+	ID                persist.DBID           `db:"id" json:"id"`
+	Version           int32                  `db:"version" json:"version"`
+	TokenDefinitionID persist.DBID           `db:"token_definition_id" json:"token_definition_id"`
+	CommunityID       persist.DBID           `db:"community_id" json:"community_id"`
+	CreatedAt         time.Time              `db:"created_at" json:"created_at"`
+	LastUpdated       time.Time              `db:"last_updated" json:"last_updated"`
+	Deleted           bool                   `db:"deleted" json:"deleted"`
+	TokenID           persist.DecimalTokenID `db:"token_id" json:"token_id"`
 }
 
 type TokenDefinition struct {

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -2925,9 +2925,9 @@ where (chain, contract_address, token_id) = ($1, $2, $3)
 `
 
 type GetMediaByTokenIdentifiersIgnoringStatusParams struct {
-	Chain           persist.Chain   `db:"chain" json:"chain"`
-	ContractAddress persist.Address `db:"contract_address" json:"contract_address"`
-	TokenID         persist.TokenID `db:"token_id" json:"token_id"`
+	Chain           persist.Chain      `db:"chain" json:"chain"`
+	ContractAddress persist.Address    `db:"contract_address" json:"contract_address"`
+	TokenID         persist.HexTokenID `db:"token_id" json:"token_id"`
 }
 
 func (q *Queries) GetMediaByTokenIdentifiersIgnoringStatus(ctx context.Context, arg GetMediaByTokenIdentifiersIgnoringStatusParams) (TokenMedia, error) {
@@ -2992,7 +2992,7 @@ const getMerchDiscountCodeByTokenID = `-- name: GetMerchDiscountCodeByTokenID :o
 select discount_code from merch where token_id = $1 and redeemed = true and deleted = false
 `
 
-func (q *Queries) GetMerchDiscountCodeByTokenID(ctx context.Context, tokenHex persist.TokenID) (sql.NullString, error) {
+func (q *Queries) GetMerchDiscountCodeByTokenID(ctx context.Context, tokenHex persist.HexTokenID) (sql.NullString, error) {
 	row := q.db.QueryRow(ctx, getMerchDiscountCodeByTokenID, tokenHex)
 	var discount_code sql.NullString
 	err := row.Scan(&discount_code)
@@ -4007,10 +4007,10 @@ where t.token_definition_id = td.id
 `
 
 type GetTokenByUserTokenIdentifiersParams struct {
-	OwnerID         persist.DBID    `db:"owner_id" json:"owner_id"`
-	TokenID         persist.TokenID `db:"token_id" json:"token_id"`
-	Chain           persist.Chain   `db:"chain" json:"chain"`
-	ContractAddress persist.Address `db:"contract_address" json:"contract_address"`
+	OwnerID         persist.DBID       `db:"owner_id" json:"owner_id"`
+	TokenID         persist.HexTokenID `db:"token_id" json:"token_id"`
+	Chain           persist.Chain      `db:"chain" json:"chain"`
+	ContractAddress persist.Address    `db:"contract_address" json:"contract_address"`
 }
 
 type GetTokenByUserTokenIdentifiersRow struct {
@@ -4152,9 +4152,9 @@ where (chain, contract_address, token_id) = ($1, $2, $3) and not deleted
 `
 
 type GetTokenDefinitionByTokenIdentifiersParams struct {
-	Chain           persist.Chain   `db:"chain" json:"chain"`
-	ContractAddress persist.Address `db:"contract_address" json:"contract_address"`
-	TokenID         persist.TokenID `db:"token_id" json:"token_id"`
+	Chain           persist.Chain      `db:"chain" json:"chain"`
+	ContractAddress persist.Address    `db:"contract_address" json:"contract_address"`
+	TokenID         persist.HexTokenID `db:"token_id" json:"token_id"`
 }
 
 func (q *Queries) GetTokenDefinitionByTokenIdentifiers(ctx context.Context, arg GetTokenDefinitionByTokenIdentifiersParams) (TokenDefinition, error) {
@@ -4372,10 +4372,10 @@ order by tokens.block_number desc
 `
 
 type GetTokenFullDetailsByUserTokenIdentifiersParams struct {
-	OwnerUserID     persist.DBID    `db:"owner_user_id" json:"owner_user_id"`
-	Chain           persist.Chain   `db:"chain" json:"chain"`
-	ContractAddress persist.Address `db:"contract_address" json:"contract_address"`
-	TokenID         persist.TokenID `db:"token_id" json:"token_id"`
+	OwnerUserID     persist.DBID       `db:"owner_user_id" json:"owner_user_id"`
+	Chain           persist.Chain      `db:"chain" json:"chain"`
+	ContractAddress persist.Address    `db:"contract_address" json:"contract_address"`
+	TokenID         persist.HexTokenID `db:"token_id" json:"token_id"`
 }
 
 type GetTokenFullDetailsByUserTokenIdentifiersRow struct {
@@ -4769,11 +4769,11 @@ group by (token_definitions.token_id, token_definitions.contract_address, token_
 `
 
 type GetUniqueTokenIdentifiersByTokenIDRow struct {
-	TokenID         persist.TokenID   `db:"token_id" json:"token_id"`
-	ContractAddress persist.Address   `db:"contract_address" json:"contract_address"`
-	Chain           persist.Chain     `db:"chain" json:"chain"`
-	Quantity        persist.HexString `db:"quantity" json:"quantity"`
-	OwnerAddresses  []string          `db:"owner_addresses" json:"owner_addresses"`
+	TokenID         persist.HexTokenID `db:"token_id" json:"token_id"`
+	ContractAddress persist.Address    `db:"contract_address" json:"contract_address"`
+	Chain           persist.Chain      `db:"chain" json:"chain"`
+	Quantity        persist.HexString  `db:"quantity" json:"quantity"`
+	OwnerAddresses  []string           `db:"owner_addresses" json:"owner_addresses"`
 }
 
 func (q *Queries) GetUniqueTokenIdentifiersByTokenID(ctx context.Context, id persist.DBID) (GetUniqueTokenIdentifiersByTokenIDRow, error) {
@@ -6164,7 +6164,7 @@ type InsertTokenPipelineResultsParams struct {
 	RetiringMediaID  persist.DBID             `db:"retiring_media_id" json:"retiring_media_id"`
 	Chain            persist.Chain            `db:"chain" json:"chain"`
 	ContractAddress  persist.Address          `db:"contract_address" json:"contract_address"`
-	TokenID          persist.TokenID          `db:"token_id" json:"token_id"`
+	TokenID          persist.HexTokenID       `db:"token_id" json:"token_id"`
 	NewMediaIsActive bool                     `db:"new_media_is_active" json:"new_media_is_active"`
 	NewMediaID       persist.DBID             `db:"new_media_id" json:"new_media_id"`
 	NewMedia         pgtype.JSONB             `db:"new_media" json:"new_media"`
@@ -6661,8 +6661,8 @@ update merch set redeemed = true, token_id = $1, last_updated = now() where id =
 `
 
 type RedeemMerchParams struct {
-	TokenHex   persist.TokenID `db:"token_hex" json:"token_hex"`
-	ObjectType int32           `db:"object_type" json:"object_type"`
+	TokenHex   persist.HexTokenID `db:"token_hex" json:"token_hex"`
+	ObjectType int32              `db:"object_type" json:"object_type"`
 }
 
 func (q *Queries) RedeemMerch(ctx context.Context, arg RedeemMerchParams) (sql.NullString, error) {
@@ -7213,11 +7213,11 @@ returning id, created_at, last_updated, deleted, name, description, token_type, 
 `
 
 type UpdateTokenMetadataFieldsByTokenIdentifiersParams struct {
-	Name        sql.NullString  `db:"name" json:"name"`
-	Description sql.NullString  `db:"description" json:"description"`
-	TokenID     persist.TokenID `db:"token_id" json:"token_id"`
-	ContractID  persist.DBID    `db:"contract_id" json:"contract_id"`
-	Chain       persist.Chain   `db:"chain" json:"chain"`
+	Name        sql.NullString     `db:"name" json:"name"`
+	Description sql.NullString     `db:"description" json:"description"`
+	TokenID     persist.HexTokenID `db:"token_id" json:"token_id"`
+	ContractID  persist.DBID       `db:"contract_id" json:"contract_id"`
+	Chain       persist.Chain      `db:"chain" json:"chain"`
 }
 
 func (q *Queries) UpdateTokenMetadataFieldsByTokenIdentifiers(ctx context.Context, arg UpdateTokenMetadataFieldsByTokenIdentifiersParams) (TokenDefinition, error) {

--- a/db/gen/coredb/token_gallery.sql.go
+++ b/db/gen/coredb/token_gallery.sql.go
@@ -169,6 +169,42 @@ with token_definitions_insert as (
     , contract_id = excluded.contract_id
   returning id, deleted, version, created_at, last_updated, collectors_note, quantity, block_number, owner_user_id, owned_by_wallets, contract_id, is_user_marked_spam, last_synced, is_creator_token, token_definition_id, is_holder_token, displayable
 )
+, community_memberships_insert as (
+  insert into token_community_memberships
+  (
+    id
+    , token_definition_id
+    , community_id
+    , created_at
+    , last_updated
+    , deleted
+    , token_id
+  ) (
+    select community_memberships.id
+      , token_definitions_insert.id
+      , communities.id
+      , now()
+      , now()
+      , false
+      , community_memberships.token_id
+    from (
+      select unnest($29::varchar[]) as id
+        , unnest($30::numeric[]) as token_id
+        , unnest($10) as definition_contract_id
+        , unnest($5) as definition_token_id
+    ) community_memberships
+    join token_definitions_insert on
+        community_memberships.definition_contract_id = token_definitions_insert.contract_id
+        and community_memberships.definition_token_id = token_definitions_insert.token_id
+    -- Left join ensures that the insert will fail with a constraint violation (trying to insert null) if there isn't a
+    -- contract community for this token. Every contract should have a community created for it by the time we get here!
+    left join communities on communities.contract_id = community_memberships.definition_contract_id and communities.community_type = 0
+  )
+  on conflict (community_id, token_definition_id) where deleted = false
+  do update set
+    last_updated = excluded.last_updated
+  returning id, version, token_definition_id, community_id, created_at, last_updated, deleted, token_id
+)
 select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
 from tokens_insert tokens
 join token_definitions_insert token_definitions on tokens.token_definition_id = token_definitions.id
@@ -176,34 +212,36 @@ join contracts on token_definitions.contract_id = contracts.id
 `
 
 type UpsertTokensParams struct {
-	DefinitionDbid              []string       `db:"definition_dbid" json:"definition_dbid"`
-	DefinitionName              []string       `db:"definition_name" json:"definition_name"`
-	DefinitionDescription       []string       `db:"definition_description" json:"definition_description"`
-	DefinitionTokenType         []string       `db:"definition_token_type" json:"definition_token_type"`
-	DefinitionTokenID           []string       `db:"definition_token_id" json:"definition_token_id"`
-	DefinitionExternalUrl       []string       `db:"definition_external_url" json:"definition_external_url"`
-	DefinitionChain             []int32        `db:"definition_chain" json:"definition_chain"`
-	DefinitionFallbackMedia     []pgtype.JSONB `db:"definition_fallback_media" json:"definition_fallback_media"`
-	DefinitionContractAddress   []string       `db:"definition_contract_address" json:"definition_contract_address"`
-	DefinitionContractID        []string       `db:"definition_contract_id" json:"definition_contract_id"`
-	DefinitionMetadata          []pgtype.JSONB `db:"definition_metadata" json:"definition_metadata"`
-	DefinitionIsFxhash          []bool         `db:"definition_is_fxhash" json:"definition_is_fxhash"`
-	SetHolderFields             bool           `db:"set_holder_fields" json:"set_holder_fields"`
-	SetCreatorFields            bool           `db:"set_creator_fields" json:"set_creator_fields"`
-	TokenDbid                   []string       `db:"token_dbid" json:"token_dbid"`
-	TokenVersion                []int32        `db:"token_version" json:"token_version"`
-	TokenCollectorsNote         []string       `db:"token_collectors_note" json:"token_collectors_note"`
-	TokenQuantity               []string       `db:"token_quantity" json:"token_quantity"`
-	TokenBlockNumber            []int64        `db:"token_block_number" json:"token_block_number"`
-	TokenOwnerUserID            []string       `db:"token_owner_user_id" json:"token_owner_user_id"`
-	TokenOwnedByWallets         []string       `db:"token_owned_by_wallets" json:"token_owned_by_wallets"`
-	TokenOwnedByWalletsStartIdx []int32        `db:"token_owned_by_wallets_start_idx" json:"token_owned_by_wallets_start_idx"`
-	TokenOwnedByWalletsEndIdx   []int32        `db:"token_owned_by_wallets_end_idx" json:"token_owned_by_wallets_end_idx"`
-	TokenIsCreatorToken         []bool         `db:"token_is_creator_token" json:"token_is_creator_token"`
-	TokenTokenID                []string       `db:"token_token_id" json:"token_token_id"`
-	TokenContractAddress        []string       `db:"token_contract_address" json:"token_contract_address"`
-	TokenChain                  []int32        `db:"token_chain" json:"token_chain"`
-	TokenContractID             []string       `db:"token_contract_id" json:"token_contract_id"`
+	DefinitionDbid              []string         `db:"definition_dbid" json:"definition_dbid"`
+	DefinitionName              []string         `db:"definition_name" json:"definition_name"`
+	DefinitionDescription       []string         `db:"definition_description" json:"definition_description"`
+	DefinitionTokenType         []string         `db:"definition_token_type" json:"definition_token_type"`
+	DefinitionTokenID           []string         `db:"definition_token_id" json:"definition_token_id"`
+	DefinitionExternalUrl       []string         `db:"definition_external_url" json:"definition_external_url"`
+	DefinitionChain             []int32          `db:"definition_chain" json:"definition_chain"`
+	DefinitionFallbackMedia     []pgtype.JSONB   `db:"definition_fallback_media" json:"definition_fallback_media"`
+	DefinitionContractAddress   []string         `db:"definition_contract_address" json:"definition_contract_address"`
+	DefinitionContractID        []string         `db:"definition_contract_id" json:"definition_contract_id"`
+	DefinitionMetadata          []pgtype.JSONB   `db:"definition_metadata" json:"definition_metadata"`
+	DefinitionIsFxhash          []bool           `db:"definition_is_fxhash" json:"definition_is_fxhash"`
+	SetHolderFields             bool             `db:"set_holder_fields" json:"set_holder_fields"`
+	SetCreatorFields            bool             `db:"set_creator_fields" json:"set_creator_fields"`
+	TokenDbid                   []string         `db:"token_dbid" json:"token_dbid"`
+	TokenVersion                []int32          `db:"token_version" json:"token_version"`
+	TokenCollectorsNote         []string         `db:"token_collectors_note" json:"token_collectors_note"`
+	TokenQuantity               []string         `db:"token_quantity" json:"token_quantity"`
+	TokenBlockNumber            []int64          `db:"token_block_number" json:"token_block_number"`
+	TokenOwnerUserID            []string         `db:"token_owner_user_id" json:"token_owner_user_id"`
+	TokenOwnedByWallets         []string         `db:"token_owned_by_wallets" json:"token_owned_by_wallets"`
+	TokenOwnedByWalletsStartIdx []int32          `db:"token_owned_by_wallets_start_idx" json:"token_owned_by_wallets_start_idx"`
+	TokenOwnedByWalletsEndIdx   []int32          `db:"token_owned_by_wallets_end_idx" json:"token_owned_by_wallets_end_idx"`
+	TokenIsCreatorToken         []bool           `db:"token_is_creator_token" json:"token_is_creator_token"`
+	TokenTokenID                []string         `db:"token_token_id" json:"token_token_id"`
+	TokenContractAddress        []string         `db:"token_contract_address" json:"token_contract_address"`
+	TokenChain                  []int32          `db:"token_chain" json:"token_chain"`
+	TokenContractID             []string         `db:"token_contract_id" json:"token_contract_id"`
+	CommunityMembershipDbid     []string         `db:"community_membership_dbid" json:"community_membership_dbid"`
+	CommunityMembershipTokenID  []pgtype.Numeric `db:"community_membership_token_id" json:"community_membership_token_id"`
 }
 
 type UpsertTokensRow struct {
@@ -242,6 +280,8 @@ func (q *Queries) UpsertTokens(ctx context.Context, arg UpsertTokensParams) ([]U
 		arg.TokenContractAddress,
 		arg.TokenChain,
 		arg.TokenContractID,
+		arg.CommunityMembershipDbid,
+		arg.CommunityMembershipTokenID,
 	)
 	if err != nil {
 		return nil, err

--- a/db/migrations/core/000153_add_token_id_to_community_tokens.up.sql
+++ b/db/migrations/core/000153_add_token_id_to_community_tokens.up.sql
@@ -1,0 +1,1 @@
+alter table token_community_memberships add column token_id numeric;

--- a/db/queries/core/community.sql
+++ b/db/queries/core/community.sql
@@ -56,6 +56,7 @@ with memberships as (
     select unnest(@ids::varchar[]) as id
          , unnest(@token_definition_id::varchar[]) as token_definition_id
          , unnest(@community_id::varchar[]) as community_id
+         , unnest(@token_id::numeric[]) as token_id
          , now() as created_at
          , now() as last_updated
          , false as deleted
@@ -66,7 +67,7 @@ valid_memberships as (
     join communities on communities.id = memberships.community_id and not communities.deleted
     join token_definitions on token_definitions.id = memberships.token_definition_id and not token_definitions.deleted
 )
-insert into token_community_memberships(id, token_definition_id, community_id, created_at, last_updated, deleted) (
+insert into token_community_memberships(id, token_definition_id, community_id, token_id, created_at, last_updated, deleted) (
     select * from valid_memberships
 )
 on conflict (community_id, token_definition_id) where not deleted

--- a/db/queries/core/token_gallery.sql
+++ b/db/queries/core/token_gallery.sql
@@ -110,6 +110,42 @@ with token_definitions_insert as (
     , contract_id = excluded.contract_id
   returning *
 )
+, community_memberships_insert as (
+  insert into token_community_memberships
+  (
+    id
+    , token_definition_id
+    , community_id
+    , created_at
+    , last_updated
+    , deleted
+    , token_id
+  ) (
+    select community_memberships.id
+      , token_definitions_insert.id
+      , communities.id
+      , now()
+      , now()
+      , false
+      , community_memberships.token_id
+    from (
+      select unnest(@community_membership_dbid::varchar[]) as id
+        , unnest(@community_membership_token_id::numeric[]) as token_id
+        , unnest(@definition_contract_id) as definition_contract_id
+        , unnest(@definition_token_id) as definition_token_id
+    ) community_memberships
+    join token_definitions_insert on
+        community_memberships.definition_contract_id = token_definitions_insert.contract_id
+        and community_memberships.definition_token_id = token_definitions_insert.token_id
+    -- Left join ensures that the insert will fail with a constraint violation (trying to insert null) if there isn't a
+    -- contract community for this token. Every contract should have a community created for it by the time we get here!
+    left join communities on communities.contract_id = community_memberships.definition_contract_id and communities.community_type = 0
+  )
+  on conflict (community_id, token_definition_id) where deleted = false
+  do update set
+    last_updated = excluded.last_updated
+  returning *
+)
 select sqlc.embed(tokens), sqlc.embed(token_definitions), sqlc.embed(contracts)
 from tokens_insert tokens
 join token_definitions_insert token_definitions on tokens.token_definition_id = token_definitions.id

--- a/emails/genqlient.yaml
+++ b/emails/genqlient.yaml
@@ -9,7 +9,7 @@ bindings:
   DBID:
     type: github.com/mikeydub/go-gallery/service/persist.DBID
   TokenId:
-    type: github.com/mikeydub/go-gallery/service/persist.TokenID
+    type: github.com/mikeydub/go-gallery/service/persist.HexTokenID
   Address:
     type: github.com/mikeydub/go-gallery/service/persist.Address
   ChainAddressInput:

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -114,7 +114,7 @@ models:
       - github.com/mikeydub/go-gallery/service/persist.CommunityType
   TokenId:
     model:
-      - github.com/mikeydub/go-gallery/service/persist.TokenID
+      - github.com/mikeydub/go-gallery/service/persist.HexTokenID
   ReportReason:
     model:
       - github.com/mikeydub/go-gallery/service/persist.ReportReason

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -94353,13 +94353,13 @@ func (ec *executionContext) marshalNTokenDefinition2ᚖgithubᚗcomᚋmikeydub�
 	return ec._TokenDefinition(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNTokenId2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐTokenID(ctx context.Context, v interface{}) (persist.TokenID, error) {
-	var res persist.TokenID
+func (ec *executionContext) unmarshalNTokenId2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐTokenID(ctx context.Context, v interface{}) (persist.HexTokenID, error) {
+	var res persist.HexTokenID
 	err := res.UnmarshalGQL(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNTokenId2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐTokenID(ctx context.Context, sel ast.SelectionSet, v persist.TokenID) graphql.Marshaler {
+func (ec *executionContext) marshalNTokenId2githubᚗcomᚋmikeydubᚋgoᚑgalleryᚋserviceᚋpersistᚐTokenID(ctx context.Context, sel ast.SelectionSet, v persist.HexTokenID) graphql.Marshaler {
 	return v
 }
 

--- a/graphql/genqlient.yaml
+++ b/graphql/genqlient.yaml
@@ -17,7 +17,7 @@ bindings:
   Time:
     type: string
   TokenId:
-    type: github.com/mikeydub/go-gallery/service/persist.TokenID
+    type: github.com/mikeydub/go-gallery/service/persist.HexTokenID
 operations:
 - testdata/*.graphql
 generated: generated_test.go

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -1033,7 +1033,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process image", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x0"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x0"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/image", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1048,7 +1048,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process video", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x1"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x1"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/video", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1063,7 +1063,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process iframe", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x2"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x2"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/iframe", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1078,7 +1078,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process gif", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x3"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x3"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/gif", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1093,7 +1093,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process bad metadata", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x4"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x4"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/bad", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1107,7 +1107,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process missing metadata", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x5"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x5"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/notfound", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1121,7 +1121,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process bad media", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x6"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x6"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/bad", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1135,7 +1135,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process missing media", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x7"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x7"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/notfound", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1149,7 +1149,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process svg", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x8"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x8"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/svg", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1164,7 +1164,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process base64 encoded svg", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x9"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x9"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/base64svg", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1179,7 +1179,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process base64 encoded metadata", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0xa"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xa"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/base64", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1194,7 +1194,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process ipfs", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0xb"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xb"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/ipfs", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1209,7 +1209,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process bad dns", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0xc"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xc"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/dnsbad", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1223,7 +1223,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process different keyword", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0xd"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xd"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/differentkeyword", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1238,7 +1238,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process wrong keyword", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0xe"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xe"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/wrongkeyword", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1253,7 +1253,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process animation", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0xf"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xf"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/animation", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1268,7 +1268,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process pdf", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x10"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x10"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/pdf", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1283,7 +1283,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process text", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x11"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x11"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/text", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1298,7 +1298,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process bad image", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.TokenID("0x12"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x12"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/badimage", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
@@ -1589,7 +1589,7 @@ func dummyTokenContract(ownerAddress, contractAddress persist.Address) multichai
 }
 
 // dummyTokenIDContract returns a dummy token owned by the provided address from the provided contract with the given tokenID
-func dummyTokenIDContract(ownerAddress, contractAddress persist.Address, tokenID persist.TokenID) multichain.ChainAgnosticToken {
+func dummyTokenIDContract(ownerAddress, contractAddress persist.Address, tokenID persist.HexTokenID) multichain.ChainAgnosticToken {
 	return multichain.ChainAgnosticToken{
 		TokenID:         tokenID,
 		Quantity:        "1",

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -637,7 +637,7 @@ func (BlockUserPayload) IsBlockUserPayloadOrError() {}
 type ChainAddressTokenInput struct {
 	ChainAddress *persist.ChainAddress `json:"chainAddress"`
 	// Refers to the id of the token in the contract either in decimal, or interpreted as hexadecimal when prefixed with '0x'
-	TokenID persist.TokenID `json:"tokenId"`
+	TokenID persist.HexTokenID `json:"tokenId"`
 }
 
 type ChainTokens struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2010,9 +2010,9 @@ func (r *mutationResolver) VerifyEmailMagicLink(ctx context.Context, input model
 
 // RedeemMerch is the resolver for the redeemMerch field.
 func (r *mutationResolver) RedeemMerch(ctx context.Context, input model.RedeemMerchInput) (model.RedeemMerchPayloadOrError, error) {
-	tokenIDList := make([]persist.TokenID, len(input.TokenIds))
+	tokenIDList := make([]persist.HexTokenID, len(input.TokenIds))
 	for i, id := range input.TokenIds {
-		tokenIDList[i] = persist.TokenID(id)
+		tokenIDList[i] = persist.HexTokenID(id)
 	}
 	if input.Address == nil {
 		return nil, fmt.Errorf("address is required")

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1348,7 +1348,7 @@ func resolveCommentByCommentID(ctx context.Context, commentID persist.DBID) (*mo
 }
 
 func resolveMerchTokenByTokenID(ctx context.Context, tokenID string) (*model.MerchToken, error) {
-	token, err := publicapi.For(ctx).Merch.GetMerchTokenByTokenID(ctx, persist.TokenID(tokenID))
+	token, err := publicapi.For(ctx).Merch.GetMerchTokenByTokenID(ctx, persist.HexTokenID(tokenID))
 
 	if err != nil {
 		return nil, err

--- a/graphql/stub_test.go
+++ b/graphql/stub_test.go
@@ -105,7 +105,7 @@ func withDummyTokenN(contract multichain.ChainAgnosticContract, ownerAddress per
 	return func(p *stubProvider) {
 		tokens := []multichain.ChainAgnosticToken{}
 		for i := 0; i < n; i++ {
-			tokenID := persist.TokenID(fmt.Sprintf("%X", i))
+			tokenID := persist.HexTokenID(fmt.Sprintf("%X", i))
 			token := dummyTokenIDContract(ownerAddress, contract.Address, tokenID)
 			tokens = append(tokens, token)
 		}
@@ -115,7 +115,7 @@ func withDummyTokenN(contract multichain.ChainAgnosticContract, ownerAddress per
 }
 
 // withDummyTokenID will generate a token with the provided token ID
-func withDummyTokenID(ownerAddress persist.Address, tokenID persist.TokenID) providerOpt {
+func withDummyTokenID(ownerAddress persist.Address, tokenID persist.HexTokenID) providerOpt {
 	c := multichain.ChainAgnosticContract{Address: "0x123"}
 	return func(p *stubProvider) {
 		withContracts([]multichain.ChainAgnosticContract{c})(p)

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -484,7 +484,7 @@ func logsToTransfers(ctx context.Context, pLogs []types.Log) []rpc.Transfer {
 			result = append(result, rpc.Transfer{
 				From:            persist.EthereumAddress(pLog.Topics[1].Hex()),
 				To:              persist.EthereumAddress(pLog.Topics[2].Hex()),
-				TokenID:         persist.TokenID(pLog.Topics[3].Hex()),
+				TokenID:         persist.HexTokenID(pLog.Topics[3].Hex()),
 				Amount:          1,
 				BlockNumber:     persist.BlockNumber(pLog.BlockNumber),
 				ContractAddress: persist.EthereumAddress(pLog.Address.Hex()),
@@ -519,7 +519,7 @@ func logsToTransfers(ctx context.Context, pLogs []types.Log) []rpc.Transfer {
 			result = append(result, rpc.Transfer{
 				From:            persist.EthereumAddress(pLog.Topics[2].Hex()),
 				To:              persist.EthereumAddress(pLog.Topics[3].Hex()),
-				TokenID:         persist.TokenID(id.Text(16)),
+				TokenID:         persist.HexTokenID(id.Text(16)),
 				Amount:          value.Uint64(),
 				BlockNumber:     persist.BlockNumber(pLog.BlockNumber),
 				ContractAddress: persist.EthereumAddress(pLog.Address.Hex()),
@@ -556,7 +556,7 @@ func logsToTransfers(ctx context.Context, pLogs []types.Log) []rpc.Transfer {
 				result = append(result, rpc.Transfer{
 					From:            persist.EthereumAddress(pLog.Topics[2].Hex()),
 					To:              persist.EthereumAddress(pLog.Topics[3].Hex()),
-					TokenID:         persist.TokenID(ids[j].Text(16)),
+					TokenID:         persist.HexTokenID(ids[j].Text(16)),
 					Amount:          values[j].Uint64(),
 					ContractAddress: persist.EthereumAddress(pLog.Address.Hex()),
 					TokenType:       persist.TokenTypeERC1155,

--- a/publicapi/merch.go
+++ b/publicapi/merch.go
@@ -107,7 +107,7 @@ func (api MerchAPI) GetMerchTokens(ctx context.Context, address persist.Address)
 	return merchTokens, nil
 }
 
-func (api MerchAPI) GetMerchTokenByTokenID(ctx context.Context, tokenID persist.TokenID) (*model.MerchToken, error) {
+func (api MerchAPI) GetMerchTokenByTokenID(ctx context.Context, tokenID persist.HexTokenID) (*model.MerchToken, error) {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
 		"tokenID": validate.WithTag(tokenID, "required"),
@@ -163,7 +163,7 @@ func (api MerchAPI) GetMerchTokenByTokenID(ctx context.Context, tokenID persist.
 	return t, nil
 }
 
-func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.TokenID, address persist.ChainAddress, sig string, walletType persist.WalletType) ([]*model.MerchToken, error) {
+func (api MerchAPI) RedeemMerchItems(ctx context.Context, tokenIDs []persist.HexTokenID, address persist.ChainAddress, sig string, walletType persist.WalletType) ([]*model.MerchToken, error) {
 
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
 		"tokenIDs": validate.WithTag(tokenIDs, "required,unique"),

--- a/service/eth/eth.go
+++ b/service/eth/eth.go
@@ -107,7 +107,7 @@ func ReverseResolvesTo(ctx context.Context, ethClient *ethclient.Client, domain 
 }
 
 // DeriveTokenID derives the token ID (in hexadecimal) from a domain
-func DeriveTokenID(domain string) (persist.TokenID, error) {
+func DeriveTokenID(domain string) (persist.HexTokenID, error) {
 	domain, err := NormalizeDomain(domain)
 	if err != nil {
 		return "", err
@@ -120,7 +120,7 @@ func DeriveTokenID(domain string) (persist.TokenID, error) {
 	if err != nil {
 		return "", err
 	}
-	return persist.TokenID(fmt.Sprintf("%x", labelHash)), nil
+	return persist.HexTokenID(fmt.Sprintf("%x", labelHash)), nil
 }
 
 // NormalizeDomain converts a domain to its canonical form
@@ -209,7 +209,7 @@ func IsOwner(ctx context.Context, ethClient *ethclient.Client, addr persist.Ethe
 }
 
 // TokenInfoFor is a helper function for parsing info from a token record
-func TokenInfoFor(r EnsTokenRecord) (persist.Chain, persist.Address, persist.TokenType, persist.TokenID, error) {
+func TokenInfoFor(r EnsTokenRecord) (persist.Chain, persist.Address, persist.TokenType, persist.HexTokenID, error) {
 	errs := make([]error, 4)
 	chain, err := r.Chain()
 	errs[0] = err
@@ -291,7 +291,7 @@ func (e EnsTokenRecord) TokenType() (persist.TokenType, error) {
 	return "", ErrUnknownTokenType
 }
 
-func (e EnsTokenRecord) TokenID() (persist.TokenID, error) {
+func (e EnsTokenRecord) TokenID() (persist.HexTokenID, error) {
 	if e.ChainID != ethMainnetChainID {
 		return "", ErrChainNotSupported
 	}

--- a/service/membership/alchemy.go
+++ b/service/membership/alchemy.go
@@ -24,7 +24,7 @@ type indexerTokenResponse struct {
 	NFTs []persist.Token `json:"nfts"`
 }
 
-func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress persist.EthereumAddress) ([]persist.EthereumAddress, error) {
+func getOwnersForToken(ctx context.Context, tid persist.HexTokenID, contractAddress persist.EthereumAddress) ([]persist.EthereumAddress, error) {
 	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s", env.GetString("INDEXER_HOST"), tid, contractAddress)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -53,7 +53,7 @@ func getOwnersForToken(ctx context.Context, tid persist.TokenID, contractAddress
 	return owners, nil
 }
 
-func getTokenMetadata(ctx context.Context, tid persist.TokenID, contractAddress persist.EthereumAddress, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client) (alchemyNFTMetadata, error) {
+func getTokenMetadata(ctx context.Context, tid persist.HexTokenID, contractAddress persist.EthereumAddress, ipfsClient *shell.Shell, arweaveClient *goar.Client, stg *storage.Client) (alchemyNFTMetadata, error) {
 	url := fmt.Sprintf("%s/nfts/get?token_id=%s&contract_address=%s&limit=1", env.GetString("INDEXER_HOST"), tid, contractAddress)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/service/multichain/alchemy/alchemy.go
+++ b/service/multichain/alchemy/alchemy.go
@@ -61,20 +61,20 @@ func (t TokenID) String() string {
 	return string(t)
 }
 
-func (t TokenID) ToTokenID() persist.TokenID {
+func (t TokenID) ToTokenID() persist.HexTokenID {
 
 	if strings.HasPrefix(t.String(), "0x") {
 		big, ok := new(big.Int).SetString(strings.TrimPrefix(t.String(), "0x"), 16)
 		if !ok {
 			return ""
 		}
-		return persist.TokenID(big.Text(16))
+		return persist.HexTokenID(big.Text(16))
 	}
 	big, ok := new(big.Int).SetString(t.String(), 10)
 	if !ok {
 		return ""
 	}
-	return persist.TokenID(big.Text(16))
+	return persist.HexTokenID(big.Text(16))
 
 }
 

--- a/service/multichain/artblocks.go
+++ b/service/multichain/artblocks.go
@@ -390,6 +390,7 @@ func (p *Provider) processArtBlocksTokenCommunities(ctx context.Context, knownPr
 			upsertParams.Ids = append(upsertParams.Ids, persist.GenerateID().String())
 			upsertParams.TokenDefinitionID = append(upsertParams.TokenDefinitionID, token.Definition.ID.String())
 			upsertParams.CommunityID = append(upsertParams.CommunityID, community.ID.String())
+			upsertParams.TokenID = append(upsertParams.TokenID, token.Definition.TokenID.ToDecimalTokenID().Numeric())
 		}
 	}
 

--- a/service/multichain/artblocks.go
+++ b/service/multichain/artblocks.go
@@ -217,7 +217,7 @@ func (a artBlocksCommunityKey) String() string {
 	return fmt.Sprintf("ProjectID=%s:Chain=%d:ContractAddress=%s", a.ProjectID, a.ContractChain, a.ContractAddress)
 }
 
-func (p *Provider) processArtBlocksTokenCommunities(ctx context.Context, knownProviders []db.CommunityContractProvider, tokens []op.TokenFullDetails) error {
+func (p *Provider) processArtBlocksCommunityTokens(ctx context.Context, knownProviders []db.CommunityContractProvider, tokens []op.TokenFullDetails) error {
 	artBlocksContracts := make(map[persist.DBID]bool)
 	for _, t := range knownProviders {
 		if t.CommunityType == persist.CommunityTypeArtBlocks {

--- a/service/multichain/artblocks.go
+++ b/service/multichain/artblocks.go
@@ -111,7 +111,7 @@ func (i artBlocksCommunityInfo) GetWebsiteURL() string {
 // Art Blocks project IDs are the token ID divided by 1,000,000
 var oneMillion = big.NewInt(1000000)
 
-func tokenIDToArtBlocksProjectID(tokenID persist.TokenID) string {
+func tokenIDToArtBlocksProjectID(tokenID persist.HexTokenID) string {
 	var projectIDInt big.Int
 	projectIDInt.Div(tokenID.BigInt(), oneMillion)
 	return projectIDInt.String()
@@ -119,7 +119,7 @@ func tokenIDToArtBlocksProjectID(tokenID persist.TokenID) string {
 
 // projectIDToTokenID returns the first token ID that would belong to a given project ID.
 // Note: the Art Blocks API expects base 10 token IDs, so for efficiency, this helper method
-// works directly with base 10 numbers and doesn't use the hex-based persist.TokenID type.
+// works directly with base 10 numbers and doesn't use the hex-based persist.HexTokenID type.
 func projectIDToBase10ArtBlocksTokenID(projectID string) string {
 	var projectIDInt big.Int
 	projectIDInt.SetString(projectID, 10)

--- a/service/multichain/infura/infura.go
+++ b/service/multichain/infura/infura.go
@@ -32,13 +32,13 @@ func (t TokenID) String() string {
 	return string(t)
 }
 
-func (t TokenID) ToTokenID() persist.TokenID {
+func (t TokenID) ToTokenID() persist.HexTokenID {
 
 	big, ok := new(big.Int).SetString(t.String(), 10)
 	if !ok {
 		return ""
 	}
-	return persist.TokenID(big.Text(16))
+	return persist.HexTokenID(big.Text(16))
 
 }
 
@@ -314,9 +314,9 @@ func getNFTsPaginate[T tokensPaginated](ctx context.Context, startingURL string,
 }
 
 type TokenMetadata struct {
-	Contract persist.Address `json:"contract"`
-	TokenID  persist.TokenID `json:"token_id"`
-	Metadata Metadata        `json:"metadata"`
+	Contract persist.Address    `json:"contract"`
+	TokenID  persist.HexTokenID `json:"token_id"`
+	Metadata Metadata           `json:"metadata"`
 }
 
 // GetTokenMetadataByTokenIdentifiers retrieves a token's metadata for a given contract address and token ID

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -57,7 +57,7 @@ type ChainAgnosticToken struct {
 	Descriptors     ChainAgnosticTokenDescriptors `json:"descriptors"`
 	TokenType       persist.TokenType             `json:"token_type"`
 	TokenURI        persist.TokenURI              `json:"token_uri"`
-	TokenID         persist.TokenID               `json:"token_id"`
+	TokenID         persist.HexTokenID            `json:"token_id"`
 	Quantity        persist.HexString             `json:"quantity"`
 	OwnerAddress    persist.Address               `json:"owner_address"`
 	TokenMetadata   persist.TokenMetadata         `json:"metadata"`
@@ -97,8 +97,8 @@ type ChainAgnosticContractDescriptors struct {
 
 // ChainAgnosticIdentifiers identify tokens despite their chain
 type ChainAgnosticIdentifiers struct {
-	ContractAddress persist.Address `json:"contract_address"`
-	TokenID         persist.TokenID `json:"token_id"`
+	ContractAddress persist.Address    `json:"contract_address"`
+	TokenID         persist.HexTokenID `json:"token_id"`
 }
 
 func (t ChainAgnosticIdentifiers) String() string {
@@ -960,7 +960,7 @@ func (p *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, 
 	return f.GetTokenMetadataByTokenIdentifiersBatch(ctx, tIDs)
 }
 
-func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contractAddress persist.Address, tokenID persist.TokenID, chain persist.Chain) (persist.TokenMetadata, error) {
+func (p *Provider) GetTokenMetadataByTokenIdentifiers(ctx context.Context, contractAddress persist.Address, tokenID persist.HexTokenID, chain persist.Chain) (persist.TokenMetadata, error) {
 	fetcher, ok := p.Chains[chain].(TokenMetadataFetcher)
 	if !ok {
 		return nil, fmt.Errorf("no metadata fetchers for chain %d", chain)

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -629,14 +629,14 @@ func (p *Provider) SyncCreatedTokensForExistingContract(ctx context.Context, use
 	return err
 }
 
-func (p *Provider) processTokenCommunities(ctx context.Context, contracts []db.Contract, tokens []op.TokenFullDetails) error {
+func (p *Provider) processCommunities(ctx context.Context, contracts []db.Contract, tokens []op.TokenFullDetails) error {
 	knownProviders, err := p.Queries.GetCommunityContractProviders(ctx, util.MapWithoutError(contracts, func(c db.Contract) persist.DBID { return c.ID }))
 	if err != nil {
 		return fmt.Errorf("failed to retrieve contract community types: %w", err)
 	}
 
 	// TODO: Make this more flexible, allow other providers, etc (possibly via wire)
-	return p.processArtBlocksTokenCommunities(ctx, knownProviders, tokens)
+	return p.processArtBlocksCommunityTokens(ctx, knownProviders, tokens)
 }
 
 func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chain, users map[persist.DBID]persist.User, chainTokensForUsers map[persist.DBID][]ChainAgnosticToken,
@@ -677,7 +677,7 @@ func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chai
 	// TODO: Consider tracking (token_definition_id, community_type) in a table so we'd know whether we've already
 	// evaluated a token for a given community type and can avoid checking it again.
 	communityTokens := upsertedTokens
-	err = p.processTokenCommunities(ctx, contracts, communityTokens)
+	err = p.processCommunities(ctx, contracts, communityTokens)
 	if err != nil {
 		// Report errors, but don't return. We can retry token community memberships at some point, but the whole
 		// sync shouldn't fail because a community provider's API was unavailable.

--- a/service/multichain/opensea/opensea.go
+++ b/service/multichain/opensea/opensea.go
@@ -98,7 +98,7 @@ type Contract struct {
 	Name            string          `json:"name"`
 }
 
-func FetchAssetsForTokenIdentifiers(ctx context.Context, chain persist.Chain, contractAddress persist.Address, tokenID persist.TokenID) ([]Asset, error) {
+func FetchAssetsForTokenIdentifiers(ctx context.Context, chain persist.Chain, contractAddress persist.Address, tokenID persist.HexTokenID) ([]Asset, error) {
 	outCh := make(chan assetsReceived)
 
 	go func() {
@@ -495,7 +495,7 @@ func mustCollectionEndpoint(slug string) *url.URL {
 	return checkURL(s)
 }
 
-func mustNftEndpoint(chain persist.Chain, address persist.Address, tokenID persist.TokenID) *url.URL {
+func mustNftEndpoint(chain persist.Chain, address persist.Address, tokenID persist.HexTokenID) *url.URL {
 	s := fmt.Sprintf(getNftEndpointTemplate, mustChainIdentifierFrom(chain), address, tokenID.Base10String())
 	return checkURL(s)
 }
@@ -510,7 +510,7 @@ func mustNftsByContractEndpoint(chain persist.Chain, address persist.Address) *u
 	return checkURL(s)
 }
 
-func streamAssetsForToken(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
+func streamAssetsForToken(ctx context.Context, client *http.Client, chain persist.Chain, address persist.Address, tokenID persist.HexTokenID, outCh chan assetsReceived) {
 	endpoint := mustNftEndpoint(chain, address, tokenID)
 	setPagingParams(endpoint)
 	paginateAssets(ctx, client, mustAuthRequest(ctx, endpoint), outCh)
@@ -528,7 +528,7 @@ func streamAssetsForContract(ctx context.Context, client *http.Client, chain per
 	paginateAssets(ctx, client, mustAuthRequest(ctx, endpoint), outCh)
 }
 
-func streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, client *http.Client, chain persist.Chain, ownerAddress, contractAddress persist.Address, tokenID persist.TokenID, outCh chan assetsReceived) {
+func streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, client *http.Client, chain persist.Chain, ownerAddress, contractAddress persist.Address, tokenID persist.HexTokenID, outCh chan assetsReceived) {
 	endpoint := mustNftsByWalletEndpoint(chain, ownerAddress)
 	setPagingParams(endpoint)
 	paginateAssetsFilter(ctx, client, mustAuthRequest(ctx, endpoint), outCh, func(a Asset) bool {

--- a/service/multichain/operation/operation.go
+++ b/service/multichain/operation/operation.go
@@ -144,6 +144,10 @@ func BulkUpsert(ctx context.Context, q *db.Queries, tokens []UpsertToken, defini
 		params.DefinitionContractAddress = append(params.DefinitionContractAddress, d.ContractAddress.String())
 		params.DefinitionContractID = append(params.DefinitionContractID, d.ContractID.String())
 		params.DefinitionIsFxhash = append(params.DefinitionIsFxhash, d.IsFxhash)
+
+		// Community memberships
+		params.CommunityMembershipDbid = append(params.CommunityMembershipDbid, persist.GenerateID().String())
+		params.CommunityMembershipTokenID = append(params.CommunityMembershipTokenID, d.TokenID.ToDecimalTokenID().Numeric())
 		// Defer error checking until now to keep the code above from being
 		// littered with multiline "if" statements
 		if len(errors) > 0 {

--- a/service/multichain/poap/poap.go
+++ b/service/multichain/poap/poap.go
@@ -295,7 +295,7 @@ func (d *Provider) poapToToken(pPoap poapToken) multichain.ChainAgnosticToken {
 
 	return multichain.ChainAgnosticToken{
 		OwnerAddress: persist.Address(pPoap.Owner),
-		TokenID:      persist.TokenID(pPoap.TokenID.toBase16()),
+		TokenID:      persist.HexTokenID(pPoap.TokenID.toBase16()),
 		Descriptors: multichain.ChainAgnosticTokenDescriptors{
 			Name:        pPoap.Event.Name,
 			Description: pPoap.Event.Description,

--- a/service/multichain/reservoir/reservoir.go
+++ b/service/multichain/reservoir/reservoir.go
@@ -61,7 +61,7 @@ func mustCollectionsEndpoint(baseURL string) *url.URL {
 
 type ErrTokenNotFoundByIdentifiers struct {
 	ContractAddress persist.Address
-	TokenID         persist.TokenID
+	TokenID         persist.HexTokenID
 	OwnerAddress    persist.Address
 }
 
@@ -388,7 +388,7 @@ func paginateTokens(ctx context.Context, client *http.Client, req *http.Request,
 	}
 }
 
-func (p *Provider) streamAssetsForToken(ctx context.Context, contractAddress persist.Address, tokenID persist.TokenID, outCh chan<- pageResult) {
+func (p *Provider) streamAssetsForToken(ctx context.Context, contractAddress persist.Address, tokenID persist.HexTokenID, outCh chan<- pageResult) {
 	endpoint := mustTokensEndpoint(p.apiURL)
 	setToken(endpoint, contractAddress, tokenID)
 	paginateTokens(ctx, p.httpClient, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
@@ -412,7 +412,7 @@ func (p *Provider) streamAssetsForWallet(ctx context.Context, addr persist.Addre
 	paginateTokens(ctx, p.httpClient, mustAuthRequest(ctx, endpoint, p.apiKey), outCh)
 }
 
-func (p *Provider) streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, ownerAddress, contractAddress persist.Address, tokenID persist.TokenID, outCh chan<- pageResult) {
+func (p *Provider) streamAssetsForTokenIdentifiersAndOwner(ctx context.Context, ownerAddress, contractAddress persist.Address, tokenID persist.HexTokenID, outCh chan<- pageResult) {
 	endpoint := mustUserTokensEndpoint(p.apiURL, ownerAddress)
 	setLimit(endpoint, 1)
 	setToken(endpoint, contractAddress, tokenID)
@@ -647,7 +647,7 @@ func setLimit(url *url.URL, limit int) {
 	url.RawQuery = query.Encode()
 }
 
-func setToken(url *url.URL, contractAddress persist.Address, tokenID persist.TokenID) {
+func setToken(url *url.URL, contractAddress persist.Address, tokenID persist.HexTokenID) {
 	setTokens(url, []persist.TokenIdentifiers{{ContractAddress: contractAddress, TokenID: tokenID}})
 }
 

--- a/service/multichain/tzkt/tzkt.go
+++ b/service/multichain/tzkt/tzkt.go
@@ -693,7 +693,7 @@ func dedupeBalances(tzTokens []tzktBalanceToken) []tzktBalanceToken {
 	seen := map[string]tzktBalanceToken{}
 	result := make([]tzktBalanceToken, 0, len(tzTokens))
 	for _, t := range tzTokens {
-		id := multichain.ChainAgnosticIdentifiers{ContractAddress: t.Token.Contract.Address, TokenID: persist.TokenID(t.Token.TokenID)}
+		id := multichain.ChainAgnosticIdentifiers{ContractAddress: t.Token.Contract.Address, TokenID: persist.HexTokenID(t.Token.TokenID)}
 		seen[id.String()] = t
 	}
 	for _, t := range seen {

--- a/service/multichain/zora/zora.go
+++ b/service/multichain/zora/zora.go
@@ -610,7 +610,7 @@ func (*Provider) tokenToAgnostic(ctx context.Context, token zoraToken) (multicha
 		},
 		TokenType:       tokenType,
 		TokenMetadata:   token.Metadata,
-		TokenID:         persist.TokenID(token.TokenID.toBase16String()),
+		TokenID:         persist.HexTokenID(token.TokenID.toBase16String()),
 		Quantity:        persist.HexString("1"),
 		OwnerAddress:    persist.Address(strings.ToLower(token.Owner)),
 		ContractAddress: persist.Address(strings.ToLower(token.CollectionAddress)),

--- a/service/persist/membership.go
+++ b/service/persist/membership.go
@@ -17,7 +17,7 @@ type MembershipTier struct {
 	Deleted      NullBool      `json:"-"`
 	LastUpdated  time.Time     `json:"last_updated"`
 	Name         NullString    `json:"name"`
-	TokenID      TokenID       `json:"token_id"`
+	TokenID      HexTokenID    `json:"token_id"`
 	AssetURL     NullString    `json:"asset_url"`
 	Owners       []TokenHolder `json:"owners"`
 }
@@ -42,8 +42,8 @@ func (l *TokenHolderList) Scan(value interface{}) error {
 
 // MembershipRepository represents the interface for interacting with the persisted state of users
 type MembershipRepository interface {
-	UpsertByTokenID(context.Context, TokenID, MembershipTier) error
-	GetByTokenID(context.Context, TokenID) (MembershipTier, error)
+	UpsertByTokenID(context.Context, HexTokenID, MembershipTier) error
+	GetByTokenID(context.Context, HexTokenID) (MembershipTier, error)
 	GetAll(context.Context) ([]MembershipTier, error)
 }
 
@@ -63,7 +63,7 @@ func (o *TokenHolder) Scan(src interface{}) error {
 
 // ErrMembershipNotFoundByTokenID represents an error when a membership is not found by token id
 type ErrMembershipNotFoundByTokenID struct {
-	TokenID TokenID
+	TokenID HexTokenID
 }
 
 // ErrMembershipNotFoundByID represents an error when a membership is not found by its id

--- a/service/persist/opensea.go
+++ b/service/persist/opensea.go
@@ -10,7 +10,7 @@ import (
 type OpenseaNFTID struct {
 	Chain           Chain
 	ContractAddress Address
-	TokenID         TokenID
+	TokenID         HexTokenID
 }
 
 func (o OpenseaNFTID) String() string {
@@ -70,7 +70,7 @@ func (o *OpenseaNFTID) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("invalid opensea token id: %s", split[2])
 		}
 	}
-	o.TokenID = TokenID(asBig.Text(16))
+	o.TokenID = HexTokenID(asBig.Text(16))
 
 	return nil
 }

--- a/service/persist/postgres/membership.go
+++ b/service/persist/postgres/membership.go
@@ -37,13 +37,13 @@ func NewMembershipRepository(db *sql.DB, queries *db.Queries) *MembershipReposit
 }
 
 // UpsertByTokenID upserts the given tier
-func (m *MembershipRepository) UpsertByTokenID(pCtx context.Context, pTokenID persist.TokenID, pTier persist.MembershipTier) error {
+func (m *MembershipRepository) UpsertByTokenID(pCtx context.Context, pTokenID persist.HexTokenID, pTier persist.MembershipTier) error {
 	_, err := m.upsertByTokenIDStmt.ExecContext(pCtx, persist.GenerateID(), pTier.TokenID, pTier.Name, pTier.AssetURL, pq.Array(pTier.Owners), pTier.LastUpdated)
 	return err
 }
 
 // GetByTokenID returns the tier with the given token ID
-func (m *MembershipRepository) GetByTokenID(pCtx context.Context, pTokenID persist.TokenID) (persist.MembershipTier, error) {
+func (m *MembershipRepository) GetByTokenID(pCtx context.Context, pTokenID persist.HexTokenID) (persist.MembershipTier, error) {
 	tier := persist.MembershipTier{TokenID: pTokenID}
 	err := m.getByTokenIDStmt.QueryRowContext(pCtx, pTokenID).Scan(&tier.ID, &tier.CreationTime, &tier.LastUpdated, &tier.Version, &tier.Name, &tier.AssetURL, pq.Array(&tier.Owners))
 	if err != nil {

--- a/service/persist/token_gallery.go
+++ b/service/persist/token_gallery.go
@@ -9,16 +9,16 @@ import (
 
 // TokenIdentifiers represents a unique identifier for a token
 type TokenIdentifiers struct {
-	TokenID         TokenID `json:"token_id"`
-	ContractAddress Address `json:"contract_address"`
-	Chain           Chain   `json:"chain"`
+	TokenID         HexTokenID `json:"token_id"`
+	ContractAddress Address    `json:"contract_address"`
+	Chain           Chain      `json:"chain"`
 }
 
 type TokenUniqueIdentifiers struct {
-	Chain           Chain   `json:"chain"`
-	ContractAddress Address `json:"contract_address"`
-	TokenID         TokenID `json:"token_id"`
-	OwnerAddress    Address `json:"owner_address"`
+	Chain           Chain      `json:"chain"`
+	ContractAddress Address    `json:"contract_address"`
+	TokenID         HexTokenID `json:"token_id"`
+	OwnerAddress    Address    `json:"owner_address"`
 }
 
 // ContractIdentifiers represents a unique identifier for a contract
@@ -28,9 +28,9 @@ type ContractIdentifiers struct {
 }
 
 // NewTokenIdentifiers creates a new token identifiers
-func NewTokenIdentifiers(pContractAddress Address, pTokenID TokenID, pChain Chain) TokenIdentifiers {
+func NewTokenIdentifiers(pContractAddress Address, pTokenID HexTokenID, pChain Chain) TokenIdentifiers {
 	return TokenIdentifiers{
-		TokenID:         TokenID(pTokenID.BigInt().Text(16)),
+		TokenID:         HexTokenID(pTokenID.BigInt().Text(16)),
 		ContractAddress: Address(pChain.NormalizeAddress(pContractAddress)),
 		Chain:           pChain,
 	}
@@ -60,7 +60,7 @@ func (t *TokenIdentifiers) Scan(i interface{}) error {
 		return err
 	}
 	*t = TokenIdentifiers{
-		TokenID:         TokenID(res[1]),
+		TokenID:         HexTokenID(res[1]),
 		ContractAddress: Address(res[0]),
 		Chain:           Chain(chain),
 	}
@@ -81,7 +81,7 @@ func TokenUniqueIdentifiersFromString(s string) (TokenUniqueIdentifiers, error) 
 		return TokenUniqueIdentifiers{}, err
 	}
 	return TokenUniqueIdentifiers{
-		TokenID:         TokenID(res[1]),
+		TokenID:         HexTokenID(res[1]),
 		ContractAddress: Address(res[0]),
 		Chain:           Chain(chain),
 		OwnerAddress:    Address(res[2]),

--- a/service/rpc/rpc.go
+++ b/service/rpc/rpc.go
@@ -93,7 +93,7 @@ type Transfer struct {
 	BlockNumber     persist.BlockNumber
 	From            persist.EthereumAddress
 	To              persist.EthereumAddress
-	TokenID         persist.TokenID
+	TokenID         persist.HexTokenID
 	TokenType       persist.TokenType
 	Amount          uint64
 	ContractAddress persist.EthereumAddress
@@ -618,7 +618,7 @@ func GetHTTPHeaders(ctx context.Context, url string) (http.Header, error) {
 }
 
 // GetTokenURI returns metadata URI for a given token address.
-func GetTokenURI(ctx context.Context, pTokenType persist.TokenType, pContractAddress persist.EthereumAddress, pTokenID persist.TokenID, ethClient *ethclient.Client) (persist.TokenURI, error) {
+func GetTokenURI(ctx context.Context, pTokenType persist.TokenType, pContractAddress persist.EthereumAddress, pTokenID persist.HexTokenID, ethClient *ethclient.Client) (persist.TokenURI, error) {
 
 	contract := pContractAddress.Address()
 	switch pTokenType {
@@ -677,7 +677,7 @@ func GetTokenURI(ctx context.Context, pTokenType persist.TokenType, pContractAdd
 }
 
 // RetryGetTokenURI calls GetTokenURI with backoff.
-func RetryGetTokenURI(ctx context.Context, tokenType persist.TokenType, contractAddress persist.EthereumAddress, tokenID persist.TokenID, ethClient *ethclient.Client) (persist.TokenURI, error) {
+func RetryGetTokenURI(ctx context.Context, tokenType persist.TokenType, contractAddress persist.EthereumAddress, tokenID persist.HexTokenID, ethClient *ethclient.Client) (persist.TokenURI, error) {
 	var u persist.TokenURI
 	var err error
 	for i := 0; i < retry.DefaultRetry.Tries; i++ {
@@ -691,7 +691,7 @@ func RetryGetTokenURI(ctx context.Context, tokenType persist.TokenType, contract
 }
 
 // GetBalanceOfERC1155Token returns the balance of an ERC1155 token
-func GetBalanceOfERC1155Token(ctx context.Context, pOwnerAddress, pContractAddress persist.EthereumAddress, pTokenID persist.TokenID, ethClient *ethclient.Client) (*big.Int, error) {
+func GetBalanceOfERC1155Token(ctx context.Context, pOwnerAddress, pContractAddress persist.EthereumAddress, pTokenID persist.HexTokenID, ethClient *ethclient.Client) (*big.Int, error) {
 	contract := common.HexToAddress(string(pContractAddress))
 	owner := common.HexToAddress(string(pOwnerAddress))
 	instance, err := contracts.NewIERC1155(contract, ethClient)
@@ -710,7 +710,7 @@ func GetBalanceOfERC1155Token(ctx context.Context, pOwnerAddress, pContractAddre
 }
 
 // GetOwnerOfERC721Token returns the Owner of an ERC721 token
-func GetOwnerOfERC721Token(ctx context.Context, pContractAddress persist.EthereumAddress, pTokenID persist.TokenID, ethClient *ethclient.Client) (persist.EthereumAddress, error) {
+func GetOwnerOfERC721Token(ctx context.Context, pContractAddress persist.EthereumAddress, pTokenID persist.HexTokenID, ethClient *ethclient.Client) (persist.EthereumAddress, error) {
 	contract := common.HexToAddress(string(pContractAddress))
 
 	instance, err := contracts.NewIERC721Caller(contract, ethClient)

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -206,6 +206,10 @@ sql:
           - column: 'reported_posts.reason'
             go_type: 'github.com/mikeydub/go-gallery/service/persist.ReportReason'
 
+          # Token community memberships
+          - column: 'token_community_memberships.token_id'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.DecimalTokenID'
+
           # Wildcards
           # Note: to override one of these wildcard entries, add a more specific entry (like some_table.id) above.
           # Format is schema.table.column; where *.*.<column> applies to all schemas and tables.

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -166,7 +166,7 @@ sql:
 
           # Merch
           - column: 'merch.token_id'
-            go_type: 'github.com/mikeydub/go-gallery/service/persist.TokenID'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.HexTokenID'
 
           # pii.AccountCreationInfo
           - column: pii.account_creation_info.ip_address
@@ -190,7 +190,7 @@ sql:
 
           # Token Definitions
           - column: 'token_definitions.token_id'
-            go_type: 'github.com/mikeydub/go-gallery/service/persist.TokenID'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.HexTokenID'
           - column: 'token_definitions.fallback_media'
             go_type: 'github.com/mikeydub/go-gallery/service/persist.FallbackMedia'
           - column: 'token_definitions.token_type'
@@ -250,9 +250,9 @@ sql:
           - column: '*.*.roles'
             go_type: 'github.com/mikeydub/go-gallery/service/persist.RoleList'
           - column: '*.*.tokens_hex'
-            go_type: 'github.com/mikeydub/go-gallery/service/persist.TokenIDList'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.HexTokenIDList'
           - column: '*.*.token_hex'
-            go_type: 'github.com/mikeydub/go-gallery/service/persist.TokenID'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.HexTokenID'
           - column: '*.previews'
             go_type: 'github.com/mikeydub/go-gallery/service/persist.NullString'
           - column: '*.*.*socials'

--- a/tokenprocessing/media.go
+++ b/tokenprocessing/media.go
@@ -544,7 +544,7 @@ func mediaTypeToObjectType(mediaType persist.MediaType, startType objectType) ob
 
 type cachedMediaObject struct {
 	MediaType       persist.MediaType
-	TokenID         persist.TokenID
+	TokenID         persist.HexTokenID
 	ContractAddress persist.Address
 	Chain           persist.Chain
 	ContentType     string

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -31,9 +31,9 @@ import (
 )
 
 type ProcessMediaForTokenInput struct {
-	TokenID         persist.TokenID `json:"token_id" binding:"required"`
-	ContractAddress persist.Address `json:"contract_address" binding:"required"`
-	Chain           persist.Chain   `json:"chain"`
+	TokenID         persist.HexTokenID `json:"token_id" binding:"required"`
+	ContractAddress persist.Address    `json:"contract_address" binding:"required"`
+	Chain           persist.Chain      `json:"chain"`
 }
 
 func processBatch(tp *tokenProcessor, queries *db.Queries, taskClient *task.Client, tm *tokenmanage.Manager) gin.HandlerFunc {

--- a/tokenprocessing/tokenprocessing.go
+++ b/tokenprocessing/tokenprocessing.go
@@ -174,7 +174,7 @@ func reportJobError(ctx context.Context, err error, job tokenProcessingJob) {
 	})
 }
 
-func setTokenTags(scope *sentry.Scope, chain persist.Chain, contractAddress persist.Address, tokenID persist.TokenID) {
+func setTokenTags(scope *sentry.Scope, chain persist.Chain, contractAddress persist.Address, tokenID persist.HexTokenID) {
 	scope.SetTag("chain", fmt.Sprintf("%d", chain))
 	scope.SetTag("contractAddress", contractAddress.String())
 	scope.SetTag("nftID", string(tokenID))
@@ -185,7 +185,7 @@ func setTokenTags(scope *sentry.Scope, chain persist.Chain, contractAddress pers
 	scope.SetTag("assetURL", assetPage)
 }
 
-func assetURL(chain persist.Chain, contractAddress persist.Address, tokenID persist.TokenID) string {
+func assetURL(chain persist.Chain, contractAddress persist.Address, tokenID persist.HexTokenID) string {
 	switch chain {
 	case persist.ChainETH:
 		return fmt.Sprintf("https://opensea.io/assets/ethereum/%s/%d", contractAddress.String(), tokenID.ToInt())
@@ -198,7 +198,7 @@ func assetURL(chain persist.Chain, contractAddress persist.Address, tokenID pers
 	}
 }
 
-func setTokenContext(scope *sentry.Scope, chain persist.Chain, contractAddress persist.Address, tokenID persist.TokenID, isSpam bool) {
+func setTokenContext(scope *sentry.Scope, chain persist.Chain, contractAddress persist.Address, tokenID persist.HexTokenID, isSpam bool) {
 	scope.SetContext(sentryTokenContextName, sentry.Context{
 		"Chain":           chain,
 		"ContractAddress": contractAddress,

--- a/util/numbers.go
+++ b/util/numbers.go
@@ -6,26 +6,27 @@ import (
 )
 
 // RemoveLeftPaddedZeros is a function that removes the left padded zeros from a large hex string
-func RemoveLeftPaddedZeros(hex string) string {
+func RemoveLeftPaddedZeros(str string) string {
 
 	// if string is just 0x, return 0x
-	if hex == "0x" {
+	if str == "0x" {
 		return "0"
 	}
 
-	hex = strings.TrimPrefix(hex, "0x")
+	// If the string is hex, remove the 0x prefix
+	str = strings.TrimPrefix(str, "0x")
 
 	// if string is just a bunch of zeros after 0x, return 0
-	if strings.ReplaceAll(hex, "0", "") == "" {
+	if strings.ReplaceAll(str, "0", "") == "" {
 		return "0"
 	}
 
-	for i := 0; i < len(hex); i++ {
-		if hex[i] != '0' {
-			return hex[i:]
+	for i := 0; i < len(str); i++ {
+		if str[i] != '0' {
+			return str[i:]
 		}
 	}
-	return hex
+	return str
 }
 
 func Base64Decode(s string, encodings ...*base64.Encoding) ([]byte, error) {


### PR DESCRIPTION
## What's new?
- Added a new `persist.DecimalTokenID` type for decimal representation of TokenIDs
- Renamed `TokenID` to `HexTokenID` to distinguish it from `DecimalTokenID`
- Added a new `token_id` column to the `token_community_memberships` table, which will be used in the near future (phase 3!) to speed up community queries and return results ordered by token ID
- Updated `UpsertTokens` to add contract community entries to the `token_community_memberships` table. Previously, only non-contract communities had entries in this table, but moving forward, every community's tokens will be defined by `token_community_memberships`