### PR TITLE
Try to look up a user by email address when using Privy login

### DIFF
--- a/service/auth/privy/privy.go
+++ b/service/auth/privy/privy.go
@@ -63,6 +63,18 @@ func (a PrivyAuthenticator) Authenticate(ctx context.Context) (*auth.AuthResult,
 		user = &u
 	}
 
+	// If we didn't find a user by Privy DID, see if we can find one by verified email address
+	if user == nil && details.EmailAddress != nil {
+		u, err = a.queries.GetUserByVerifiedEmailAddress(ctx, string(*details.EmailAddress))
+		if err != nil {
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return nil, err
+			}
+		} else {
+			user = &u
+		}
+	}
+
 	authResult := auth.AuthResult{
 		User:     user,
 		Email:    details.EmailAddress,


### PR DESCRIPTION
This PR adds an extra user lookup step during Privy login. If we can't find an existing Gallery user via Privy DID, now we'll also try to find an existing Gallery user by verified email address.