### PR TITLE
Simplehash fast follows and sync improvements

### DIFF
--- a/db/gen/coredb/query.sql.go
+++ b/db/gen/coredb/query.sql.go
@@ -4241,182 +4241,6 @@ func (q *Queries) GetTokenDefinitionByTokenIdentifiers(ctx context.Context, arg 
 	return i, err
 }
 
-const getTokenFullDetailsByContractId = `-- name: GetTokenFullDetailsByContractId :many
-select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
-from tokens
-join token_definitions on tokens.token_definition_id = token_definitions.id
-join contracts on token_definitions.contract_id = contracts.id
-where contracts.id = $1 and tokens.displayable and not tokens.deleted and not token_definitions.deleted and not contracts.deleted
-order by tokens.block_number desc
-`
-
-type GetTokenFullDetailsByContractIdRow struct {
-	Token           Token           `db:"token" json:"token"`
-	TokenDefinition TokenDefinition `db:"tokendefinition" json:"tokendefinition"`
-	Contract        Contract        `db:"contract" json:"contract"`
-}
-
-func (q *Queries) GetTokenFullDetailsByContractId(ctx context.Context, id persist.DBID) ([]GetTokenFullDetailsByContractIdRow, error) {
-	rows, err := q.db.Query(ctx, getTokenFullDetailsByContractId, id)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetTokenFullDetailsByContractIdRow
-	for rows.Next() {
-		var i GetTokenFullDetailsByContractIdRow
-		if err := rows.Scan(
-			&i.Token.ID,
-			&i.Token.Deleted,
-			&i.Token.Version,
-			&i.Token.CreatedAt,
-			&i.Token.LastUpdated,
-			&i.Token.CollectorsNote,
-			&i.Token.Quantity,
-			&i.Token.BlockNumber,
-			&i.Token.OwnerUserID,
-			&i.Token.OwnedByWallets,
-			&i.Token.ContractID,
-			&i.Token.IsUserMarkedSpam,
-			&i.Token.LastSynced,
-			&i.Token.IsCreatorToken,
-			&i.Token.TokenDefinitionID,
-			&i.Token.IsHolderToken,
-			&i.Token.Displayable,
-			&i.TokenDefinition.ID,
-			&i.TokenDefinition.CreatedAt,
-			&i.TokenDefinition.LastUpdated,
-			&i.TokenDefinition.Deleted,
-			&i.TokenDefinition.Name,
-			&i.TokenDefinition.Description,
-			&i.TokenDefinition.TokenType,
-			&i.TokenDefinition.TokenID,
-			&i.TokenDefinition.ExternalUrl,
-			&i.TokenDefinition.Chain,
-			&i.TokenDefinition.Metadata,
-			&i.TokenDefinition.FallbackMedia,
-			&i.TokenDefinition.ContractAddress,
-			&i.TokenDefinition.ContractID,
-			&i.TokenDefinition.TokenMediaID,
-			&i.TokenDefinition.IsFxhash,
-			&i.Contract.ID,
-			&i.Contract.Deleted,
-			&i.Contract.Version,
-			&i.Contract.CreatedAt,
-			&i.Contract.LastUpdated,
-			&i.Contract.Name,
-			&i.Contract.Symbol,
-			&i.Contract.Address,
-			&i.Contract.CreatorAddress,
-			&i.Contract.Chain,
-			&i.Contract.ProfileBannerUrl,
-			&i.Contract.ProfileImageUrl,
-			&i.Contract.BadgeUrl,
-			&i.Contract.Description,
-			&i.Contract.OwnerAddress,
-			&i.Contract.IsProviderMarkedSpam,
-			&i.Contract.ParentID,
-			&i.Contract.OverrideCreatorUserID,
-			&i.Contract.L1Chain,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getTokenFullDetailsByUserId = `-- name: GetTokenFullDetailsByUserId :many
-select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
-from tokens
-join token_definitions on tokens.token_definition_id = token_definitions.id
-join contracts on token_definitions.contract_id = contracts.id
-where tokens.owner_user_id = $1 and tokens.displayable and not tokens.deleted and not token_definitions.deleted and not contracts.deleted
-order by tokens.block_number desc
-`
-
-type GetTokenFullDetailsByUserIdRow struct {
-	Token           Token           `db:"token" json:"token"`
-	TokenDefinition TokenDefinition `db:"tokendefinition" json:"tokendefinition"`
-	Contract        Contract        `db:"contract" json:"contract"`
-}
-
-func (q *Queries) GetTokenFullDetailsByUserId(ctx context.Context, ownerUserID persist.DBID) ([]GetTokenFullDetailsByUserIdRow, error) {
-	rows, err := q.db.Query(ctx, getTokenFullDetailsByUserId, ownerUserID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetTokenFullDetailsByUserIdRow
-	for rows.Next() {
-		var i GetTokenFullDetailsByUserIdRow
-		if err := rows.Scan(
-			&i.Token.ID,
-			&i.Token.Deleted,
-			&i.Token.Version,
-			&i.Token.CreatedAt,
-			&i.Token.LastUpdated,
-			&i.Token.CollectorsNote,
-			&i.Token.Quantity,
-			&i.Token.BlockNumber,
-			&i.Token.OwnerUserID,
-			&i.Token.OwnedByWallets,
-			&i.Token.ContractID,
-			&i.Token.IsUserMarkedSpam,
-			&i.Token.LastSynced,
-			&i.Token.IsCreatorToken,
-			&i.Token.TokenDefinitionID,
-			&i.Token.IsHolderToken,
-			&i.Token.Displayable,
-			&i.TokenDefinition.ID,
-			&i.TokenDefinition.CreatedAt,
-			&i.TokenDefinition.LastUpdated,
-			&i.TokenDefinition.Deleted,
-			&i.TokenDefinition.Name,
-			&i.TokenDefinition.Description,
-			&i.TokenDefinition.TokenType,
-			&i.TokenDefinition.TokenID,
-			&i.TokenDefinition.ExternalUrl,
-			&i.TokenDefinition.Chain,
-			&i.TokenDefinition.Metadata,
-			&i.TokenDefinition.FallbackMedia,
-			&i.TokenDefinition.ContractAddress,
-			&i.TokenDefinition.ContractID,
-			&i.TokenDefinition.TokenMediaID,
-			&i.TokenDefinition.IsFxhash,
-			&i.Contract.ID,
-			&i.Contract.Deleted,
-			&i.Contract.Version,
-			&i.Contract.CreatedAt,
-			&i.Contract.LastUpdated,
-			&i.Contract.Name,
-			&i.Contract.Symbol,
-			&i.Contract.Address,
-			&i.Contract.CreatorAddress,
-			&i.Contract.Chain,
-			&i.Contract.ProfileBannerUrl,
-			&i.Contract.ProfileImageUrl,
-			&i.Contract.BadgeUrl,
-			&i.Contract.Description,
-			&i.Contract.OwnerAddress,
-			&i.Contract.IsProviderMarkedSpam,
-			&i.Contract.ParentID,
-			&i.Contract.OverrideCreatorUserID,
-			&i.Contract.L1Chain,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getTokenFullDetailsByUserTokenIdentifiers = `-- name: GetTokenFullDetailsByUserTokenIdentifiers :one
 select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
 from tokens
@@ -4507,6 +4331,110 @@ func (q *Queries) GetTokenFullDetailsByUserTokenIdentifiers(ctx context.Context,
 		&i.Contract.L1Chain,
 	)
 	return i, err
+}
+
+const getTokensByContractAddressUserId = `-- name: GetTokensByContractAddressUserId :many
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain
+from tokens t
+join token_definitions td on t.token_definition_id = td.id
+join contracts c on td.contract_id = c.id
+where t.owner_user_id = $1 
+    and td.contract_address = $2
+    and td.chain = $3
+    and $4::varchar = any(t.owned_by_wallets)
+    and not t.deleted
+    and not td.deleted
+`
+
+type GetTokensByContractAddressUserIdParams struct {
+	OwnerUserID     persist.DBID    `db:"owner_user_id" json:"owner_user_id"`
+	ContractAddress persist.Address `db:"contract_address" json:"contract_address"`
+	Chain           persist.Chain   `db:"chain" json:"chain"`
+	WalletID        string          `db:"wallet_id" json:"wallet_id"`
+}
+
+type GetTokensByContractAddressUserIdRow struct {
+	Token           Token           `db:"token" json:"token"`
+	TokenDefinition TokenDefinition `db:"tokendefinition" json:"tokendefinition"`
+	Contract        Contract        `db:"contract" json:"contract"`
+}
+
+func (q *Queries) GetTokensByContractAddressUserId(ctx context.Context, arg GetTokensByContractAddressUserIdParams) ([]GetTokensByContractAddressUserIdRow, error) {
+	rows, err := q.db.Query(ctx, getTokensByContractAddressUserId,
+		arg.OwnerUserID,
+		arg.ContractAddress,
+		arg.Chain,
+		arg.WalletID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetTokensByContractAddressUserIdRow
+	for rows.Next() {
+		var i GetTokensByContractAddressUserIdRow
+		if err := rows.Scan(
+			&i.Token.ID,
+			&i.Token.Deleted,
+			&i.Token.Version,
+			&i.Token.CreatedAt,
+			&i.Token.LastUpdated,
+			&i.Token.CollectorsNote,
+			&i.Token.Quantity,
+			&i.Token.BlockNumber,
+			&i.Token.OwnerUserID,
+			&i.Token.OwnedByWallets,
+			&i.Token.ContractID,
+			&i.Token.IsUserMarkedSpam,
+			&i.Token.LastSynced,
+			&i.Token.IsCreatorToken,
+			&i.Token.TokenDefinitionID,
+			&i.Token.IsHolderToken,
+			&i.Token.Displayable,
+			&i.TokenDefinition.ID,
+			&i.TokenDefinition.CreatedAt,
+			&i.TokenDefinition.LastUpdated,
+			&i.TokenDefinition.Deleted,
+			&i.TokenDefinition.Name,
+			&i.TokenDefinition.Description,
+			&i.TokenDefinition.TokenType,
+			&i.TokenDefinition.TokenID,
+			&i.TokenDefinition.ExternalUrl,
+			&i.TokenDefinition.Chain,
+			&i.TokenDefinition.Metadata,
+			&i.TokenDefinition.FallbackMedia,
+			&i.TokenDefinition.ContractAddress,
+			&i.TokenDefinition.ContractID,
+			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
+			&i.Contract.ID,
+			&i.Contract.Deleted,
+			&i.Contract.Version,
+			&i.Contract.CreatedAt,
+			&i.Contract.LastUpdated,
+			&i.Contract.Name,
+			&i.Contract.Symbol,
+			&i.Contract.Address,
+			&i.Contract.CreatorAddress,
+			&i.Contract.Chain,
+			&i.Contract.ProfileBannerUrl,
+			&i.Contract.ProfileImageUrl,
+			&i.Contract.BadgeUrl,
+			&i.Contract.Description,
+			&i.Contract.OwnerAddress,
+			&i.Contract.IsProviderMarkedSpam,
+			&i.Contract.ParentID,
+			&i.Contract.OverrideCreatorUserID,
+			&i.Contract.L1Chain,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getTokensByContractIdPaginate = `-- name: GetTokensByContractIdPaginate :many

--- a/db/gen/coredb/token_gallery.sql.go
+++ b/db/gen/coredb/token_gallery.sql.go
@@ -57,7 +57,7 @@ func (q *Queries) DeleteTokensBeforeTimestamp(ctx context.Context, arg DeleteTok
 	return result.RowsAffected(), nil
 }
 
-const upsertTokens = `-- name: UpsertTokens :many
+const upsertTokenDefinitions = `-- name: UpsertTokenDefinitions :many
 with token_definitions_insert as (
   insert into token_definitions
   ( 
@@ -106,7 +106,123 @@ with token_definitions_insert as (
     , is_fxhash = excluded.is_fxhash
   returning id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id, is_fxhash
 )
-, tokens_insert as (
+, community_memberships_insert as (
+  insert into token_community_memberships
+  (
+    id
+    , token_definition_id
+    , community_id
+    , created_at
+    , last_updated
+    , deleted
+    , token_id
+  ) (
+    select community_memberships.id
+      , token_definitions_insert.id
+      , communities.id
+      , now()
+      , now()
+      , false
+      , community_memberships.token_id
+    from (
+      select unnest($13::varchar[]) as id
+        , unnest($14::numeric[]) as token_id
+        , unnest($10::varchar[]) as definition_contract_id
+        , unnest($5::varchar[]) as definition_token_id
+    ) community_memberships
+    join token_definitions_insert on
+        community_memberships.definition_contract_id = token_definitions_insert.contract_id
+        and community_memberships.definition_token_id = token_definitions_insert.token_id
+    -- Left join ensures that the insert will fail with a constraint violation (trying to insert null) if there isn't a
+    -- contract community for this token. Every contract should have a community created for it by the time we get here!
+    left join communities on communities.contract_id = community_memberships.definition_contract_id and communities.community_type = 0
+  )
+  on conflict (token_definition_id, community_id) where not deleted
+  do update set
+    last_updated = excluded.last_updated
+  returning id, version, token_definition_id, community_id, created_at, last_updated, deleted, token_id
+)
+select token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash
+from token_definitions_insert token_definitions
+left join token_definitions prior_state on token_definitions.chain = prior_state.chain and token_definitions.contract_id = prior_state.contract_id and token_definitions.token_id = prior_state.token_id and not prior_state.deleted
+where prior_state.id is null
+`
+
+type UpsertTokenDefinitionsParams struct {
+	DefinitionDbid             []string         `db:"definition_dbid" json:"definition_dbid"`
+	DefinitionName             []string         `db:"definition_name" json:"definition_name"`
+	DefinitionDescription      []string         `db:"definition_description" json:"definition_description"`
+	DefinitionTokenType        []string         `db:"definition_token_type" json:"definition_token_type"`
+	DefinitionTokenID          []string         `db:"definition_token_id" json:"definition_token_id"`
+	DefinitionExternalUrl      []string         `db:"definition_external_url" json:"definition_external_url"`
+	DefinitionChain            []int32          `db:"definition_chain" json:"definition_chain"`
+	DefinitionFallbackMedia    []pgtype.JSONB   `db:"definition_fallback_media" json:"definition_fallback_media"`
+	DefinitionContractAddress  []string         `db:"definition_contract_address" json:"definition_contract_address"`
+	DefinitionContractID       []string         `db:"definition_contract_id" json:"definition_contract_id"`
+	DefinitionMetadata         []pgtype.JSONB   `db:"definition_metadata" json:"definition_metadata"`
+	DefinitionIsFxhash         []bool           `db:"definition_is_fxhash" json:"definition_is_fxhash"`
+	CommunityMembershipDbid    []string         `db:"community_membership_dbid" json:"community_membership_dbid"`
+	CommunityMembershipTokenID []pgtype.Numeric `db:"community_membership_token_id" json:"community_membership_token_id"`
+}
+
+type UpsertTokenDefinitionsRow struct {
+	TokenDefinition TokenDefinition `db:"tokendefinition" json:"tokendefinition"`
+}
+
+func (q *Queries) UpsertTokenDefinitions(ctx context.Context, arg UpsertTokenDefinitionsParams) ([]UpsertTokenDefinitionsRow, error) {
+	rows, err := q.db.Query(ctx, upsertTokenDefinitions,
+		arg.DefinitionDbid,
+		arg.DefinitionName,
+		arg.DefinitionDescription,
+		arg.DefinitionTokenType,
+		arg.DefinitionTokenID,
+		arg.DefinitionExternalUrl,
+		arg.DefinitionChain,
+		arg.DefinitionFallbackMedia,
+		arg.DefinitionContractAddress,
+		arg.DefinitionContractID,
+		arg.DefinitionMetadata,
+		arg.DefinitionIsFxhash,
+		arg.CommunityMembershipDbid,
+		arg.CommunityMembershipTokenID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []UpsertTokenDefinitionsRow
+	for rows.Next() {
+		var i UpsertTokenDefinitionsRow
+		if err := rows.Scan(
+			&i.TokenDefinition.ID,
+			&i.TokenDefinition.CreatedAt,
+			&i.TokenDefinition.LastUpdated,
+			&i.TokenDefinition.Deleted,
+			&i.TokenDefinition.Name,
+			&i.TokenDefinition.Description,
+			&i.TokenDefinition.TokenType,
+			&i.TokenDefinition.TokenID,
+			&i.TokenDefinition.ExternalUrl,
+			&i.TokenDefinition.Chain,
+			&i.TokenDefinition.Metadata,
+			&i.TokenDefinition.FallbackMedia,
+			&i.TokenDefinition.ContractAddress,
+			&i.TokenDefinition.ContractID,
+			&i.TokenDefinition.TokenMediaID,
+			&i.TokenDefinition.IsFxhash,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const upsertTokens = `-- name: UpsertTokens :many
+with tokens_insert as (
   insert into tokens
   (
     id
@@ -134,34 +250,34 @@ with token_definitions_insert as (
       , bulk_upsert.quantity
       , bulk_upsert.block_number
       , bulk_upsert.owner_user_id
-      , case when $13::bool then bulk_upsert.owned_by_wallets[bulk_upsert.owned_by_wallets_start_idx::int:bulk_upsert.owned_by_wallets_end_idx::int] else '{}' end
-      , case when $14::bool then bulk_upsert.is_creator_token else false end
+      , case when $1::bool then bulk_upsert.owned_by_wallets[bulk_upsert.owned_by_wallets_start_idx::int:bulk_upsert.owned_by_wallets_end_idx::int] else '{}' end
+      , case when $2::bool then bulk_upsert.is_creator_token else false end
       , now()
-      , token_definitions_insert.id
+      , token_definitions.id
       , bulk_upsert.contract_id
     from (
-      select unnest($15::varchar[]) as id
-        , unnest($16::int[]) as version
-        , unnest($17::varchar[]) as collectors_note
-        , unnest($18::varchar[]) as quantity
-        , unnest($19::bigint[]) as block_number
-        , unnest($20::varchar[]) as owner_user_id
-        , $21::varchar[] as owned_by_wallets
-        , unnest($22::int[]) as owned_by_wallets_start_idx
-        , unnest($23::int[]) as owned_by_wallets_end_idx
-        , unnest($24::bool[]) as is_creator_token
-        , unnest($25::varchar[]) as token_id
-        , unnest($26::varchar[]) as contract_address
-        , unnest($27::int[]) as chain
-        , unnest($28::varchar[]) as contract_id
+      select unnest($3::varchar[]) as id
+        , unnest($4::int[]) as version
+        , unnest($5::varchar[]) as collectors_note
+        , unnest($6::varchar[]) as quantity
+        , unnest($7::bigint[]) as block_number
+        , unnest($8::varchar[]) as owner_user_id
+        , $9::varchar[] as owned_by_wallets
+        , unnest($10::int[]) as owned_by_wallets_start_idx
+        , unnest($11::int[]) as owned_by_wallets_end_idx
+        , unnest($12::bool[]) as is_creator_token
+        , unnest($13::varchar[]) as token_id
+        , unnest($14::varchar[]) as contract_address
+        , unnest($15::int[]) as chain
+        , unnest($16::varchar[]) as contract_id
     ) bulk_upsert
-    join token_definitions_insert on (bulk_upsert.chain, bulk_upsert.contract_address, bulk_upsert.token_id) = (token_definitions_insert.chain, token_definitions_insert.contract_address, token_definitions_insert.token_id)
+    join token_definitions on (bulk_upsert.chain, bulk_upsert.contract_address, bulk_upsert.token_id) = (token_definitions.chain, token_definitions.contract_address, token_definitions.token_id)
   )
   on conflict (owner_user_id, token_definition_id) where deleted = false
   do update set
     quantity = excluded.quantity
-    , owned_by_wallets = case when $13 then excluded.owned_by_wallets else tokens.owned_by_wallets end
-    , is_creator_token = case when $14 then excluded.is_creator_token else tokens.is_creator_token end
+    , owned_by_wallets = case when $1 then excluded.owned_by_wallets else tokens.owned_by_wallets end
+    , is_creator_token = case when $2 then excluded.is_creator_token else tokens.is_creator_token end
     , block_number = excluded.block_number
     , version = excluded.version
     , last_updated = excluded.last_updated
@@ -169,79 +285,31 @@ with token_definitions_insert as (
     , contract_id = excluded.contract_id
   returning id, deleted, version, created_at, last_updated, collectors_note, quantity, block_number, owner_user_id, owned_by_wallets, contract_id, is_user_marked_spam, last_synced, is_creator_token, token_definition_id, is_holder_token, displayable
 )
-, community_memberships_insert as (
-  insert into token_community_memberships
-  (
-    id
-    , token_definition_id
-    , community_id
-    , created_at
-    , last_updated
-    , deleted
-    , token_id
-  ) (
-    select community_memberships.id
-      , token_definitions_insert.id
-      , communities.id
-      , now()
-      , now()
-      , false
-      , community_memberships.token_id
-    from (
-      select unnest($29::varchar[]) as id
-        , unnest($30::numeric[]) as token_id
-        , unnest($10::varchar[]) as definition_contract_id
-        , unnest($5::varchar[]) as definition_token_id
-    ) community_memberships
-    join token_definitions_insert on
-        community_memberships.definition_contract_id = token_definitions_insert.contract_id
-        and community_memberships.definition_token_id = token_definitions_insert.token_id
-    -- Left join ensures that the insert will fail with a constraint violation (trying to insert null) if there isn't a
-    -- contract community for this token. Every contract should have a community created for it by the time we get here!
-    left join communities on communities.contract_id = community_memberships.definition_contract_id and communities.community_type = 0
-  )
-  on conflict (token_definition_id, community_id) where not deleted
-  do update set
-    last_updated = excluded.last_updated
-  returning id, version, token_definition_id, community_id, created_at, last_updated, deleted, token_id
-)
 select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last_updated, tokens.collectors_note, tokens.quantity, tokens.block_number, tokens.owner_user_id, tokens.owned_by_wallets, tokens.contract_id, tokens.is_user_marked_spam, tokens.last_synced, tokens.is_creator_token, tokens.token_definition_id, tokens.is_holder_token, tokens.displayable, token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, contracts.id, contracts.deleted, contracts.version, contracts.created_at, contracts.last_updated, contracts.name, contracts.symbol, contracts.address, contracts.creator_address, contracts.chain, contracts.profile_banner_url, contracts.profile_image_url, contracts.badge_url, contracts.description, contracts.owner_address, contracts.is_provider_marked_spam, contracts.parent_id, contracts.override_creator_user_id, contracts.l1_chain
 from tokens_insert tokens
-join token_definitions_insert token_definitions on tokens.token_definition_id = token_definitions.id
+join token_definitions on tokens.token_definition_id = token_definitions.id
 join contracts on token_definitions.contract_id = contracts.id
+left join tokens prior_state on tokens.owner_user_id = prior_state.owner_user_id and tokens.token_definition_id = prior_state.token_definition_id and not prior_state.deleted
+where prior_state.id is null
 `
 
 type UpsertTokensParams struct {
-	DefinitionDbid              []string         `db:"definition_dbid" json:"definition_dbid"`
-	DefinitionName              []string         `db:"definition_name" json:"definition_name"`
-	DefinitionDescription       []string         `db:"definition_description" json:"definition_description"`
-	DefinitionTokenType         []string         `db:"definition_token_type" json:"definition_token_type"`
-	DefinitionTokenID           []string         `db:"definition_token_id" json:"definition_token_id"`
-	DefinitionExternalUrl       []string         `db:"definition_external_url" json:"definition_external_url"`
-	DefinitionChain             []int32          `db:"definition_chain" json:"definition_chain"`
-	DefinitionFallbackMedia     []pgtype.JSONB   `db:"definition_fallback_media" json:"definition_fallback_media"`
-	DefinitionContractAddress   []string         `db:"definition_contract_address" json:"definition_contract_address"`
-	DefinitionContractID        []string         `db:"definition_contract_id" json:"definition_contract_id"`
-	DefinitionMetadata          []pgtype.JSONB   `db:"definition_metadata" json:"definition_metadata"`
-	DefinitionIsFxhash          []bool           `db:"definition_is_fxhash" json:"definition_is_fxhash"`
-	SetHolderFields             bool             `db:"set_holder_fields" json:"set_holder_fields"`
-	SetCreatorFields            bool             `db:"set_creator_fields" json:"set_creator_fields"`
-	TokenDbid                   []string         `db:"token_dbid" json:"token_dbid"`
-	TokenVersion                []int32          `db:"token_version" json:"token_version"`
-	TokenCollectorsNote         []string         `db:"token_collectors_note" json:"token_collectors_note"`
-	TokenQuantity               []string         `db:"token_quantity" json:"token_quantity"`
-	TokenBlockNumber            []int64          `db:"token_block_number" json:"token_block_number"`
-	TokenOwnerUserID            []string         `db:"token_owner_user_id" json:"token_owner_user_id"`
-	TokenOwnedByWallets         []string         `db:"token_owned_by_wallets" json:"token_owned_by_wallets"`
-	TokenOwnedByWalletsStartIdx []int32          `db:"token_owned_by_wallets_start_idx" json:"token_owned_by_wallets_start_idx"`
-	TokenOwnedByWalletsEndIdx   []int32          `db:"token_owned_by_wallets_end_idx" json:"token_owned_by_wallets_end_idx"`
-	TokenIsCreatorToken         []bool           `db:"token_is_creator_token" json:"token_is_creator_token"`
-	TokenTokenID                []string         `db:"token_token_id" json:"token_token_id"`
-	TokenContractAddress        []string         `db:"token_contract_address" json:"token_contract_address"`
-	TokenChain                  []int32          `db:"token_chain" json:"token_chain"`
-	TokenContractID             []string         `db:"token_contract_id" json:"token_contract_id"`
-	CommunityMembershipDbid     []string         `db:"community_membership_dbid" json:"community_membership_dbid"`
-	CommunityMembershipTokenID  []pgtype.Numeric `db:"community_membership_token_id" json:"community_membership_token_id"`
+	SetHolderFields             bool     `db:"set_holder_fields" json:"set_holder_fields"`
+	SetCreatorFields            bool     `db:"set_creator_fields" json:"set_creator_fields"`
+	TokenDbid                   []string `db:"token_dbid" json:"token_dbid"`
+	TokenVersion                []int32  `db:"token_version" json:"token_version"`
+	TokenCollectorsNote         []string `db:"token_collectors_note" json:"token_collectors_note"`
+	TokenQuantity               []string `db:"token_quantity" json:"token_quantity"`
+	TokenBlockNumber            []int64  `db:"token_block_number" json:"token_block_number"`
+	TokenOwnerUserID            []string `db:"token_owner_user_id" json:"token_owner_user_id"`
+	TokenOwnedByWallets         []string `db:"token_owned_by_wallets" json:"token_owned_by_wallets"`
+	TokenOwnedByWalletsStartIdx []int32  `db:"token_owned_by_wallets_start_idx" json:"token_owned_by_wallets_start_idx"`
+	TokenOwnedByWalletsEndIdx   []int32  `db:"token_owned_by_wallets_end_idx" json:"token_owned_by_wallets_end_idx"`
+	TokenIsCreatorToken         []bool   `db:"token_is_creator_token" json:"token_is_creator_token"`
+	TokenTokenID                []string `db:"token_token_id" json:"token_token_id"`
+	TokenContractAddress        []string `db:"token_contract_address" json:"token_contract_address"`
+	TokenChain                  []int32  `db:"token_chain" json:"token_chain"`
+	TokenContractID             []string `db:"token_contract_id" json:"token_contract_id"`
 }
 
 type UpsertTokensRow struct {
@@ -252,18 +320,6 @@ type UpsertTokensRow struct {
 
 func (q *Queries) UpsertTokens(ctx context.Context, arg UpsertTokensParams) ([]UpsertTokensRow, error) {
 	rows, err := q.db.Query(ctx, upsertTokens,
-		arg.DefinitionDbid,
-		arg.DefinitionName,
-		arg.DefinitionDescription,
-		arg.DefinitionTokenType,
-		arg.DefinitionTokenID,
-		arg.DefinitionExternalUrl,
-		arg.DefinitionChain,
-		arg.DefinitionFallbackMedia,
-		arg.DefinitionContractAddress,
-		arg.DefinitionContractID,
-		arg.DefinitionMetadata,
-		arg.DefinitionIsFxhash,
 		arg.SetHolderFields,
 		arg.SetCreatorFields,
 		arg.TokenDbid,
@@ -280,8 +336,6 @@ func (q *Queries) UpsertTokens(ctx context.Context, arg UpsertTokensParams) ([]U
 		arg.TokenContractAddress,
 		arg.TokenChain,
 		arg.TokenContractID,
-		arg.CommunityMembershipDbid,
-		arg.CommunityMembershipTokenID,
 	)
 	if err != nil {
 		return nil, err

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -133,22 +133,6 @@ where tokens.owner_user_id = $1
     and not contracts.deleted
 order by tokens.block_number desc;
 
--- name: GetTokenFullDetailsByUserId :many
-select sqlc.embed(tokens), sqlc.embed(token_definitions), sqlc.embed(contracts)
-from tokens
-join token_definitions on tokens.token_definition_id = token_definitions.id
-join contracts on token_definitions.contract_id = contracts.id
-where tokens.owner_user_id = $1 and tokens.displayable and not tokens.deleted and not token_definitions.deleted and not contracts.deleted
-order by tokens.block_number desc;
-
--- name: GetTokenFullDetailsByContractId :many
-select sqlc.embed(tokens), sqlc.embed(token_definitions), sqlc.embed(contracts)
-from tokens
-join token_definitions on tokens.token_definition_id = token_definitions.id
-join contracts on token_definitions.contract_id = contracts.id
-where contracts.id = $1 and tokens.displayable and not tokens.deleted and not token_definitions.deleted and not contracts.deleted
-order by tokens.block_number desc;
-
 -- name: UpdateTokenCollectorsNoteByTokenDbidUserId :exec
 update tokens set collectors_note = $1, last_updated = now() where id = $2 and owner_user_id = $3;
 
@@ -349,6 +333,18 @@ from tokens t
 join tokens td on t.token_definition_id = td.id
 where t.owned_by_wallets && $1 and t.displayable and t.deleted = false and td.deleted = false
 order by t.created_at desc, td.name desc, t.id desc;
+
+-- name: GetTokensByContractAddressUserId :many
+select sqlc.embed(t), sqlc.embed(td), sqlc.embed(c)
+from tokens t
+join token_definitions td on t.token_definition_id = td.id
+join contracts c on td.contract_id = c.id
+where t.owner_user_id = $1 
+    and td.contract_address = $2
+    and td.chain = $3
+    and @wallet_id::varchar = any(t.owned_by_wallets)
+    and not t.deleted
+    and not td.deleted;
 
 -- name: GetTokensByContractIdPaginate :many
 select sqlc.embed(t), sqlc.embed(td), sqlc.embed(c), sqlc.embed(u) from tokens t

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/james-bowman/sparse v0.0.0-20210729090128-1e6c7dd483e9
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/pkg/errors v0.9.1
+	github.com/pkg/profile v1.5.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/wealdtech/go-ens/v3 v3.5.5
 	go.mozilla.org/sops/v3 v3.7.3

--- a/go.sum
+++ b/go.sum
@@ -1489,6 +1489,8 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v1.5.0 h1:042Buzk+NhDI+DeSAA62RwJL8VAuZUMQZUjCsRz1Mug=
+github.com/pkg/profile v1.5.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -1039,9 +1039,8 @@ func testSyncShouldProcessMedia(t *testing.T) {
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
-		<-time.After(time.Second)
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeImage), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1049,14 +1048,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process video", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x1"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x1423897231"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/video", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaVideoMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaVideoMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeVideo), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1064,14 +1063,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process iframe", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x2"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x232474823"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/iframe", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaHtmlMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaHtmlMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeHTML), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1079,14 +1078,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process gif", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x3"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x342789"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/gif", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaVideoMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaVideoMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeGIF), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1094,70 +1093,70 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process bad metadata", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x4"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x4234789123"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/bad", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeSyncing), *media.MediaType)
 	})
 
 	t.Run("should process missing metadata", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x5"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x523489"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/notfound", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeSyncing), *media.MediaType)
 	})
 
 	t.Run("should process bad media", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x6"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x612387192"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/bad", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeSyncing), *media.MediaType)
 	})
 
 	t.Run("should process missing media", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x7"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x72342897"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/notfound", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeSyncing), *media.MediaType)
 	})
 
 	t.Run("should process svg", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x8"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x821347892"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/svg", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeSVG), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1165,14 +1164,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process base64 encoded svg", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x9"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x9123487912"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/base64svg", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeSVG), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1180,14 +1179,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process base64 encoded metadata", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xa"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xa123781"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/base64", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia](*tokens[0].Media)
 		assert.Equal(t, *media.MediaType, string(persist.MediaTypeImage))
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1195,14 +1194,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process ipfs", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xb"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xb1234891"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/ipfs", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia](*tokens[0].Media)
 		assert.Equal(t, *media.MediaType, string(persist.MediaTypeImage))
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1210,28 +1209,28 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process bad dns", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xc"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xc42358972"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/media/dnsbad", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaSyncingMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeSyncing), *media.MediaType)
 	})
 
 	t.Run("should process different keyword", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xd"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xd1238901"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/differentkeyword", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeImage), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1239,14 +1238,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process wrong keyword", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xe"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xe234902"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/wrongkeyword", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaVideoMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaVideoMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeVideo), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1254,14 +1253,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process animation", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xf"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0xf2348912"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/animation", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaGltfMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaGltfMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeAnimation), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1269,14 +1268,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process pdf", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x10"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x101231789"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/pdf", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaPdfMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaPdfMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypePDF), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1284,14 +1283,14 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process text", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x11"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x11123891"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/text", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaTextMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaTextMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeText), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
@@ -1299,17 +1298,31 @@ func testSyncShouldProcessMedia(t *testing.T) {
 	t.Run("should process bad image", func(t *testing.T) {
 		ctx := context.Background()
 		userF := newUserFixture(t)
-		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x12"))
+		dummyTokenOpt := withDummyTokenID(userF.Wallet.Address, persist.HexTokenID("0x2348971232"))
 		h := newDummyMetadataProviderFixture(t, ctx, persist.ChainETH, userF.Wallet.Address, "/metadata/badimage", dummyTokenOpt)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
 		tokens := assertSyncedTokens(t, response, err, 1)
-		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
+		media := waitForSynced[*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia](*tokens[0].Media)
 		assert.Equal(t, string(persist.MediaTypeImage), *media.MediaType)
 		assert.NotEmpty(t, *media.MediaURL)
 	})
+}
+
+// Ideally testing syncs are synchronous, but for now we have to wait for the media to be processed
+func waitForSynced[T any](media any) T {
+	_, ok := (media).(T)
+	for i := 0; i < 10 && !ok; i++ {
+		<-time.After(time.Second)
+		t, ok := (media).(T)
+		if ok {
+			return t
+		}
+	}
+	// let it fail
+	return media.(T)
 }
 
 func assertSyncedTokens(t *testing.T, response *syncTokensMutationResponse, err error, expectedLen int) []*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensToken {

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -944,7 +944,7 @@ func testSyncNewTokensMultichain(t *testing.T) {
 
 func testSyncOnlySubmitsNewTokens(t *testing.T) {
 	userF := newUserFixture(t)
-	provider := defaultStubProvider(userF.Wallet.Address)
+	provider := newStubProvider(withDummyTokenN(multichain.ChainAgnosticContract{Address: "0xdead"}, userF.Wallet.Address, 10))
 	providers := multichain.ProviderLookup{persist.ChainETH: provider}
 	tokenRecorder := sendTokensRecorder{}
 	h := handlerWithProviders(t, tokenRecorder.Send, providers)
@@ -1039,6 +1039,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 
+		<-time.After(time.Second)
 		tokens := assertSyncedTokens(t, response, err, 1)
 		media := (*tokens[0].Media).(*syncTokensMutationSyncTokensSyncTokensPayloadViewerUserGalleryUserTokensTokenMediaImageMedia)
 		assert.Equal(t, string(persist.MediaTypeImage), *media.MediaType)

--- a/graphql/stub_test.go
+++ b/graphql/stub_test.go
@@ -102,11 +102,12 @@ func withReturnError(err error) providerOpt {
 
 // withDummyTokenN will generate n dummy tokens from the provided contract
 func withDummyTokenN(contract multichain.ChainAgnosticContract, ownerAddress persist.Address, n int) providerOpt {
+	start := 1337
 	return func(p *stubProvider) {
 		tokens := []multichain.ChainAgnosticToken{}
-		for i := 0; i < n; i++ {
-			tokenID := persist.HexTokenID(fmt.Sprintf("%X", i))
-			token := dummyTokenIDContract(ownerAddress, contract.Address, tokenID)
+		for i := start; i < start+n; i++ {
+			tokenID := persist.DecimalTokenID(fmt.Sprint(i))
+			token := dummyTokenIDContract(ownerAddress, contract.Address, tokenID.ToHexTokenID())
 			tokens = append(tokens, token)
 		}
 		withContracts([]multichain.ChainAgnosticContract{contract})(p)

--- a/opensea-streamer/main.go
+++ b/opensea-streamer/main.go
@@ -714,7 +714,8 @@ func listenerLoop(ctx context.Context, connectionID int, conn *websocket.Conn, t
 		logger.For(reportCtx).Infof("received user item transfer event for token (contract=%s, tokenID=%s) transferred to wallet %s on chain %d",
 			win.Payload.Item.NFTID.ContractAddress.String(), win.Payload.Item.NFTID.TokenID.String(), win.Payload.ToAccount.Address.String(), win.Payload.Item.NFTID.Chain)
 
-		if !addSeenEvent(message) {
+		key := append(oe.Payload.Payload.ToAccount.Address.Address().Bytes(), []byte(oe.Payload.Payload.Item.NFTID.String())...)
+		if !addSeenEvent(key) {
 			continue
 		}
 

--- a/publicapi/merch.go
+++ b/publicapi/merch.go
@@ -90,15 +90,15 @@ func (api MerchAPI) GetMerchTokens(ctx context.Context, address persist.Address)
 			t.DiscountCode = &discountCode.String
 		}
 
-		switch token.Definition.Metadata["name"] {
-		case "T-Shirt":
+		switch strings.ToLower(token.Definition.Name.String) {
+		case "t-shirt":
 			t.ObjectType = model.MerchTypeTShirt
-		case "Hat":
+		case "hat":
 			t.ObjectType = model.MerchTypeHat
-		case "Card":
+		case "card":
 			t.ObjectType = model.MerchTypeCard
 		default:
-			return nil, fmt.Errorf("unknown merch type for token %v", token.Definition.TokenID)
+			return nil, fmt.Errorf("unknown merch type for token %v: %s", token.Definition.TokenID, token.Definition.Name.String)
 		}
 
 		merchTokens[i] = t

--- a/secrets/dev/local/app-dev-opensea-streamer.yaml
+++ b/secrets/dev/local/app-dev-opensea-streamer.yaml
@@ -1,12 +1,13 @@
 OPENSEA_API_KEY: ENC[AES256_GCM,data:BaClbQK16Ar3rM9H17PyJSUOK1RaPp6t6pKl6iOU1bQ=,iv:5MJdmo7J+sgQMCT+Hg9+TbOzCetgHSJO0KiKjeFkKsM=,tag:Qx3OL39TC3aBsgLmKh/9Uw==,type:str]
 WEBHOOK_TOKEN: ENC[AES256_GCM,data:W+ZvJ+8YX3c013hqKLUvHp9U2+SUxB3Ko5Sjxx3lIRtAoIuw,iv:46mwSL5LVMllZuEYIUIeqdB2az7M3yTVXPX3SzZRQuA=,tag:/Hu7gp2X2/uwsBIRZ+H94A==,type:str]
 SENTRY_DSN: ENC[AES256_GCM,data:ZxILUIWgannNllBD+ohC1AxOc/QMeaBKxKRXG475wpkbHv1GMLemXP7s2Uml2YOc1MR/bA8DKuoBSOwx1q3fPV1y8uniSo4xErdUa8A0jaztt9Y=,iv:bRnCJRVgX2Q7CRRs6AvkyeyHhvWsgaM2w4jmjzxlIU8=,tag:GfalAaBYXkcFA5+sdQjLSQ==,type:str]
-TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:SeeG5TfwOo+706Cc668RljElI2OHw/8MHPQpFI0J41L3I1lSBujGGn1noutZS9OAvvs=,iv:krrdVNeaxzMzyVSrFHBoNeuCXIXI880l2xCVk+r0oSU=,tag:oGeXh1o2buVz4osrFtAUag==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:Ty/rueC3+5GM,iv:jetHEHqE6M6LRciaBvtNKAcYAqS9Uw//cGt8Dxyo1VU=,tag:wWdhsnAsM65sEcS3/NoWOQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:VHGKgw==,iv:R/ZuESXm9jrBJIEqyVXMBQq4WoE70yU4GMp3Mwp7MW8=,tag:6qqnklXPOvZ9nP+xIdbM+g==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:08DJmw==,iv:KR3/cXA0O0BmjNxq2Mi646YuJvSH+9LTzoPz9fS14D0=,tag:2P1q1zuaq9Odlix+lcgfqg==,type:str]
 POSTGRES_DB: ENC[AES256_GCM,data:m6lAorFYhm8=,iv:H5cLzyKzqFETvo7Sr9em3z3fGd7xcHqdwAH/RXE/ySU=,tag:nWWqKqo0YcH1LZ5dRk6LqA==,type:str]
-POSTGRES_USER: ENC[AES256_GCM,data:jQ+jpjKfgSwg13pUFg/N,iv:RZMCf5kZDLXfj/sd53esfp5x4IHYkOH8aDlYEuFlYKo=,tag:0BhyIRVbGAiz2KHcSMKuUg==,type:str]
-POSTGRES_PASSWORD: ENC[AES256_GCM,data:wfHa8VDDIMv8DGIoUesjHObxC29r2EXvWiCm3VMPleg=,iv:LqjjvAfn0FwRUONu2/hcI9W+Z56L9gICvuq1InZIqpg=,tag:3tvUnmc8uyMrT/OpRtggFQ==,type:str]
+POSTGRES_USER: ENC[AES256_GCM,data:h0APZ6LpsSk=,iv:UJJbrDx/uPDMpI7zu1Q0nH5PcITcixdb6hcbwhJAsh0=,tag:hiqnl+DrkB3MyqDYbbeqwA==,type:str]
+TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:i9odwOnyVULQQ7PQibslA8ZgxyqJPBdy416qYM1taXM=,iv:lQ9bFPGCxbIGHPY47HGPH3n+NxZb24lXCjDAjChHago=,tag:uYnEvQtP9B0bV5pE1SR3+g==,type:str]
+TASK_QUEUE_HOST: ENC[AES256_GCM,data:5OoVInvYUahOMi3r+Y4=,iv:Cuh17XDdjSsISbZ4Uk+BkSzHHyvKrUxNcfiCTVtm1yM=,tag:Y5vdXJ/PYRV3QUoCcp36LA==,type:str]
+GCLOUD_OPENSEA_STREAMER_QUEUE: ENC[AES256_GCM,data:NEqucVcLnH689Mn1GDfGNde5c8C/Cjlt+dz0G+pHQlsQ14DY507OFX+kIwaenKwSK1Wx9avigiHrqf0u8Q==,iv:HUPAMCMjjFKP3/oAOaY8SYzeTTVQSbvR8G1i+wZqPxM=,tag:KmuU4IpwCh3AJjtj8F8kmQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -16,8 +17,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-02-20T16:58:26Z"
-    mac: ENC[AES256_GCM,data:sTsy4gW7Ee5K/2FaKubmAV9ordfMhodjgTmuUA7rdMEAd8xxGLA8Y65ZM6dF3aZW46uBtk4IILdm3qn3FutzUhRFsmHKBo2/EzfMmK7QZUi2Cicx/QpxvV+lwoXUcwc0qYW5H7nzA1fkMbscQRLRQvL2Rowf67IH+PnWoW0mJT0=,iv:wpPAZZijlT3OBWXn0qquo8NLPP5RADHxBbtK8QrGpqo=,tag:hF347e2ROjuvxKyNXEtxZw==,type:str]
+    lastmodified: "2024-04-17T00:55:47Z"
+    mac: ENC[AES256_GCM,data:7ytWenHINm6Rx5g/tlcGWTkgsq5mURY4bvJuzj+44YCuGcAG0bOwxre1Dqui0Htd2Eqcxn3Yrk5w/VDgFHeo+f0PGLnw8bq5M0FH/RwF35DfdlblN7gzdg7lJGss91Ya8uSZGNA6dI4aMrT9GHBQyAmX4/FDWxnDo+BINu54u9E=,iv:6detjVsbtkn3D6j13a12OFTs9p1JtIp9HBzmepLrpWM=,tag:SC9Iv4EFYOxMJVdfpAOkJA==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/dev/local/app-dev-opensea-streamer.yaml
+++ b/secrets/dev/local/app-dev-opensea-streamer.yaml
@@ -1,13 +1,12 @@
 OPENSEA_API_KEY: ENC[AES256_GCM,data:BaClbQK16Ar3rM9H17PyJSUOK1RaPp6t6pKl6iOU1bQ=,iv:5MJdmo7J+sgQMCT+Hg9+TbOzCetgHSJO0KiKjeFkKsM=,tag:Qx3OL39TC3aBsgLmKh/9Uw==,type:str]
 WEBHOOK_TOKEN: ENC[AES256_GCM,data:W+ZvJ+8YX3c013hqKLUvHp9U2+SUxB3Ko5Sjxx3lIRtAoIuw,iv:46mwSL5LVMllZuEYIUIeqdB2az7M3yTVXPX3SzZRQuA=,tag:/Hu7gp2X2/uwsBIRZ+H94A==,type:str]
 SENTRY_DSN: ENC[AES256_GCM,data:ZxILUIWgannNllBD+ohC1AxOc/QMeaBKxKRXG475wpkbHv1GMLemXP7s2Uml2YOc1MR/bA8DKuoBSOwx1q3fPV1y8uniSo4xErdUa8A0jaztt9Y=,iv:bRnCJRVgX2Q7CRRs6AvkyeyHhvWsgaM2w4jmjzxlIU8=,tag:GfalAaBYXkcFA5+sdQjLSQ==,type:str]
+TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:SeeG5TfwOo+706Cc668RljElI2OHw/8MHPQpFI0J41L3I1lSBujGGn1noutZS9OAvvs=,iv:krrdVNeaxzMzyVSrFHBoNeuCXIXI880l2xCVk+r0oSU=,tag:oGeXh1o2buVz4osrFtAUag==,type:str]
 POSTGRES_HOST: ENC[AES256_GCM,data:Ty/rueC3+5GM,iv:jetHEHqE6M6LRciaBvtNKAcYAqS9Uw//cGt8Dxyo1VU=,tag:wWdhsnAsM65sEcS3/NoWOQ==,type:str]
-POSTGRES_PORT: ENC[AES256_GCM,data:08DJmw==,iv:KR3/cXA0O0BmjNxq2Mi646YuJvSH+9LTzoPz9fS14D0=,tag:2P1q1zuaq9Odlix+lcgfqg==,type:str]
+POSTGRES_PORT: ENC[AES256_GCM,data:VHGKgw==,iv:R/ZuESXm9jrBJIEqyVXMBQq4WoE70yU4GMp3Mwp7MW8=,tag:6qqnklXPOvZ9nP+xIdbM+g==,type:str]
 POSTGRES_DB: ENC[AES256_GCM,data:m6lAorFYhm8=,iv:H5cLzyKzqFETvo7Sr9em3z3fGd7xcHqdwAH/RXE/ySU=,tag:nWWqKqo0YcH1LZ5dRk6LqA==,type:str]
-POSTGRES_USER: ENC[AES256_GCM,data:h0APZ6LpsSk=,iv:UJJbrDx/uPDMpI7zu1Q0nH5PcITcixdb6hcbwhJAsh0=,tag:hiqnl+DrkB3MyqDYbbeqwA==,type:str]
-TOKEN_PROCESSING_URL: ENC[AES256_GCM,data:i9odwOnyVULQQ7PQibslA8ZgxyqJPBdy416qYM1taXM=,iv:lQ9bFPGCxbIGHPY47HGPH3n+NxZb24lXCjDAjChHago=,tag:uYnEvQtP9B0bV5pE1SR3+g==,type:str]
-TASK_QUEUE_HOST: ENC[AES256_GCM,data:5OoVInvYUahOMi3r+Y4=,iv:Cuh17XDdjSsISbZ4Uk+BkSzHHyvKrUxNcfiCTVtm1yM=,tag:Y5vdXJ/PYRV3QUoCcp36LA==,type:str]
-GCLOUD_OPENSEA_STREAMER_QUEUE: ENC[AES256_GCM,data:NEqucVcLnH689Mn1GDfGNde5c8C/Cjlt+dz0G+pHQlsQ14DY507OFX+kIwaenKwSK1Wx9avigiHrqf0u8Q==,iv:HUPAMCMjjFKP3/oAOaY8SYzeTTVQSbvR8G1i+wZqPxM=,tag:KmuU4IpwCh3AJjtj8F8kmQ==,type:str]
+POSTGRES_USER: ENC[AES256_GCM,data:jQ+jpjKfgSwg13pUFg/N,iv:RZMCf5kZDLXfj/sd53esfp5x4IHYkOH8aDlYEuFlYKo=,tag:0BhyIRVbGAiz2KHcSMKuUg==,type:str]
+POSTGRES_PASSWORD: ENC[AES256_GCM,data:wfHa8VDDIMv8DGIoUesjHObxC29r2EXvWiCm3VMPleg=,iv:LqjjvAfn0FwRUONu2/hcI9W+Z56L9gICvuq1InZIqpg=,tag:3tvUnmc8uyMrT/OpRtggFQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -17,8 +16,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-17T00:55:47Z"
-    mac: ENC[AES256_GCM,data:7ytWenHINm6Rx5g/tlcGWTkgsq5mURY4bvJuzj+44YCuGcAG0bOwxre1Dqui0Htd2Eqcxn3Yrk5w/VDgFHeo+f0PGLnw8bq5M0FH/RwF35DfdlblN7gzdg7lJGss91Ya8uSZGNA6dI4aMrT9GHBQyAmX4/FDWxnDo+BINu54u9E=,iv:6detjVsbtkn3D6j13a12OFTs9p1JtIp9HBzmepLrpWM=,tag:SC9Iv4EFYOxMJVdfpAOkJA==,type:str]
+    lastmodified: "2024-02-20T16:58:26Z"
+    mac: ENC[AES256_GCM,data:sTsy4gW7Ee5K/2FaKubmAV9ordfMhodjgTmuUA7rdMEAd8xxGLA8Y65ZM6dF3aZW46uBtk4IILdm3qn3FutzUhRFsmHKBo2/EzfMmK7QZUi2Cicx/QpxvV+lwoXUcwc0qYW5H7nzA1fkMbscQRLRQvL2Rowf67IH+PnWoW0mJT0=,iv:wpPAZZijlT3OBWXn0qquo8NLPP5RADHxBbtK8QrGpqo=,tag:hF347e2ROjuvxKyNXEtxZw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/server/inject.go
+++ b/server/inject.go
@@ -133,17 +133,17 @@ func ethProviderInjector(
 ) *multichain.EthereumProvider {
 	panic(wire.Build(
 		wire.Struct(new(multichain.EthereumProvider), "*"),
-		wire.Bind(new(multichain.Verifier), util.ToPointer(indexerProvider)),
-		wire.Bind(new(multichain.ContractRefresher), util.ToPointer(indexerProvider)),
-		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.Verifier), util.ToPointer(indexerProvider)),
 	))
 }
 
@@ -159,6 +159,7 @@ func ethSyncPipelineInjector(
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(simplehashProvider)),
 		customMetadataHandlersInjector,
 	))
@@ -201,14 +202,16 @@ func optimismProviderInjector(
 ) *multichain.OptimismProvider {
 	panic(wire.Build(
 		wire.Struct(new(multichain.OptimismProvider), "*"),
-		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -225,6 +228,7 @@ func optimismSyncPipelineInjector(
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(simplehashProvider)),
 		customMetadataHandlersInjector,
 	))
 }
@@ -244,14 +248,16 @@ func arbitrumProviderInjector(
 ) *multichain.ArbitrumProvider {
 	panic(wire.Build(
 		wire.Struct(new(multichain.ArbitrumProvider), "*"),
-		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -268,6 +274,7 @@ func arbitrumSyncPipelineInjector(
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(simplehashProvider)),
 		customMetadataHandlersInjector,
 	))
 }
@@ -304,15 +311,16 @@ func zoraProviderInjector(
 ) *multichain.ZoraProvider {
 	panic(wire.Build(
 		wire.Struct(new(multichain.ZoraProvider), "*"),
-		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -329,6 +337,7 @@ func zoraSyncPipelineInjector(
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(simplehashProvider)),
 		customMetadataHandlersInjector,
 	))
 }
@@ -348,14 +357,16 @@ func baseProvidersInjector(
 ) *multichain.BaseProvider {
 	panic(wire.Build(
 		wire.Struct(new(multichain.BaseProvider), "*"),
-		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
-		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 	))
 }
 
@@ -372,6 +383,7 @@ func baseSyncPipelineInjector(
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(simplehashProvider)),
 		customMetadataHandlersInjector,
 	))
 }
@@ -391,10 +403,12 @@ func polygonProvidersInjector(
 ) *multichain.PolygonProvider {
 	panic(wire.Build(
 		wire.Struct(new(multichain.PolygonProvider), "*"),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(syncPipeline)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(syncPipeline)),
 		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(simplehashProvider)),
@@ -413,7 +427,8 @@ func polygonSyncPipelineInjector(
 		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(simplehashProvider)),
-		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider))
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(simplehashProvider)),
 		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(simplehashProvider)),
 		customMetadataHandlersInjector,
 	))

--- a/server/wire_gen.go
+++ b/server/wire_gen.go
@@ -114,16 +114,16 @@ var (
 
 func ethProviderInjector(ctx context.Context, syncPipeline *wrapper.SyncPipelineWrapper, indexerProvider *indexer.Provider, simplehashProvider *simplehash.Provider) *multichain.EthereumProvider {
 	ethereumProvider := &multichain.EthereumProvider{
-		ContractRefresher:                indexerProvider,
 		ContractFetcher:                  simplehashProvider,
 		ContractsCreatorFetcher:          simplehashProvider,
 		TokenDescriptorsFetcher:          simplehashProvider,
-		TokenMetadataFetcher:             simplehashProvider,
-		TokensIncrementalContractFetcher: syncPipeline,
-		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
 		TokenMetadataBatcher:             syncPipeline,
+		TokenMetadataFetcher:             syncPipeline,
+		TokensByContractWalletFetcher:    syncPipeline,
 		TokensByTokenIdentifiersFetcher:  syncPipeline,
+		TokensIncrementalContractFetcher: syncPipeline,
+		TokensIncrementalOwnerFetcher:    syncPipeline,
 		Verifier:                         indexerProvider,
 	}
 	return ethereumProvider
@@ -138,6 +138,7 @@ func ethSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chain
 		TokensIncrementalContractFetcher: simplehashProvider,
 		TokenMetadataBatcher:             simplehashProvider,
 		TokensByTokenIdentifiersFetcher:  simplehashProvider,
+		TokensByContractWalletFetcher:    simplehashProvider,
 		CustomMetadataWrapper:            customMetadataHandlers,
 	}
 	return syncPipelineWrapper, func() {
@@ -180,14 +181,16 @@ var (
 
 func optimismProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, simplehashProvider *simplehash.Provider) *multichain.OptimismProvider {
 	optimismProvider := &multichain.OptimismProvider{
+		ContractFetcher:                  simplehashProvider,
 		ContractsCreatorFetcher:          simplehashProvider,
 		TokenDescriptorsFetcher:          simplehashProvider,
-		TokenMetadataFetcher:             simplehashProvider,
-		TokensIncrementalContractFetcher: syncPipeline,
-		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
 		TokenMetadataBatcher:             syncPipeline,
+		TokenMetadataFetcher:             syncPipeline,
+		TokensByContractWalletFetcher:    syncPipeline,
 		TokensByTokenIdentifiersFetcher:  syncPipeline,
+		TokensIncrementalContractFetcher: syncPipeline,
+		TokensIncrementalOwnerFetcher:    syncPipeline,
 	}
 	return optimismProvider
 }
@@ -201,6 +204,7 @@ func optimismSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 		TokensIncrementalContractFetcher: simplehashProvider,
 		TokenMetadataBatcher:             simplehashProvider,
 		TokensByTokenIdentifiersFetcher:  simplehashProvider,
+		TokensByContractWalletFetcher:    simplehashProvider,
 		CustomMetadataWrapper:            customMetadataHandlers,
 	}
 	return syncPipelineWrapper, func() {
@@ -223,14 +227,16 @@ var (
 
 func arbitrumProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, simplehashProvider *simplehash.Provider) *multichain.ArbitrumProvider {
 	arbitrumProvider := &multichain.ArbitrumProvider{
+		ContractFetcher:                  simplehashProvider,
 		ContractsCreatorFetcher:          simplehashProvider,
 		TokenDescriptorsFetcher:          simplehashProvider,
-		TokenMetadataFetcher:             simplehashProvider,
-		TokensIncrementalContractFetcher: syncPipeline,
-		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
 		TokenMetadataBatcher:             syncPipeline,
+		TokenMetadataFetcher:             syncPipeline,
+		TokensByContractWalletFetcher:    syncPipeline,
 		TokensByTokenIdentifiersFetcher:  syncPipeline,
+		TokensIncrementalContractFetcher: syncPipeline,
+		TokensIncrementalOwnerFetcher:    syncPipeline,
 	}
 	return arbitrumProvider
 }
@@ -244,6 +250,7 @@ func arbitrumSyncPipelineInjector(ctx context.Context, httpClient *http.Client, 
 		TokensIncrementalContractFetcher: simplehashProvider,
 		TokenMetadataBatcher:             simplehashProvider,
 		TokensByTokenIdentifiersFetcher:  simplehashProvider,
+		TokensByContractWalletFetcher:    simplehashProvider,
 		CustomMetadataWrapper:            customMetadataHandlers,
 	}
 	return syncPipelineWrapper, func() {
@@ -285,12 +292,13 @@ func zoraProviderInjector(syncPipeline *wrapper.SyncPipelineWrapper, simplehashP
 		ContractFetcher:                  simplehashProvider,
 		ContractsCreatorFetcher:          simplehashProvider,
 		TokenDescriptorsFetcher:          simplehashProvider,
-		TokenMetadataFetcher:             simplehashProvider,
-		TokensIncrementalContractFetcher: syncPipeline,
-		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
 		TokenMetadataBatcher:             syncPipeline,
+		TokenMetadataFetcher:             syncPipeline,
+		TokensByContractWalletFetcher:    syncPipeline,
 		TokensByTokenIdentifiersFetcher:  syncPipeline,
+		TokensIncrementalContractFetcher: syncPipeline,
+		TokensIncrementalOwnerFetcher:    syncPipeline,
 	}
 	return zoraProvider
 }
@@ -304,6 +312,7 @@ func zoraSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 		TokensIncrementalContractFetcher: simplehashProvider,
 		TokenMetadataBatcher:             simplehashProvider,
 		TokensByTokenIdentifiersFetcher:  simplehashProvider,
+		TokensByContractWalletFetcher:    simplehashProvider,
 		CustomMetadataWrapper:            customMetadataHandlers,
 	}
 	return syncPipelineWrapper, func() {
@@ -326,14 +335,16 @@ var (
 
 func baseProvidersInjector(syncPipeline *wrapper.SyncPipelineWrapper, simplehashProvider *simplehash.Provider) *multichain.BaseProvider {
 	baseProvider := &multichain.BaseProvider{
+		ContractFetcher:                  simplehashProvider,
 		ContractsCreatorFetcher:          simplehashProvider,
 		TokenDescriptorsFetcher:          simplehashProvider,
-		TokenMetadataFetcher:             simplehashProvider,
-		TokensIncrementalContractFetcher: syncPipeline,
-		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
 		TokenMetadataBatcher:             syncPipeline,
+		TokenMetadataFetcher:             syncPipeline,
+		TokensByContractWalletFetcher:    syncPipeline,
 		TokensByTokenIdentifiersFetcher:  syncPipeline,
+		TokensIncrementalContractFetcher: syncPipeline,
+		TokensIncrementalOwnerFetcher:    syncPipeline,
 	}
 	return baseProvider
 }
@@ -347,6 +358,7 @@ func baseSyncPipelineInjector(ctx context.Context, httpClient *http.Client, chai
 		TokensIncrementalContractFetcher: simplehashProvider,
 		TokenMetadataBatcher:             simplehashProvider,
 		TokensByTokenIdentifiersFetcher:  simplehashProvider,
+		TokensByContractWalletFetcher:    simplehashProvider,
 		CustomMetadataWrapper:            customMetadataHandlers,
 	}
 	return syncPipelineWrapper, func() {
@@ -369,14 +381,16 @@ var (
 
 func polygonProvidersInjector(syncPipeline *wrapper.SyncPipelineWrapper, simplehashProvider *simplehash.Provider) *multichain.PolygonProvider {
 	polygonProvider := &multichain.PolygonProvider{
+		ContractFetcher:                  simplehashProvider,
 		ContractsCreatorFetcher:          simplehashProvider,
 		TokenDescriptorsFetcher:          simplehashProvider,
-		TokenMetadataFetcher:             simplehashProvider,
-		TokensIncrementalContractFetcher: syncPipeline,
-		TokensIncrementalOwnerFetcher:    syncPipeline,
 		TokenIdentifierOwnerFetcher:      syncPipeline,
 		TokenMetadataBatcher:             syncPipeline,
+		TokenMetadataFetcher:             simplehashProvider,
+		TokensByContractWalletFetcher:    syncPipeline,
 		TokensByTokenIdentifiersFetcher:  syncPipeline,
+		TokensIncrementalContractFetcher: syncPipeline,
+		TokensIncrementalOwnerFetcher:    syncPipeline,
 	}
 	return polygonProvider
 }
@@ -390,6 +404,7 @@ func polygonSyncPipelineInjector(ctx context.Context, httpClient *http.Client, c
 		TokensIncrementalContractFetcher: simplehashProvider,
 		TokenMetadataBatcher:             simplehashProvider,
 		TokensByTokenIdentifiersFetcher:  simplehashProvider,
+		TokensByContractWalletFetcher:    simplehashProvider,
 		CustomMetadataWrapper:            customMetadataHandlers,
 	}
 	return syncPipelineWrapper, func() {

--- a/service/multichain/config.go
+++ b/service/multichain/config.go
@@ -18,16 +18,16 @@ type ChainProvider struct {
 }
 
 type EthereumProvider struct {
-	ContractRefresher
 	ContractFetcher
 	ContractsCreatorFetcher
 	TokenDescriptorsFetcher
-	TokenMetadataFetcher
-	TokensIncrementalContractFetcher
-	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
 	TokenMetadataBatcher
+	TokenMetadataFetcher
+	TokensByContractWalletFetcher
 	TokensByTokenIdentifiersFetcher
+	TokensIncrementalContractFetcher
+	TokensIncrementalOwnerFetcher
 	Verifier
 }
 
@@ -42,25 +42,29 @@ type TezosProvider struct {
 }
 
 type OptimismProvider struct {
+	ContractFetcher
 	ContractsCreatorFetcher
 	TokenDescriptorsFetcher
-	TokenMetadataFetcher
-	TokensIncrementalContractFetcher
-	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
 	TokenMetadataBatcher
+	TokenMetadataFetcher
+	TokensByContractWalletFetcher
 	TokensByTokenIdentifiersFetcher
+	TokensIncrementalContractFetcher
+	TokensIncrementalOwnerFetcher
 }
 
 type ArbitrumProvider struct {
+	ContractFetcher
 	ContractsCreatorFetcher
 	TokenDescriptorsFetcher
-	TokenMetadataFetcher
-	TokensIncrementalContractFetcher
-	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
 	TokenMetadataBatcher
+	TokenMetadataFetcher
+	TokensByContractWalletFetcher
 	TokensByTokenIdentifiersFetcher
+	TokensIncrementalContractFetcher
+	TokensIncrementalOwnerFetcher
 }
 
 type PoapProvider struct {
@@ -74,32 +78,37 @@ type ZoraProvider struct {
 	ContractFetcher
 	ContractsCreatorFetcher
 	TokenDescriptorsFetcher
-	TokenMetadataFetcher
-	TokensIncrementalContractFetcher
-	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
 	TokenMetadataBatcher
+	TokenMetadataFetcher
+	TokensByContractWalletFetcher
 	TokensByTokenIdentifiersFetcher
+	TokensIncrementalContractFetcher
+	TokensIncrementalOwnerFetcher
 }
 
 type BaseProvider struct {
+	ContractFetcher
 	ContractsCreatorFetcher
 	TokenDescriptorsFetcher
-	TokenMetadataFetcher
-	TokensIncrementalContractFetcher
-	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
 	TokenMetadataBatcher
+	TokenMetadataFetcher
+	TokensByContractWalletFetcher
 	TokensByTokenIdentifiersFetcher
+	TokensIncrementalContractFetcher
+	TokensIncrementalOwnerFetcher
 }
 
 type PolygonProvider struct {
+	ContractFetcher
 	ContractsCreatorFetcher
 	TokenDescriptorsFetcher
-	TokenMetadataFetcher
-	TokensIncrementalContractFetcher
-	TokensIncrementalOwnerFetcher
 	TokenIdentifierOwnerFetcher
 	TokenMetadataBatcher
+	TokenMetadataFetcher
+	TokensByContractWalletFetcher
 	TokensByTokenIdentifiersFetcher
+	TokensIncrementalContractFetcher
+	TokensIncrementalOwnerFetcher
 }

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/sourcegraph/conc"
+	"github.com/sourcegraph/conc/pool"
 
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/env"
@@ -138,6 +139,14 @@ type TokenIdentifierOwnerFetcher interface {
 	GetTokenByTokenIdentifiersAndOwner(context.Context, ChainAgnosticIdentifiers, persist.Address) (ChainAgnosticToken, ChainAgnosticContract, error)
 }
 
+type TokensByContractWalletFetcher interface {
+	GetTokensByContractWallet(ctx context.Context, contract persist.ChainAddress, wallet persist.Address) ([]ChainAgnosticToken, ChainAgnosticContract, error)
+}
+
+type TokensByTokenIdentifiersFetcher interface {
+	GetTokensByTokenIdentifiers(context.Context, ChainAgnosticIdentifiers) ([]ChainAgnosticToken, ChainAgnosticContract, error)
+}
+
 // TokensIncrementalOwnerFetcher supports fetching tokens for syncing incrementally
 type TokensIncrementalOwnerFetcher interface {
 	// NOTE: implementation MUST close the rec channel
@@ -157,15 +166,6 @@ type ContractFetcher interface {
 
 type ContractsCreatorFetcher interface {
 	GetContractsByCreatorAddress(ctx context.Context, owner persist.Address) ([]ChainAgnosticContract, error)
-}
-
-// ContractRefresher supports refreshes of a contract
-type ContractRefresher interface {
-	RefreshContract(context.Context, persist.Address) error
-}
-
-type TokensByTokenIdentifiersFetcher interface {
-	GetTokensByTokenIdentifiers(context.Context, ChainAgnosticIdentifiers) ([]ChainAgnosticToken, ChainAgnosticContract, error)
 }
 
 // TokenMetadataFetcher supports fetching token metadata
@@ -245,7 +245,7 @@ func (p *Provider) SyncTokensByUserID(ctx context.Context, userID persist.DBID, 
 		wg.Wait()
 	}()
 
-	_, _, _, err = p.addHolderTokensForUser(ctx, user, chains, recCh, errCh)
+	_, _, err = p.addHolderTokensForUser(ctx, user, chains, recCh, errCh)
 	return err
 }
 
@@ -325,7 +325,7 @@ func (p *Provider) SyncCreatedTokensForNewContracts(ctx context.Context, userID 
 		wg.Wait()
 	}()
 
-	_, _, _, err = p.addCreatorTokensForUser(ctx, user, chains, recCh, errCh)
+	_, _, err = p.addCreatorTokensForUser(ctx, user, chains, recCh, errCh)
 	if err != nil {
 		return err
 	}
@@ -427,7 +427,7 @@ outer:
 		}
 	}()
 
-	_, newTokens, _, err := p.addHolderTokensForUser(ctx, user, util.MapKeys(chainPages), recCh, errCh)
+	newTokens, _, err := p.addHolderTokensForUser(ctx, user, util.MapKeys(chainPages), recCh, errCh)
 	return newTokens, err
 }
 
@@ -502,7 +502,7 @@ func (p *Provider) SyncTokensByUserIDAndTokenIdentifiers(ctx context.Context, us
 		wg.Wait()
 	}()
 
-	_, newTokens, _, err := p.addHolderTokensForUser(ctx, user, chains, recCh, errCh)
+	newTokens, _, err := p.addHolderTokensForUser(ctx, user, chains, recCh, errCh)
 	return newTokens, err
 }
 
@@ -624,7 +624,7 @@ func (p *Provider) SyncCreatedTokensForExistingContract(ctx context.Context, use
 		}
 	}()
 
-	_, _, _, err = p.addCreatorTokensForUser(ctx, user, []persist.Chain{contract.Chain}, recCh, errCh)
+	_, _, err = p.addCreatorTokensForUser(ctx, user, []persist.Chain{contract.Chain}, recCh, errCh)
 	return err
 }
 
@@ -638,45 +638,52 @@ func (p *Provider) processCommunities(ctx context.Context, contracts []db.Contra
 	return p.processArtBlocksCommunityTokens(ctx, knownProviders, tokens)
 }
 
-func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chain, users map[persist.DBID]persist.User, chainTokensForUsers map[persist.DBID][]ChainAgnosticToken,
-	existingTokensForUsers map[persist.DBID][]op.TokenFullDetails, contracts []db.Contract,
-	upsertParams op.TokenUpsertParams) (currentUserTokens map[persist.DBID][]op.TokenFullDetails, newUserTokens map[persist.DBID][]op.TokenFullDetails, err error) {
-
-	upsertableDefinitions := make([]db.TokenDefinition, 0)
-	upsertableTokens := make([]op.UpsertToken, 0)
-	tokensIsNewForUser := make(map[persist.DBID]map[persist.TokenIdentifiers]bool)
+func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chain, users map[persist.DBID]persist.User, chainTokensForUsers map[persist.DBID][]ChainAgnosticToken, contracts []db.Contract, upsertParams op.TokenUpsertParams) (newUserTokens map[persist.DBID][]op.TokenFullDetails, err error) {
+	definitionsToAdd := make([]db.TokenDefinition, 0)
+	tokensToAdd := make([]op.UpsertToken, 0)
 
 	for userID, user := range users {
 		tokens := chainTokensToUpsertableTokens(chain, chainTokensForUsers[userID], contracts, user)
-		tokensIsNewForUser[userID] = differenceTokens(
-			util.MapWithoutError(tokens, func(t op.UpsertToken) persist.TokenIdentifiers { return t.Identifiers }),
-			util.MapWithoutError(existingTokensForUsers[userID], func(t op.TokenFullDetails) persist.TokenIdentifiers {
-				return persist.NewTokenIdentifiers(t.Definition.ContractAddress, t.Definition.TokenID, t.Definition.Chain)
-			}),
-		)
 		definitions := chainTokensToUpsertableTokenDefinitions(ctx, chain, chainTokensForUsers[userID], contracts)
-		upsertableTokens = append(upsertableTokens, tokens...)
-		upsertableDefinitions = append(upsertableDefinitions, definitions...)
+		tokensToAdd = append(tokensToAdd, tokens...)
+		definitionsToAdd = append(definitionsToAdd, definitions...)
 	}
 
-	uniqueTokens := dedupeTokenInstances(upsertableTokens)
-	uniqueDefinitions := dedupeTokenDefinitions(upsertableDefinitions)
+	// Insert token definitions
+	definitionsToAdd = dedupeTokenDefinitions(definitionsToAdd)
+	addedDefinitions, err := op.InsertTokenDefinitions(ctx, p.Queries, definitionsToAdd)
+	if err != nil {
+		logger.For(ctx).Errorf("error in bulk upsert of token definitions: %s", err)
+		return nil, err
+	}
 
-	upsertTime, upsertedTokens, err := op.BulkUpsert(ctx, p.Queries, uniqueTokens, uniqueDefinitions, upsertParams.SetCreatorFields, upsertParams.SetHolderFields)
+	// Send definitions to tokenprocessing
+	w := pool.New().WithMaxGoroutines(10)
+	definitionsToProcess := make([]persist.DBID, len(addedDefinitions))
+	for i, d := range addedDefinitions {
+		definitionsToProcess[i] = d.ID
+	}
+	for _, b := range util.ChunkBy(definitionsToProcess, 50) {
+		b := b
+		w.Go(func() {
+			if err := p.SubmitTokens(ctx, b); err != nil {
+				logger.For(ctx).Errorf("failed to submit batch: %s", err)
+				sentryutil.ReportError(ctx, err)
+			}
+		})
+	}
+
+	// Insert tokens
+	tokensToAdd = dedupeTokenInstances(tokensToAdd)
+	upsertTime, addedTokens, err := op.InsertTokens(ctx, p.Queries, tokensToAdd)
 	if err != nil {
 		logger.For(ctx).Errorf("error in bulk upsert of tokens: %s", err)
-		return nil, nil, err
-	}
-
-	// Create a lookup for userID to persisted token IDs
-	currentUserTokens = make(map[persist.DBID][]op.TokenFullDetails)
-	for _, token := range upsertedTokens {
-		currentUserTokens[token.Instance.OwnerUserID] = append(currentUserTokens[token.Instance.OwnerUserID], token)
+		return nil, err
 	}
 
 	// TODO: Consider tracking (token_definition_id, community_type) in a table so we'd know whether we've already
 	// evaluated a token for a given community type and can avoid checking it again.
-	communityTokens := upsertedTokens
+	communityTokens := addedTokens
 	err = p.processCommunities(ctx, contracts, communityTokens)
 	if err != nil {
 		// Report errors, but don't return. We can retry token community memberships at some point, but the whole
@@ -689,120 +696,83 @@ func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chai
 	if upsertParams.OptionalDelete != nil {
 		numAffectedRows, err := p.Queries.DeleteTokensBeforeTimestamp(ctx, upsertParams.OptionalDelete.ToParams(upsertTime))
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to delete tokens: %w", err)
+			return nil, fmt.Errorf("failed to delete tokens: %w", err)
 		}
 		logger.For(ctx).Infof("deleted %d tokens", numAffectedRows)
 	}
 
 	newUserTokens = make(map[persist.DBID][]op.TokenFullDetails, len(users))
-
-	for userID := range users {
-		newTokensForUser := tokensIsNewForUser[userID]
-		currentTokensForUser := currentUserTokens[userID]
-		newUserTokens[userID] = make([]op.TokenFullDetails, 0, len(currentTokensForUser))
-		for _, token := range currentTokensForUser {
-			tID := persist.NewTokenIdentifiers(token.Definition.ContractAddress, token.Definition.TokenID, token.Definition.Chain)
-			if newTokensForUser[tID] {
-				newUserTokens[userID] = append(newUserTokens[userID], token)
-			}
-		}
+	for _, t := range addedTokens {
+		newUserTokens[t.Instance.OwnerUserID] = append(newUserTokens[t.Instance.OwnerUserID], t)
 	}
 
-	for userID := range users {
-		// include the existing tokens that were not persisted with the bulk upsert
-		currentUserTokens[userID] = util.DedupeWithTranslate(append(currentUserTokens[userID], existingTokensForUsers[userID]...), false, func(t op.TokenFullDetails) persist.DBID { return t.Instance.ID })
-	}
+	w.Wait()
 
-	// Send tokens to tokenprocessing
-	toSend := map[persist.DBID]bool{}
-	for _, tokens := range currentUserTokens {
-		for _, t := range tokens {
-			if !toSend[t.Definition.ID] && t.Definition.TokenMediaID == "" {
-				toSend[t.Definition.ID] = true
-			}
-		}
-	}
-	for _, b := range util.ChunkBy(util.MapKeys(toSend), 50) {
-		err = p.SubmitTokens(ctx, b)
-		if err != nil {
-			logger.For(ctx).Errorf("failed to submit batch: %s", err)
-			sentryutil.ReportError(ctx, err)
-		}
-	}
-
-	return currentUserTokens, newUserTokens, err
+	return newUserTokens, err
 }
 
-type addTokensFunc func(context.Context, persist.User, persist.Chain, []ChainAgnosticToken, []db.Contract, []op.TokenFullDetails) (allTokens []op.TokenFullDetails, newTokens []op.TokenFullDetails, err error)
+type addTokensFunc func(context.Context, persist.User, persist.Chain, []ChainAgnosticToken, []db.Contract) (newTokens []op.TokenFullDetails, err error)
 
-func (p *Provider) addCreatorTokensOfContractsToUser(ctx context.Context, user persist.User, chain persist.Chain, tokens []ChainAgnosticToken, contracts []db.Contract, existingTokens []op.TokenFullDetails) (currentTokenState []op.TokenFullDetails, newTokens []op.TokenFullDetails, err error) {
-	return p.processTokensForUser(ctx, user, chain, tokens, contracts, existingTokens, op.TokenUpsertParams{
+func (p *Provider) addCreatorTokensOfContractsToUser(ctx context.Context, user persist.User, chain persist.Chain, tokens []ChainAgnosticToken, contracts []db.Contract) (newTokens []op.TokenFullDetails, err error) {
+	return p.processTokensForUser(ctx, user, chain, tokens, contracts, op.TokenUpsertParams{
 		SetCreatorFields: true,
 		SetHolderFields:  false,
 		OptionalDelete:   nil,
 	})
 }
 
-func (p *Provider) addHolderTokensToUser(ctx context.Context, user persist.User, chain persist.Chain, tokens []ChainAgnosticToken, contracts []db.Contract, existingTokens []op.TokenFullDetails) (currentTokenState []op.TokenFullDetails, newTokens []op.TokenFullDetails, err error) {
-	return p.processTokensForUser(ctx, user, chain, tokens, contracts, existingTokens, op.TokenUpsertParams{
+func (p *Provider) addHolderTokensToUser(ctx context.Context, user persist.User, chain persist.Chain, tokens []ChainAgnosticToken, contracts []db.Contract) (newTokens []op.TokenFullDetails, err error) {
+	return p.processTokensForUser(ctx, user, chain, tokens, contracts, op.TokenUpsertParams{
 		SetCreatorFields: false,
 		SetHolderFields:  true,
 		OptionalDelete:   nil,
 	})
 }
 
-func (p *Provider) processTokensForUser(ctx context.Context, user persist.User, chain persist.Chain, tokens []ChainAgnosticToken, contracts []db.Contract, existingTokens []op.TokenFullDetails, upsertParams op.TokenUpsertParams) (currentTokenState []op.TokenFullDetails, newTokens []op.TokenFullDetails, error error) {
+func (p *Provider) processTokensForUser(ctx context.Context, user persist.User, chain persist.Chain, tokens []ChainAgnosticToken, contracts []db.Contract, upsertParams op.TokenUpsertParams) (newTokens []op.TokenFullDetails, error error) {
 	userMap := map[persist.DBID]persist.User{user.ID: user}
 	providerTokenMap := map[persist.DBID][]ChainAgnosticToken{user.ID: tokens}
-	existingTokenMap := map[persist.DBID][]op.TokenFullDetails{user.ID: existingTokens}
-	currentUserTokens, newUserTokens, err := p.processTokensForUsers(ctx, chain, userMap, providerTokenMap, existingTokenMap, contracts, upsertParams)
+	newUserTokens, err := p.processTokensForUsers(ctx, chain, userMap, providerTokenMap, contracts, upsertParams)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return currentUserTokens[user.ID], newUserTokens[user.ID], nil
+	return newUserTokens[user.ID], nil
 }
 
-func (p *Provider) receiveProviderData(ctx context.Context, user persist.User, recCh <-chan chainTokensAndContracts, errCh <-chan error, addTokensF addTokensFunc) (
-	currentTokens []op.TokenFullDetails,
-	newTokens []op.TokenFullDetails,
-	currentContracts []db.Contract,
-	err error,
-) {
-	currentTokens, err = op.TokensFullDetailsByUserID(ctx, p.Queries, user.ID)
-	if err != nil {
-		return
-	}
-
-	currentContracts = util.MapWithoutError(currentTokens, func(t op.TokenFullDetails) db.Contract { return t.Contract })
-	currentContracts = util.DedupeWithTranslate(currentContracts, true, func(c db.Contract) persist.DBID { return c.ID })
-
+func (p *Provider) receiveProviderData(ctx context.Context, user persist.User, recCh <-chan chainTokensAndContracts, errCh <-chan error, addTokensF addTokensFunc) ([]op.TokenFullDetails, []db.Contract, error) {
+	var newTokens []op.TokenFullDetails
+	var currentContracts []db.Contract
+	var err error
 	for {
 		select {
 		case page, ok := <-recCh:
 			if !ok {
-				return
+				return newTokens, currentContracts, nil
 			}
-			currentContracts, _, err = p.processContracts(ctx, page.Chain, page.Contracts, currentContracts, false)
+
+			currentContracts, _, err = p.processContracts(ctx, page.Chain, page.Contracts, false)
 			if err != nil {
-				return
+				return nil, nil, err
 			}
-			currentTokens, newTokens, err = addTokensF(ctx, user, page.Chain, page.Tokens, currentContracts, currentTokens)
+
+			addedTokens, err := addTokensF(ctx, user, page.Chain, page.Tokens, currentContracts)
 			if err != nil {
-				return
+				return nil, nil, err
 			}
+
+			newTokens = append(newTokens, addedTokens...)
 		case <-ctx.Done():
 			err = ctx.Err()
-			return
+			return nil, nil, err
 		case err, ok := <-errCh:
 			if ok {
-				return nil, nil, nil, err
+				return nil, nil, err
 			}
 		}
 	}
 }
 
 func (p *Provider) addHolderTokensForUser(ctx context.Context, user persist.User, chains []persist.Chain, recCh <-chan chainTokensAndContracts, errCh <-chan error) (
-	currentTokens []op.TokenFullDetails,
 	newTokens []op.TokenFullDetails,
 	currentContracts []db.Contract,
 	err error,
@@ -811,7 +781,6 @@ func (p *Provider) addHolderTokensForUser(ctx context.Context, user persist.User
 }
 
 func (p *Provider) addCreatorTokensForUser(ctx context.Context, user persist.User, chains []persist.Chain, recCh <-chan chainTokensAndContracts, errCh <-chan error) (
-	currentTokens []op.TokenFullDetails,
 	newTokens []op.TokenFullDetails,
 	currentContracts []db.Contract,
 	err error,
@@ -822,13 +791,12 @@ func (p *Provider) addCreatorTokensForUser(ctx context.Context, user persist.Use
 // replaceCreatorTokensForUser adds new creator tokens to a user and deletes old creator tokens. If onlyForContractIDs is not empty,
 // only tokens for the specified contracts will be deleted.
 func (p *Provider) replaceCreatorTokensForUser(ctx context.Context, user persist.User, onlyForContractIDs []persist.DBID, chains []persist.Chain, recCh <-chan chainTokensAndContracts, errCh <-chan error) (
-	currentTokens []op.TokenFullDetails,
 	newTokens []op.TokenFullDetails,
 	currentContracts []db.Contract,
 	err error,
 ) {
 	now := time.Now()
-	currentTokens, newTokens, currentContracts, err = p.receiveProviderData(ctx, user, recCh, errCh, p.addCreatorTokensOfContractsToUser)
+	newTokens, currentContracts, err = p.receiveProviderData(ctx, user, recCh, errCh, p.addCreatorTokensOfContractsToUser)
 	if err != nil {
 		return
 	}
@@ -861,7 +829,7 @@ func (p *Provider) replaceHolderTokensForUser(ctx context.Context, user persist.
 	err error,
 ) {
 	now := time.Now()
-	currentTokens, newTokens, currentContracts, err = p.receiveProviderData(ctx, user, recCh, errCh, p.addHolderTokensToUser)
+	newTokens, currentContracts, err = p.receiveProviderData(ctx, user, recCh, errCh, p.addHolderTokensToUser)
 	if err != nil {
 		return
 	}
@@ -885,49 +853,26 @@ func (p *Provider) GetTokensOfContractForWallet(ctx context.Context, contractAdd
 		return nil, err
 	}
 
-	f, ok := p.Chains[contractAddress.Chain()].(TokensIncrementalOwnerFetcher)
+	var walletID persist.DBID
+
+	for _, w := range user.Wallets {
+		if w.Chain.L1Chain() == wallet.L1Chain() && w.Address == wallet.Address() {
+			walletID = w.ID
+		}
+	}
+
+	if walletID == "" {
+		return nil, fmt.Errorf("user does not own wallet with address: %s", wallet)
+	}
+
+	f, ok := p.Chains[contractAddress.Chain()].(TokensByContractWalletFetcher)
 	if !ok {
 		return nil, fmt.Errorf("no tokens owner fetcher for chain: %d", contractAddress.Chain())
 	}
 
-	var targetContract *ChainAgnosticContract
-	var targetTokens []ChainAgnosticToken
-	recCh, errCh := f.GetTokensIncrementallyByWalletAddress(ctx, wallet.Address())
-
-outer:
-	for {
-		select {
-		case page, ok := <-recCh:
-			if !ok {
-				break outer
-			}
-			// Only process the contract and tokens of that contract instead of all tokens held in the wallet
-			for _, c := range page.Contracts {
-				if c.Address == contractAddress.Address() {
-					targetContract = &c
-					break
-				}
-			}
-			for _, t := range page.Tokens {
-				if t.ContractAddress == contractAddress.Address() {
-					targetTokens = append(targetTokens, t)
-				}
-			}
-		case err, ok := <-errCh:
-			if ok {
-				return nil, err
-			}
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-	}
-
-	if targetContract == nil {
-		return nil, fmt.Errorf("unable to fetch %s", contractAddress.String())
-	}
-
-	if len(targetTokens) == 0 {
-		return nil, fmt.Errorf("unable to find tokens owned by wallet=%s for contract=%s", wallet.Address().String(), contractAddress.String())
+	tokens, contract, err := f.GetTokensByContractWallet(ctx, contractAddress, wallet.Address())
+	if err != nil {
+		return nil, err
 	}
 
 	outCh := make(chan chainTokensAndContracts)
@@ -938,21 +883,36 @@ outer:
 		defer close(outErr)
 		outCh <- chainTokensAndContracts{
 			Chain:     contractAddress.Chain(),
-			Tokens:    targetTokens,
-			Contracts: []ChainAgnosticContract{*targetContract},
+			Tokens:    tokens,
+			Contracts: []ChainAgnosticContract{contract},
 		}
 	}()
 
-	currentTokens, _, _, err := p.addHolderTokensForUser(ctx, user, []persist.Chain{contractAddress.Chain()}, outCh, outErr)
+	_, _, err = p.addHolderTokensForUser(ctx, user, []persist.Chain{contractAddress.Chain()}, outCh, outErr)
 	if err != nil {
 		return nil, err
 	}
 
-	tokens := util.Filter(currentTokens, func(t op.TokenFullDetails) bool {
-		return persist.NewChainAddress(t.Contract.Address, t.Contract.Chain) == contractAddress
-	}, false)
+	t, err := p.Queries.GetTokensByContractAddressUserId(ctx, db.GetTokensByContractAddressUserIdParams{
+		OwnerUserID:     user.ID,
+		ContractAddress: contractAddress.Address(),
+		Chain:           contractAddress.Chain(),
+		WalletID:        walletID.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
 
-	return tokens, nil
+	ownedTokens := make([]op.TokenFullDetails, len(t))
+	for i := range t {
+		ownedTokens[i] = op.TokenFullDetails{
+			Instance:   t[i].Token,
+			Contract:   t[i].Contract,
+			Definition: t[i].TokenDefinition,
+		}
+	}
+
+	return ownedTokens, nil
 }
 
 func (p *Provider) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, chain persist.Chain, tIDs []ChainAgnosticIdentifiers) ([]persist.TokenMetadata, error) {
@@ -1066,12 +1026,6 @@ func (p *Provider) RefreshTokenDescriptorsByTokenIdentifiers(ctx context.Context
 func (p *Provider) RefreshContract(ctx context.Context, ci persist.ContractIdentifiers) error {
 	var contracts []ChainAgnosticContract
 
-	if refresher, ok := p.Chains[ci.Chain].(ContractRefresher); ok {
-		if err := refresher.RefreshContract(ctx, ci.ContractAddress); err != nil {
-			return err
-		}
-	}
-
 	if fetcher, ok := p.Chains[ci.Chain].(ContractFetcher); ok {
 		c, err := fetcher.GetContractByAddress(ctx, ci.ContractAddress)
 		if err != nil {
@@ -1080,7 +1034,7 @@ func (p *Provider) RefreshContract(ctx context.Context, ci persist.ContractIdent
 		contracts = append(contracts, c)
 	}
 
-	_, _, err := p.processContracts(ctx, ci.Chain, contracts, nil, false)
+	_, _, err := p.processContracts(ctx, ci.Chain, contracts, false)
 	return err
 }
 
@@ -1212,19 +1166,14 @@ func (d *Provider) processContractCommunities(ctx context.Context, contracts []d
 // processContracts deduplicates contracts and upserts them into the database. If canOverwriteOwnerAddress is true, then
 // the owner address of an existing contract will be overwritten if the new contract provides a non-empty owner address.
 // An empty owner address will never overwrite an existing address, even if canOverwriteOwnerAddress is true.
-func (d *Provider) processContracts(ctx context.Context, chain persist.Chain, contracts []ChainAgnosticContract, existingContracts []db.Contract, canOverwriteOwnerAddress bool) (dbContracts []db.Contract, newContracts []db.Contract, err error) {
-	contractsToUpsert := chainContractsToUpsertableContracts(chain, contracts, existingContracts)
-	newUpsertedContracts, err := d.Repos.ContractRepository.BulkUpsert(ctx, contractsToUpsert, canOverwriteOwnerAddress)
+func (d *Provider) processContracts(ctx context.Context, chain persist.Chain, contracts []ChainAgnosticContract, canOverwriteOwnerAddress bool) (dbContracts []db.Contract, newContracts []db.Contract, err error) {
+	contractsToAdd := chainContractsToUpsertableContracts(chain, contracts)
+	newUpsertedContracts, err := d.Repos.ContractRepository.BulkUpsert(ctx, contractsToAdd, canOverwriteOwnerAddress)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	dbContracts = util.DedupeWithTranslate(append(newUpsertedContracts, existingContracts...), false, func(c db.Contract) persist.DBID { return c.ID })
-	if err != nil {
-		return nil, nil, err
-	}
-
-	_, err = d.processContractCommunities(ctx, dbContracts)
+	_, err = d.processContractCommunities(ctx, contractsToAdd)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1396,11 +1345,8 @@ func chainTokensToUpsertableTokens(chain persist.Chain, tokens []ChainAgnosticTo
 }
 
 // contractsToUpsertableContracts returns a unique slice of contracts that are ready to be upserted into the database.
-func chainContractsToUpsertableContracts(chain persist.Chain, contracts []ChainAgnosticContract, existingContracts []db.Contract) []db.Contract {
+func chainContractsToUpsertableContracts(chain persist.Chain, contracts []ChainAgnosticContract) []db.Contract {
 	result := map[persist.Address]db.Contract{}
-	for _, c := range existingContracts {
-		result[c.Address] = c
-	}
 	for _, c := range contracts {
 		normalizedAddress := persist.Address(chain.NormalizeAddress(c.Address))
 		result[normalizedAddress] = mergeContracts(result[normalizedAddress], db.Contract{
@@ -1477,21 +1423,4 @@ func dedupeTokenInstances(tokens []op.UpsertToken) (uniqueTokens []op.UpsertToke
 
 	t := util.DedupeWithTranslate(keys, false, func(k Key) string { return k.ID })
 	return util.MapWithoutError(t, func(k Key) op.UpsertToken { return k.Val })
-}
-
-// differenceTokens finds the difference of newState - oldState to get the new tokens
-func differenceTokens(newState []persist.TokenIdentifiers, oldState []persist.TokenIdentifiers) map[persist.TokenIdentifiers]bool {
-	old := make(map[persist.TokenIdentifiers]bool, len(oldState))
-	for _, t := range oldState {
-		old[t] = true
-	}
-
-	diff := make(map[persist.TokenIdentifiers]bool)
-	for _, t := range newState {
-		if !old[t] {
-			diff[t] = true
-		}
-	}
-
-	return diff
 }

--- a/service/multichain/operation/operation.go
+++ b/service/multichain/operation/operation.go
@@ -110,10 +110,6 @@ func InsertTokenDefinitions(ctx context.Context, q *db.Queries, tokens []db.Toke
 		p.DefinitionContractAddress = append(p.DefinitionContractAddress, t.ContractAddress.String())
 		p.DefinitionContractID = append(p.DefinitionContractID, t.ContractID.String())
 		p.DefinitionIsFxhash = append(p.DefinitionIsFxhash, t.IsFxhash)
-		// Community memberships
-		// p.CommunityMembershipDbid = append(p.CommunityMembershipDbid, persist.GenerateID().String())
-		// p.CommunityMembershipTokenID = append(p.CommunityMembershipTokenID, t.TokenID.ToDecimalTokenID().Numeric())
-		// Defer error checking until now to keep the code above from being littered with multiline "if" statements
 		if len(errors) > 0 {
 			return nil, nil, errors[0]
 		}

--- a/service/multichain/operation/operation.go
+++ b/service/multichain/operation/operation.go
@@ -124,7 +124,7 @@ func InsertTokenDefinitions(ctx context.Context, q *db.Queries, tokens []db.Toke
 	}
 
 	if len(added) == 0 {
-		logger.For(ctx).Infof("no new definitions added")
+		logger.For(ctx).Infof("no new definitions added, definitions already existed in the db")
 		return []db.TokenDefinition{}, nil
 	}
 
@@ -187,9 +187,8 @@ func InsertTokens(ctx context.Context, q *db.Queries, tokens []UpsertToken) (tim
 		return time.Time{}, nil, err
 	}
 
-	// No new tokens were added
 	if len(added) == 0 {
-		logger.For(ctx).Infof("no new tokens added")
+		logger.For(ctx).Infof("no new tokens added, tokens already existed in the db")
 		return time.Time{}, []TokenFullDetails{}, nil
 	}
 

--- a/service/multichain/simplehash/simplehash.go
+++ b/service/multichain/simplehash/simplehash.go
@@ -26,7 +26,7 @@ var (
 	getContractsByDeployerEndpoint = checkURL(fmt.Sprintf(getContractsByDeployerEndpointTemplate, baseURL))
 )
 
-var retryPolicy = retry.Retry{MaxWait: 24, MaxRetries: 8}
+var retryPolicy = retry.Retry{MinWait: 1, MaxWait: 24, MaxRetries: 8}
 
 var chainToSimpleHashChain = map[persist.Chain]string{
 	persist.ChainETH:      "ethereum",
@@ -77,7 +77,7 @@ type authMiddleware struct {
 }
 
 func (a *authMiddleware) RoundTrip(r *http.Request) (*http.Response, error) {
-	r.Header.Add("X-API-KEY", a.apiKey)
+	r.Header.Set("X-API-KEY", a.apiKey)
 	t := a.t
 	if t == nil {
 		t = http.DefaultTransport

--- a/service/multichain/simplehash/simplehash.go
+++ b/service/multichain/simplehash/simplehash.go
@@ -820,7 +820,7 @@ func (p *Provider) GetTokensByTokenIdentifiers(ctx context.Context, tID mc.Chain
 }
 
 func (p *Provider) GetTokensByContractWallet(ctx context.Context, contract persist.ChainAddress, wallet persist.Address) ([]mc.ChainAgnosticToken, mc.ChainAgnosticContract, error) {
-	u := setChain(getContractsByWalletEndpoint, contract.Chain())
+	u := setChain(getNftsByWalletEndpoint, contract.Chain())
 	u = setContractAddress(u, contract.Chain(), contract.Address())
 	u = setWallet(u, wallet)
 	u = setLimit(u, tokenBatchLimit)

--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -20,26 +20,8 @@ type SyncPipelineWrapper struct {
 	TokensIncrementalContractFetcher multichain.TokensIncrementalContractFetcher
 	TokenMetadataBatcher             multichain.TokenMetadataBatcher
 	TokensByTokenIdentifiersFetcher  multichain.TokensByTokenIdentifiersFetcher
+	TokensByContractWalletFetcher    multichain.TokensByContractWalletFetcher
 	CustomMetadataWrapper            *multichain.CustomMetadataHandlers
-}
-
-func NewSyncPipelineWrapper(
-	ctx context.Context,
-	chain persist.Chain,
-	tokenIdentifierOwnerFetcher multichain.TokenIdentifierOwnerFetcher,
-	tokensIncrementalOwnerFetcher multichain.TokensIncrementalOwnerFetcher,
-	tokensIncrementalContractFetcher multichain.TokensIncrementalContractFetcher,
-	tokenMetadataBatcher multichain.TokenMetadataBatcher,
-	customMetadataHandlers *multichain.CustomMetadataHandlers,
-) *SyncPipelineWrapper {
-	return &SyncPipelineWrapper{
-		Chain:                            chain,
-		TokensIncrementalOwnerFetcher:    tokensIncrementalOwnerFetcher,
-		TokenIdentifierOwnerFetcher:      tokenIdentifierOwnerFetcher,
-		TokensIncrementalContractFetcher: tokensIncrementalContractFetcher,
-		TokenMetadataBatcher:             tokenMetadataBatcher,
-		CustomMetadataWrapper:            customMetadataHandlers,
-	}
 }
 
 func (w SyncPipelineWrapper) GetTokenByTokenIdentifiersAndOwner(ctx context.Context, ti multichain.ChainAgnosticIdentifiers, address persist.Address) (t multichain.ChainAgnosticToken, c multichain.ChainAgnosticContract, err error) {
@@ -64,6 +46,15 @@ func (w SyncPipelineWrapper) GetTokensByTokenIdentifiers(ctx context.Context, ti
 	t, c, err := w.TokensByTokenIdentifiersFetcher.GetTokensByTokenIdentifiers(ctx, ti)
 	t = w.CustomMetadataWrapper.LoadAll(ctx, w.Chain, t)
 	return t, c, err
+}
+
+func (w SyncPipelineWrapper) GetTokensByContractWallet(ctx context.Context, c persist.ChainAddress, wallet persist.Address) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	panic("not implemented")
+}
+
+func (w SyncPipelineWrapper) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {
+	metadata, err := w.GetTokenMetadataByTokenIdentifiersBatch(ctx, []multichain.ChainAgnosticIdentifiers{ti})
+	return metadata[0], err
 }
 
 func (w SyncPipelineWrapper) GetTokenMetadataByTokenIdentifiersBatch(ctx context.Context, tIDs []multichain.ChainAgnosticIdentifiers) ([]persist.TokenMetadata, error) {

--- a/service/multichain/wrapper/wrapper.go
+++ b/service/multichain/wrapper/wrapper.go
@@ -48,8 +48,10 @@ func (w SyncPipelineWrapper) GetTokensByTokenIdentifiers(ctx context.Context, ti
 	return t, c, err
 }
 
-func (w SyncPipelineWrapper) GetTokensByContractWallet(ctx context.Context, c persist.ChainAddress, wallet persist.Address) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
-	panic("not implemented")
+func (w SyncPipelineWrapper) GetTokensByContractWallet(ctx context.Context, address persist.ChainAddress, wallet persist.Address) ([]multichain.ChainAgnosticToken, multichain.ChainAgnosticContract, error) {
+	t, c, err := w.TokensByContractWalletFetcher.GetTokensByContractWallet(ctx, address, wallet)
+	t = w.CustomMetadataWrapper.LoadAll(ctx, w.Chain, t)
+	return t, c, err
 }
 
 func (w SyncPipelineWrapper) GetTokenMetadataByTokenIdentifiers(ctx context.Context, ti multichain.ChainAgnosticIdentifiers) (persist.TokenMetadata, error) {

--- a/service/persist/postgres/contract_gallery.go
+++ b/service/persist/postgres/contract_gallery.go
@@ -4,67 +4,20 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
-	"github.com/lib/pq"
 	db "github.com/mikeydub/go-gallery/db/gen/coredb"
 	"github.com/mikeydub/go-gallery/service/persist"
-	"github.com/sirupsen/logrus"
 )
 
 // ContractGalleryRepository represents a contract repository in the postgres database
 type ContractGalleryRepository struct {
-	db                    *sql.DB
-	queries               *db.Queries
-	getOwnersStmt         *sql.Stmt
-	getUserByWalletIDStmt *sql.Stmt
-	getPreviewNFTsStmt    *sql.Stmt
+	db      *sql.DB
+	queries *db.Queries
 }
 
 // NewContractGalleryRepository creates a new postgres repository for interacting with contracts
 func NewContractGalleryRepository(db *sql.DB, queries *db.Queries) *ContractGalleryRepository {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-
-	getOwnersStmt, err := db.PrepareContext(ctx, `
-		select unnest(t.owned_by_wallets)
-		from galleries g, unnest(g.collections) with ordinality sections(id, idx)
-		join (
-			select collections.id collection_id, section_tokens.*
-			from collections, unnest(collections.nfts) with ordinality section_tokens(token_id, token_idx)
-			where not collections.deleted
-		) c on sections.id = c.collection_id
-		join tokens t on t.id = c.token_id
-		join token_definitions td on t.token_definition_id = td.id
-		where td.contract_id = $1
-			and not g.deleted
-			and not t.deleted
-			and not td.deleted
-		group by unnest(t.owned_by_wallets)
-		order by min(sections.idx), min(c.token_idx), unnest(t.owned_by_wallets)
-		limit $2 offset $3;`)
-	checkNoErr(err)
-
-	getUserByWalletIDStmt, err := db.PrepareContext(ctx, `SELECT ID,USERNAME FROM users WHERE WALLETS @> ARRAY[$1]:: varchar[] AND DELETED = false`)
-	checkNoErr(err)
-
-	getPreviewNFTsStmt, err := db.PrepareContext(ctx, `
-		select coalesce(nullif(token_medias.media->>'thumbnail_url', ''), nullif(token_medias.media->>'media_url', ''))::varchar
-		from tokens, token_definitions, token_medias
-		where token_definitions.contract_id = $1
-			and tokens.owned_by_wallets && $2
-			and tokens.token_definition_id = token_definitions.id
-			and token_definitions.token_media_id = token_medias.id
-			and (length(token_medias.media->>'thumbnail_url') > 0 or length(token_medias.media->>'media_url') > 0)
-			and not tokens.deleted
-			and not token_definitions.deleted
-			and not token_medias.deleted
-		order by tokens.id
-		limit 3;
-	`)
-	checkNoErr(err)
-
-	return &ContractGalleryRepository{db: db, queries: queries, getOwnersStmt: getOwnersStmt, getUserByWalletIDStmt: getUserByWalletIDStmt, getPreviewNFTsStmt: getPreviewNFTsStmt}
+	return &ContractGalleryRepository{db: db, queries: queries}
 }
 
 func (c *ContractGalleryRepository) Upsert(pCtx context.Context, contract db.Contract, canOverwriteOwnerAddress bool) (db.Contract, error) {
@@ -110,90 +63,4 @@ func (c *ContractGalleryRepository) BulkUpsert(pCtx context.Context, contracts [
 	}
 
 	return upserted, nil
-}
-
-func (c *ContractGalleryRepository) GetOwnersByAddress(ctx context.Context, contractAddr persist.Address, chain persist.Chain, limit, offset int) ([]persist.TokenHolder, error) {
-	contract, err := c.queries.GetContractByChainAddress(ctx, db.GetContractByChainAddressParams{Address: contractAddr, Chain: chain})
-	if err != nil {
-		return nil, err
-	}
-
-	rows, err := c.getOwnersStmt.QueryContext(ctx, contract.ID, limit, offset)
-	if err != nil {
-		return nil, fmt.Errorf("error getting owners: %w", err)
-	}
-	defer rows.Close()
-
-	walletIDs := make([]persist.DBID, 0)
-
-	for rows.Next() {
-		var walletID persist.DBID
-		err = rows.Scan(pq.Array(&walletID))
-		if err != nil {
-			return nil, fmt.Errorf("error scanning owners: %w", err)
-		}
-		walletIDs = append(walletIDs, walletID)
-	}
-
-	if err = rows.Err(); err != nil {
-		return nil, fmt.Errorf("error getting owners: %w", err)
-	}
-
-	if len(walletIDs) == 0 {
-		return []persist.TokenHolder{}, nil
-	}
-
-	tokenHolders := map[persist.DBID]*persist.TokenHolder{}
-	for _, walletID := range walletIDs {
-		var username persist.NullString
-		var userID persist.DBID
-		err := c.getUserByWalletIDStmt.QueryRowContext(ctx, walletID).Scan(&userID, &username)
-		if err != nil {
-			logrus.Warnf("error getting member of community '%s' by wallet ID '%s': %s", contractAddr, walletID, err)
-			continue
-		}
-
-		if username.String() == "" {
-			continue
-		}
-
-		if tokenHolder, ok := tokenHolders[userID]; ok {
-			tokenHolder.WalletIDs = append(tokenHolder.WalletIDs, walletID)
-		} else {
-			tokenHolders[userID] = &persist.TokenHolder{
-				UserID:        userID,
-				WalletIDs:     []persist.DBID{walletID},
-				PreviewTokens: nil,
-			}
-		}
-	}
-
-	result := make([]persist.TokenHolder, 0, len(tokenHolders))
-
-	for _, tokenHolder := range tokenHolders {
-		previewNFTs := make([]persist.NullString, 0, 3)
-
-		rows, err = c.getPreviewNFTsStmt.QueryContext(ctx, contract.ID, pq.Array(tokenHolder.WalletIDs))
-
-		if err != nil {
-			logrus.Warnf("error getting preview NFTs of community '%s' by wallet IDs '%s': %s", contractAddr, tokenHolder.WalletIDs, err)
-		} else {
-			defer rows.Close()
-			for rows.Next() {
-				var imageURL persist.NullString
-				err = rows.Scan(&imageURL)
-				if err != nil {
-					logrus.Warnf("error scanning preview NFT of community '%s' by wallet IDs '%s': %s", contractAddr, tokenHolder.WalletIDs, err)
-					continue
-				}
-				previewNFTs = append(previewNFTs, imageURL)
-			}
-		}
-
-		tokenHolder.PreviewTokens = previewNFTs
-		result = append(result, *tokenHolder)
-	}
-
-	return result, nil
-
 }

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -270,7 +270,7 @@ func processOwnersForOpenseaTokens(mc *multichain.Provider, queries *db.Queries)
 
 			dbToken, err := queries.GetUniqueTokenIdentifiersByTokenID(c, token.Instance.ID)
 			if err != nil {
-				logger.For(ctx).Errorf("error getting unique token identifiers: %s", err)
+				logger.For(ctx).Errorf("error getting unique token identifiers from tokenID=%s: %s", token.Instance.ID, err)
 				continue
 			}
 

--- a/util/retry/retry.go
+++ b/util/retry/retry.go
@@ -169,7 +169,7 @@ func RetryRequestWithRetry(c *http.Client, req *http.Request, r Retry) (*http.Re
 			return resp, err
 		}
 		wait := WaitTime(r.MinWait, r.MaxWait, i)
-		logger.For(req.Context()).Infof("rate limited by %s (attempt=%d/%d); waiting for %s", req.Host, i, r.MaxRetries, wait)
+		logger.For(req.Context()).Infof("rate limited by %s (attempt=%d/%d); waiting for %s", req.Host, i+1, r.MaxRetries, wait)
 		<-time.After(wait)
 	}
 	return nil, ErrOutOfRetries


### PR DESCRIPTION
**Changes**
#### Syncing
This PR refactors the upsert of definitions, token community memberships, and token instances into separate queries. Rows are also sorted before inserting into the DB. These changes should prevent deadlocks since each transaction would hold fewer row locks and ensure a consistent insertion order.

Fetching metadata now uses the `SyncPipeline` wrapper instead of calling the Simplehash provider directly so that our custom metadata handlers are applied to a token.

Finding new tokens previously required accumulating an in-memory map of added tokens. New tokens are now instead found by joining the inserted rows with the state of the table at the beginning of the transaction. These tokens are also submitted to tokenprocessing for media processing.

#### Opensea Streamer
The streamer now uses the recipient address and the token to duplicate messages rather than the entire message body. This reduces the number of messages sent to tokenprocessing.

#### Merch store
A new interface, `TokensByContractWalletFetcher`, is used to fetch specific tokens of a contract held by a wallet. This is used in place of `TokensIncrementalOwnerFetcher` which requires fetching all tokens for a wallet and filtering the result.

**Misc**
* Fixes bug where retrying after a rate limit error fails because the API key is appended to the request header instead of set
* Removes unused `GetTokenFullDetailsBy*` queries
* Removes unused `ContractGalleryRepo` methods