### PR TITLE
Get rid of the ActiveStatus property on NeynarUser

### DIFF
--- a/autosocial/handler.go
+++ b/autosocial/handler.go
@@ -201,13 +201,13 @@ func addFarcasterProfilesToUsers(ctx context.Context, n *farcaster.NeynarAPI, ad
 		u := fusers[0]
 
 		for _, fuser := range fusers {
-			if fuser.Fid.String() != "" && fuser.ActiveStatus == "active" {
+			if fuser.Fid.String() != "" {
 				u = fuser
 				break
 			}
 		}
 
-		if u.ActiveStatus != "active" || u.Fid.String() == "" {
+		if u.Fid.String() == "" {
 			continue
 		}
 

--- a/service/farcaster/neynar.go
+++ b/service/farcaster/neynar.go
@@ -113,7 +113,6 @@ type NeynarUser struct {
 			Text string `json:"text"`
 		} `json:"bio"`
 	} `json:"profile"`
-	ActiveStatus string `json:"active_status"`
 }
 
 type NeynarUserByVerificationResponse struct {


### PR DESCRIPTION
ActiveStatus doesn't actually mean what we thought it did, and it's no longer being used. This fixes an issue where we intentionally didn't associate a user's Farcaster account if they were "inactive"
