### PR TITLE
Add more tracing to token media dispatch

### DIFF
--- a/db/gen/coredb/batch.go
+++ b/db/gen/coredb/batch.go
@@ -2520,7 +2520,7 @@ func (b *GetGalleryByIdBatchBatchResults) Close() error {
 }
 
 const getGalleryTokenMediasByGalleryIDBatch = `-- name: GetGalleryTokenMediasByGalleryIDBatch :batchmany
-select tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted
+select tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted, tm.chain, tm.contract_address, tm.token_id
 from galleries g, collections c, tokens t, token_medias tm, token_definitions td
 where
 	g.id = $1
@@ -2588,6 +2588,9 @@ func (b *GetGalleryTokenMediasByGalleryIDBatchBatchResults) Query(f func(int, []
 					&i.Media,
 					&i.ProcessingJobID,
 					&i.Deleted,
+					&i.Chain,
+					&i.ContractAddress,
+					&i.TokenID,
 				); err != nil {
 					return err
 				}
@@ -2607,7 +2610,7 @@ func (b *GetGalleryTokenMediasByGalleryIDBatchBatchResults) Close() error {
 }
 
 const getMediaByMediaIdIgnoringStatusBatch = `-- name: GetMediaByMediaIdIgnoringStatusBatch :batchone
-select m.id, m.created_at, m.last_updated, m.version, m.active, m.media, m.processing_job_id, m.deleted from token_medias m where m.id = $1 and not deleted
+select m.id, m.created_at, m.last_updated, m.version, m.active, m.media, m.processing_job_id, m.deleted, m.chain, m.contract_address, m.token_id from token_medias m where m.id = $1 and not deleted
 `
 
 type GetMediaByMediaIdIgnoringStatusBatchBatchResults struct {
@@ -2648,6 +2651,9 @@ func (b *GetMediaByMediaIdIgnoringStatusBatchBatchResults) QueryRow(f func(int, 
 			&i.Media,
 			&i.ProcessingJobID,
 			&i.Deleted,
+			&i.Chain,
+			&i.ContractAddress,
+			&i.TokenID,
 		)
 		if f != nil {
 			f(t, i, err)
@@ -3893,7 +3899,7 @@ func (b *GetTokenByUserTokenIdentifiersBatchBatchResults) Close() error {
 }
 
 const getTokenByUserTokenIdentifiersIgnoreDisplayableBatch = `-- name: GetTokenByUserTokenIdentifiersIgnoreDisplayableBatch :batchone
-select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain, tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted
+select t.id, t.deleted, t.version, t.created_at, t.last_updated, t.collectors_note, t.quantity, t.block_number, t.owner_user_id, t.owned_by_wallets, t.contract_id, t.is_user_marked_spam, t.last_synced, t.is_creator_token, t.token_definition_id, t.is_holder_token, t.displayable, td.id, td.created_at, td.last_updated, td.deleted, td.name, td.description, td.token_type, td.token_id, td.external_url, td.chain, td.metadata, td.fallback_media, td.contract_address, td.contract_id, td.token_media_id, td.is_fxhash, c.id, c.deleted, c.version, c.created_at, c.last_updated, c.name, c.symbol, c.address, c.creator_address, c.chain, c.profile_banner_url, c.profile_image_url, c.badge_url, c.description, c.owner_address, c.is_provider_marked_spam, c.parent_id, c.override_creator_user_id, c.l1_chain, tm.id, tm.created_at, tm.last_updated, tm.version, tm.active, tm.media, tm.processing_job_id, tm.deleted, tm.chain, tm.contract_address, tm.token_id
 from tokens t, token_definitions td, contracts c, token_medias tm
 where t.token_definition_id = td.id
     and td.contract_id = c.id
@@ -4015,6 +4021,9 @@ func (b *GetTokenByUserTokenIdentifiersIgnoreDisplayableBatchBatchResults) Query
 			&i.TokenMedia.Media,
 			&i.TokenMedia.ProcessingJobID,
 			&i.TokenMedia.Deleted,
