### PR TITLE
Add more logging to processing

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -3680,11 +3680,10 @@ func (b *GetTokenByIdBatchBatchResults) Close() error {
 }
 
 const getTokenByIdIgnoreDisplayableBatch = `-- name: GetTokenByIdIgnoreDisplayableBatch :batchone
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash
 from tokens t
 join token_definitions td on t.token_definition_id = td.id
-join token_medias tm on td.token_media_id = tm.id
-where t.id = $1 and t.deleted = false and td.deleted = false and tm.deleted = false
+where t.id = $1 and t.deleted = false and td.deleted = false
 `
 
 type GetTokenByIdIgnoreDisplayableBatchBatchResults struct {
@@ -3696,7 +3695,6 @@ type GetTokenByIdIgnoreDisplayableBatchBatchResults struct {
 type GetTokenByIdIgnoreDisplayableBatchRow struct {
 	Token           Token           `db:"token" json:"token"`
 	TokenDefinition TokenDefinition `db:"tokendefinition" json:"tokendefinition"`
-	TokenMedia      TokenMedia      `db:"tokenmedia" json:"tokenmedia"`
 }
 
 func (q *Queries) GetTokenByIdIgnoreDisplayableBatch(ctx context.Context, id []persist.DBID) *GetTokenByIdIgnoreDisplayableBatchBatchResults {
@@ -3756,14 +3754,6 @@ func (b *GetTokenByIdIgnoreDisplayableBatchBatchResults) QueryRow(f func(int, Ge
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
 			&i.TokenDefinition.IsFxhash,
-			&i.TokenMedia.ID,
-			&i.TokenMedia.CreatedAt,
-			&i.TokenMedia.LastUpdated,
-			&i.TokenMedia.Version,
-			&i.TokenMedia.Active,
-			&i.TokenMedia.Media,
-			&i.TokenMedia.ProcessingJobID,
-			&i.TokenMedia.Deleted,
 		)
 		if f != nil {
 			f(t, i, err)

--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -6264,6 +6264,7 @@ with insert_job(id) as (
     set metadata = $13,
         name = $14,
         description = $15,
+        last_updated = (select last_updated from insert_new_media),
         token_media_id = case
             -- If there isn't any media, use the new media regardless of its status
             when token_media_id is null then (select id from insert_new_media)

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1481,6 +1481,7 @@ with insert_job(id) as (
     set metadata = @new_metadata,
         name = @new_name,
         description = @new_description,
+        last_updated = (select last_updated from insert_new_media),
         token_media_id = case
             -- If there isn't any media, use the new media regardless of its status
             when token_media_id is null then (select id from insert_new_media)

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -166,11 +166,10 @@ join token_definitions td on t.token_definition_id = td.id
 where t.id = $1 and t.displayable and t.deleted = false and td.deleted = false;
 
 -- name: GetTokenByIdIgnoreDisplayableBatch :batchone
-select sqlc.embed(t), sqlc.embed(td), sqlc.embed(tm)
+select sqlc.embed(t), sqlc.embed(td)
 from tokens t
 join token_definitions td on t.token_definition_id = td.id
-join token_medias tm on td.token_media_id = tm.id
-where t.id = $1 and t.deleted = false and td.deleted = false and tm.deleted = false;
+where t.id = $1 and t.deleted = false and td.deleted = false;
 
 -- name: GetTokenByUserTokenIdentifiersBatch :batchone
 -- Fetch the definition and contract to cache since downstream queries will likely use them

--- a/graphql/dataloader/api_gen.go
+++ b/graphql/dataloader/api_gen.go
@@ -355,9 +355,6 @@ func NewLoaders(ctx context.Context, q *coredb.Queries, disableCaching bool, pre
 			loaders.GetMediaByMediaIdIgnoringStatusBatch.Prime(loaders.GetMediaByMediaIdIgnoringStatusBatch.getKeyForResult(entry), entry)
 		}
 	})
-	loaders.GetTokenByIdIgnoreDisplayableBatch.RegisterResultSubscriber(func(result coredb.GetTokenByIdIgnoreDisplayableBatchRow) {
-		loaders.GetMediaByMediaIdIgnoringStatusBatch.Prime(loaders.GetMediaByMediaIdIgnoringStatusBatch.getKeyForResult(result.TokenMedia), result.TokenMedia)
-	})
 	loaders.GetTokenByUserTokenIdentifiersIgnoreDisplayableBatch.RegisterResultSubscriber(func(result coredb.GetTokenByUserTokenIdentifiersIgnoreDisplayableBatchRow) {
 		loaders.GetMediaByMediaIdIgnoringStatusBatch.Prime(loaders.GetMediaByMediaIdIgnoringStatusBatch.getKeyForResult(result.TokenMedia), result.TokenMedia)
 	})

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -665,6 +665,7 @@ func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chai
 
 	upsertTime, upsertedTokens, err := op.BulkUpsert(ctx, p.Queries, uniqueTokens, uniqueDefinitions, upsertParams.SetCreatorFields, upsertParams.SetHolderFields)
 	if err != nil {
+		logger.For(ctx).Errorf("error in bulk upsert of tokens: %s", err)
 		return nil, nil, err
 	}
 

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -785,7 +785,7 @@ func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage
 		pipelineMetadata: new(persist.PipelineMetadata),
 	}
 
-	for _, opt := range opts {
+	for _, opt := range runOpts {
 		opt(job)
 	}
 


### PR DESCRIPTION
Changes
* Updates the `last_updated` column of `token_definition` when media is updated
* Removes requirement for media to exist for queries that fetch a token
* Adds more logging around syncing and token processing
* Fixes bug where no media is saved if a contract is paused