### PR TITLE
Use simplehash for tezos

### DIFF
--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -1314,7 +1314,7 @@ func testSyncShouldProcessMedia(t *testing.T) {
 // Ideally testing syncs are synchronous, but for now we have to wait for the media to be processed
 func waitForSynced[T any](media any) T {
 	_, ok := (media).(T)
-	for i := 0; i < 10 && !ok; i++ {
+	for i := 0; i < 20 && !ok; i++ {
 		<-time.After(time.Second)
 		t, ok := (media).(T)
 		if ok {

--- a/server/inject.go
+++ b/server/inject.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mikeydub/go-gallery/service/multichain/poap"
 	"github.com/mikeydub/go-gallery/service/multichain/simplehash"
 	"github.com/mikeydub/go-gallery/service/multichain/tezos"
-	"github.com/mikeydub/go-gallery/service/multichain/tzkt"
 	"github.com/mikeydub/go-gallery/service/multichain/wrapper"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
@@ -173,22 +172,27 @@ func ethSyncPipelineInjector(
 func tezosInjector(envInit, *http.Client) *multichain.TezosProvider {
 	wire.Build(
 		tezosProviderInjector,
+		wire.Value(persist.ChainTezos),
 		tezos.NewProvider,
-		tzkt.NewProvider,
+		simplehash.NewProvider,
 	)
 	return nil
 }
 
-func tezosProviderInjector(tezosProvider *tezos.Provider, tzktProvider *tzkt.Provider) *multichain.TezosProvider {
+func tezosProviderInjector(tezosProvider *tezos.Provider, simplehashProvider *simplehash.Provider) *multichain.TezosProvider {
 	panic(wire.Build(
 		wire.Struct(new(multichain.TezosProvider), "*"),
 		wire.Bind(new(multichain.Verifier), util.ToPointer(tezosProvider)),
-		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(tzktProvider)),
-		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(tzktProvider)),
-		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(tzktProvider)),
-		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(tzktProvider)),
-		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(tzktProvider)),
-		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(tzktProvider)),
+		wire.Bind(new(multichain.ContractFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.ContractsCreatorFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenDescriptorsFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenIdentifierOwnerFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenMetadataBatcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokenMetadataFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensByTokenIdentifiersFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensByContractWalletFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensIncrementalContractFetcher), util.ToPointer(simplehashProvider)),
+		wire.Bind(new(multichain.TokensIncrementalOwnerFetcher), util.ToPointer(simplehashProvider)),
 	))
 }
 

--- a/service/multichain/config.go
+++ b/service/multichain/config.go
@@ -32,12 +32,16 @@ type EthereumProvider struct {
 }
 
 type TezosProvider struct {
+	ContractFetcher
 	ContractsCreatorFetcher
 	TokenDescriptorsFetcher
+	TokenIdentifierOwnerFetcher
+	TokenMetadataBatcher
 	TokenMetadataFetcher
+	TokensByContractWalletFetcher
+	TokensByTokenIdentifiersFetcher
 	TokensIncrementalContractFetcher
 	TokensIncrementalOwnerFetcher
-	TokenIdentifierOwnerFetcher
 	Verifier
 }
 

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -690,16 +690,9 @@ func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chai
 			definitionsToProcess = append(definitionsToProcess, addedDefinitions[i].ID)
 		}
 	}
-	for _, b := range util.ChunkBy(definitionsToProcess, 50) {
-		b := b
-		if len(b) > 0 {
-			w.Go(func() {
-				if err := p.SubmitTokens(ctx, b); err != nil {
-					logger.For(ctx).Errorf("failed to submit batch: %s", err)
-					sentryutil.ReportError(ctx, err)
-				}
-			})
-		}
+	if err := p.SubmitTokens(ctx, definitionsToProcess); err != nil {
+		logger.For(ctx).Errorf("failed to submit batch: %s", err)
+		sentryutil.ReportError(ctx, err)
 	}
 
 	// Insert tokens

--- a/service/tracing/http.go
+++ b/service/tracing/http.go
@@ -8,7 +8,7 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-type tracingTransport struct {
+type TracingTransport struct {
 	http.RoundTripper
 
 	continueOnly bool
@@ -18,24 +18,24 @@ type tracingTransport struct {
 // NewTracingTransport creates an http transport that will trace requests via Sentry. If continueOnly is true,
 // traces will only be generated if they'd contribute to an existing parent trace (e.g. if a trace is not in progress,
 // no new trace would be started). It errorsOnly is true, only requests that returned an error status code (400 and above) are reported.
-func NewTracingTransport(roundTripper http.RoundTripper, continueOnly bool, spanOptions ...sentry.SpanOption) *tracingTransport {
+func NewTracingTransport(roundTripper http.RoundTripper, continueOnly bool, spanOptions ...sentry.SpanOption) *TracingTransport {
 	// If roundTripper is already a tracer, grab its underlying RoundTripper instead
-	if existingTracer, ok := roundTripper.(*tracingTransport); ok {
-		return &tracingTransport{
+	if existingTracer, ok := roundTripper.(*TracingTransport); ok {
+		return &TracingTransport{
 			RoundTripper: existingTracer.RoundTripper,
 			continueOnly: continueOnly,
 			opts:         spanOptions,
 		}
 	}
 
-	return &tracingTransport{
+	return &TracingTransport{
 		RoundTripper: roundTripper,
 		continueOnly: continueOnly,
 		opts:         spanOptions,
 	}
 }
 
-func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+func (t *TracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.continueOnly {
 		transaction := sentry.TransactionFromContext(req.Context())
 		if transaction == nil {


### PR DESCRIPTION
This PR uses Simplehash for Tezos and enables creator support for Tezos. Creator support is only available for contracts you deployed, shared contracts like fxhash aren't supported. This PR also fixes a bug in the wallet repo query where the L1 chain of the wallet wasn't returned, resulting in a default L1 Chain of 0 (which corresponds to Ethereum).

Misc
* Increases wait time for syncing tests
* Submits the whole page of tokens to tokenprocessing instead of batching in groups of 50
* Turns off idle connections in tokenprocessing to reduce the number of open file sockets