+			&i.TokenMedia.Chain,
+			&i.TokenMedia.ContractAddress,
+			&i.TokenMedia.TokenID,
 		)
 		if f != nil {
 			f(t, i, err)

--- a/db/gen/coredb/models_gen.go
+++ b/db/gen/coredb/models_gen.go
@@ -679,14 +679,17 @@ type TokenDefinition struct {
 }
 
 type TokenMedia struct {
-	ID              persist.DBID  `db:"id" json:"id"`
-	CreatedAt       time.Time     `db:"created_at" json:"created_at"`
-	LastUpdated     time.Time     `db:"last_updated" json:"last_updated"`
-	Version         int32         `db:"version" json:"version"`
-	Active          bool          `db:"active" json:"active"`
-	Media           persist.Media `db:"media" json:"media"`
-	ProcessingJobID persist.DBID  `db:"processing_job_id" json:"processing_job_id"`
-	Deleted         bool          `db:"deleted" json:"deleted"`
+	ID              persist.DBID           `db:"id" json:"id"`
+	CreatedAt       time.Time              `db:"created_at" json:"created_at"`
+	LastUpdated     time.Time              `db:"last_updated" json:"last_updated"`
+	Version         int32                  `db:"version" json:"version"`
+	Active          bool                   `db:"active" json:"active"`
+	Media           persist.Media          `db:"media" json:"media"`
+	ProcessingJobID persist.DBID           `db:"processing_job_id" json:"processing_job_id"`
+	Deleted         bool                   `db:"deleted" json:"deleted"`
+	Chain           persist.Chain          `db:"chain" json:"chain"`
+	ContractAddress persist.Address        `db:"contract_address" json:"contract_address"`
+	TokenID         persist.DecimalTokenID `db:"token_id" json:"token_id"`
 }
 
 type TokenMediasActive struct {

--- a/db/gen/coredb/token_gallery.sql.go
+++ b/db/gen/coredb/token_gallery.sql.go
@@ -182,9 +182,8 @@ with token_definitions_insert as (
     , is_fxhash = excluded.is_fxhash
   returning id, created_at, last_updated, deleted, name, description, token_type, token_id, external_url, chain, metadata, fallback_media, contract_address, contract_id, token_media_id, is_fxhash
 )
-select token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash, (prior_state.id is null)::bool is_new_definition
+select token_definitions.id, token_definitions.created_at, token_definitions.last_updated, token_definitions.deleted, token_definitions.name, token_definitions.description, token_definitions.token_type, token_definitions.token_id, token_definitions.external_url, token_definitions.chain, token_definitions.metadata, token_definitions.fallback_media, token_definitions.contract_address, token_definitions.contract_id, token_definitions.token_media_id, token_definitions.is_fxhash
 from token_definitions_insert token_definitions
-left join token_definitions prior_state on token_definitions.chain = prior_state.chain and token_definitions.contract_id = prior_state.contract_id and token_definitions.token_id = prior_state.token_id and not prior_state.deleted
 `
 
 type UpsertTokenDefinitionsParams struct {
@@ -204,10 +203,8 @@ type UpsertTokenDefinitionsParams struct {
 
 type UpsertTokenDefinitionsRow struct {
 	TokenDefinition TokenDefinition `db:"token_definition" json:"token_definition"`
-	IsNewDefinition bool            `db:"is_new_definition" json:"is_new_definition"`
 }
 
-// token_definitions is the snapshot of the table prior to inserting. We can determine if a token is new by checking against this table.
 func (q *Queries) UpsertTokenDefinitions(ctx context.Context, arg UpsertTokenDefinitionsParams) ([]UpsertTokenDefinitionsRow, error) {
 	rows, err := q.db.Query(ctx, upsertTokenDefinitions,
 		arg.DefinitionDbid,
@@ -247,7 +244,6 @@ func (q *Queries) UpsertTokenDefinitions(ctx context.Context, arg UpsertTokenDef
 			&i.TokenDefinition.ContractID,
 			&i.TokenDefinition.TokenMediaID,
 			&i.TokenDefinition.IsFxhash,
-			&i.IsNewDefinition,
 		); err != nil {
 			return nil, err
 		}
@@ -327,8 +323,7 @@ select tokens.id, tokens.deleted, tokens.version, tokens.created_at, tokens.last
 from tokens_insert tokens
 join token_definitions on tokens.token_definition_id = token_definitions.id and not token_definitions.deleted
 join contracts on token_definitions.contract_id = contracts.id
-left join tokens prior_state on tokens.owner_user_id = prior_state.owner_user_id and tokens.token_definition_id = prior_state.token_definition_id and not prior_state.deleted
-where prior_state.id is null
+where tokens.created_at = tokens.last_updated
 `
 
 type UpsertTokensParams struct {
@@ -357,7 +352,6 @@ type UpsertTokensRow struct {
 	Contract        Contract        `db:"contract" json:"contract"`
 }
 
-// tokens is the snapshot of the table prior to inserting. We can determine if a token is new by checking against this table.
 func (q *Queries) UpsertTokens(ctx context.Context, arg UpsertTokensParams) ([]UpsertTokensRow, error) {
 	rows, err := q.db.Query(ctx, upsertTokens,
 		arg.SetHolderFields,

--- a/db/migrations/core/000159_add_token_columns_to_media.up.sql
+++ b/db/migrations/core/000159_add_token_columns_to_media.up.sql
@@ -1,0 +1,4 @@
+alter table token_medias add column chain int;
+alter table token_medias add column contract_address varchar;
+alter table token_medias add column token_id numeric;
+create index token_medias_chain_contract_token_idx on token_medias(chain, contract_address, token_id) where not deleted;

--- a/db/queries/core/query.sql
+++ b/db/queries/core/query.sql
@@ -1463,8 +1463,8 @@ with insert_job(id) as (
     returning last_updated
 )
 , insert_new_media as (
-    insert into token_medias (id, media, processing_job_id, active, created_at, last_updated)
-    values (@new_media_id, @new_media::jsonb, (select id from insert_job), @new_media_is_active,
+    insert into token_medias (id, chain, contract_address, token_id, media, processing_job_id, active, created_at, last_updated)
+    values (@new_media_id, @chain, @contract_address, @decimal_token_id, @new_media::jsonb, (select id from insert_job), @new_media_is_active,
         -- Using timestamps generated from set_conditionally_current_media_to_inactive ensures that the new record is only inserted after the current media is moved
         (select coalesce((select last_updated from set_conditionally_current_media_to_inactive), now())),
         (select coalesce((select last_updated from set_conditionally_current_media_to_inactive), now()))
@@ -1571,12 +1571,12 @@ select * from reprocess_jobs where id = $1;
 select m.* from token_medias m where m.id = $1 and not deleted;
 
 -- name: GetMediaByTokenIdentifiersIgnoringStatus :one
-select token_medias.*
-from token_definitions
-join token_medias on token_definitions.token_media_id = token_medias.id
-where (chain, contract_address, token_id) = (@chain, @contract_address::address, @token_id::hextokenid)
-    and not token_definitions.deleted
-    and not token_medias.deleted;
+select tm.*
+from token_definitions td
+join token_medias tm on td.token_media_id = tm.id
+where (td.chain, td.contract_address, td.token_id) = (@chain, @contract_address::address, @token_id::hextokenid)
+    and not td.deleted
+    and not tm.deleted;
 
 -- name: UpsertSession :one
 insert into sessions (id, user_id,

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -90,6 +90,8 @@ sql:
           # TokenMedias
           - column: 'token_medias.media'
             go_type: 'github.com/mikeydub/go-gallery/service/persist.Media'
+          - column: 'token_medias.token_id'
+            go_type: 'github.com/mikeydub/go-gallery/service/persist.DecimalTokenID'
 
           # TokenProcessingJobs
           - column: 'token_processing_jobs.pipeline_metadata'

--- a/tokenprocessing/pipeline.go
+++ b/tokenprocessing/pipeline.go
@@ -457,6 +457,7 @@ func (tpj *tokenProcessingJob) saveResult(ctx context.Context, media persist.Med
 		Chain:            tpj.token.Chain,
 		ContractAddress:  tpj.contract.ContractAddress,
 		TokenID:          tpj.token.TokenID,
+		DecimalTokenID:   tpj.token.TokenID.ToDecimalTokenID(),
 		NewMediaIsActive: tpj.activeStatus(ctx, media),
 		NewMediaID:       persist.GenerateID(),
 		NewMedia:         newMedia,


### PR DESCRIPTION
Changes
* Adds chain, contract, and token ID to the token media table so that we can trace if we ever processed media for a token
* Changes heuristic that determines if a definition is new by comparing when the definition was created to when it was last updated
* Adds more logging to around when a definition is dispatched