### PR TITLE
Add submitter interface for submitting tokens to tokenprocessing

### DIFF
--- a/db/queries/core/token_gallery.sql
+++ b/db/queries/core/token_gallery.sql
@@ -47,8 +47,10 @@ with token_definitions_insert as (
     , is_fxhash = excluded.is_fxhash
   returning *
 )
-select sqlc.embed(token_definitions)
-from token_definitions_insert token_definitions;
+select sqlc.embed(token_definitions), (prior_state.id is null)::bool is_new_definition
+from token_definitions_insert token_definitions
+-- token_definitions is the snapshot of the table prior to inserting. We can determine if a token is new by checking against this snapshot.
+left join token_definitions prior_state on token_definitions.chain = prior_state.chain and token_definitions.contract_id = prior_state.contract_id and token_definitions.token_id = prior_state.token_id and not prior_state.deleted;
 
 -- name: UpsertTokenDefinitionCommunityMemberships :many
 insert into token_community_memberships
@@ -152,7 +154,9 @@ select sqlc.embed(tokens), sqlc.embed(token_definitions), sqlc.embed(contracts)
 from tokens_insert tokens
 join token_definitions on tokens.token_definition_id = token_definitions.id and not token_definitions.deleted
 join contracts on token_definitions.contract_id = contracts.id
-where tokens.created_at = tokens.last_updated;
+-- tokens is the snapshot of the table prior to inserting. We can determine if a token is new by checking against this snapshot.
+left join tokens prior_state on tokens.owner_user_id = prior_state.owner_user_id and tokens.token_definition_id = prior_state.token_definition_id and not prior_state.deleted
+where prior_state.id is null;
 
 -- name: DeleteTokensBeforeTimestamp :execrows
 update tokens t

