### PR TITLE
Add optional authenticator when updating an email address

### DIFF
--- a/graphql/generated/generated.go
+++ b/graphql/generated/generated.go
@@ -11913,8 +11913,10 @@ input NeynarAuth {
   message: String!
   signature: String! @scrub
 
-  """primaryPubKey is an optional parameter that lets callers specify a different wallet to use with Gallery, provided
-  that both primaryPubKey and the required custodyPubKey are owned by the same Neynar user"""
+  """
+  primaryPubKey is an optional parameter that lets callers specify a different wallet to use with Gallery, provided
+  that both primaryPubKey and the required custodyPubKey are owned by the same Neynar user
+  """
   primaryPubKey: ChainPubKeyInput
 }
 
@@ -12412,6 +12414,9 @@ union VerifyEmailMagicLinkPayloadOrError = VerifyEmailMagicLinkPayload | ErrInva
 
 input UpdateEmailInput {
   email: Email! @scrub
+  """authMechanism is an optional parameter that can verify a user's email address in lieu of sending
+  a verification email to the user. If not provided, a verification email will be sent."""
+  authMechanism: AuthMechanism
 }
 
 type UpdateEmailPayload {
@@ -71676,7 +71681,7 @@ func (ec *executionContext) unmarshalInputUpdateEmailInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"email"}
+	fieldsInOrder := [...]string{"email", "authMechanism"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -71690,6 +71695,13 @@ func (ec *executionContext) unmarshalInputUpdateEmailInput(ctx context.Context, 
 				return it, err
 			}
 			it.Email = data
+		case "authMechanism":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("authMechanism"))
+			data, err := ec.unmarshalOAuthMechanism2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAuthMechanism(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AuthMechanism = data
 		}
 	}
 
