### PR TITLE
Set last_updated when updating user info

### DIFF
--- a/service/persist/postgres/user.go
+++ b/service/persist/postgres/user.go
@@ -47,7 +47,7 @@ func NewUserRepository(db *sql.DB, queries *db.Queries, pgx *pgxpool.Pool) *User
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	updateInfoStmt, err := db.PrepareContext(ctx, `UPDATE users SET USERNAME = $2, USERNAME_IDEMPOTENT = $3, LAST_UPDATED = $4, BIO = $5 WHERE ID = $1;`)
+	updateInfoStmt, err := db.PrepareContext(ctx, `UPDATE users SET USERNAME = $2, USERNAME_IDEMPOTENT = $3, LAST_UPDATED = now(), BIO = $4 WHERE ID = $1;`)
 	checkNoErr(err)
 
 	getByIDStmt, err := db.PrepareContext(ctx, `SELECT ID,DELETED,VERSION,USERNAME,USERNAME_IDEMPOTENT,BIO,TRAITS,WALLETS,UNIVERSAL,PRIMARY_WALLET_ID,CREATED_AT,LAST_UPDATED FROM users WHERE ID = $1 AND DELETED = false;`)
@@ -137,7 +137,7 @@ func (u *UserRepository) UpdateByID(pCtx context.Context, pID persist.DBID, pUpd
 			}
 		}
 
-		res, err := u.updateInfoStmt.ExecContext(pCtx, pID, update.Username, strings.ToLower(update.UsernameIdempotent.String()), update.LastUpdated, update.Bio)
+		res, err := u.updateInfoStmt.ExecContext(pCtx, pID, update.Username, strings.ToLower(update.UsernameIdempotent.String()), update.Bio)
 		if err != nil {
 			return err
 		}

--- a/service/persist/user.go
+++ b/service/persist/user.go
@@ -61,7 +61,6 @@ type User struct {
 
 // UserUpdateInfoInput represents the data to be updated when updating a user
 type UserUpdateInfoInput struct {
-	LastUpdated        time.Time  `json:"last_updated"`
 	Username           NullString `json:"username"`
 	UsernameIdempotent NullString `json:"username_idempotent"`
 	Bio                NullString `json:"bio"`


### PR DESCRIPTION
This PR fixes a longstanding bug where updating a user's info would set their `last_updated` time to zero. We were accidentally passing in an empty `time.Time` for the `LastUpdatedTime` parameter, but in reality, there shouldn't be a `LastUpdatedTime` parameter at all -- we should just be using `now()` as part of the SQL statement. Now we are!