### PR TITLE
Highlight - catch media processing errors

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -7233,18 +7233,18 @@ func (q *Queries) UpdateHighlightMintClaimStatus(ctx context.Context, arg Update
 	return i, err
 }
 
-const updateHighlightMintClaimStatusTokenSynced = `-- name: UpdateHighlightMintClaimStatusTokenSynced :one
+const updateHighlightMintClaimStatusMediaProcessing = `-- name: UpdateHighlightMintClaimStatusMediaProcessing :one
 update highlight_mint_claims set last_updated = now(), status = $1, token_id = $2 where id = $3 returning id, user_id, chain, contract_address, token_mint_id, token_metadata, recipient_wallet_id, highlight_collection_id, token_id, claim_id, status, error_message, created_at, last_updated, deleted
 `
 
-type UpdateHighlightMintClaimStatusTokenSyncedParams struct {
+type UpdateHighlightMintClaimStatusMediaProcessingParams struct {
 	Status  highlight.ClaimStatus `db:"status" json:"status"`
 	TokenID persist.DBID          `db:"token_id" json:"token_id"`
 	ID      persist.DBID          `db:"id" json:"id"`
 }
 
-func (q *Queries) UpdateHighlightMintClaimStatusTokenSynced(ctx context.Context, arg UpdateHighlightMintClaimStatusTokenSyncedParams) (HighlightMintClaim, error) {
-	row := q.db.QueryRow(ctx, updateHighlightMintClaimStatusTokenSynced, arg.Status, arg.TokenID, arg.ID)
+func (q *Queries) UpdateHighlightMintClaimStatusMediaProcessing(ctx context.Context, arg UpdateHighlightMintClaimStatusMediaProcessingParams) (HighlightMintClaim, error) {
+	row := q.db.QueryRow(ctx, updateHighlightMintClaimStatusMediaProcessing, arg.Status, arg.TokenID, arg.ID)
 	var i HighlightMintClaim
 	err := row.Scan(
 		&i.ID,

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -2028,5 +2028,5 @@ update highlight_mint_claims set last_updated = now(), status = $1, error_messag
 -- name: UpdateHighlightMintClaimStatusTxSucceeded :one
 update highlight_mint_claims set last_updated = now(), status = $1, token_mint_id = $2, token_metadata = $3 where id = @id returning *;
 
--- name: UpdateHighlightMintClaimStatusTokenSynced :one
+-- name: UpdateHighlightMintClaimStatusMediaProcessing :one
 update highlight_mint_claims set last_updated = now(), status = $1, token_id = $2 where id = @id returning *;

--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -12926,7 +12926,6 @@ enum HighlightTxStatus {
   TX_PENDING
   TX_COMPLETE
   TOKEN_SYNCED
-  MINT_FAILED
 }
 
 type HighlightMintClaimStatusPayload @goEmbedHelper {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -3177,19 +3177,17 @@ const (
 	HighlightTxStatusTxPending   HighlightTxStatus = "TX_PENDING"
 	HighlightTxStatusTxComplete  HighlightTxStatus = "TX_COMPLETE"
 	HighlightTxStatusTokenSynced HighlightTxStatus = "TOKEN_SYNCED"
-	HighlightTxStatusMintFailed  HighlightTxStatus = "MINT_FAILED"
 )
 
 var AllHighlightTxStatus = []HighlightTxStatus{
 	HighlightTxStatusTxPending,
 	HighlightTxStatusTxComplete,
 	HighlightTxStatusTokenSynced,
-	HighlightTxStatusMintFailed,
 }
 
 func (e HighlightTxStatus) IsValid() bool {
 	switch e {
-	case HighlightTxStatusTxPending, HighlightTxStatusTxComplete, HighlightTxStatusTokenSynced, HighlightTxStatusMintFailed:
+	case HighlightTxStatusTxPending, HighlightTxStatusTxComplete, HighlightTxStatusTokenSynced:
 		return true
 	}
 	return false

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -2913,17 +2913,14 @@ func (r *queryResolver) HighlightMintClaimStatus(ctx context.Context, claimID pe
 	switch claim.Status {
 	case highlight.ClaimStatusTxPending:
 		return model.HighlightMintClaimStatusPayload{Status: model.HighlightTxStatusTxPending}, nil
-	case highlight.ClaimStatusTxSucceeded:
+	case highlight.ClaimStatusTxSucceeded, highlight.ClaimStatusMediaProcessing:
 		return model.HighlightMintClaimStatusPayload{Status: model.HighlightTxStatusTxComplete}, nil
 	case highlight.ClaimStatusTxFailed:
 		return nil, highlight.ErrHighlightTxnFailed{Msg: claim.ErrorMessage.String}
 	case highlight.ClaimStatusFailedInternal:
-		return model.HighlightMintClaimStatusPayload{
-			HelperHighlightMintClaimStatusPayloadData: model.HelperHighlightMintClaimStatusPayloadData{TokenID: claim.TokenID},
-			Status: model.HighlightTxStatusMintFailed,
-			Token:  nil, // handled by dedicated resolver
-		}, fmt.Errorf("internal error handling mint claim: %s", claim.ErrorMessage.String)
-	case highlight.ClaimStatusMediaProcessed:
+		return nil, fmt.Errorf("error handling mint claim: %s", claim.ErrorMessage.String)
+		// ClaimStatusMediaFailed included since there might be a fallback image and to let the user refresh the token themselves
+	case highlight.ClaimStatusMediaProcessed, highlight.ClaimStatusMediaFailed:
 		return model.HighlightMintClaimStatusPayload{
 			HelperHighlightMintClaimStatusPayloadData: model.HelperHighlightMintClaimStatusPayloadData{TokenID: claim.TokenID},
 			Status: model.HighlightTxStatusTokenSynced,

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -3026,7 +3026,6 @@ enum HighlightTxStatus {
   TX_PENDING
   TX_COMPLETE
   TOKEN_SYNCED
-  MINT_FAILED
 }
 
 type HighlightMintClaimStatusPayload @goEmbedHelper {

--- a/service/multichain/highlight/highlight.go
+++ b/service/multichain/highlight/highlight.go
@@ -15,19 +15,21 @@ import (
 )
 
 const (
-	baseURL                               = "https://api.highlight.xyz:8080"
-	txCodeInitiated                       = "INITIATED"
-	txCodeSent                            = "TX_SENT"
-	txCodeReverted                        = "TX_REVERTED"
-	txCodeCancelled                       = "TX_CANCELLED"
-	txCodeComplete                        = "TX_COMPLETE"
-	claimCodeMintUnavailable              = "MINT_UNAVAILABLE"
-	ClaimStatusTxPending      ClaimStatus = "TX_PENDING"
-	ClaimStatusTxFailed       ClaimStatus = "TX_FAILED"
-	ClaimStatusTxSucceeded    ClaimStatus = "TX_SUCCEEDED"
-	ClaimStatusTokenSynced    ClaimStatus = "TOKEN_SYNCED"
-	ClaimStatusMediaProcessed ClaimStatus = "TOKEN_MEDIA_PROCESSED"
-	ClaimStatusFailedInternal ClaimStatus = "FAILED_INTERNAL"
+	baseURL                  = "https://api.highlight.xyz:8080"
+	txCodeInitiated          = "INITIATED"
+	txCodeSent               = "TX_SENT"
+	txCodeReverted           = "TX_REVERTED"
+	txCodeCancelled          = "TX_CANCELLED"
+	txCodeComplete           = "TX_COMPLETE"
+	claimCodeMintUnavailable = "MINT_UNAVAILABLE"
+	// Lifecycle of a highlight mint
+	ClaimStatusTxPending       ClaimStatus = "TX_PENDING"
+	ClaimStatusTxFailed        ClaimStatus = "TX_FAILED"
+	ClaimStatusTxSucceeded     ClaimStatus = "TX_SUCCEEDED"
+	ClaimStatusMediaProcessing ClaimStatus = "MEDIA_PROCESSING"
+	ClaimStatusMediaProcessed  ClaimStatus = "MEDIA_PROCESSED"
+	ClaimStatusMediaFailed     ClaimStatus = "MEDIA_FAILED"
+	ClaimStatusFailedInternal  ClaimStatus = "FAILED_INTERNAL"
 )
 
 var ErrHighlightChainNotSupported = errors.New("chain is not supported by highlight")


### PR DESCRIPTION
**Changes:**
* Renames `ClaimStatusTokenSynced` from `TOKEN_SYNCED` to `MEDIA_PROCESSING`
* Adds new status `ClaimStatusMediaFailed` to indicate that the media pipeline failed after too many tries
* Updates resolver to still return data when status is `ClaimStatusMediaFailed`