@@ -96894,6 +96906,14 @@ func (ec *executionContext) marshalOArtBlocksCommunityKey2ᚖgithubᚗcomᚋmike
 		return graphql.Null
 	}
 	return ec._ArtBlocksCommunityKey(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOAuthMechanism2ᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐAuthMechanism(ctx context.Context, v interface{}) (*model.AuthMechanism, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputAuthMechanism(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOBadge2ᚕᚖgithubᚗcomᚋmikeydubᚋgoᚑgalleryᚋgraphqlᚋmodelᚐBadge(ctx context.Context, sel ast.SelectionSet, v []*model.Badge) graphql.Marshaler {

--- a/graphql/model/models_gen.go
+++ b/graphql/model/models_gen.go
@@ -1959,7 +1959,7 @@ type NeynarAuth struct {
 	Message       string               `json:"message"`
 	Signature     string               `json:"signature"`
 	// primaryPubKey is an optional parameter that lets callers specify a different wallet to use with Gallery, provided
-	//   that both primaryPubKey and the required custodyPubKey are owned by the same Neynar user
+	// that both primaryPubKey and the required custodyPubKey are owned by the same Neynar user
 	PrimaryPubKey *persist.ChainPubKey `json:"primaryPubKey"`
 }
 
@@ -2860,6 +2860,9 @@ func (UpdateCollectionTokensPayload) IsUpdateCollectionTokensPayloadOrError() {}
 
 type UpdateEmailInput struct {
 	Email persist.Email `json:"email"`
+	// authMechanism is an optional parameter that can verify a user's email address in lieu of sending
+	//   a verification email to the user. If not provided, a verification email will be sent.
+	AuthMechanism *AuthMechanism `json:"authMechanism"`
 }
 
 type UpdateEmailNotificationSettingsInput struct {

--- a/graphql/resolver/schema.resolvers.go
+++ b/graphql/resolver/schema.resolvers.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/mikeydub/go-gallery/service/auth"
 	"strconv"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -1429,7 +1430,17 @@ func (r *mutationResolver) CreateUser(ctx context.Context, authMechanism model.A
 
 // UpdateEmail is the resolver for the updateEmail field.
 func (r *mutationResolver) UpdateEmail(ctx context.Context, input model.UpdateEmailInput) (model.UpdateEmailPayloadOrError, error) {
-	return updateUserEmail(ctx, input.Email)
+	var authenticator *auth.Authenticator
+
+	if input.AuthMechanism != nil {
+		a, err := r.authMechanismToAuthenticator(ctx, *input.AuthMechanism)
+		if err != nil {
+			return nil, err
+		}
+		authenticator = &a
+	}
+
+	return updateUserEmail(ctx, input.Email, authenticator)
 }
 
 // ResendVerificationEmail is the resolver for the resendVerificationEmail field.

--- a/graphql/resolver/schema.resolvers.helpers.go
+++ b/graphql/resolver/schema.resolvers.helpers.go
@@ -1419,8 +1419,15 @@ func verifyEmail(ctx context.Context, token string) (*model.VerifyEmailPayload, 
 
 }
 
-func updateUserEmail(ctx context.Context, email persist.Email) (*model.UpdateEmailPayload, error) {
-	err := publicapi.For(ctx).User.UpdateUserEmail(ctx, email)
+func updateUserEmail(ctx context.Context, email persist.Email, authenticator *auth.Authenticator) (*model.UpdateEmailPayload, error) {
+	var err error
+
+	if authenticator != nil {
+		err = publicapi.For(ctx).User.UpdateUserEmailWithAuthenticator(ctx, email, *authenticator)
+	} else {
+		err = publicapi.For(ctx).User.UpdateUserEmailWithManualVerification(ctx, email)
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2471,8 +2471,10 @@ union VerifyEmailMagicLinkPayloadOrError = VerifyEmailMagicLinkPayload | ErrInva
 
 input UpdateEmailInput {
   email: Email! @scrub
-  """authMechanism is an optional parameter that can verify a user's email address in lieu of sending
-  a verification email to the user. If not provided, a verification email will be sent."""
+  """
+  authMechanism is an optional parameter that can verify a user's email address in lieu of sending
+  a verification email to the user. If not provided, a verification email will be sent.
+  """
   authMechanism: AuthMechanism
 }
 

--- a/graphql/schema/schema.graphql
+++ b/graphql/schema/schema.graphql
@@ -2471,6 +2471,9 @@ union VerifyEmailMagicLinkPayloadOrError = VerifyEmailMagicLinkPayload | ErrInva
 
 input UpdateEmailInput {
   email: Email! @scrub
+  """authMechanism is an optional parameter that can verify a user's email address in lieu of sending
+  a verification email to the user. If not provided, a verification email will be sent."""
+  authMechanism: AuthMechanism
 }
 
 type UpdateEmailPayload {

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -720,7 +720,7 @@ func (api UserAPI) UpdateFeaturedGallery(ctx context.Context, galleryID persist.
 	return nil
 }
 
-func (api UserAPI) UpdateUserEmail(ctx context.Context, email persist.Email) error {
+func (api UserAPI) UpdateUserEmailWithManualVerification(ctx context.Context, email persist.Email) error {
 	// Validate
 	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
 		"email": validate.WithTag(email, "required"),
@@ -741,6 +741,44 @@ func (api UserAPI) UpdateUserEmail(ctx context.Context, email persist.Email) err
 	}
 
 	err = emails.RequestVerificationEmail(ctx, userID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (api UserAPI) UpdateUserEmailWithAuthenticator(ctx context.Context, email persist.Email, authenticator auth.Authenticator) error {
+	// Validate
+	if err := validate.ValidateFields(api.validator, validate.ValidationMap{
+		"email": validate.WithTag(email, "required"),
+	}); err != nil {
+		return err
+	}
+
+	userID, err := getAuthenticatedUserID(ctx)
+	if err != nil {
+		return err
+	}
+
+	authResult, err := authenticator.Authenticate(ctx)
+	if err != nil {
+		return err
+	}
+
+	if authResult.Email == nil {
+		return fmt.Errorf("authenticator did not return a verified email address")
+	}
+
+	if email.String() != authResult.Email.String() {
+		return fmt.Errorf("supplied email address (%s) does not match verified email address from authenticator (%s)", email.String(), authResult.Email.String())
+	}
+
+	err = api.queries.UpdateUserVerifiedEmail(ctx, db.UpdateUserVerifiedEmailParams{
+		UserID:       userID,
+		EmailAddress: email,
+	})
+
 	if err != nil {
 		return err
 	}

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -604,10 +604,17 @@ func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authentica
 		return "", "", err
 	}
 
-	if createUserParams.EmailStatus == persist.EmailVerificationStatusUnverified && email != nil {
-		if err := emails.RequestVerificationEmail(ctx, userID); err != nil {
-			// Just the log the error since the user can verify their email later
-			logger.For(ctx).Warnf("failed to send verification email: %s", err)
+	// Temporary fix for the mobile app
+	if gc.GetHeader("X-Platform") == "Mobile" {
+		if email != nil {
+			createUserParams.EmailStatus = persist.EmailVerificationStatusVerified
+		}
+	} else {
+		if createUserParams.EmailStatus == persist.EmailVerificationStatusUnverified && email != nil {
+			if err := emails.RequestVerificationEmail(ctx, userID); err != nil {
+				// Just the log the error since the user can verify their email later
+				logger.For(ctx).Warnf("failed to send verification email: %s", err)
+			}
 		}
 	}
 

--- a/publicapi/user.go
+++ b/publicapi/user.go
@@ -604,17 +604,10 @@ func (api UserAPI) CreateUser(ctx context.Context, authenticator auth.Authentica
 		return "", "", err
 	}
 
-	// Temporary fix for the mobile app
-	if gc.GetHeader("X-Platform") == "Mobile" {
-		if email != nil {
-			createUserParams.EmailStatus = persist.EmailVerificationStatusVerified
-		}
-	} else {
-		if createUserParams.EmailStatus == persist.EmailVerificationStatusUnverified && email != nil {
-			if err := emails.RequestVerificationEmail(ctx, userID); err != nil {
-				// Just the log the error since the user can verify their email later
-				logger.For(ctx).Warnf("failed to send verification email: %s", err)
-			}
+	if createUserParams.EmailStatus == persist.EmailVerificationStatusUnverified && email != nil {
+		if err := emails.RequestVerificationEmail(ctx, userID); err != nil {
+			// Just the log the error since the user can verify their email later
+			logger.For(ctx).Warnf("failed to send verification email: %s", err)
 		}
 	}
 


### PR DESCRIPTION
Prior to this PR, the `updateEmail` mutation would send a verification email to the user whenever it was called. This PR adds an optional authenticator to the `updateEmail` mutation. If the authenticator can verify the supplied email address, no manual verification email will be sent.