### PR TITLE
Add verified email addresses to the SendGrid marketing list

### DIFF
--- a/emails/emails.go
+++ b/emails/emails.go
@@ -87,6 +87,7 @@ func setDefaults() {
 	viper.SetDefault("SENDGRID_VALIDATION_KEY", "")
 	viper.SetDefault("FROM_EMAIL", "test@gallery.so")
 	viper.SetDefault("SENDGRID_DEFAULT_LIST_ID", "865cea98-bf23-4ca3-a8d7-2dc9ea29951b")
+	viper.SetDefault("SENDGRID_MARKETING_LIST_ID", "")
 	viper.SetDefault("SENDGRID_NOTIFICATIONS_TEMPLATE_ID", "d-6135d8f36e9946979b0dcf1800363ab4")
 	viper.SetDefault("SENDGRID_VERIFICATION_TEMPLATE_ID", "d-b575d54dc86d40fdbf67b3119589475a")
 	viper.SetDefault("SENDGRID_DIGEST_TEMPLATE_ID", "d-0b9b6b0b0b5e4b6e9b0b0b5e4b6e9b0b")

--- a/emails/verify.go
+++ b/emails/verify.go
@@ -104,7 +104,8 @@ func verifyEmail(queries *coredb.Queries) gin.HandlerFunc {
 			return
 		}
 
-		err = addEmailToSendgridList(c, verifiedEmail.String(), env.GetString("SENDGRID_DEFAULT_LIST_ID"))
+		lists := []string{env.GetString("SENDGRID_DEFAULT_LIST_ID"), env.GetString("SENDGRID_MARKETING_LIST_ID")}
+		err = addEmailToSendgridList(c, verifiedEmail.String(), lists)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return
@@ -138,7 +139,8 @@ func processAddToMailingList(queries *coredb.Queries) gin.HandlerFunc {
 			return
 		}
 
-		err = addEmailToSendgridList(c, userWithPII.PiiVerifiedEmailAddress.String(), env.GetString("SENDGRID_DEFAULT_LIST_ID"))
+		lists := []string{env.GetString("SENDGRID_DEFAULT_LIST_ID"), env.GetString("SENDGRID_MARKETING_LIST_ID")}
+		err = addEmailToSendgridList(c, userWithPII.PiiVerifiedEmailAddress.String(), lists)
 		if err != nil {
 			util.ErrResponse(c, http.StatusInternalServerError, err)
 			return
@@ -185,13 +187,13 @@ type sendgridContact struct {
 	CustomFields map[string]interface{} `json:"custom_fields"`
 }
 
-func addEmailToSendgridList(ctx context.Context, email string, listID string) error {
+func addEmailToSendgridList(ctx context.Context, email string, listIDs []string) error {
 
 	request := sendgrid.GetRequest(env.GetString("SENDGRID_API_KEY"), "/v3/marketing/contacts", "https://api.sendgrid.com")
 	request.Method = "PUT"
 
 	contacts := sendgridContacts{
-		ListIDs: []string{listID},
+		ListIDs: listIDs,
 		Contacts: []sendgridContact{
 			{
 				Email: email,

--- a/secrets/dev/emails-server-env.yaml
+++ b/secrets/dev/emails-server-env.yaml
@@ -16,6 +16,7 @@ FROM_EMAIL: ENC[AES256_GCM,data:6bRg4a7tBfs9zVYv20nMGGWcVbCSJ+WF,iv:y948sCRNq6e+
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:VlWVTKpgHTAtAXlOaKURYWM3XUinX/bVq7bPYFkVlsi4pA==,iv:+CM/xBzHYyGiBrL1ncagkp9Nhrkz2CAhyIoUoFqsOVU=,tag:/ChuQfA8IlXbYQjmUe3rMA==,type:str]
 SENDGRID_DIGEST_TEMPLATE_ID: ENC[AES256_GCM,data:6P8LFYtgyrjW9MhPVZrE8kmZ2X5KkCo3fxlxvGq8Y+ajXA==,iv:rNTRzgMoXyFzTxK24rN/LPlqYw81fSL+hZXrd7EwGOY=,tag:oeFM8aMuofWGvYJiPJK5gA==,type:str]
 SENDGRID_VERIFICATION_TEMPLATE_ID: ENC[AES256_GCM,data:eHCDyF5BxRcbY6eZ1vzlJhMNCgfjMGeEnZY1FMEdD0cVKQ==,iv:l2YPYWUdiq4bmDS5JRSzmPqTc0uWAShd66ck1he+rU0=,tag:PUNs6SC5hSwTkOooZknuPA==,type:str]
+SENDGRID_MARKETING_LIST_ID: ENC[AES256_GCM,data:Yh/FZ14fG1WLxRbO6tWS7DbsOh/JJ46AvrWPS8Pv7UgYQG94,iv:AGyErBpi676WdH9eTrwHm6lvWWfe4qaeFPiUXw8lfYk=,tag:QXlruOVhbxNK4i/acmPNEg==,type:str]
 ADMIN_PASS: ENC[AES256_GCM,data:e3KL5ArncPTMZNQ2zqxDDqzYdw0=,iv:c/nc/nUaQdH3/VXvs7/2+ehXILIUbba1c6fkolHoM0A=,tag:JflvT3ZM5gAXqIYbpcv3Pg==,type:str]
 BASIC_AUTH_TOKEN_RETOOL: ENC[AES256_GCM,data:3b4ZuuZO0hlNhV+xeMTnc2/UUJ8Ut9TUdg+41B8m,iv:PdemmgXiWmNxYpFvyBSNvBryZWwar4/DfuQUQKlyGxk=,tag:7H3isUuEy2aHZrXew0a40A==,type:str]
 BASIC_AUTH_TOKEN_MONITORING: ENC[AES256_GCM,data:F9md+f06kywP9Tve72tp9KvTL0mBNVHmCoenWdtm,iv:0/1yFhelMCsO45ogTmI8ihPbKJWi+C7EcmlcJ71C7Kw=,tag:eh6LWFeGh/0ZSKrDvxwq2g==,type:str]
@@ -35,8 +36,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-21T18:49:48Z"
-    mac: ENC[AES256_GCM,data:B2EfhS56wVoULBAKCLQBv7k50NGBHom/E/ebm8vN86UIsdrN+ZAHLeURLnMI3MaNAjl1s/6nErK0m/kCuOmmqeRErwRTLJDtIVJ76oH2OHLIZvSNs4idHDEF+3DWVEc3JH+7R9oGjCQ0VZ+iM2T1C51K+SvcugVNwJiru15uni8=,iv:VedCGM/IE8dCf2V9001i/iJePqGzaMvBluuZYJCTVFg=,tag:BNUNIZ3CaXNzcgCwLDeRqA==,type:str]
+    lastmodified: "2024-03-19T17:37:57Z"
+    mac: ENC[AES256_GCM,data:B5LY2epUXFp4gTClVxTfoPYrBolCAyfCZY3cuda4WIV9i+t1gkuI09dyOWBzdqB6c0X7ITA7/xm/Q2cLPB6VHVcrnqLpbWiOiM9SDTq+guafuAxQKD9tCz1Vh0+iaF6UVOLET4Ie9e2QNgyQ4Tf6tdpMldzsbZEaLEsUsJed0d4=,iv:wuRofDvlMo2vAflHeHSv+vnHaji92YFGYid8Ib+t+oA=,tag:8s8Vw6FDX79wAVFyhwK5WQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-emails.yaml
+++ b/secrets/dev/local/app-dev-emails.yaml
@@ -6,6 +6,7 @@ SENDGRID_VALIDATION_KEY: ENC[AES256_GCM,data:6X2ZW++8NiHbDOvp1MOtkGoJF1/z6RdIvNF
 SENDGRID_DIGEST_TEMPLATE_ID: ENC[AES256_GCM,data:362r+ZuSxkttt9gMXshbVnKJGoz1IzP4K21GES2xGAj4yQ==,iv:MV2u7e0E8neSGaWor11NqkzISvifHT75V8VCJvdKZCA=,tag:OxUAe8MW9KYmthTt0U3+pw==,type:str]
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:Xc0dGaaONHCjo0ScozOBGWPXmCUPDIOJmxIODehzc9JwsQ==,iv:EQvur2c7bi5NFaMfnXep8E9zd0pPCZJu25y0hoW/WyM=,tag:wtg+r0Kp69MlZirH0cDgfA==,type:str]
 SENDGRID_VERIFICATION_TEMPLATE_ID: ENC[AES256_GCM,data:VgJVguiNqi7KQCChlSBsthOeOJEO5wWW7RZe7z+/jSJmLg==,iv:GLMo9mWQhItbHphLPDlnqI17q2CFIId/cwkZG4JEFLA=,tag:HPLqHyhpWGVd/dT1IhgA9g==,type:str]
+SENDGRID_MARKETING_LIST_ID: ENC[AES256_GCM,data:rdWZVmVyGIlgQPp1YvgRrVJAM+jviqUWIPalwHTEOYBoPn20,iv:IslfZsrgk/OQx6UfM4WcLYrkPqACJZ5svDHQBOvYyAQ=,tag:zMDU5Vt66qxZmq72GMu+ww==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:rDeLsG0xnWCf,iv:bkqEm2TSwjtnKRDeHCChCuYbb5k2iQl2l5LQ7J5yql4=,tag:xdRDhIFPm2wZKOIsbCaOeA==,type:str]
 POSTGRES_PORT: ENC[AES256_GCM,data:NKLFdQ==,iv:fv9QGzMQsVtLiUiEYFZsRYcv0ZhlEcHUprl3MkE+HMU=,tag:SoWlV2tmUIdLX4ASpTRCwA==,type:str]
 POSTGRES_USER: ENC[AES256_GCM,data:/cJ3lRJR1b5Fp6TxIeFh,iv:8Vc226u1PDKw1uhLpu5ljr3FFDoW7WgtKVQuiJowaDk=,tag:MT6WdZ1ljqEZ5pxb0OX62w==,type:str]
@@ -22,8 +23,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-01-24T01:51:23Z"
-    mac: ENC[AES256_GCM,data:aUqQMGtOrqrHgtSkp6HDzlbJnoQM/Q7JpUKuZ6QBwSCPekHMsTwnNM+yth+5piq+o4LQB20+AAfSeyKaZZ4PZvSqh1C3h0ncirdZCcATfMQmX0cNhZHH2ikrqQAwq5GraJeGExoybwbIcwx/JTU18f0oWa+WS6K4jwE5csC0qr8=,iv:s5WFJ6CZ7GlntRfzVc5AiLtVhyLo7D816554+2sbK+o=,tag:PV6++JJtTVoz5Wjz+89Mxw==,type:str]
+    lastmodified: "2024-03-19T17:38:11Z"
+    mac: ENC[AES256_GCM,data:Lqi6jdyKWSdGKWhhWkmlyUC75uywtmTBKv9VeEUPpy37uQ4ofN3cyd+KNIOcAPO1CxM7Cr+324FWzv6A2EedVPoKZCFFTuwVcbWYdSHhDATRw0bD6cRvgrhZfzJu2FrS0eAbWZuUI+tcA4kNWnemBck0y6JPCFFJQsKwfPgtwdQ=,iv:CrOjnQX3q+3nZ4oZsf3qe20y9wS8Cahv3AgNxfqG0bQ=,tag:fvygGuNuBxuLLMEDOYrnAQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/local/local/app-local-emails.yaml
+++ b/secrets/local/local/app-local-emails.yaml
@@ -6,6 +6,7 @@ SENDGRID_VALIDATION_KEY: ENC[AES256_GCM,data:Yx8d2pO2TL0lMqYfSscrrv9n9qtYnWACy8S
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:+PmeNqQhZT77GCbjZIVqSw3vQBASrTXKjKzqzBIy1yfQbg==,iv:mJwv4X7rD6VW5FdAIvh4oPmsBCPMGHl352DPCTZrrQ4=,tag:5kMXWqN3y0AlupgUOfahhg==,type:str]
 SENDGRID_DIGEST_TEMPLATE_ID: ENC[AES256_GCM,data:h541W+0JEg1BW5X+kie+ZFy/oSLIIUggcyGC6kUvWaIWig==,iv:CaLQkUOiE/kn+62C4xHTLuNkjYhq4jgl+PlP3mOEN+E=,tag:HPMZEh4eH0vHdHbah+3dqg==,type:str]
 SENDGRID_VERIFICATION_TEMPLATE_ID: ENC[AES256_GCM,data:GwZ+AZP/JbuokUI43t3L2DyJAPTUM6q1Muh091JvhrUrFQ==,iv:1Z7GGX4G9916yXbLpNZJ2subxmkaELWel81PKFA8Zio=,tag:s/riIcloflDyWabAjDgYAA==,type:str]
+SENDGRID_MARKETING_LIST_ID: ENC[AES256_GCM,data:g/qOLHo0QYla1vpeo/q6H1hp8hwwBQ9pDH0qyMnHIoFUbEdL,iv:DVJCB3JK061wcDCVhVHg3LFaDQJWEQJzh0XFGGpCpH4=,tag:pLM7o4SXaam5kKIlHyfQEg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -15,8 +16,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-01-24T02:00:45Z"
-    mac: ENC[AES256_GCM,data:mVMs6vVcGV/LPB/r3pUNST7RBrX8wqvaNRvjl8KZTYe6xUXmeF2mn/ZKk8y3YfUQ5lnlBKWDzE5UeN8AEwM7j+3wKJtovC48Vm2Db0jmsxTVytbGtTBjo5McpaBI6R8ITqPNrh7Ll3k2txbIggCS5Gapp+cEcpd3n4efWiFxzuA=,iv:1qc74jorOINMv5YKmfgMJj1XCpp/IrRfDFcldLfI4GM=,tag:hWixjvmfPL6exkCLg485mA==,type:str]
+    lastmodified: "2024-03-19T17:38:41Z"
+    mac: ENC[AES256_GCM,data:CAKi2rCyXXyd71sJWiAm53OjixZty9iRLyQxGzZO6/BWmeJ598icS4weBG0UC9QulIHZKtKq9SJ6q8CyNmpokLhbaLdv07giIOjQXkAE1ffpjB2XjYW3CO58jHvGt6vyG7Qw+HSzU7PJTEVxEOW3uypkqh0bwM8hwsYH6pvhsb8=,iv:k+dcPFjADODmb/9NzkVxahJWJ3PKFjPknsDxWXgr1sQ=,tag:Jp4jDrHfnwGlfjXPlGg9EQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/emails-server-env.yaml
+++ b/secrets/prod/emails-server-env.yaml
@@ -16,6 +16,7 @@ FROM_EMAIL: ENC[AES256_GCM,data:kgYIedXo/ld5vYWG/R4Np3vN3eemGKKD,iv:cW7ZecgzTPdw
 SENDGRID_NOTIFICATIONS_TEMPLATE_ID: ENC[AES256_GCM,data:BYyNEnFaxn62sHkEI+AyIWHnFotWL9qOE2qRVBg440kGlA==,iv:MUE8LMimE87sgATUfsqS8Nv+TvDOmQG0CfPUbjHQ/Sw=,tag:lVbHfh1tRkAKG6ONrYtIPw==,type:str]
 SENDGRID_DIGEST_TEMPLATE_ID: ENC[AES256_GCM,data:he+6VLOznumBAuNBmutgNmDAIBTEvvY1SC2b8Mpgp+yHzg==,iv:tlFfk6fIOyuzPgkgBUEbqxrLvHkgWgXhZXKTf2Um42s=,tag:xZvTow2WRF8bdBWFm8nfAw==,type:str]
 SENDGRID_VERIFICATION_TEMPLATE_ID: ENC[AES256_GCM,data:uqHHDvtHBXsYxx3jquk0cTxl1fJmYjp5P61MRAM3vElmTg==,iv:D2V5Us4UlUzc9Y2/QNIseFbMg5SS2VnsTh9dylyGWi0=,tag:Mf1eVe3KjtbYNVCNtwyGag==,type:str]
+SENDGRID_MARKETING_LIST_ID: ENC[AES256_GCM,data:DIdAG+oEQ8Sh7w3j1dqx99NyjthYrxVWmXm4j3tBA8b7Gi7D,iv:1+4XZAUrA80LWauuiGvJB4FJg0EU6twcsgIjM/oK/kA=,tag:xY6V6iI1hvZdvLFzNu31hQ==,type:str]
 ADMIN_PASS: ENC[AES256_GCM,data:0a5zN+TnXU9aysMCI+Gz2nqXmU8=,iv:wn6sQ1uxF1uoqyEfOU8/Gdkyazx+4CvevJU/P4IgZ1Q=,tag:3/bR0V9H1rEpymCE85oHAA==,type:str]
 GOOGLE_CLOUD_PROJECT: ENC[AES256_GCM,data:WHjiJNS8slNKJQU9+3Un8cGh8w==,iv:dTgkj/bxhSL7ME1Ocivi+C/ZyHjyeoEUk6cD3fabkOw=,tag:ByguVZxWzWeOJZwP1jS7qA==,type:str]
 BASIC_AUTH_TOKEN_RETOOL: ENC[AES256_GCM,data:nhWccpDIZgplDLyFSCcBhKVYHpX+JPlPCGvlvza9,iv:qvXO9pMsdBFHhFyQgtnAcybmI/ChUAYyElgAoa1CovI=,tag:4rrSaRnvUyuk4l9jPpgGcw==,type:str]
@@ -37,8 +38,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-03-15T18:06:24Z"
-    mac: ENC[AES256_GCM,data:Ld+m3xYLuflUZhtXoCaMrbExMmB56OpnI1885ijFb/cunckl0/NH5fECELIAMFIlshkvrWehPcLdPdAY6SRMhCQBvUf8tfJFgsa5NXClL0UmPGpWbqITItW3fjzYMfvO2oAbuIvnVW6d7OQJuCMz5Fu5jyyO1LUwUUNnHWgtMtA=,iv:1IC5SkfTED7jAotl/63Rlk8/5WRucRagvwvzeuWNHRY=,tag:Yl5xpihfUvTbOJqWRqdx/w==,type:str]
+    lastmodified: "2024-03-19T17:37:42Z"
+    mac: ENC[AES256_GCM,data:iYzmsjM47kBcsYnWY/0tkZun4nkR1C4ApVSpBrjNiBn2TqV+3TNptpy/QYFyuFuz0zgt+Zvsx57VRqm1c6vgYEUya98L/EdXHAxgGx395eyRTRmmJu3WndpZOJv9IOJDYwbtMyzjtCkWXm2o3HHpNVmXTVg6ZdVWECl5YH4zC/A=,iv:CeZtPMYWLLzFQf9CwR/bZrVY8fbv4rU8IH8fHDSGKdc=,tag:feofa2na5g7xcrd5LhaEAQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
This PR auto-adds verified email addresses to the marketing list so they don't need to be added manually.