--- a/graphql/fixture_test.go
+++ b/graphql/fixture_test.go
@@ -228,7 +228,7 @@ func newUserWithTokensFixture(t *testing.T) userWithTokensFixture {
 	user := newUserFixture(t)
 	ctx := context.Background()
 	providers := multichain.ProviderLookup{persist.ChainETH: defaultStubProvider(user.Wallet.Address)}
-	h := handlerWithProviders(t, submitUserTokensNoop, providers)
+	h := handlerWithProviders(t, &noopSubmitter{}, providers)
 	c := customHandlerClient(t, h, withJWTOpt(t, user.ID))
 	tokenIDs := syncTokens(t, ctx, c, user.ID)
 	return userWithTokensFixture{user, tokenIDs}

--- a/graphql/graphql_test.go
+++ b/graphql/graphql_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/mikeydub/go-gallery/service/auth"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
+	"github.com/mikeydub/go-gallery/service/tokenmanage"
+	"github.com/mikeydub/go-gallery/tokenprocessing"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -852,7 +854,7 @@ func testSyncNewTokens(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("should sync new tokens", func(t *testing.T) {
-		h := handlerWithProviders(t, submitUserTokensNoop, providers)
+		h := handlerWithProviders(t, &noopSubmitter{}, providers)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
@@ -863,7 +865,7 @@ func testSyncNewTokens(t *testing.T) {
 	})
 
 	t.Run("should not duplicate tokens from repeat syncs", func(t *testing.T) {
-		h := handlerWithProviders(t, submitUserTokensNoop, providers)
+		h := handlerWithProviders(t, &noopSubmitter{}, providers)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
@@ -877,7 +879,7 @@ func testSyncNewTokens(t *testing.T) {
 		userF := newUserWithTokensFixture(t)
 		require.Greater(t, len(userF.TokenIDs), 0)
 		providers := multichain.ProviderLookup{persist.ChainETH: newStubProvider(withReturnError(fmt.Errorf("can't get tokens")))}
-		h := handlerWithProviders(t, submitUserTokensNoop, providers)
+		h := handlerWithProviders(t, &noopSubmitter{}, providers)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		// Sync tokens with a failing provider
@@ -901,7 +903,7 @@ func testSyncNewTokensIncrementally(t *testing.T) {
 
 	tr := util.ToPointer(true)
 	t.Run("should sync new tokens incrementally", func(t *testing.T) {
-		h := handlerWithProviders(t, submitUserTokensNoop, providers)
+		h := handlerWithProviders(t, &noopSubmitter{}, providers)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, tr)
@@ -912,7 +914,7 @@ func testSyncNewTokensIncrementally(t *testing.T) {
 	})
 
 	t.Run("should not duplicate tokens from repeat incremental syncs", func(t *testing.T) {
-		h := handlerWithProviders(t, submitUserTokensNoop, providers)
+		h := handlerWithProviders(t, &noopSubmitter{}, providers)
 		c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 		response, err := syncTokensMutation(ctx, c, []Chain{ChainEthereum}, tr)
@@ -930,7 +932,7 @@ func testSyncNewTokensMultichain(t *testing.T) {
 	contract := multichain.ChainAgnosticContract{Address: "0x124", Descriptors: multichain.ChainAgnosticContractDescriptors{Name: "wow"}}
 	secondProvider := newStubProvider(withDummyTokenN(contract, userF.Wallet.Address, 10))
 	providers := multichain.ProviderLookup{persist.ChainETH: provider, persist.ChainOptimism: secondProvider}
-	h := handlerWithProviders(t, submitUserTokensNoop, providers)
+	h := handlerWithProviders(t, &noopSubmitter{}, providers)
 	c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 	ctx := context.Background()
 
@@ -946,17 +948,18 @@ func testSyncOnlySubmitsNewTokens(t *testing.T) {
 	userF := newUserFixture(t)
 	provider := newStubProvider(withDummyTokenN(multichain.ChainAgnosticContract{Address: "0xdead"}, userF.Wallet.Address, 10))
 	providers := multichain.ProviderLookup{persist.ChainETH: provider}
-	tokenRecorder := sendTokensRecorder{}
-	h := handlerWithProviders(t, tokenRecorder.Send, providers)
+	submitter := &recorderSubmitter{}
+	h := handlerWithProviders(t, submitter, providers)
 	c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 	// Ideally this compares against expected values, but mocks seems to behave weirdly with slices
-	tokenRecorder.On("Send", mock.Anything, mock.Anything).Times(1).Return(nil)
+	submitter.On("SubmitNewTokens", mock.Anything, mock.Anything).Times(1).Return(nil)
 
 	_, err := syncTokensMutation(context.Background(), c, []Chain{ChainEthereum}, nil)
 
 	require.NoError(t, err)
-	tokenRecorder.AssertExpectations(t)
-	assert.Len(t, tokenRecorder.Tasks[0].TokenDefinitionIDs, len(provider.Tokens))
+	submitter.AssertExpectations(t)
+	tokens := submitter.Calls[0].Arguments.Get(1).([]persist.DBID)
+	assert.Len(t, tokens, len(provider.Tokens))
 }
 
 func testSyncSkipsSubmittingOldTokens(t *testing.T) {
@@ -972,13 +975,13 @@ func testSyncSkipsSubmittingOldTokens(t *testing.T) {
 	require.NoError(t, err)
 
 	// Then sync again, with a provider that returns the same tokens
-	tokenRecorder := sendTokensRecorder{}
-	h = handlerWithProviders(t, tokenRecorder.Send, providers)
+	submitter := &recorderSubmitter{}
+	h = handlerWithProviders(t, submitter, providers)
 	c = customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 	_, err = syncTokensMutation(ctx, c, []Chain{ChainEthereum}, nil)
 	require.NoError(t, err)
-	tokenRecorder.AssertNotCalled(t, "Send")
+	submitter.AssertNotCalled(t, "Send")
 }
 
 func testSyncKeepsOldTokens(t *testing.T) {
@@ -987,7 +990,7 @@ func testSyncKeepsOldTokens(t *testing.T) {
 	newTokensLen := 4
 	provider := newStubProvider(withDummyTokenN(multichain.ChainAgnosticContract{Address: "0x1337"}, userF.Wallet.Address, newTokensLen))
 	providers := multichain.ProviderLookup{persist.ChainETH: provider}
-	h := handlerWithProviders(t, submitUserTokensNoop, providers)
+	h := handlerWithProviders(t, &noopSubmitter{}, providers)
 	c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 	response, err := syncTokensMutation(context.Background(), c, []Chain{ChainEthereum}, nil)
@@ -1007,7 +1010,7 @@ func testSyncShouldMergeDuplicatesInProvider(t *testing.T) {
 		withTokens([]multichain.ChainAgnosticToken{token, token}),
 	)
 	providers := multichain.ProviderLookup{persist.ChainETH: provider}
-	h := handlerWithProviders(t, submitUserTokensNoop, providers)
+	h := handlerWithProviders(t, &noopSubmitter{}, providers)
 	c := customHandlerClient(t, h, withJWTOpt(t, userF.ID))
 
 	response, err := syncTokensMutation(context.Background(), c, []Chain{ChainEthereum}, nil)
@@ -1023,9 +1026,10 @@ func newDummyMetadataProviderFixture(t *testing.T, ctx context.Context, chain pe
 	provider := newStubProvider(pOpts...)
 	providers := multichain.ProviderLookup{chain: provider}
 	c := server.ClientInit(ctx)
-	mc := newMultichainProvider(c, submitUserTokensNoop, providers)
+	mc := newMultichainProvider(c, &noopSubmitter{}, providers)
 	t.Cleanup(func() { c.Close() })
-	return handlerWithProviders(t, sendTokensToTokenProcessing(ctx, c, &mc), providers)
+	submitter := &httpSubmitter{Handler: tokenprocessing.CoreInitServer(ctx, c, &mc)}
+	return handlerWithProviders(t, submitter, providers)
 }
 
 func testSyncShouldProcessMedia(t *testing.T) {
@@ -1638,21 +1642,21 @@ func defaultHandler(t *testing.T) http.Handler {
 }
 
 // handlerWithProviders returns a GraphQL http.Handler
-func handlerWithProviders(t *testing.T, submitF multichain.SubmitTokensF, p multichain.ProviderLookup) http.Handler {
+func handlerWithProviders(t *testing.T, submitter tokenmanage.Submitter, p multichain.ProviderLookup) http.Handler {
 	ctx := context.Background()
 	c := server.ClientInit(context.Background())
-	provider := newMultichainProvider(c, submitF, p)
+	provider := newMultichainProvider(c, submitter, p)
 	t.Cleanup(c.Close)
 	return server.CoreInit(ctx, c, &provider, newStubRecommender(t, []persist.DBID{}), newStubPersonaliztion(t))
 }
 
 // newMultichainProvider a new multichain provider configured with the given providers
-func newMultichainProvider(c *server.Clients, submitF multichain.SubmitTokensF, p multichain.ProviderLookup) multichain.Provider {
+func newMultichainProvider(c *server.Clients, submitter tokenmanage.Submitter, p multichain.ProviderLookup) multichain.Provider {
 	return multichain.Provider{
-		Repos:        c.Repos,
-		Queries:      c.Queries,
-		Chains:       p,
-		SubmitTokens: submitF,
+		Repos:     c.Repos,
+		Queries:   c.Queries,
+		Chains:    p,
+		Submitter: submitter,
 	}
 }
 

--- a/graphql/stub_test.go
+++ b/graphql/stub_test.go
@@ -11,14 +11,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/mikeydub/go-gallery/server"
 	"github.com/mikeydub/go-gallery/service/multichain"
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/recommend"
 	"github.com/mikeydub/go-gallery/service/recommend/userpref"
 	"github.com/mikeydub/go-gallery/service/task"
-	"github.com/mikeydub/go-gallery/tokenprocessing"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/stretchr/testify/mock"
 )
@@ -150,47 +149,47 @@ func newStubPersonaliztion(t *testing.T) *userpref.Personalization {
 	return &userpref.Personalization{}
 }
 
-// sendTokensRecorder records tokenprocessing messages
-type sendTokensRecorder struct {
-	mock.Mock
-	SubmitTokens multichain.SubmitTokensF
-	Tasks        []task.TokenProcessingBatchMessage
-}
+// noopSubmitter is useful when the code under test doesn't require tokenprocessing
+type noopSubmitter struct{}
 
-func (r *sendTokensRecorder) Send(ctx context.Context, tDefIDs []persist.DBID) error {
-	r.Called(ctx, tDefIDs)
-	r.Tasks = append(r.Tasks, task.TokenProcessingBatchMessage{BatchID: persist.GenerateID(), TokenDefinitionIDs: tDefIDs})
+func (n *noopSubmitter) SubmitNewTokens(context.Context, []persist.DBID) error { return nil }
+func (n *noopSubmitter) SubmitTokenManaged(context.Context, persist.DBID, int, time.Duration) error {
 	return nil
 }
 
-// submitUserTokensNoop is useful when the code under test doesn't require tokenprocessing
-func submitUserTokensNoop(ctx context.Context, tDefIDs []persist.DBID) error {
+// recorderSubmitter records tokens sent to tokenprocessing
+type recorderSubmitter struct{ mock.Mock }
+
+func (r *recorderSubmitter) SubmitNewTokens(ctx context.Context, tokenDefinitionIDs []persist.DBID) error {
+	r.Called(ctx, tokenDefinitionIDs)
 	return nil
 }
 
-// sendTokensToHTTPHandler makes an HTTP request to the passed handler
-func sendTokensToHTTPHandler(handler http.Handler, method, endpoint string) multichain.SubmitTokensF {
-	return func(ctx context.Context, tDefIDs []persist.DBID) error {
-		m := task.TokenProcessingBatchMessage{BatchID: persist.GenerateID(), TokenDefinitionIDs: tDefIDs}
-		byt, _ := json.Marshal(m)
-		r := bytes.NewReader(byt)
-		req := httptest.NewRequest(method, endpoint, r)
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		res := w.Result()
-		if res.StatusCode != http.StatusOK {
-			return util.BodyAsError(res)
-		}
-		return nil
-	}
+func (r *recorderSubmitter) SubmitTokenManaged(context.Context, persist.DBID, int, time.Duration) error {
+	panic("not implemented") // shouldn't be needed in syncing tests
 }
 
-// sendTokensToTokenProcessing processes a batch of tokens synchronously through tokenprocessing
-func sendTokensToTokenProcessing(ctx context.Context, c *server.Clients, provider *multichain.Provider) multichain.SubmitTokensF {
-	return func(ctx context.Context, tDefIDs []persist.DBID) error {
-		h := tokenprocessing.CoreInitServer(ctx, c, provider)
-		return sendTokensToHTTPHandler(h, http.MethodPost, "/media/process")(ctx, tDefIDs)
+// httpSubmitter processes tokens synchronously via HTTP
+type httpSubmitter struct {
+	Handler http.Handler
+}
+
+func (h *httpSubmitter) SubmitNewTokens(ctx context.Context, tokenDefinitionIDs []persist.DBID) error {
+	m := task.TokenProcessingBatchMessage{BatchID: persist.GenerateID(), TokenDefinitionIDs: tokenDefinitionIDs}
+	byt, _ := json.Marshal(m)
+	r := bytes.NewReader(byt)
+	req := httptest.NewRequest(http.MethodPost, "/media/process", r)
+	w := httptest.NewRecorder()
+	h.Handler.ServeHTTP(w, req)
+	res := w.Result()
+	if res.StatusCode != http.StatusOK {
+		return util.BodyAsError(res)
 	}
+	return nil
+}
+
+func (h *httpSubmitter) SubmitTokenManaged(context.Context, persist.DBID, int, time.Duration) error {
+	panic("not implemented") // shouldn't be needed in syncing tests
 }
 
 // fetchFromDummyEndpoint fetches metadata from the given endpoint

--- a/opensea-streamer/main.go
+++ b/opensea-streamer/main.go
@@ -161,7 +161,7 @@ func addSeenEvent(messageBytes []byte) bool {
 }
 
 func dispatchToTokenProcessing(ctx context.Context, taskClient *task.Client, payload persist.OpenSeaWebhookInput) {
-	err := taskClient.CreateTaskForOpenseaStreamerTokenProcessing(ctx, payload)
+	err := taskClient.CreateTaskTokenProcessingForOpenseaStreamer(ctx, payload)
 	if err != nil {
 		err = fmt.Errorf("error creating task for token processing: %w", err)
 		logger.For(ctx).Error(err)

--- a/service/multichain/multichain.go
+++ b/service/multichain/multichain.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 	"github.com/mikeydub/go-gallery/service/persist/postgres"
 	sentryutil "github.com/mikeydub/go-gallery/service/sentry"
+	"github.com/mikeydub/go-gallery/service/tokenmanage"
 	"github.com/mikeydub/go-gallery/util"
 	"github.com/mikeydub/go-gallery/util/retry"
 	"github.com/mikeydub/go-gallery/validate"
@@ -41,14 +42,11 @@ var unknownContractNames = map[string]bool{
 
 const maxCommunitySize = 1000
 
-// SubmitTokens is called to process a batch of tokens
-type SubmitTokensF func(ctx context.Context, tDefIDs []persist.DBID) error
-
 type Provider struct {
-	Repos        *postgres.Repositories
-	Queries      *db.Queries
-	SubmitTokens SubmitTokensF
-	Chains       ProviderLookup
+	Repos     *postgres.Repositories
+	Queries   *db.Queries
+	Chains    ProviderLookup
+	Submitter tokenmanage.Submitter
 }
 
 // ChainAgnosticToken is a token that is agnostic to the chain it is on
@@ -678,19 +676,17 @@ func (p *Provider) processTokensForUsers(ctx context.Context, chain persist.Chai
 		// Compare when the token was last updated to when it was created to determine if a token is new
 		// Add a fudge factor of a second to account for difference in clock times
 		if t.LastUpdated.Sub(t.CreatedAt) < time.Second {
-			logger.For(ctx).Infof("%s is new (dbid=%s); sending to tokenprocessing", tID, t.ID)
+			logger.For(ctx).Infof("%s is new (dbid=%s); adding to tokenprocessing batch", tID, t.ID)
 			definitionsToSendToTokenProcessing = append(definitionsToSendToTokenProcessing, addedDefinitions[i].ID)
 		} else {
-			logger.For(ctx).Infof("%s already in db (dbid=%s); added %s ago; not sending to tokenprocessing", tID, t.ID, time.Since(t.CreatedAt))
+			logger.For(ctx).Infof("%s already in db (dbid=%s); first added %s ago; not adding to tokenprocessing batch", tID, t.ID, time.Since(t.CreatedAt))
 		}
 	}
 
 	// Send definitions to tokenprocessing
-	if len(definitionsToSendToTokenProcessing) > 0 {
-		if err := p.SubmitTokens(ctx, definitionsToSendToTokenProcessing); err != nil {
-			logger.For(ctx).Errorf("failed to submit batch: %s", err)
-			sentryutil.ReportError(ctx, err)
-		}
+	if err := p.Submitter.SubmitNewTokens(ctx, definitionsToSendToTokenProcessing); err != nil {
+		logger.For(ctx).Errorf("failed to submit batch: %s", err)
+		sentryutil.ReportError(ctx, err)
 	}
 
 	// Insert token memberships

--- a/service/persist/token_processing_jobs.go
+++ b/service/persist/token_processing_jobs.go
@@ -185,7 +185,7 @@ func TrackStepStatus(ctx context.Context, status *PipelineStepStatus, name strin
 
 	go func() {
 		for {
-			<-time.After(5 * time.Second)
+			<-time.After(20 * time.Second)
 			if status == nil || *status == PipelineStepStatusSuccess || *status == PipelineStepStatusError {
 				return
 			}

--- a/service/task/task.go
+++ b/service/task/task.go
@@ -174,8 +174,8 @@ func (c *Client) CreateTaskTokenProcessingSyncBatch(ctx context.Context, message
 	return c.submitTask(ctx, queue, url, withDeadline(time.Minute*30), withJSON(message), withTrace(span))
 }
 
-func (c *Client) CreateTaskTokenProcessingManagedToken(ctx context.Context, message TokenProcessingTokenMessage, delayFor time.Duration) error {
-	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskTokenProcessingManagedToken")
+func (c *Client) CreateTaskTokenProcessingRetryToken(ctx context.Context, message TokenProcessingTokenMessage, delayFor time.Duration) error {
+	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskTokenProcessingRetryToken")
 	defer tracing.FinishSpan(span)
 	queue := env.GetString("TOKEN_PROCESSING_QUEUE")
 	url := fmt.Sprintf("%s/media/tokenmanage/process/token", env.GetString("TOKEN_PROCESSING_URL"))

--- a/service/task/task.go
+++ b/service/task/task.go
@@ -166,20 +166,20 @@ func (c *Client) CreateTaskForFeedbot(ctx context.Context, message FeedbotMessag
 	return c.submitTask(ctx, queue, url, withJSON(message), withTrace(span), withBasicAuth(secret))
 }
 
-func (c *Client) CreateTaskForTokenProcessing(ctx context.Context, message TokenProcessingBatchMessage) error {
-	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForTokenProcessing")
+func (c *Client) CreateTaskTokenProcessingSyncBatch(ctx context.Context, message TokenProcessingBatchMessage) error {
+	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskTokenProcessingSyncBatch")
 	defer tracing.FinishSpan(span)
 	queue := env.GetString("TOKEN_PROCESSING_QUEUE")
 	url := fmt.Sprintf("%s/media/process", env.GetString("TOKEN_PROCESSING_URL"))
 	return c.submitTask(ctx, queue, url, withDeadline(time.Minute*30), withJSON(message), withTrace(span))
 }
 
-func (c *Client) CreateTaskForTokenTokenProcessing(ctx context.Context, message TokenProcessingTokenMessage, delay time.Duration) error {
-	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForTokenTokenProcessing")
+func (c *Client) CreateTaskTokenProcessingManagedToken(ctx context.Context, message TokenProcessingTokenMessage, delayFor time.Duration) error {
+	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskTokenProcessingManagedToken")
 	defer tracing.FinishSpan(span)
 	queue := env.GetString("TOKEN_PROCESSING_QUEUE")
 	url := fmt.Sprintf("%s/media/tokenmanage/process/token", env.GetString("TOKEN_PROCESSING_URL"))
-	return c.submitTask(ctx, queue, url, withJSON(message), withTrace(span), WithDelay(delay))
+	return c.submitTask(ctx, queue, url, withJSON(message), withTrace(span), WithDelay(delayFor))
 }
 
 func (c *Client) CreateTaskForWalletRemoval(ctx context.Context, message TokenProcessingWalletRemovalMessage) error {
@@ -191,8 +191,8 @@ func (c *Client) CreateTaskForWalletRemoval(ctx context.Context, message TokenPr
 	return c.submitTask(ctx, queue, url, withJSON(message), withTrace(span))
 }
 
-func (c *Client) CreateTaskForOpenseaStreamerTokenProcessing(ctx context.Context, message persist.OpenSeaWebhookInput) error {
-	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskForOpenseaStreamerTokenProcessing")
+func (c *Client) CreateTaskTokenProcessingForOpenseaStreamer(ctx context.Context, message persist.OpenSeaWebhookInput) error {
+	span, ctx := tracing.StartSpan(ctx, "cloudtask.create", "createTaskTokenProcessingForOpenseaStreamer")
 	defer tracing.FinishSpan(span)
 	tracing.AddEventDataToSpan(span, map[string]any{
 		"contract": message.Payload.Item.NFTID.ContractAddress.String(),

--- a/service/tokenmanage/tokenmanage.go
+++ b/service/tokenmanage/tokenmanage.go
@@ -79,7 +79,7 @@ func (t *TokenProcessingSubmitter) SubmitNewTokens(ctx context.Context, tokenDef
 
 func (t *TokenProcessingSubmitter) SubmitTokenForRetry(ctx context.Context, tokenDefinitionID persist.DBID, attempt int, delayFor time.Duration) error {
 	msg := task.TokenProcessingTokenMessage{TokenDefinitionID: tokenDefinitionID, Attempts: attempt}
-	return t.TaskClient.CreateTaskTokenProcessingManagedToken(ctx, msg, delayFor)
+	return t.TaskClient.CreateTaskTokenProcessingRetryToken(ctx, msg, delayFor)
 }
 
 // TickTokenF marks a token as ran and returns the wait time before it can be run again

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -572,7 +572,6 @@ func processHighlightMintClaim(mc *multichain.Provider, highlightProvider *highl
 
 		logger.For(ctx).Infof("succesfully handled highlight mint claimID=%s", msg.ClaimID)
 		ctx.JSON(http.StatusOK, util.SuccessResponse{Success: true})
-		return
 	}
 }
 
@@ -581,12 +580,19 @@ var (
 	errHighlightTokenStillSyncing = fmt.Errorf("minted token is still syncing")
 )
 
+// The default behavior of SubmitTokens is to send the new token to tokenprocessing by a queue.
+// Sometimes, we want to run the token as soon as we get it - such as for minting, to accurately track the minting state.
+// noopSubmiiter is used so the token isn't processed twice.
+type noopSubmiiter struct{}
+
+func (n *noopSubmiiter) SubmitNewTokens(context.Context, []persist.DBID) error { return nil }
+func (n *noopSubmiiter) SubmitTokenManaged(context.Context, persist.DBID, int, time.Duration) error {
+	return nil
+}
+
 func trackMint(ctx context.Context, mc *multichain.Provider, tp *tokenProcessor, tm *tokenmanage.Manager, h *highlight.Provider, tracker *highlightTracker, claim db.HighlightMintClaim) error {
-	// The default behavior of SubmitTokens is to send the new token to tokenprocessing by a queue.
-	// We want to run the token as soon as we get it and also to accurately track the minting state,
-	// so SubmitTokens is updated to a noop so the token isn't processed twice.
 	mc = &(*mc)
-	mc.SubmitTokens = func(context.Context, []persist.DBID) error { return nil }
+	mc.Submitter = &noopSubmiiter{}
 
 	// Guard to protect against the pipeline never exiting if something is buggy with the state machine
 	maxDepth := 10
@@ -752,8 +758,7 @@ func runManagedPipeline(ctx context.Context, tp *tokenProcessor, tm *tokenmanage
 	ctx = logger.NewContextWithFields(ctx, logrus.Fields{
 		"tokenDefinitionDBID": td.ID,
 		"contractDBID":        td.ContractID,
-		"tokenID":             td.TokenID,
-		"tokenID_base10":      td.TokenID.Base10String(),
+		"tokenID":             td.TokenID.ToDecimalTokenID(),
 		"contractAddress":     td.ContractAddress,
 		"chain":               td.Chain,
 		"cause":               cause,

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -583,16 +583,17 @@ var (
 // The default behavior of SubmitTokens is to send the new token to tokenprocessing by a queue.
 // Sometimes, we want to run the token as soon as we get it such as for minting in order to track the minting state.
 // noopSubmiiter is used so the token isn't processed twice.
-type noopSubmiiter struct{}
+type noopSubmitter struct{}
 
-func (n *noopSubmiiter) SubmitNewTokens(context.Context, []persist.DBID) error { return nil }
-func (n *noopSubmiiter) SubmitTokenForRetry(context.Context, persist.DBID, int, time.Duration) error {
+func (n *noopSubmitter) SubmitNewTokens(context.Context, []persist.DBID) error { return nil }
+func (n *noopSubmitter) SubmitTokenForRetry(context.Context, persist.DBID, int, time.Duration) error {
 	return nil
 }
 
 func trackMint(ctx context.Context, mc *multichain.Provider, tp *tokenProcessor, tm *tokenmanage.Manager, h *highlight.Provider, tracker *highlightTracker, claim db.HighlightMintClaim) error {
-	mc = &(*mc)
-	mc.Submitter = &noopSubmiiter{}
+	cpy := *mc
+	cpy.Submitter = &noopSubmitter{}
+	mc = &cpy // pointers are passed by value, so this has no impact on the caller
 
 	// Guard to protect against the pipeline never exiting if something is buggy with the state machine
 	maxDepth := 10

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -581,12 +581,12 @@ var (
 )
 
 // The default behavior of SubmitTokens is to send the new token to tokenprocessing by a queue.
-// Sometimes, we want to run the token as soon as we get it - such as for minting, to accurately track the minting state.
+// Sometimes, we want to run the token as soon as we get it such as for minting in order to track the minting state.
 // noopSubmiiter is used so the token isn't processed twice.
 type noopSubmiiter struct{}
 
 func (n *noopSubmiiter) SubmitNewTokens(context.Context, []persist.DBID) error { return nil }
-func (n *noopSubmiiter) SubmitTokenManaged(context.Context, persist.DBID, int, time.Duration) error {
+func (n *noopSubmiiter) SubmitTokenForRetry(context.Context, persist.DBID, int, time.Duration) error {
 	return nil
 }
 


### PR DESCRIPTION
**Changes**
* Fixes bug where minting would prevent future synced tokens from being submitted to tokenprocessing
* Finds new tokens using the past heuristic of comparing a snapshot of the definitions table before and after insertion
* Refactors submission to tokenprocessing to use the new `Submitter` interface
  * Tests should also fail less often
* Renames tokenprocessing task functions for clarity:
  * `CreateTaskForTokenProcessing` -> `CreateTaskTokenProcessingSyncBatch`
  * `CreateTaskForTokenTokenProcessing` -> `CreateTaskTokenProcessingRetryToken`
  * `CreateTaskForOpenseaStreamerTokenProcessing` -> `CreateTaskTokenProcessingForOpenseaStreamer`
* Various minor tweaks