### PR TITLE
Add restrictEnvironment to mint mutation

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -13048,6 +13048,7 @@ type Mutation {
   deletePost(postId: DBID!): DeletePostPayloadOrError @authRequired
 
   highlightClaimMint(input: HighlightClaimMintInput!): HighlightClaimMintPayloadOrError
+    @restrictEnvironment(allowed: ["local", "development", "sandbox"])
     @authRequired
 
   viewGallery(galleryId: DBID!): ViewGalleryPayloadOrError
@@ -41374,13 +41375,23 @@ func (ec *executionContext) _Mutation_highlightClaimMint(ctx context.Context, fi
 			return ec.resolvers.Mutation().HighlightClaimMint(rctx, fc.Args["input"].(model.HighlightClaimMintInput))
 		}
 		directive1 := func(ctx context.Context) (interface{}, error) {
+			allowed, err := ec.unmarshalNString2ᚕstringᚄ(ctx, []interface{}{"local", "development", "sandbox"})
+			if err != nil {
+				return nil, err
+			}
+			if ec.directives.RestrictEnvironment == nil {
+				return nil, errors.New("directive restrictEnvironment is not implemented")
+			}
+			return ec.directives.RestrictEnvironment(ctx, nil, directive0, allowed)
+		}
+		directive2 := func(ctx context.Context) (interface{}, error) {
 			if ec.directives.AuthRequired == nil {
 				return nil, errors.New("directive authRequired is not implemented")
 			}
-			return ec.directives.AuthRequired(ctx, nil, directive0)
+			return ec.directives.AuthRequired(ctx, nil, directive1)
 		}
 
-		tmp, err := directive1(rctx)
+		tmp, err := directive2(rctx)
 		if err != nil {
 			return nil, graphql.ErrorOnPath(ctx, err)
 		}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -3148,6 +3148,7 @@ type Mutation {
   deletePost(postId: DBID!): DeletePostPayloadOrError @authRequired
 
   highlightClaimMint(input: HighlightClaimMintInput!): HighlightClaimMintPayloadOrError
+    @restrictEnvironment(allowed: ["local", "development", "sandbox"])
     @authRequired
 
   viewGallery(galleryId: DBID!): ViewGalleryPayloadOrError


### PR DESCRIPTION
Adds `@restrictEnvironment` directive so test tokens aren't created on prod.