### PR TITLE
Refactor dataloaders into a general-purpose batching struct

### DIFF
--- a/cmd/dataloaders/generator/dataloader.go
+++ b/cmd/dataloaders/generator/dataloader.go
@@ -2,361 +2,61 @@ package generator
 
 import (
 	"context"
-	"encoding/json"
-	"sync"
-	"sync/atomic"
+	"github.com/mikeydub/go-gallery/util/batch"
 	"time"
 )
 
-type batchStatus int
-
-const (
-	Open batchStatus = iota
-	Closed
-)
-
+// Dataloader is a thin wrapper around the Batcher type that provides idiomatic dataloader
+// function names (i.e. "Load" instead of "Do")
 type Dataloader[TKey any, TResult any] struct {
-	ctx context.Context
-
-	maxBatchSize   int
-	batchTimeout   time.Duration
-	cacheResults   bool
-	publishResults bool
-	fetchFunc      func([]TKey) ([]TResult, []error)
-
-	currentBatchID  int32
-	batches         sync.Map
-	resultCache     sync.Map
-	subscribers     []func(TResult)
-	subscribersMu   sync.RWMutex
-	keyIsComparable bool
-	keyIndexFunc    func([]TKey, TKey) int
-}
-
-type batch[TKey any, TResult any] struct {
-	dataloader *Dataloader[TKey, TResult]
-	id         int32
-	keys       []TKey
-	jsonKeys   []string
-	results    []TResult
-	errors     []error
-	status     batchStatus
-	done       chan struct{}
-	mu         sync.Mutex
-	numCallers int32
+	b *batch.Batcher[TKey, TResult]
 }
 
 func NewDataloader[TKey comparable, TResult any](ctx context.Context, maxBatchSize int, batchTimeout time.Duration, cacheResults bool, publishResults bool,
 	fetchFunc func(context.Context, []TKey) ([]TResult, []error)) *Dataloader[TKey, TResult] {
-	return newDataloader(ctx, maxBatchSize, batchTimeout, cacheResults, publishResults, fetchFunc, indexOf[TKey])
+	return &Dataloader[TKey, TResult]{
+		b: batch.NewBatcher(ctx, maxBatchSize, batchTimeout, cacheResults, publishResults, fetchFunc),
+	}
 }
 
 func NewDataloaderWithNonComparableKey[TKey any, TResult any](ctx context.Context, maxBatchSize int, batchTimeout time.Duration, cacheResults bool, publishResults bool,
 	fetchFunc func(context.Context, []TKey) ([]TResult, []error)) *Dataloader[TKey, TResult] {
-	return newDataloader(ctx, maxBatchSize, batchTimeout, cacheResults, publishResults, fetchFunc, nil)
-}
-
-func newDataloader[TKey any, TResult any](ctx context.Context, maxBatchSize int, batchTimeout time.Duration, cacheResults bool, publishResults bool,
-	fetchFunc func(context.Context, []TKey) ([]TResult, []error),
-	keyIndexFunc func([]TKey, TKey) int) *Dataloader[TKey, TResult] {
 	return &Dataloader[TKey, TResult]{
-		ctx:             ctx,
-		maxBatchSize:    maxBatchSize,
-		batchTimeout:    batchTimeout,
-		cacheResults:    cacheResults,
-		publishResults:  publishResults,
-		fetchFunc:       func(keys []TKey) ([]TResult, []error) { return fetchFunc(ctx, keys) },
-		keyIndexFunc:    keyIndexFunc,
-		keyIsComparable: keyIndexFunc != nil,
+		b: batch.NewBatcherWithNonComparableParam(ctx, maxBatchSize, batchTimeout, cacheResults, publishResults, fetchFunc),
 	}
 }
 
-// Load a ContractCreator by key, batching and caching will be applied automatically
+// Load a TResult by key, batching and caching will be applied automatically
 func (d *Dataloader[TKey, TResult]) Load(key TKey) (TResult, error) {
-	return d.LoadThunk(key)()
+	return d.b.Do(key)
 }
 
