### PR TITLE
Fix missing unique constraint for "on conflict" check

### DIFF
--- a/db/gen/coredb/community.sql.go
+++ b/db/gen/coredb/community.sql.go
@@ -632,7 +632,7 @@ valid_memberships as (
 insert into token_community_memberships(id, token_definition_id, community_id, token_id, created_at, last_updated, deleted) (
     select id, token_definition_id, community_id, token_id, created_at, last_updated, deleted from valid_memberships
 )
-on conflict (community_id, token_definition_id) where not deleted
+on conflict (token_definition_id, community_id) where not deleted
     do nothing
 returning id, version, token_definition_id, community_id, created_at, last_updated, deleted, token_id
 `

--- a/db/gen/coredb/token_gallery.sql.go
+++ b/db/gen/coredb/token_gallery.sql.go
@@ -190,8 +190,8 @@ with token_definitions_insert as (
     from (
       select unnest($29::varchar[]) as id
         , unnest($30::numeric[]) as token_id
-        , unnest($10) as definition_contract_id
-        , unnest($5) as definition_token_id
+        , unnest($10::varchar[]) as definition_contract_id
+        , unnest($5::varchar[]) as definition_token_id
     ) community_memberships
     join token_definitions_insert on
         community_memberships.definition_contract_id = token_definitions_insert.contract_id
@@ -200,7 +200,7 @@ with token_definitions_insert as (
     -- contract community for this token. Every contract should have a community created for it by the time we get here!
     left join communities on communities.contract_id = community_memberships.definition_contract_id and communities.community_type = 0
   )
-  on conflict (community_id, token_definition_id) where deleted = false
+  on conflict (token_definition_id, community_id) where not deleted
   do update set
     last_updated = excluded.last_updated
   returning id, version, token_definition_id, community_id, created_at, last_updated, deleted, token_id

--- a/db/migrations/core/000155_fix_token_community_memberships_indexes.up.sql
+++ b/db/migrations/core/000155_fix_token_community_memberships_indexes.up.sql
@@ -1,0 +1,4 @@
+drop index if exists token_community_memberships_token_def_id_idx;
+create unique index token_community_memberships_token_definition_community_idx
+    on token_community_memberships(token_definition_id, community_id)
+    where not deleted;

--- a/db/queries/core/community.sql
+++ b/db/queries/core/community.sql
@@ -70,7 +70,7 @@ valid_memberships as (
 insert into token_community_memberships(id, token_definition_id, community_id, token_id, created_at, last_updated, deleted) (
     select * from valid_memberships
 )
-on conflict (community_id, token_definition_id) where not deleted
+on conflict (token_definition_id, community_id) where not deleted
     do nothing
 returning *;
 

--- a/db/queries/core/token_gallery.sql
+++ b/db/queries/core/token_gallery.sql
@@ -131,8 +131,8 @@ with token_definitions_insert as (
     from (
       select unnest(@community_membership_dbid::varchar[]) as id
         , unnest(@community_membership_token_id::numeric[]) as token_id
-        , unnest(@definition_contract_id) as definition_contract_id
-        , unnest(@definition_token_id) as definition_token_id
+        , unnest(@definition_contract_id::varchar[]) as definition_contract_id
+        , unnest(@definition_token_id::varchar[]) as definition_token_id
     ) community_memberships
     join token_definitions_insert on
         community_memberships.definition_contract_id = token_definitions_insert.contract_id
@@ -141,7 +141,7 @@ with token_definitions_insert as (
     -- contract community for this token. Every contract should have a community created for it by the time we get here!
     left join communities on communities.contract_id = community_memberships.definition_contract_id and communities.community_type = 0
   )
-  on conflict (community_id, token_definition_id) where deleted = false
+  on conflict (token_definition_id, community_id) where not deleted
   do update set
     last_updated = excluded.last_updated
   returning *


### PR DESCRIPTION
This PR fixes an issue I created yesterday, where dropping an index on the `token_community_memberships` table and replacing it with a new one inadvertently broke a few `on conflict` clauses that referenced the old constraint.