### PR TITLE
Kafka VMs: more vCPUs, less memory

### DIFF
--- a/secrets/prod/makevars.yaml
+++ b/secrets/prod/makevars.yaml
@@ -55,8 +55,8 @@ OPENSEA_STREAMER_CPU: ENC[AES256_GCM,data:140kBcA=,iv:cDc+RLV5uqBLPFrBMsefBXUOLh
 OPENSEA_STREAMER_MEMORY: ENC[AES256_GCM,data:Aw+d,iv:JzDlSRiVUoqVUgxg2ZWz0YPE6ww9Ygt+N0hp3krFtOo=,tag:fsl4p6TZWbazboQtFGIMkg==,type:str]
 OPENSEA_STREAMER_CONCURRENCY: ENC[AES256_GCM,data:qYRQ,iv:qGjL4U9TWFtWdrJmuI1yTzyiW9tA6x07BzAvRbzjXRE=,tag:1Nf1D7OCY/cKbeyEZgfz+A==,type:str]
 KAFKA_STREAMER_TIMEOUT: ENC[AES256_GCM,data:POjCfKw=,iv:klDf3jCtBClx65vPBkq8st4DCjSQr0s2K1usRIXHRKM=,tag:kp7mcW98MI1QFzVC6QKe7w==,type:str]
-KAFKA_STREAMER_CPU: ENC[AES256_GCM,data:7IOgwSc=,iv:yV/2S9FQD49K2ooUdjoA2S9fmCdQKHUZn3dWtuA6Hs0=,tag:aVzIwdO0YPzL4iyxjfjBNg==,type:str]
-KAFKA_STREAMER_MEMORY: ENC[AES256_GCM,data:nHv+,iv:/f22fARFyVbSc03FEHyi5b5TAmY7fub4WmZP3oeSE6g=,tag:H+0xLxjOKaW0uD0lBIE/gA==,type:str]
+KAFKA_STREAMER_CPU: ENC[AES256_GCM,data:iCrXlUw=,iv:aschMFtFYuOUN53gcwrEz5cCftWiYUVOZPVjsEJ8P9w=,tag:pMo6XQybu6dP2D1q+RXh1Q==,type:str]
+KAFKA_STREAMER_MEMORY: ENC[AES256_GCM,data:IjjD,iv:fTufDsRBepWed21VKvJyBPNR7MwQ7pEkTR1ZmP8e7q0=,tag:hFDMw+cOjdN5zsqK35A4oQ==,type:str]
 KAFKA_STREAMER_CONCURRENCY: ENC[AES256_GCM,data:4A==,iv:OL5FcWzJywThxVuiNQAV2suFOX1k3HcYNrgQjlByxdU=,tag:H7VN+JXqM7bfrVymHR5Nbg==,type:str]
 RASTERIZER_CPU: ENC[AES256_GCM,data:5GBusF8=,iv:ObgQL9L4TEKfNCjFcy16gxdiroNjy00YvpG/SyAr+lw=,tag:91j6RDoFa8FjAiP0/nO52A==,type:str]
 RASTERIZER_MEMORY: ENC[AES256_GCM,data:hOx5Iw==,iv:KGEM3f+vDfF8xds6rBQPDZLbQruFH/KNFS9lX2vkhS8=,tag:hjH9d0f6/PD/ppBaOuWXVA==,type:str]
@@ -71,8 +71,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-20T20:17:22Z"
-    mac: ENC[AES256_GCM,data:H9no97BUIvciDBCrG3kFu5/oaqdcjWaYuwDYre6XwRVdxiZHwfn90tMtXe0oo5A++Y/3+ksmhbI2e0EN/Vk17/OPwTc+d/oANPVn5eHShU6B+OvnbgnRyjsCp+lG1FhJYbXB+kuSeix3R/Xxmmm3qHNFkrCsFZjNc/Bs2fEOcrc=,iv:Yyv8CPadkT0lRZIItFA68FZ5bko+zQPXK6/WiNbrNFM=,tag:9bH3GwsEWeFjwD/L9SZlPw==,type:str]
+    lastmodified: "2024-04-30T13:42:37Z"
+    mac: ENC[AES256_GCM,data:m85P4zfDe3FfHDJMifdXjNM+FjYxWm+39ZiUhcSDj3eVQUN80TyHMeGeLi5YdLjQUFpHGT8QCrqFePSuvLpkGh8xdY1UTHTPwJAfMNrKFGSLoSNveLZKKAyxlll8ZxQRsjPa0uzIjQ3SvWPoco8CemZ3wl6c3gFLoYHYJC6XFak=,iv:9dohWMdYwes1FMhSkcScBkvHsqqrviQI3x8dN8w8Nmk=,tag:fyxN6TCkIFxxkjeEBCneIw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
This PR updates the specs of the instances that run our kafka event handler