-// LoadThunk returns a function that when called will block waiting for a ContractCreator.
+// LoadThunk returns a function that when called will block waiting for a TResult.
 // This method should be used if you want one goroutine to make requests to many
 // different data loaders without blocking until the thunk is called.
 func (d *Dataloader[TKey, TResult]) LoadThunk(key TKey) func() (TResult, error) {
-	var jsonKey string
-	if !d.keyIsComparable {
-		var err error
-		jsonKey, err = keyToJSON(key)
-		if err != nil {
-			return func() (TResult, error) {
-				return *new(TResult), err
-			}
-		}
-	}
-
-	if d.cacheResults {
-		if d.keyIsComparable {
-			if value, ok := d.resultCache.Load(key); ok {
-				return func() (TResult, error) {
-					return value.(TResult), nil
-				}
-			}
-		} else {
-			if value, ok := d.resultCache.Load(jsonKey); ok {
-				return func() (TResult, error) {
-					return value.(TResult), nil
-				}
-			}
-		}
-	}
-
-	b, index := d.addKeyToBatch(key, jsonKey)
-
-	return func() (TResult, error) {
-		<-b.done
-
-		var result TResult
-		if index < len(b.results) {
-			result = b.results[index]
-		}
-
-		var err error
-		// its convenient to be able to return a single error for everything
-		if len(b.errors) == 1 {
-			err = b.errors[0]
-		} else if b.errors != nil {
-			err = b.errors[index]
-		}
-
-		if err == nil {
-			if d.cacheResults {
-				if d.keyIsComparable {
-					d.resultCache.LoadOrStore(key, result)
-				} else {
-					d.resultCache.LoadOrStore(jsonKey, result)
-				}
-			}
-		}
-
-		return result, err
-	}
+	return d.b.DoThunk(key)
 }
 
 // LoadAll fetches many keys at once. It will be broken into appropriate sized
 // sub batches depending on how the loader is configured
 func (d *Dataloader[TKey, TResult]) LoadAll(keys []TKey) ([]TResult, []error) {
-	resultThunks := make([]func() (TResult, error), len(keys))
-	for i, key := range keys {
-		resultThunks[i] = d.LoadThunk(key)
-	}
-
-	results := make([]TResult, len(keys))
-	errors := make([]error, len(keys))
-	for i, thunk := range resultThunks {
-		results[i], errors[i] = thunk()
-	}
-
-	return results, errors
+	return d.b.DoAll(keys)
 }
 
 // LoadAllThunk returns a function that when called will block waiting for results.
 // This method should be used if you want one goroutine to make requests to many
 // different data loaders without blocking until the thunk is called.
 func (d *Dataloader[TKey, TResult]) LoadAllThunk(keys []TKey) func() ([]TResult, []error) {
-	resultThunks := make([]func() (TResult, error), len(keys))
-	for i, key := range keys {
-		resultThunks[i] = d.LoadThunk(key)
-	}
-
-	return func() ([]TResult, []error) {
-		results := make([]TResult, len(keys))
-		errors := make([]error, len(keys))
-		for i, thunk := range resultThunks {
-			results[i], errors[i] = thunk()
-		}
-		return results, errors
-	}
+	return d.b.DoAllThunk(keys)
 }
 
 func (d *Dataloader[TKey, TResult]) Prime(key TKey, result TResult) {
-	if !d.cacheResults {
-		return
-	}
-
-	if d.keyIsComparable {
-		d.resultCache.LoadOrStore(key, result)
-	} else {
-		jsonKey, err := keyToJSON(key)
-		if err != nil {
-			return
-		}
-
-		d.resultCache.LoadOrStore(jsonKey, result)
-	}
+	d.b.Prime(key, result)
 }
 
 // RegisterResultSubscriber registers a function that will be called with every
 // result that is loaded.
 func (d *Dataloader[TKey, TResult]) RegisterResultSubscriber(subscriber func(TResult)) {
-	d.subscribersMu.Lock()
-	defer d.subscribersMu.Unlock()
-	d.subscribers = append(d.subscribers, subscriber)
-}
-
-func (d *Dataloader[TKey, TResult]) newBatch(batchID int32) *batch[TKey, TResult] {
-	b := batch[TKey, TResult]{
-		dataloader: d,
-		id:         batchID,
-		keys:       make([]TKey, 0, d.maxBatchSize),
-		done:       make(chan struct{}),
-	}
-
-	if !d.keyIsComparable {
-		b.jsonKeys = make([]string, 0, d.maxBatchSize)
-	}
-
-	return &b
-}
-
-func (b *batch[TKey, TResult]) closeAfterTimeout(timeout time.Duration) {
-	time.Sleep(timeout)
-
-	b.mu.Lock()
-
-	if b.status == Open {
-		b.status = Closed
-		b.mu.Unlock()
-		b.submitBatch()
-	} else {
-		b.mu.Unlock()
-	}
-}
-
-func (d *Dataloader[TKey, TResult]) addKeyToBatch(key TKey, jsonKey string) (*batch[TKey, TResult], int) {
-	for {
-		// Read the current batch ID
-		currentID := atomic.LoadInt32(&d.currentBatchID)
-
-		// Attempt to load the batch first. LoadOrStore requires that we create a "just in case" batch
-		// to store if the key isn't present. Since we expect the batch to exist most of the time, these
-		// "just in case" batches will usually be unnecessary. To avoid creating many unused structs,
-		// we try to load the batch first, and only call LoadOrStore if we can't find an existing batch.
-		actual, ok := d.batches.Load(currentID)
-
-		// If the batch doesn't exist, create it
-		if !ok {
-			newBatch := d.newBatch(currentID)
-
-			var loaded bool
-			actual, loaded = d.batches.LoadOrStore(currentID, newBatch)
-			if loaded {
-				// If newBatch wasn't actually stored, close the Done channel since it won't be used
-				close(newBatch.done)
-			}
-		}
-
-		b := actual.(*batch[TKey, TResult])
-
-		// Prevent lock contention within a batch by allowing only the first maxBatchSize callers
-		// to obtain the lock.
-		numAssigned := atomic.AddInt32(&b.numCallers, 1)
-		if numAssigned > int32(d.maxBatchSize) {
-			atomic.CompareAndSwapInt32(&d.currentBatchID, currentID, currentID+1)
-			continue
-		}
-
-		b.mu.Lock()
-
-		// If the batch we were assigned to is closed, increment the batch ID and try again
-		if b.status == Closed {
-			b.mu.Unlock()
-			atomic.CompareAndSwapInt32(&d.currentBatchID, currentID, currentID+1)
-			continue
-		}
-
-		var keyIndex int
-
-		if d.keyIsComparable {
-			// If the key is comparable, look for it in the keys slice
-			keyIndex = d.keyIndexFunc(b.keys, key)
-		} else {
-			// If the key is not comparable, look for its JSON representation in the jsonKeys slice
-			keyIndex = indexOf(b.jsonKeys, jsonKey)
-		}
-
-		// If the key is already in the batch, return the batch and the key's index
-		if keyIndex != -1 {
-			b.mu.Unlock()
-			return b, keyIndex
-		}
-
-		// Otherwise, add the key to the batch
-		keyIndex = len(b.keys)
-
-		b.keys = append(b.keys, key)
-		if !d.keyIsComparable {
-			b.jsonKeys = append(b.jsonKeys, jsonKey)
-		}
-
-		// If this is the first thing we've added to the batch, start the timeout
-		if keyIndex == 0 {
-			go b.closeAfterTimeout(d.batchTimeout)
-		}
-
-		if len(b.keys) == d.maxBatchSize {
-			b.status = Closed
-			b.mu.Unlock()
-			b.submitBatch()
-			atomic.CompareAndSwapInt32(&d.currentBatchID, currentID, currentID+1)
-		} else {
-			b.mu.Unlock()
-		}
-
-		return b, keyIndex
-	}
-}
-
-func keyToJSON[TKey any](key TKey) (string, error) {
-	bytes, err := json.Marshal(key)
-	if err != nil {
-		return "", err
-	}
-
-	return string(bytes), nil
-}
-
-func indexOf[T comparable](slice []T, item T) int {
-	for i, existingItem := range slice {
-		if item == existingItem {
-			return i
-		}
-	}
-
-	return -1
-}
-
-func (d *Dataloader[TKey, TResult]) publishToSubscribers(results []TResult, errors []error) {
-	// Only hold the mutex long enough to get a snapshot of the subscribers
-	d.subscribersMu.RLock()
-	subscribers := d.subscribers
-	d.subscribersMu.RUnlock()
-
-	for i, result := range results {
-		// Only publish results that didn't return an error
-		if errors[i] != nil {
-			continue
-		}
-
-		for _, s := range subscribers {
-			s(result)
-		}
-	}
-
-}
-
-func (b *batch[TKey, TResult]) submitBatch() {
-	b.results, b.errors = b.dataloader.fetchFunc(b.keys)
-
-	if b.dataloader.publishResults {
-		b.dataloader.publishToSubscribers(b.results, b.errors)
-	}
-
-	close(b.done)
+	d.b.RegisterResultSubscriber(subscriber)
 }

--- a/util/batch/batch.go
+++ b/util/batch/batch.go
@@ -1,0 +1,362 @@
+package batch
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type batchStatus int
+
+const (
+	Open batchStatus = iota
+	Closed
+)
+
+type Batcher[TParam any, TResult any] struct {
+	ctx context.Context
+
+	maxBatchSize   int
+	batchTimeout   time.Duration
+	cacheResults   bool
+	publishResults bool
+	batchFunc      func([]TParam) ([]TResult, []error)
+
+	currentBatchID    int32
+	batches           sync.Map
+	resultCache       sync.Map
+	subscribers       []func(TResult)
+	subscribersMu     sync.RWMutex
+	paramIsComparable bool
+	paramIndexFunc    func([]TParam, TParam) int
+}
+
+type batch[TParam any, TResult any] struct {
+	batcher    *Batcher[TParam, TResult]
+	id         int32
+	params     []TParam
+	jsonParams []string
+	results    []TResult
+	errors     []error
+	status     batchStatus
+	done       chan struct{}
+	mu         sync.Mutex
+	numCallers int32
+}
+
+func NewBatcher[TParam comparable, TResult any](ctx context.Context, maxBatchSize int, batchTimeout time.Duration, cacheResults bool, publishResults bool,
+	batchFunc func(context.Context, []TParam) ([]TResult, []error)) *Batcher[TParam, TResult] {
+	return newBatcher(ctx, maxBatchSize, batchTimeout, cacheResults, publishResults, batchFunc, indexOf[TParam])
+}
+
+func NewBatcherWithNonComparableParam[TParam any, TResult any](ctx context.Context, maxBatchSize int, batchTimeout time.Duration, cacheResults bool, publishResults bool,
+	batchFunc func(context.Context, []TParam) ([]TResult, []error)) *Batcher[TParam, TResult] {
+	return newBatcher(ctx, maxBatchSize, batchTimeout, cacheResults, publishResults, batchFunc, nil)
+}
+
+func newBatcher[TParam any, TResult any](ctx context.Context, maxBatchSize int, batchTimeout time.Duration, cacheResults bool, publishResults bool,
+	batchFunc func(context.Context, []TParam) ([]TResult, []error),
+	paramIndexFunc func([]TParam, TParam) int) *Batcher[TParam, TResult] {
+	return &Batcher[TParam, TResult]{
+		ctx:               ctx,
+		maxBatchSize:      maxBatchSize,
+		batchTimeout:      batchTimeout,
+		cacheResults:      cacheResults,
+		publishResults:    publishResults,
+		batchFunc:         func(params []TParam) ([]TResult, []error) { return batchFunc(ctx, params) },
+		paramIndexFunc:    paramIndexFunc,
+		paramIsComparable: paramIndexFunc != nil,
+	}
+}
+
+// Do gets a TResult for the specified param, with batching and caching applied automatically (if configured)
+func (d *Batcher[TParam, TResult]) Do(param TParam) (TResult, error) {
+	return d.DoThunk(param)()
+}
+
+// DoThunk returns a function that when called will block waiting for a TResult.
+// This method should be used if you want one goroutine to make requests to many
+// different batchers without blocking until the thunk is called.
+func (d *Batcher[TParam, TResult]) DoThunk(param TParam) func() (TResult, error) {
+	var jsonParam string
+	if !d.paramIsComparable {
+		var err error
+		jsonParam, err = paramToJSON(param)
+		if err != nil {
+			return func() (TResult, error) {
+				return *new(TResult), err
+			}
+		}
+	}
+
+	if d.cacheResults {
+		if d.paramIsComparable {
+			if value, ok := d.resultCache.Load(param); ok {
+				return func() (TResult, error) {
+					return value.(TResult), nil
+				}
+			}
+		} else {
+			if value, ok := d.resultCache.Load(jsonParam); ok {
+				return func() (TResult, error) {
+					return value.(TResult), nil
+				}
+			}
+		}
+	}
+
+	b, index := d.addParamToBatch(param, jsonParam)
+
+	return func() (TResult, error) {
+		<-b.done
+
+		var result TResult
+		if index < len(b.results) {
+			result = b.results[index]
+		}
+
+		var err error
+		// its convenient to be able to return a single error for everything
+		if len(b.errors) == 1 {
+			err = b.errors[0]
+		} else if b.errors != nil {
+			err = b.errors[index]
+		}
+
+		if err == nil {
+			if d.cacheResults {
+				if d.paramIsComparable {
+					d.resultCache.LoadOrStore(param, result)
+				} else {
+					d.resultCache.LoadOrStore(jsonParam, result)
+				}
+			}
+		}
+
+		return result, err
+	}
+}
+
+// DoAll gets TResults for many params at once. It will be broken into appropriate sized
+// sub batches depending on how the batcher is configured
+func (d *Batcher[TParam, TResult]) DoAll(params []TParam) ([]TResult, []error) {
+	resultThunks := make([]func() (TResult, error), len(params))
+	for i, param := range params {
+		resultThunks[i] = d.DoThunk(param)
+	}
+
+	results := make([]TResult, len(params))
+	errors := make([]error, len(params))
+	for i, thunk := range resultThunks {
+		results[i], errors[i] = thunk()
+	}
+
+	return results, errors
+}
+
+// DoAllThunk returns a function that when called will block waiting for results.
+// This method should be used if you want one goroutine to make requests to many
+// different batchers without blocking until the thunk is called.
+func (d *Batcher[TParam, TResult]) DoAllThunk(params []TParam) func() ([]TResult, []error) {
+	resultThunks := make([]func() (TResult, error), len(params))
+	for i, param := range params {
+		resultThunks[i] = d.DoThunk(param)
+	}
+
+	return func() ([]TResult, []error) {
+		results := make([]TResult, len(params))
+		errors := make([]error, len(params))
+		for i, thunk := range resultThunks {
+			results[i], errors[i] = thunk()
+		}
+		return results, errors
+	}
+}
+
+func (d *Batcher[TParam, TResult]) Prime(param TParam, result TResult) {
+	if !d.cacheResults {
+		return
+	}
+
+	if d.paramIsComparable {
+		d.resultCache.LoadOrStore(param, result)
+	} else {
+		jsonParam, err := paramToJSON(param)
+		if err != nil {
+			return
+		}
+
+		d.resultCache.LoadOrStore(jsonParam, result)
+	}
+}
+
+// RegisterResultSubscriber registers a function that will be called for every
+// result that is returned by this batcher.
+func (d *Batcher[TParam, TResult]) RegisterResultSubscriber(subscriber func(TResult)) {
+	d.subscribersMu.Lock()
+	defer d.subscribersMu.Unlock()
+	d.subscribers = append(d.subscribers, subscriber)
+}
+
+func (d *Batcher[TParam, TResult]) newBatch(batchID int32) *batch[TParam, TResult] {
+	b := batch[TParam, TResult]{
+		batcher: d,
+		id:      batchID,
+		params:  make([]TParam, 0, d.maxBatchSize),
+		done:    make(chan struct{}),
+	}
+
+	if !d.paramIsComparable {
+		b.jsonParams = make([]string, 0, d.maxBatchSize)
+	}
+
+	return &b
+}
+
+func (b *batch[TParam, TResult]) closeAfterTimeout(timeout time.Duration) {
+	time.Sleep(timeout)
+
+	b.mu.Lock()
+
+	if b.status == Open {
+		b.status = Closed
+		b.mu.Unlock()
+		b.submitBatch()
+	} else {
+		b.mu.Unlock()
+	}
+}
+
+func (d *Batcher[TParam, TResult]) addParamToBatch(param TParam, jsonParam string) (*batch[TParam, TResult], int) {
+	for {
+		// Read the current batch ID
+		currentID := atomic.LoadInt32(&d.currentBatchID)
+
+		// Attempt to load the batch first. LoadOrStore requires that we create a "just in case" batch
+		// to store if the param isn't present. Since we expect the batch to exist most of the time, these
+		// "just in case" batches will usually be unnecessary. To avoid creating many unused structs,
+		// we try to load the batch first, and only call LoadOrStore if we can't find an existing batch.
+		actual, ok := d.batches.Load(currentID)
+
+		// If the batch doesn't exist, create it
+		if !ok {
+			newBatch := d.newBatch(currentID)
+
+			var loaded bool
+			actual, loaded = d.batches.LoadOrStore(currentID, newBatch)
+			if loaded {
+				// If newBatch wasn't actually stored, close the Done channel since it won't be used
+				close(newBatch.done)
+			}
+		}
+
+		b := actual.(*batch[TParam, TResult])
+
+		// Prevent lock contention within a batch by allowing only the first maxBatchSize callers
+		// to obtain the lock.
+		numAssigned := atomic.AddInt32(&b.numCallers, 1)
+		if numAssigned > int32(d.maxBatchSize) {
+			atomic.CompareAndSwapInt32(&d.currentBatchID, currentID, currentID+1)
+			continue
+		}
+
+		b.mu.Lock()
+
+		// If the batch we were assigned to is closed, increment the batch ID and try again
+		if b.status == Closed {
+			b.mu.Unlock()
+			atomic.CompareAndSwapInt32(&d.currentBatchID, currentID, currentID+1)
+			continue
+		}
+
+		var paramIndex int
+
+		if d.paramIsComparable {
+			// If the param is comparable, look for it in the params slice
+			paramIndex = d.paramIndexFunc(b.params, param)
+		} else {
+			// If the param is not comparable, look for its JSON representation in the jsonParams slice
+			paramIndex = indexOf(b.jsonParams, jsonParam)
+		}
+
+		// If the param is already in the batch, return the batch and the param's index
+		if paramIndex != -1 {
+			b.mu.Unlock()
+			return b, paramIndex
+		}
+
+		// Otherwise, add the param to the batch
+		paramIndex = len(b.params)
+
+		b.params = append(b.params, param)
+		if !d.paramIsComparable {
+			b.jsonParams = append(b.jsonParams, jsonParam)
+		}
+
+		// If this is the first thing we've added to the batch, start the timeout
+		if paramIndex == 0 {
+			go b.closeAfterTimeout(d.batchTimeout)
+		}
+
+		if len(b.params) == d.maxBatchSize {
+			b.status = Closed
+			b.mu.Unlock()
+			b.submitBatch()
+			atomic.CompareAndSwapInt32(&d.currentBatchID, currentID, currentID+1)
+		} else {
+			b.mu.Unlock()
+		}
+
+		return b, paramIndex
+	}
+}
+
+func paramToJSON[TParam any](param TParam) (string, error) {
+	bytes, err := json.Marshal(param)
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}
+
+func indexOf[T comparable](slice []T, item T) int {
+	for i, existingItem := range slice {
+		if item == existingItem {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func (d *Batcher[TParam, TResult]) publishToSubscribers(results []TResult, errors []error) {
+	// Only hold the mutex long enough to get a snapshot of the subscribers
+	d.subscribersMu.RLock()
+	subscribers := d.subscribers
+	d.subscribersMu.RUnlock()
+
+	for i, result := range results {
+		// Only publish results that didn't return an error
+		if errors[i] != nil {
+			continue
+		}
+
+		for _, s := range subscribers {
+			s(result)
+		}
+	}
+
+}
+
+func (b *batch[TParam, TResult]) submitBatch() {
+	b.results, b.errors = b.batcher.batchFunc(b.params)
+
+	if b.batcher.publishResults {
+		b.batcher.publishToSubscribers(b.results, b.errors)
+	}
+
+	close(b.done)
+}


### PR DESCRIPTION
## What's new?
I occasionally find myself wanting a reusable batcher that can do what dataloaders do: open a batch with a max size and timeout, wait for requests to come in, submit all the queued up requests when the batch closes, etc. I've reused this pattern in our push notifications handling, and wanted to use it again for Kafka event handling.

This PR refactors the `Dataloader[TKey, TResult]` type to be a thin wrapper around a reusable `batch.Batcher[TParam, TResult]` class that can be reused in any other context where we want batching.

The most notable change is that the `Load` functions have been renamed to `Do`, since we don't really know if a generic batch is "loading" things or just executing commands and receiving a result status. The `Dataloader` wrapper maintains the existing `Load` function names, since those feel appropriate and idiomatic for a dataloader.