### PR TITLE
Fill in contract and collection info for tokens via SimpleHash API

### DIFF
--- a/db/gen/mirrordb/batch.go
+++ b/db/gen/mirrordb/batch.go
@@ -158,128 +158,135 @@ func (b *ProcessBaseOwnerEntryBatchResults) Close() error {
 	return b.br.Close()
 }
 
-const processBaseTokenEntry = `-- name: ProcessBaseTokenEntry :batchexec
+const processBaseTokenEntry = `-- name: ProcessBaseTokenEntry :batchone
 with deletion as (
-    delete from base.tokens where $34::bool and simplehash_kafka_key = $1
+    delete from base.tokens where $2::bool and base.tokens.simplehash_kafka_key = $3
 ),
 
 contract_insert as (
     insert into base.contracts (address, simplehash_lookup_nft_id)
-    select $3::text, $2
-    where $33::bool and $3 is not null
+    select $4::text, $1
+    where $5::bool and $4 is not null
     on conflict (address) do nothing
+    returning (xmax = 0) as inserted
 ),
     
 collection_insert as (
     insert into public.collections (id, simplehash_lookup_nft_id)
-    select $20::text, $2
-    where $33::bool and $20 is not null
+    select $6::text, $1
+    where $5::bool and $6 is not null
     on conflict (id) do nothing
-)
+    returning (xmax = 0) as inserted
+),
 
-insert into base.tokens (
-    simplehash_kafka_key,
-    simplehash_nft_id,
-    contract_address,
-    token_id,
-    name,
-    description,
-    previews,
-    image_url,
-    video_url,
-    audio_url,
-    model_url,
-    other_url,
-    background_color,
-    external_url,
-    on_chain_created_date,
-    status,
-    token_count,
-    owner_count,
-    contract,
-    collection_id,
-    last_sale,
-    first_created,
-    rarity,
-    extra_metadata,
-    image_properties,
-    video_properties,
-    audio_properties,
-    model_properties,
-    other_properties,
-    last_updated,
-    kafka_offset,
-    kafka_partition,
-    kafka_timestamp
-    )
-    select
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        $6,
-        $7,
-        $8,
-        $9,
-        $10,
-        $11,
-        $12,
-        $13,
-        $14,
-        $15,
-        $16,
-        $17,
-        $18,
-        $19,
-        $20,
-        $21,
-        $22,
-        $23,
-        $24,
-        $25,
-        $26,
-        $27,
-        $28,
-        $29,
-        now(),
-        $30,
-        $31,
-        $32
-    where $33::bool
-    on conflict (simplehash_kafka_key) do update
-        set simplehash_nft_id = excluded.simplehash_nft_id,
-            contract_address = excluded.contract_address,
-            token_id = excluded.token_id,
-            name = excluded.name,
-            description = excluded.description,
-            previews = excluded.previews,
-            image_url = excluded.image_url,
-            video_url = excluded.video_url,
-            audio_url = excluded.audio_url,
-            model_url = excluded.model_url,
-            other_url = excluded.other_url,
-            background_color = excluded.background_color,
-            external_url = excluded.external_url,
-            on_chain_created_date = excluded.on_chain_created_date,
-            status = excluded.status,
-            token_count = excluded.token_count,
-            owner_count = excluded.owner_count,
-            contract = excluded.contract,
-            collection_id = excluded.collection_id,
-            last_sale = excluded.last_sale,
-            first_created = excluded.first_created,
-            rarity = excluded.rarity,
-            extra_metadata = excluded.extra_metadata,
-            image_properties = excluded.image_properties,
-            video_properties = excluded.video_properties,
-            audio_properties = excluded.audio_properties,
-            model_properties = excluded.model_properties,
-            other_properties = excluded.other_properties,
-            last_updated = now(),
-            kafka_offset = excluded.kafka_offset,
-            kafka_partition = excluded.kafka_partition,
-            kafka_timestamp = excluded.kafka_timestamp
+token_insert as (
+    insert into base.tokens (
+        simplehash_kafka_key,
+        simplehash_nft_id,
+        contract_address,
+        token_id,
+        name,
+        description,
+        previews,
+        image_url,
+        video_url,
+        audio_url,
+        model_url,
+        other_url,
+        background_color,
+        external_url,
+        on_chain_created_date,
+        status,
+        token_count,
+        owner_count,
+        contract,
+        collection_id,
+        last_sale,
+        first_created,
+        rarity,
+        extra_metadata,
+        image_properties,
+        video_properties,
+        audio_properties,
+        model_properties,
+        other_properties,
+        last_updated,
+        kafka_offset,
+        kafka_partition,
+        kafka_timestamp
+        )
+        select
+            $3,
+            $1,
+            $4,
+            $7,
+            $8,
+            $9,
+            $10,
+            $11,
+            $12,
+            $13,
+            $14,
+            $15,
+            $16,
+            $17,
+            $18,
+            $19,
+            $20,
+            $21,
+            $22,
+            $6,
+            $23,
+            $24,
+            $25,
+            $26,
+            $27,
+            $28,
+            $29,
+            $30,
+            $31,
+            now(),
+            $32,
+            $33,
+            $34
+        where $5::bool
+        on conflict (simplehash_kafka_key) do update
+            set simplehash_nft_id = excluded.simplehash_nft_id,
+                contract_address = excluded.contract_address,
+                token_id = excluded.token_id,
+                name = excluded.name,
+                description = excluded.description,
+                previews = excluded.previews,
+                image_url = excluded.image_url,
+                video_url = excluded.video_url,
+                audio_url = excluded.audio_url,
+                model_url = excluded.model_url,
+                other_url = excluded.other_url,
+                background_color = excluded.background_color,
+                external_url = excluded.external_url,
+                on_chain_created_date = excluded.on_chain_created_date,
+                status = excluded.status,
+                token_count = excluded.token_count,
+                owner_count = excluded.owner_count,
+                contract = excluded.contract,
+                collection_id = excluded.collection_id,
+                last_sale = excluded.last_sale,
+                first_created = excluded.first_created,
+                rarity = excluded.rarity,
+                extra_metadata = excluded.extra_metadata,
+                image_properties = excluded.image_properties,
+                video_properties = excluded.video_properties,
+                audio_properties = excluded.audio_properties,
+                model_properties = excluded.model_properties,
+                other_properties = excluded.other_properties,
+                last_updated = now(),
+                kafka_offset = excluded.kafka_offset,
+                kafka_partition = excluded.kafka_partition,
+                kafka_timestamp = excluded.kafka_timestamp
+)
+select $1::text
+from contract_insert, collection_insert
+    where contract_insert.inserted or collection_insert.inserted
 `
 
 type ProcessBaseTokenEntryBatchResults struct {
@@ -289,49 +296,52 @@ type ProcessBaseTokenEntryBatchResults struct {
 }
 
 type ProcessBaseTokenEntryParams struct {
-	SimplehashKafkaKey string           `db:"simplehash_kafka_key" json:"simplehash_kafka_key"`
-	SimplehashNftID    *string          `db:"simplehash_nft_id" json:"simplehash_nft_id"`
-	ContractAddress    *persist.Address `db:"contract_address" json:"contract_address"`
-	TokenID            pgtype.Numeric   `db:"token_id" json:"token_id"`
-	Name               *string          `db:"name" json:"name"`
-	Description        *string          `db:"description" json:"description"`
-	Previews           pgtype.JSONB     `db:"previews" json:"previews"`
-	ImageUrl           *string          `db:"image_url" json:"image_url"`
-	VideoUrl           *string          `db:"video_url" json:"video_url"`
-	AudioUrl           *string          `db:"audio_url" json:"audio_url"`
-	ModelUrl           *string          `db:"model_url" json:"model_url"`
-	OtherUrl           *string          `db:"other_url" json:"other_url"`
-	BackgroundColor    *string          `db:"background_color" json:"background_color"`
-	ExternalUrl        *string          `db:"external_url" json:"external_url"`
-	OnChainCreatedDate *time.Time       `db:"on_chain_created_date" json:"on_chain_created_date"`
-	Status             *string          `db:"status" json:"status"`
-	TokenCount         pgtype.Numeric   `db:"token_count" json:"token_count"`
-	OwnerCount         pgtype.Numeric   `db:"owner_count" json:"owner_count"`
-	Contract           pgtype.JSONB     `db:"contract" json:"contract"`
-	CollectionID       *string          `db:"collection_id" json:"collection_id"`
-	LastSale           pgtype.JSONB     `db:"last_sale" json:"last_sale"`
-	FirstCreated       pgtype.JSONB     `db:"first_created" json:"first_created"`
-	Rarity             pgtype.JSONB     `db:"rarity" json:"rarity"`
-	ExtraMetadata      *string          `db:"extra_metadata" json:"extra_metadata"`
-	ImageProperties    pgtype.JSONB     `db:"image_properties" json:"image_properties"`
-	VideoProperties    pgtype.JSONB     `db:"video_properties" json:"video_properties"`
-	AudioProperties    pgtype.JSONB     `db:"audio_properties" json:"audio_properties"`
-	ModelProperties    pgtype.JSONB     `db:"model_properties" json:"model_properties"`
-	OtherProperties    pgtype.JSONB     `db:"other_properties" json:"other_properties"`
-	KafkaOffset        *int64           `db:"kafka_offset" json:"kafka_offset"`
-	KafkaPartition     *int32           `db:"kafka_partition" json:"kafka_partition"`
-	KafkaTimestamp     *time.Time       `db:"kafka_timestamp" json:"kafka_timestamp"`
-	ShouldUpsert       bool             `db:"should_upsert" json:"should_upsert"`
-	ShouldDelete       bool             `db:"should_delete" json:"should_delete"`
+	SimplehashNftID    string         `db:"simplehash_nft_id" json:"simplehash_nft_id"`
+	ShouldDelete       bool           `db:"should_delete" json:"should_delete"`
+	SimplehashKafkaKey string         `db:"simplehash_kafka_key" json:"simplehash_kafka_key"`
+	ContractAddress    *string        `db:"contract_address" json:"contract_address"`
+	ShouldUpsert       bool           `db:"should_upsert" json:"should_upsert"`
+	CollectionID       *string        `db:"collection_id" json:"collection_id"`
+	TokenID            pgtype.Numeric `db:"token_id" json:"token_id"`
+	Name               *string        `db:"name" json:"name"`
+	Description        *string        `db:"description" json:"description"`
+	Previews           pgtype.JSONB   `db:"previews" json:"previews"`
+	ImageUrl           *string        `db:"image_url" json:"image_url"`
+	VideoUrl           *string        `db:"video_url" json:"video_url"`
+	AudioUrl           *string        `db:"audio_url" json:"audio_url"`
+	ModelUrl           *string        `db:"model_url" json:"model_url"`
+	OtherUrl           *string        `db:"other_url" json:"other_url"`
+	BackgroundColor    *string        `db:"background_color" json:"background_color"`
+	ExternalUrl        *string        `db:"external_url" json:"external_url"`
+	OnChainCreatedDate *time.Time     `db:"on_chain_created_date" json:"on_chain_created_date"`
+	Status             *string        `db:"status" json:"status"`
+	TokenCount         pgtype.Numeric `db:"token_count" json:"token_count"`
+	OwnerCount         pgtype.Numeric `db:"owner_count" json:"owner_count"`
+	Contract           pgtype.JSONB   `db:"contract" json:"contract"`
+	LastSale           pgtype.JSONB   `db:"last_sale" json:"last_sale"`
+	FirstCreated       pgtype.JSONB   `db:"first_created" json:"first_created"`
+	Rarity             pgtype.JSONB   `db:"rarity" json:"rarity"`
+	ExtraMetadata      *string        `db:"extra_metadata" json:"extra_metadata"`
+	ImageProperties    pgtype.JSONB   `db:"image_properties" json:"image_properties"`
+	VideoProperties    pgtype.JSONB   `db:"video_properties" json:"video_properties"`
+	AudioProperties    pgtype.JSONB   `db:"audio_properties" json:"audio_properties"`
+	ModelProperties    pgtype.JSONB   `db:"model_properties" json:"model_properties"`
+	OtherProperties    pgtype.JSONB   `db:"other_properties" json:"other_properties"`
+	KafkaOffset        *int64         `db:"kafka_offset" json:"kafka_offset"`
+	KafkaPartition     *int32         `db:"kafka_partition" json:"kafka_partition"`
+	KafkaTimestamp     *time.Time     `db:"kafka_timestamp" json:"kafka_timestamp"`
 }
 
 func (q *Queries) ProcessBaseTokenEntry(ctx context.Context, arg []ProcessBaseTokenEntryParams) *ProcessBaseTokenEntryBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
 		vals := []interface{}{
-			a.SimplehashKafkaKey,
 			a.SimplehashNftID,
+			a.ShouldDelete,
+			a.SimplehashKafkaKey,
 			a.ContractAddress,
+			a.ShouldUpsert,
+			a.CollectionID,
 			a.TokenID,
 			a.Name,
 			a.Description,
@@ -348,7 +358,6 @@ func (q *Queries) ProcessBaseTokenEntry(ctx context.Context, arg []ProcessBaseTo
 			a.TokenCount,
 			a.OwnerCount,
 			a.Contract,
-			a.CollectionID,
 			a.LastSale,
 			a.FirstCreated,
 			a.Rarity,
@@ -361,8 +370,6 @@ func (q *Queries) ProcessBaseTokenEntry(ctx context.Context, arg []ProcessBaseTo
 			a.KafkaOffset,
 			a.KafkaPartition,
 			a.KafkaTimestamp,
-			a.ShouldUpsert,
-			a.ShouldDelete,
 		}
 		batch.Queue(processBaseTokenEntry, vals...)
 	}
@@ -370,18 +377,20 @@ func (q *Queries) ProcessBaseTokenEntry(ctx context.Context, arg []ProcessBaseTo
 	return &ProcessBaseTokenEntryBatchResults{br, len(arg), false}
 }
 
-func (b *ProcessBaseTokenEntryBatchResults) Exec(f func(int, error)) {
+func (b *ProcessBaseTokenEntryBatchResults) QueryRow(f func(int, string, error)) {
 	defer b.br.Close()
 	for t := 0; t < b.tot; t++ {
+		var column_1 string
 		if b.closed {
 			if f != nil {
-				f(t, ErrBatchAlreadyClosed)
+				f(t, column_1, ErrBatchAlreadyClosed)
 			}
 			continue
 		}
-		_, err := b.br.Exec()
+		row := b.br.QueryRow()
+		err := row.Scan(&column_1)
 		if f != nil {
-			f(t, err)
+			f(t, column_1, err)
 		}
 	}
 }
@@ -530,128 +539,135 @@ func (b *ProcessEthereumOwnerEntryBatchResults) Close() error {
 	return b.br.Close()
 }
 
-const processEthereumTokenEntry = `-- name: ProcessEthereumTokenEntry :batchexec
+const processEthereumTokenEntry = `-- name: ProcessEthereumTokenEntry :batchone
 with deletion as (
-    delete from ethereum.tokens where $34::bool and simplehash_kafka_key = $1
+    delete from ethereum.tokens where $2::bool and ethereum.tokens.simplehash_kafka_key = $3
 ),
 
 contract_insert as (
     insert into ethereum.contracts (address, simplehash_lookup_nft_id)
-    select $3::text, $2
-    where $33::bool and $3 is not null
+    select $4::text, $1
+    where $5::bool and $4 is not null
     on conflict (address) do nothing
+    returning (xmax = 0) as inserted
 ),
     
 collection_insert as (
     insert into public.collections (id, simplehash_lookup_nft_id)
-    select $20::text, $2
-    where $33::bool and $20 is not null
+    select $6::text, $1
+    where $5::bool and $6 is not null
     on conflict (id) do nothing
-)
+    returning (xmax = 0) as inserted
+),
 
-insert into ethereum.tokens (
-    simplehash_kafka_key,
-    simplehash_nft_id,
-    contract_address,
-    token_id,
-    name,
-    description,
-    previews,
-    image_url,
-    video_url,
-    audio_url,
-    model_url,
-    other_url,
-    background_color,
-    external_url,
-    on_chain_created_date,
-    status,
-    token_count,
-    owner_count,
-    contract,
-    collection_id,
-    last_sale,
-    first_created,
-    rarity,
-    extra_metadata,
-    image_properties,
-    video_properties,
-    audio_properties,
-    model_properties,
-    other_properties,
-    last_updated,
-    kafka_offset,
-    kafka_partition,
-    kafka_timestamp
-    )
-    select
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        $6,
-        $7,
-        $8,
-        $9,
-        $10,
-        $11,
-        $12,
-        $13,
-        $14,
-        $15,
-        $16,
-        $17,
-        $18,
-        $19,
-        $20,
-        $21,
-        $22,
-        $23,
-        $24,
-        $25,
-        $26,
-        $27,
-        $28,
-        $29,
-        now(),
-        $30,
-        $31,
-        $32
-    where $33::bool
-    on conflict (simplehash_kafka_key) do update
-        set simplehash_nft_id = excluded.simplehash_nft_id,
-            contract_address = excluded.contract_address,
-            token_id = excluded.token_id,
-            name = excluded.name,
-            description = excluded.description,
-            previews = excluded.previews,
-            image_url = excluded.image_url,
-            video_url = excluded.video_url,
-            audio_url = excluded.audio_url,
-            model_url = excluded.model_url,
-            other_url = excluded.other_url,
-            background_color = excluded.background_color,
-            external_url = excluded.external_url,
-            on_chain_created_date = excluded.on_chain_created_date,
-            status = excluded.status,
-            token_count = excluded.token_count,
-            owner_count = excluded.owner_count,
-            contract = excluded.contract,
-            collection_id = excluded.collection_id,
-            last_sale = excluded.last_sale,
-            first_created = excluded.first_created,
-            rarity = excluded.rarity,
-            extra_metadata = excluded.extra_metadata,
-            image_properties = excluded.image_properties,
-            video_properties = excluded.video_properties,
-            audio_properties = excluded.audio_properties,
-            model_properties = excluded.model_properties,
-            other_properties = excluded.other_properties,
-            last_updated = now(),
-            kafka_offset = excluded.kafka_offset,
-            kafka_partition = excluded.kafka_partition,
-            kafka_timestamp = excluded.kafka_timestamp
+token_insert as (
+    insert into ethereum.tokens (
+        simplehash_kafka_key,
+        simplehash_nft_id,
+        contract_address,
+        token_id,
+        name,
+        description,
+        previews,
+        image_url,
+        video_url,
+        audio_url,
+        model_url,
+        other_url,
+        background_color,
+        external_url,
+        on_chain_created_date,
+        status,
+        token_count,
+        owner_count,
+        contract,
+        collection_id,
+        last_sale,
+        first_created,
+        rarity,
+        extra_metadata,
+        image_properties,
+        video_properties,
+        audio_properties,
+        model_properties,
+        other_properties,
+        last_updated,
+        kafka_offset,
+        kafka_partition,
+        kafka_timestamp
+        )
+        select
+            $3,
+            $1,
+            $4,
+            $7,
+            $8,
+            $9,
+            $10,
+            $11,
+            $12,
+            $13,
+            $14,
+            $15,
+            $16,
+            $17,
+            $18,
+            $19,
+            $20,
+            $21,
+            $22,
+            $6,
+            $23,
+            $24,
+            $25,
+            $26,
+            $27,
+            $28,
+            $29,
+            $30,
+            $31,
+            now(),
+            $32,
+            $33,
+            $34
+        where $5::bool
+        on conflict (simplehash_kafka_key) do update
+            set simplehash_nft_id = excluded.simplehash_nft_id,
+                contract_address = excluded.contract_address,
+                token_id = excluded.token_id,
+                name = excluded.name,
+                description = excluded.description,
+                previews = excluded.previews,
+                image_url = excluded.image_url,
+                video_url = excluded.video_url,
+                audio_url = excluded.audio_url,
+                model_url = excluded.model_url,
+                other_url = excluded.other_url,
+                background_color = excluded.background_color,
+                external_url = excluded.external_url,
+                on_chain_created_date = excluded.on_chain_created_date,
+                status = excluded.status,
+                token_count = excluded.token_count,
+                owner_count = excluded.owner_count,
+                contract = excluded.contract,
+                collection_id = excluded.collection_id,
+                last_sale = excluded.last_sale,
+                first_created = excluded.first_created,
+                rarity = excluded.rarity,
+                extra_metadata = excluded.extra_metadata,
+                image_properties = excluded.image_properties,
+                video_properties = excluded.video_properties,
+                audio_properties = excluded.audio_properties,
+                model_properties = excluded.model_properties,
+                other_properties = excluded.other_properties,
+                last_updated = now(),
+                kafka_offset = excluded.kafka_offset,
+                kafka_partition = excluded.kafka_partition,
+                kafka_timestamp = excluded.kafka_timestamp
+)
+select $1::text
+from contract_insert, collection_insert
+    where contract_insert.inserted or collection_insert.inserted
 `
 
 type ProcessEthereumTokenEntryBatchResults struct {
@@ -661,49 +677,52 @@ type ProcessEthereumTokenEntryBatchResults struct {
 }
 
 type ProcessEthereumTokenEntryParams struct {
-	SimplehashKafkaKey string           `db:"simplehash_kafka_key" json:"simplehash_kafka_key"`
-	SimplehashNftID    *string          `db:"simplehash_nft_id" json:"simplehash_nft_id"`
-	ContractAddress    *persist.Address `db:"contract_address" json:"contract_address"`
-	TokenID            pgtype.Numeric   `db:"token_id" json:"token_id"`
-	Name               *string          `db:"name" json:"name"`
-	Description        *string          `db:"description" json:"description"`
-	Previews           pgtype.JSONB     `db:"previews" json:"previews"`
-	ImageUrl           *string          `db:"image_url" json:"image_url"`
-	VideoUrl           *string          `db:"video_url" json:"video_url"`
-	AudioUrl           *string          `db:"audio_url" json:"audio_url"`
-	ModelUrl           *string          `db:"model_url" json:"model_url"`
-	OtherUrl           *string          `db:"other_url" json:"other_url"`
-	BackgroundColor    *string          `db:"background_color" json:"background_color"`
-	ExternalUrl        *string          `db:"external_url" json:"external_url"`
-	OnChainCreatedDate *time.Time       `db:"on_chain_created_date" json:"on_chain_created_date"`
-	Status             *string          `db:"status" json:"status"`
-	TokenCount         pgtype.Numeric   `db:"token_count" json:"token_count"`
-	OwnerCount         pgtype.Numeric   `db:"owner_count" json:"owner_count"`
-	Contract           pgtype.JSONB     `db:"contract" json:"contract"`
-	CollectionID       *string          `db:"collection_id" json:"collection_id"`
-	LastSale           pgtype.JSONB     `db:"last_sale" json:"last_sale"`
-	FirstCreated       pgtype.JSONB     `db:"first_created" json:"first_created"`
-	Rarity             pgtype.JSONB     `db:"rarity" json:"rarity"`
-	ExtraMetadata      *string          `db:"extra_metadata" json:"extra_metadata"`
-	ImageProperties    pgtype.JSONB     `db:"image_properties" json:"image_properties"`
-	VideoProperties    pgtype.JSONB     `db:"video_properties" json:"video_properties"`
-	AudioProperties    pgtype.JSONB     `db:"audio_properties" json:"audio_properties"`
-	ModelProperties    pgtype.JSONB     `db:"model_properties" json:"model_properties"`
-	OtherProperties    pgtype.JSONB     `db:"other_properties" json:"other_properties"`
-	KafkaOffset        *int64           `db:"kafka_offset" json:"kafka_offset"`
-	KafkaPartition     *int32           `db:"kafka_partition" json:"kafka_partition"`
-	KafkaTimestamp     *time.Time       `db:"kafka_timestamp" json:"kafka_timestamp"`
-	ShouldUpsert       bool             `db:"should_upsert" json:"should_upsert"`
-	ShouldDelete       bool             `db:"should_delete" json:"should_delete"`
+	SimplehashNftID    string         `db:"simplehash_nft_id" json:"simplehash_nft_id"`
+	ShouldDelete       bool           `db:"should_delete" json:"should_delete"`
+	SimplehashKafkaKey string         `db:"simplehash_kafka_key" json:"simplehash_kafka_key"`
+	ContractAddress    *string        `db:"contract_address" json:"contract_address"`
+	ShouldUpsert       bool           `db:"should_upsert" json:"should_upsert"`
+	CollectionID       *string        `db:"collection_id" json:"collection_id"`
+	TokenID            pgtype.Numeric `db:"token_id" json:"token_id"`
+	Name               *string        `db:"name" json:"name"`
+	Description        *string        `db:"description" json:"description"`
+	Previews           pgtype.JSONB   `db:"previews" json:"previews"`
+	ImageUrl           *string        `db:"image_url" json:"image_url"`
+	VideoUrl           *string        `db:"video_url" json:"video_url"`
+	AudioUrl           *string        `db:"audio_url" json:"audio_url"`
+	ModelUrl           *string        `db:"model_url" json:"model_url"`
+	OtherUrl           *string        `db:"other_url" json:"other_url"`
+	BackgroundColor    *string        `db:"background_color" json:"background_color"`
+	ExternalUrl        *string        `db:"external_url" json:"external_url"`
+	OnChainCreatedDate *time.Time     `db:"on_chain_created_date" json:"on_chain_created_date"`
+	Status             *string        `db:"status" json:"status"`
+	TokenCount         pgtype.Numeric `db:"token_count" json:"token_count"`
+	OwnerCount         pgtype.Numeric `db:"owner_count" json:"owner_count"`
+	Contract           pgtype.JSONB   `db:"contract" json:"contract"`
+	LastSale           pgtype.JSONB   `db:"last_sale" json:"last_sale"`
+	FirstCreated       pgtype.JSONB   `db:"first_created" json:"first_created"`
+	Rarity             pgtype.JSONB   `db:"rarity" json:"rarity"`
+	ExtraMetadata      *string        `db:"extra_metadata" json:"extra_metadata"`
+	ImageProperties    pgtype.JSONB   `db:"image_properties" json:"image_properties"`
+	VideoProperties    pgtype.JSONB   `db:"video_properties" json:"video_properties"`
+	AudioProperties    pgtype.JSONB   `db:"audio_properties" json:"audio_properties"`
+	ModelProperties    pgtype.JSONB   `db:"model_properties" json:"model_properties"`
+	OtherProperties    pgtype.JSONB   `db:"other_properties" json:"other_properties"`
+	KafkaOffset        *int64         `db:"kafka_offset" json:"kafka_offset"`
+	KafkaPartition     *int32         `db:"kafka_partition" json:"kafka_partition"`
+	KafkaTimestamp     *time.Time     `db:"kafka_timestamp" json:"kafka_timestamp"`
 }
 
 func (q *Queries) ProcessEthereumTokenEntry(ctx context.Context, arg []ProcessEthereumTokenEntryParams) *ProcessEthereumTokenEntryBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
 		vals := []interface{}{
-			a.SimplehashKafkaKey,
 			a.SimplehashNftID,
+			a.ShouldDelete,
+			a.SimplehashKafkaKey,
 			a.ContractAddress,
+			a.ShouldUpsert,
+			a.CollectionID,
 			a.TokenID,
 			a.Name,
 			a.Description,
@@ -720,7 +739,6 @@ func (q *Queries) ProcessEthereumTokenEntry(ctx context.Context, arg []ProcessEt
 			a.TokenCount,
 			a.OwnerCount,
 			a.Contract,
-			a.CollectionID,
 			a.LastSale,
 			a.FirstCreated,
 			a.Rarity,
@@ -733,8 +751,6 @@ func (q *Queries) ProcessEthereumTokenEntry(ctx context.Context, arg []ProcessEt
 			a.KafkaOffset,
 			a.KafkaPartition,
 			a.KafkaTimestamp,
-			a.ShouldUpsert,
-			a.ShouldDelete,
 		}
 		batch.Queue(processEthereumTokenEntry, vals...)
 	}
@@ -742,18 +758,20 @@ func (q *Queries) ProcessEthereumTokenEntry(ctx context.Context, arg []ProcessEt
 	return &ProcessEthereumTokenEntryBatchResults{br, len(arg), false}
 }
 
-func (b *ProcessEthereumTokenEntryBatchResults) Exec(f func(int, error)) {
+func (b *ProcessEthereumTokenEntryBatchResults) QueryRow(f func(int, string, error)) {
 	defer b.br.Close()
 	for t := 0; t < b.tot; t++ {
+		var column_1 string
 		if b.closed {
 			if f != nil {
-				f(t, ErrBatchAlreadyClosed)
+				f(t, column_1, ErrBatchAlreadyClosed)
 			}
 			continue
 		}
-		_, err := b.br.Exec()
+		row := b.br.QueryRow()
+		err := row.Scan(&column_1)
 		if f != nil {
-			f(t, err)
+			f(t, column_1, err)
 		}
 	}
 }
@@ -902,128 +920,135 @@ func (b *ProcessZoraOwnerEntryBatchResults) Close() error {
 	return b.br.Close()
 }
 
-const processZoraTokenEntry = `-- name: ProcessZoraTokenEntry :batchexec
+const processZoraTokenEntry = `-- name: ProcessZoraTokenEntry :batchone
 with deletion as (
-    delete from zora.tokens where $34::bool and simplehash_kafka_key = $1
+    delete from zora.tokens where $2::bool and zora.tokens.simplehash_kafka_key = $3
 ),
 
 contract_insert as (
     insert into zora.contracts (address, simplehash_lookup_nft_id)
-    select $3::text, $2
-    where $33::bool and $3 is not null
+    select $4::text, $1
+    where $5::bool and $4 is not null
     on conflict (address) do nothing
+    returning (xmax = 0) as inserted
 ),
     
 collection_insert as (
     insert into public.collections (id, simplehash_lookup_nft_id)
-    select $20::text, $2
-    where $33::bool and $20 is not null
+    select $6::text, $1
+    where $5::bool and $6 is not null
     on conflict (id) do nothing
-)
+    returning (xmax = 0) as inserted
+),
 
-insert into zora.tokens (
-    simplehash_kafka_key,
-    simplehash_nft_id,
-    contract_address,
-    token_id,
-    name,
-    description,
-    previews,
-    image_url,
-    video_url,
-    audio_url,
-    model_url,
-    other_url,
-    background_color,
-    external_url,
-    on_chain_created_date,
-    status,
-    token_count,
-    owner_count,
-    contract,
-    collection_id,
-    last_sale,
-    first_created,
-    rarity,
-    extra_metadata,
-    image_properties,
-    video_properties,
-    audio_properties,
-    model_properties,
-    other_properties,
-    last_updated,
-    kafka_offset,
-    kafka_partition,
-    kafka_timestamp
-    )
-    select
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        $6,
-        $7,
-        $8,
-        $9,
-        $10,
-        $11,
-        $12,
-        $13,
-        $14,
-        $15,
-        $16,
-        $17,
-        $18,
-        $19,
-        $20,
-        $21,
-        $22,
-        $23,
-        $24,
-        $25,
-        $26,
-        $27,
-        $28,
-        $29,
-        now(),
-        $30,
-        $31,
-        $32
-    where $33::bool
-    on conflict (simplehash_kafka_key) do update
-        set simplehash_nft_id = excluded.simplehash_nft_id,
-            contract_address = excluded.contract_address,
-            token_id = excluded.token_id,
-            name = excluded.name,
-            description = excluded.description,
-            previews = excluded.previews,
-            image_url = excluded.image_url,
-            video_url = excluded.video_url,
-            audio_url = excluded.audio_url,
-            model_url = excluded.model_url,
-            other_url = excluded.other_url,
-            background_color = excluded.background_color,
-            external_url = excluded.external_url,
-            on_chain_created_date = excluded.on_chain_created_date,
-            status = excluded.status,
-            token_count = excluded.token_count,
-            owner_count = excluded.owner_count,
-            contract = excluded.contract,
-            collection_id = excluded.collection_id,
-            last_sale = excluded.last_sale,
-            first_created = excluded.first_created,
-            rarity = excluded.rarity,
-            extra_metadata = excluded.extra_metadata,
-            image_properties = excluded.image_properties,
-            video_properties = excluded.video_properties,
-            audio_properties = excluded.audio_properties,
-            model_properties = excluded.model_properties,
-            other_properties = excluded.other_properties,
-            last_updated = now(),
-            kafka_offset = excluded.kafka_offset,
-            kafka_partition = excluded.kafka_partition,
-            kafka_timestamp = excluded.kafka_timestamp
+token_insert as (
+    insert into zora.tokens (
+        simplehash_kafka_key,
+        simplehash_nft_id,
+        contract_address,
+        token_id,
+        name,
+        description,
+        previews,
+        image_url,
+        video_url,
+        audio_url,
+        model_url,
+        other_url,
+        background_color,
+        external_url,
+        on_chain_created_date,
+        status,
+        token_count,
+        owner_count,
+        contract,
+        collection_id,
+        last_sale,
+        first_created,
+        rarity,
+        extra_metadata,
+        image_properties,
+        video_properties,
+        audio_properties,
+        model_properties,
+        other_properties,
+        last_updated,
+        kafka_offset,
+        kafka_partition,
+        kafka_timestamp
+        )
+        select
+            $3,
+            $1,
+            $4,
+            $7,
+            $8,
+            $9,
+            $10,
+            $11,
+            $12,
+            $13,
+            $14,
+            $15,
+            $16,
+            $17,
+            $18,
+            $19,
+            $20,
+            $21,
+            $22,
+            $6,
+            $23,
+            $24,
+            $25,
+            $26,
+            $27,
+            $28,
+            $29,
+            $30,
+            $31,
+            now(),
+            $32,
+            $33,
+            $34
+        where $5::bool
+        on conflict (simplehash_kafka_key) do update
+            set simplehash_nft_id = excluded.simplehash_nft_id,
+                contract_address = excluded.contract_address,
+                token_id = excluded.token_id,
+                name = excluded.name,
+                description = excluded.description,
+                previews = excluded.previews,
+                image_url = excluded.image_url,
+                video_url = excluded.video_url,
+                audio_url = excluded.audio_url,
+                model_url = excluded.model_url,
+                other_url = excluded.other_url,
+                background_color = excluded.background_color,
+                external_url = excluded.external_url,
+                on_chain_created_date = excluded.on_chain_created_date,
+                status = excluded.status,
+                token_count = excluded.token_count,
+                owner_count = excluded.owner_count,
+                contract = excluded.contract,
+                collection_id = excluded.collection_id,
+                last_sale = excluded.last_sale,
+                first_created = excluded.first_created,
+                rarity = excluded.rarity,
+                extra_metadata = excluded.extra_metadata,
+                image_properties = excluded.image_properties,
+                video_properties = excluded.video_properties,
+                audio_properties = excluded.audio_properties,
+                model_properties = excluded.model_properties,
+                other_properties = excluded.other_properties,
+                last_updated = now(),
+                kafka_offset = excluded.kafka_offset,
+                kafka_partition = excluded.kafka_partition,
+                kafka_timestamp = excluded.kafka_timestamp
+)
+select $1::text
+from contract_insert, collection_insert
+    where contract_insert.inserted or collection_insert.inserted
 `
 
 type ProcessZoraTokenEntryBatchResults struct {
@@ -1033,49 +1058,52 @@ type ProcessZoraTokenEntryBatchResults struct {
 }
 
 type ProcessZoraTokenEntryParams struct {
-	SimplehashKafkaKey string           `db:"simplehash_kafka_key" json:"simplehash_kafka_key"`
-	SimplehashNftID    *string          `db:"simplehash_nft_id" json:"simplehash_nft_id"`
-	ContractAddress    *persist.Address `db:"contract_address" json:"contract_address"`
-	TokenID            pgtype.Numeric   `db:"token_id" json:"token_id"`
-	Name               *string          `db:"name" json:"name"`
-	Description        *string          `db:"description" json:"description"`
-	Previews           pgtype.JSONB     `db:"previews" json:"previews"`
-	ImageUrl           *string          `db:"image_url" json:"image_url"`
-	VideoUrl           *string          `db:"video_url" json:"video_url"`
-	AudioUrl           *string          `db:"audio_url" json:"audio_url"`
-	ModelUrl           *string          `db:"model_url" json:"model_url"`
-	OtherUrl           *string          `db:"other_url" json:"other_url"`
-	BackgroundColor    *string          `db:"background_color" json:"background_color"`
-	ExternalUrl        *string          `db:"external_url" json:"external_url"`
-	OnChainCreatedDate *time.Time       `db:"on_chain_created_date" json:"on_chain_created_date"`
-	Status             *string          `db:"status" json:"status"`
-	TokenCount         pgtype.Numeric   `db:"token_count" json:"token_count"`
-	OwnerCount         pgtype.Numeric   `db:"owner_count" json:"owner_count"`
-	Contract           pgtype.JSONB     `db:"contract" json:"contract"`
-	CollectionID       *string          `db:"collection_id" json:"collection_id"`
-	LastSale           pgtype.JSONB     `db:"last_sale" json:"last_sale"`
-	FirstCreated       pgtype.JSONB     `db:"first_created" json:"first_created"`
-	Rarity             pgtype.JSONB     `db:"rarity" json:"rarity"`
-	ExtraMetadata      *string          `db:"extra_metadata" json:"extra_metadata"`
-	ImageProperties    pgtype.JSONB     `db:"image_properties" json:"image_properties"`
-	VideoProperties    pgtype.JSONB     `db:"video_properties" json:"video_properties"`
-	AudioProperties    pgtype.JSONB     `db:"audio_properties" json:"audio_properties"`
-	ModelProperties    pgtype.JSONB     `db:"model_properties" json:"model_properties"`
-	OtherProperties    pgtype.JSONB     `db:"other_properties" json:"other_properties"`
-	KafkaOffset        *int64           `db:"kafka_offset" json:"kafka_offset"`
-	KafkaPartition     *int32           `db:"kafka_partition" json:"kafka_partition"`
-	KafkaTimestamp     *time.Time       `db:"kafka_timestamp" json:"kafka_timestamp"`
-	ShouldUpsert       bool             `db:"should_upsert" json:"should_upsert"`
-	ShouldDelete       bool             `db:"should_delete" json:"should_delete"`
+	SimplehashNftID    string         `db:"simplehash_nft_id" json:"simplehash_nft_id"`
+	ShouldDelete       bool           `db:"should_delete" json:"should_delete"`
+	SimplehashKafkaKey string         `db:"simplehash_kafka_key" json:"simplehash_kafka_key"`
+	ContractAddress    *string        `db:"contract_address" json:"contract_address"`
+	ShouldUpsert       bool           `db:"should_upsert" json:"should_upsert"`
+	CollectionID       *string        `db:"collection_id" json:"collection_id"`
+	TokenID            pgtype.Numeric `db:"token_id" json:"token_id"`
+	Name               *string        `db:"name" json:"name"`
+	Description        *string        `db:"description" json:"description"`
+	Previews           pgtype.JSONB   `db:"previews" json:"previews"`
+	ImageUrl           *string        `db:"image_url" json:"image_url"`
+	VideoUrl           *string        `db:"video_url" json:"video_url"`
+	AudioUrl           *string        `db:"audio_url" json:"audio_url"`
+	ModelUrl           *string        `db:"model_url" json:"model_url"`
+	OtherUrl           *string        `db:"other_url" json:"other_url"`
+	BackgroundColor    *string        `db:"background_color" json:"background_color"`
+	ExternalUrl        *string        `db:"external_url" json:"external_url"`
+	OnChainCreatedDate *time.Time     `db:"on_chain_created_date" json:"on_chain_created_date"`
+	Status             *string        `db:"status" json:"status"`
+	TokenCount         pgtype.Numeric `db:"token_count" json:"token_count"`
+	OwnerCount         pgtype.Numeric `db:"owner_count" json:"owner_count"`
+	Contract           pgtype.JSONB   `db:"contract" json:"contract"`
+	LastSale           pgtype.JSONB   `db:"last_sale" json:"last_sale"`
+	FirstCreated       pgtype.JSONB   `db:"first_created" json:"first_created"`
+	Rarity             pgtype.JSONB   `db:"rarity" json:"rarity"`
+	ExtraMetadata      *string        `db:"extra_metadata" json:"extra_metadata"`
+	ImageProperties    pgtype.JSONB   `db:"image_properties" json:"image_properties"`
+	VideoProperties    pgtype.JSONB   `db:"video_properties" json:"video_properties"`
+	AudioProperties    pgtype.JSONB   `db:"audio_properties" json:"audio_properties"`
+	ModelProperties    pgtype.JSONB   `db:"model_properties" json:"model_properties"`
+	OtherProperties    pgtype.JSONB   `db:"other_properties" json:"other_properties"`
+	KafkaOffset        *int64         `db:"kafka_offset" json:"kafka_offset"`
+	KafkaPartition     *int32         `db:"kafka_partition" json:"kafka_partition"`
+	KafkaTimestamp     *time.Time     `db:"kafka_timestamp" json:"kafka_timestamp"`
 }
 
 func (q *Queries) ProcessZoraTokenEntry(ctx context.Context, arg []ProcessZoraTokenEntryParams) *ProcessZoraTokenEntryBatchResults {
 	batch := &pgx.Batch{}
 	for _, a := range arg {
 		vals := []interface{}{
-			a.SimplehashKafkaKey,
 			a.SimplehashNftID,
+			a.ShouldDelete,
+			a.SimplehashKafkaKey,
 			a.ContractAddress,
+			a.ShouldUpsert,
+			a.CollectionID,
 			a.TokenID,
 			a.Name,
 			a.Description,
@@ -1092,7 +1120,6 @@ func (q *Queries) ProcessZoraTokenEntry(ctx context.Context, arg []ProcessZoraTo
 			a.TokenCount,
 			a.OwnerCount,
 			a.Contract,
-			a.CollectionID,
 			a.LastSale,
 			a.FirstCreated,
 			a.Rarity,
@@ -1105,8 +1132,6 @@ func (q *Queries) ProcessZoraTokenEntry(ctx context.Context, arg []ProcessZoraTo
 			a.KafkaOffset,
 			a.KafkaPartition,
 			a.KafkaTimestamp,
-			a.ShouldUpsert,
-			a.ShouldDelete,
 		}
 		batch.Queue(processZoraTokenEntry, vals...)
 	}
@@ -1114,7 +1139,81 @@ func (q *Queries) ProcessZoraTokenEntry(ctx context.Context, arg []ProcessZoraTo
 	return &ProcessZoraTokenEntryBatchResults{br, len(arg), false}
 }
 
-func (b *ProcessZoraTokenEntryBatchResults) Exec(f func(int, error)) {
+func (b *ProcessZoraTokenEntryBatchResults) QueryRow(f func(int, string, error)) {
+	defer b.br.Close()
+	for t := 0; t < b.tot; t++ {
+		var column_1 string
+		if b.closed {
+			if f != nil {
+				f(t, column_1, ErrBatchAlreadyClosed)
+			}
+			continue
+		}
+		row := b.br.QueryRow()
+		err := row.Scan(&column_1)
+		if f != nil {
+			f(t, column_1, err)
+		}
+	}
+}
+
+func (b *ProcessZoraTokenEntryBatchResults) Close() error {
+	b.closed = true
+	return b.br.Close()
+}
+
+const updateBaseContract = `-- name: UpdateBaseContract :batchexec
+update base.contracts
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    type = $1,
+    name = $2,
+    symbol = $3,
+    deployed_by = $4,
+    deployed_via_contract = $5,
+    owned_by = $6,
+    has_multiple_collections = $7
+where address = $8
+`
+
+type UpdateBaseContractBatchResults struct {
+	br     pgx.BatchResults
+	tot    int
+	closed bool
+}
+
+type UpdateBaseContractParams struct {
+	Type                   *string `db:"type" json:"type"`
+	Name                   *string `db:"name" json:"name"`
+	Symbol                 *string `db:"symbol" json:"symbol"`
+	DeployedBy             *string `db:"deployed_by" json:"deployed_by"`
+	DeployedViaContract    *string `db:"deployed_via_contract" json:"deployed_via_contract"`
+	OwnedBy                *string `db:"owned_by" json:"owned_by"`
+	HasMultipleCollections *bool   `db:"has_multiple_collections" json:"has_multiple_collections"`
+	Address                string  `db:"address" json:"address"`
+}
+
+func (q *Queries) UpdateBaseContract(ctx context.Context, arg []UpdateBaseContractParams) *UpdateBaseContractBatchResults {
+	batch := &pgx.Batch{}
+	for _, a := range arg {
+		vals := []interface{}{
+			a.Type,
+			a.Name,
+			a.Symbol,
+			a.DeployedBy,
+			a.DeployedViaContract,
+			a.OwnedBy,
+			a.HasMultipleCollections,
+			a.Address,
+		}
+		batch.Queue(updateBaseContract, vals...)
+	}
+	br := q.db.SendBatch(ctx, batch)
+	return &UpdateBaseContractBatchResults{br, len(arg), false}
+}
+
+func (b *UpdateBaseContractBatchResults) Exec(f func(int, error)) {
 	defer b.br.Close()
 	for t := 0; t < b.tot; t++ {
 		if b.closed {
@@ -1130,7 +1229,262 @@ func (b *ProcessZoraTokenEntryBatchResults) Exec(f func(int, error)) {
 	}
 }
 
-func (b *ProcessZoraTokenEntryBatchResults) Close() error {
+func (b *UpdateBaseContractBatchResults) Close() error {
+	b.closed = true
+	return b.br.Close()
+}
+
+const updateCollection = `-- name: UpdateCollection :batchexec
+update public.collections
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    name = $1,
+    description = $2,
+    image_url = $3,
+    banner_image_url = $4,
+    category = $5,
+    is_nsfw = $6,
+    external_url = $7,
+    twitter_username = $8,
+    discord_url = $9,
+    instagram_url = $10,
+    medium_username = $11,
+    telegram_url = $12,
+    marketplace_pages = $13,
+    metaplex_mint = $14,
+    metaplex_candy_machine = $15,
+    metaplex_first_verified_creator = $16,
+    spam_score = $17,
+    chains = $18,
+    top_contracts = $19,
+    collection_royalties = $20
+where id = $21
+`
+
+type UpdateCollectionBatchResults struct {
+	br     pgx.BatchResults
+	tot    int
+	closed bool
+}
+
+type UpdateCollectionParams struct {
+	Name                         *string      `db:"name" json:"name"`
+	Description                  *string      `db:"description" json:"description"`
+	ImageUrl                     *string      `db:"image_url" json:"image_url"`
+	BannerImageUrl               *string      `db:"banner_image_url" json:"banner_image_url"`
+	Category                     *string      `db:"category" json:"category"`
+	IsNsfw                       *bool        `db:"is_nsfw" json:"is_nsfw"`
+	ExternalUrl                  *string      `db:"external_url" json:"external_url"`
+	TwitterUsername              *string      `db:"twitter_username" json:"twitter_username"`
+	DiscordUrl                   *string      `db:"discord_url" json:"discord_url"`
+	InstagramUrl                 *string      `db:"instagram_url" json:"instagram_url"`
+	MediumUsername               *string      `db:"medium_username" json:"medium_username"`
+	TelegramUrl                  *string      `db:"telegram_url" json:"telegram_url"`
+	MarketplacePages             pgtype.JSONB `db:"marketplace_pages" json:"marketplace_pages"`
+	MetaplexMint                 *string      `db:"metaplex_mint" json:"metaplex_mint"`
+	MetaplexCandyMachine         *string      `db:"metaplex_candy_machine" json:"metaplex_candy_machine"`
+	MetaplexFirstVerifiedCreator *string      `db:"metaplex_first_verified_creator" json:"metaplex_first_verified_creator"`
+	SpamScore                    *int32       `db:"spam_score" json:"spam_score"`
+	Chains                       []string     `db:"chains" json:"chains"`
+	TopContracts                 []string     `db:"top_contracts" json:"top_contracts"`
+	CollectionRoyalties          pgtype.JSONB `db:"collection_royalties" json:"collection_royalties"`
+	CollectionID                 string       `db:"collection_id" json:"collection_id"`
+}
+
+func (q *Queries) UpdateCollection(ctx context.Context, arg []UpdateCollectionParams) *UpdateCollectionBatchResults {
+	batch := &pgx.Batch{}
+	for _, a := range arg {
+		vals := []interface{}{
+			a.Name,
+			a.Description,
+			a.ImageUrl,
+			a.BannerImageUrl,
+			a.Category,
+			a.IsNsfw,
+			a.ExternalUrl,
+			a.TwitterUsername,
+			a.DiscordUrl,
+			a.InstagramUrl,
+			a.MediumUsername,
+			a.TelegramUrl,
+			a.MarketplacePages,
+			a.MetaplexMint,
+			a.MetaplexCandyMachine,
+			a.MetaplexFirstVerifiedCreator,
+			a.SpamScore,
+			a.Chains,
+			a.TopContracts,
+			a.CollectionRoyalties,
+			a.CollectionID,
+		}
+		batch.Queue(updateCollection, vals...)
+	}
+	br := q.db.SendBatch(ctx, batch)
+	return &UpdateCollectionBatchResults{br, len(arg), false}
+}
+
+func (b *UpdateCollectionBatchResults) Exec(f func(int, error)) {
+	defer b.br.Close()
+	for t := 0; t < b.tot; t++ {
+		if b.closed {
+			if f != nil {
+				f(t, ErrBatchAlreadyClosed)
+			}
+			continue
+		}
+		_, err := b.br.Exec()
+		if f != nil {
+			f(t, err)
+		}
+	}
+}
+
+func (b *UpdateCollectionBatchResults) Close() error {
+	b.closed = true
+	return b.br.Close()
+}
+
+const updateEthereumContract = `-- name: UpdateEthereumContract :batchexec
+update ethereum.contracts
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    type = $1,
+    name = $2,
+    symbol = $3,
+    deployed_by = $4,
+    deployed_via_contract = $5,
+    owned_by = $6,
+    has_multiple_collections = $7
+where address = $8
+`
+
+type UpdateEthereumContractBatchResults struct {
+	br     pgx.BatchResults
+	tot    int
+	closed bool
+}
+
+type UpdateEthereumContractParams struct {
+	Type                   *string `db:"type" json:"type"`
+	Name                   *string `db:"name" json:"name"`
+	Symbol                 *string `db:"symbol" json:"symbol"`
+	DeployedBy             *string `db:"deployed_by" json:"deployed_by"`
+	DeployedViaContract    *string `db:"deployed_via_contract" json:"deployed_via_contract"`
+	OwnedBy                *string `db:"owned_by" json:"owned_by"`
+	HasMultipleCollections *bool   `db:"has_multiple_collections" json:"has_multiple_collections"`
+	Address                string  `db:"address" json:"address"`
+}
+
+func (q *Queries) UpdateEthereumContract(ctx context.Context, arg []UpdateEthereumContractParams) *UpdateEthereumContractBatchResults {
+	batch := &pgx.Batch{}
+	for _, a := range arg {
+		vals := []interface{}{
+			a.Type,
+			a.Name,
+			a.Symbol,
+			a.DeployedBy,
+			a.DeployedViaContract,
+			a.OwnedBy,
+			a.HasMultipleCollections,
+			a.Address,
+		}
+		batch.Queue(updateEthereumContract, vals...)
+	}
+	br := q.db.SendBatch(ctx, batch)
+	return &UpdateEthereumContractBatchResults{br, len(arg), false}
+}
+
+func (b *UpdateEthereumContractBatchResults) Exec(f func(int, error)) {
+	defer b.br.Close()
+	for t := 0; t < b.tot; t++ {
+		if b.closed {
+			if f != nil {
+				f(t, ErrBatchAlreadyClosed)
+			}
+			continue
+		}
+		_, err := b.br.Exec()
+		if f != nil {
+			f(t, err)
+		}
+	}
+}
+
+func (b *UpdateEthereumContractBatchResults) Close() error {
+	b.closed = true
+	return b.br.Close()
+}
+
+const updateZoraContract = `-- name: UpdateZoraContract :batchexec
+update zora.contracts
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    type = $1,
+    name = $2,
+    symbol = $3,
+    deployed_by = $4,
+    deployed_via_contract = $5,
+    owned_by = $6,
+    has_multiple_collections = $7
+where address = $8
+`
+
+type UpdateZoraContractBatchResults struct {
+	br     pgx.BatchResults
+	tot    int
+	closed bool
+}
+
+type UpdateZoraContractParams struct {
+	Type                   *string `db:"type" json:"type"`
+	Name                   *string `db:"name" json:"name"`
+	Symbol                 *string `db:"symbol" json:"symbol"`
+	DeployedBy             *string `db:"deployed_by" json:"deployed_by"`
+	DeployedViaContract    *string `db:"deployed_via_contract" json:"deployed_via_contract"`
+	OwnedBy                *string `db:"owned_by" json:"owned_by"`
+	HasMultipleCollections *bool   `db:"has_multiple_collections" json:"has_multiple_collections"`
+	Address                string  `db:"address" json:"address"`
+}
+
+func (q *Queries) UpdateZoraContract(ctx context.Context, arg []UpdateZoraContractParams) *UpdateZoraContractBatchResults {
+	batch := &pgx.Batch{}
+	for _, a := range arg {
+		vals := []interface{}{
+			a.Type,
+			a.Name,
+			a.Symbol,
+			a.DeployedBy,
+			a.DeployedViaContract,
+			a.OwnedBy,
+			a.HasMultipleCollections,
+			a.Address,
+		}
+		batch.Queue(updateZoraContract, vals...)
+	}
+	br := q.db.SendBatch(ctx, batch)
+	return &UpdateZoraContractBatchResults{br, len(arg), false}
+}
+
+func (b *UpdateZoraContractBatchResults) Exec(f func(int, error)) {
+	defer b.br.Close()
+	for t := 0; t < b.tot; t++ {
+		if b.closed {
+			if f != nil {
+				f(t, ErrBatchAlreadyClosed)
+			}
+			continue
+		}
+		_, err := b.br.Exec()
+		if f != nil {
+			f(t, err)
+		}
+	}
+}
+
+func (b *UpdateZoraContractBatchResults) Close() error {
 	b.closed = true
 	return b.br.Close()
 }

--- a/db/gen/mirrordb/models_gen.go
+++ b/db/gen/mirrordb/models_gen.go
@@ -11,20 +11,19 @@ import (
 	"github.com/mikeydub/go-gallery/service/persist"
 )
 
-type BaseCollection struct {
-	ID                    string     `db:"id" json:"id"`
-	SimplehashLookupNftID string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
-	LastSimplehashSync    *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
-	CreatedAt             time.Time  `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time  `db:"last_updated" json:"last_updated"`
-}
-
 type BaseContract struct {
-	Address               string     `db:"address" json:"address"`
-	SimplehashLookupNftID string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
-	LastSimplehashSync    *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
-	CreatedAt             time.Time  `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time  `db:"last_updated" json:"last_updated"`
+	Address                string     `db:"address" json:"address"`
+	SimplehashLookupNftID  string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
+	LastSimplehashSync     *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
+	CreatedAt              time.Time  `db:"created_at" json:"created_at"`
+	LastUpdated            time.Time  `db:"last_updated" json:"last_updated"`
+	Type                   *string    `db:"type" json:"type"`
+	Name                   *string    `db:"name" json:"name"`
+	Symbol                 *string    `db:"symbol" json:"symbol"`
+	DeployedBy             *string    `db:"deployed_by" json:"deployed_by"`
+	DeployedViaContract    *string    `db:"deployed_via_contract" json:"deployed_via_contract"`
+	OwnedBy                *string    `db:"owned_by" json:"owned_by"`
+	HasMultipleCollections *bool      `db:"has_multiple_collections" json:"has_multiple_collections"`
 }
 
 type BaseOwner struct {
@@ -87,27 +86,46 @@ type BaseToken struct {
 }
 
 type Collection struct {
-	ID                    string     `db:"id" json:"id"`
-	SimplehashLookupNftID string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
-	LastSimplehashSync    *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
-	CreatedAt             time.Time  `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time  `db:"last_updated" json:"last_updated"`
-}
-
-type EthereumCollection struct {
-	ID                    string     `db:"id" json:"id"`
-	SimplehashLookupNftID string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
-	LastSimplehashSync    *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
-	CreatedAt             time.Time  `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time  `db:"last_updated" json:"last_updated"`
+	ID                           string       `db:"id" json:"id"`
+	SimplehashLookupNftID        string       `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
+	LastSimplehashSync           *time.Time   `db:"last_simplehash_sync" json:"last_simplehash_sync"`
+	CreatedAt                    time.Time    `db:"created_at" json:"created_at"`
+	LastUpdated                  time.Time    `db:"last_updated" json:"last_updated"`
+	Name                         *string      `db:"name" json:"name"`
+	Description                  *string      `db:"description" json:"description"`
+	ImageUrl                     *string      `db:"image_url" json:"image_url"`
+	BannerImageUrl               *string      `db:"banner_image_url" json:"banner_image_url"`
+	Category                     *string      `db:"category" json:"category"`
+	IsNsfw                       *bool        `db:"is_nsfw" json:"is_nsfw"`
+	ExternalUrl                  *string      `db:"external_url" json:"external_url"`
+	TwitterUsername              *string      `db:"twitter_username" json:"twitter_username"`
+	DiscordUrl                   *string      `db:"discord_url" json:"discord_url"`
+	InstagramUrl                 *string      `db:"instagram_url" json:"instagram_url"`
+	MediumUsername               *string      `db:"medium_username" json:"medium_username"`
+	TelegramUrl                  *string      `db:"telegram_url" json:"telegram_url"`
+	MarketplacePages             pgtype.JSONB `db:"marketplace_pages" json:"marketplace_pages"`
+	MetaplexMint                 *string      `db:"metaplex_mint" json:"metaplex_mint"`
+	MetaplexCandyMachine         *string      `db:"metaplex_candy_machine" json:"metaplex_candy_machine"`
+	MetaplexFirstVerifiedCreator *string      `db:"metaplex_first_verified_creator" json:"metaplex_first_verified_creator"`
+	SpamScore                    *int32       `db:"spam_score" json:"spam_score"`
+	Chains                       []string     `db:"chains" json:"chains"`
+	TopContracts                 []string     `db:"top_contracts" json:"top_contracts"`
+	CollectionRoyalties          pgtype.JSONB `db:"collection_royalties" json:"collection_royalties"`
 }
 
 type EthereumContract struct {
-	Address               string     `db:"address" json:"address"`
-	SimplehashLookupNftID string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
-	LastSimplehashSync    *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
-	CreatedAt             time.Time  `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time  `db:"last_updated" json:"last_updated"`
+	Address                string     `db:"address" json:"address"`
+	SimplehashLookupNftID  string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
+	LastSimplehashSync     *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
+	CreatedAt              time.Time  `db:"created_at" json:"created_at"`
+	LastUpdated            time.Time  `db:"last_updated" json:"last_updated"`
+	Type                   *string    `db:"type" json:"type"`
+	Name                   *string    `db:"name" json:"name"`
+	Symbol                 *string    `db:"symbol" json:"symbol"`
+	DeployedBy             *string    `db:"deployed_by" json:"deployed_by"`
+	DeployedViaContract    *string    `db:"deployed_via_contract" json:"deployed_via_contract"`
+	OwnedBy                *string    `db:"owned_by" json:"owned_by"`
+	HasMultipleCollections *bool      `db:"has_multiple_collections" json:"has_multiple_collections"`
 }
 
 type EthereumOwner struct {
@@ -169,20 +187,19 @@ type EthereumToken struct {
 	KafkaTimestamp     *time.Time       `db:"kafka_timestamp" json:"kafka_timestamp"`
 }
 
-type ZoraCollection struct {
-	ID                    string     `db:"id" json:"id"`
-	SimplehashLookupNftID string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
-	LastSimplehashSync    *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
-	CreatedAt             time.Time  `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time  `db:"last_updated" json:"last_updated"`
-}
-
 type ZoraContract struct {
-	Address               string     `db:"address" json:"address"`
-	SimplehashLookupNftID string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
-	LastSimplehashSync    *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
-	CreatedAt             time.Time  `db:"created_at" json:"created_at"`
-	LastUpdated           time.Time  `db:"last_updated" json:"last_updated"`
+	Address                string     `db:"address" json:"address"`
+	SimplehashLookupNftID  string     `db:"simplehash_lookup_nft_id" json:"simplehash_lookup_nft_id"`
+	LastSimplehashSync     *time.Time `db:"last_simplehash_sync" json:"last_simplehash_sync"`
+	CreatedAt              time.Time  `db:"created_at" json:"created_at"`
+	LastUpdated            time.Time  `db:"last_updated" json:"last_updated"`
+	Type                   *string    `db:"type" json:"type"`
+	Name                   *string    `db:"name" json:"name"`
+	Symbol                 *string    `db:"symbol" json:"symbol"`
+	DeployedBy             *string    `db:"deployed_by" json:"deployed_by"`
+	DeployedViaContract    *string    `db:"deployed_via_contract" json:"deployed_via_contract"`
+	OwnedBy                *string    `db:"owned_by" json:"owned_by"`
+	HasMultipleCollections *bool      `db:"has_multiple_collections" json:"has_multiple_collections"`
 }
 
 type ZoraOwner struct {

--- a/db/migrations/mirror/000009_contracts.up.sql
+++ b/db/migrations/mirror/000009_contracts.up.sql
@@ -1,0 +1,23 @@
+alter table ethereum.contracts add column type text;
+alter table ethereum.contracts add column name text;
+alter table ethereum.contracts add column symbol text;
+alter table ethereum.contracts add column deployed_by text;
+alter table ethereum.contracts add column deployed_via_contract text;
+alter table ethereum.contracts add column owned_by text;
+alter table ethereum.contracts add column has_multiple_collections boolean;
+
+alter table base.contracts add column type text;
+alter table base.contracts add column name text;
+alter table base.contracts add column symbol text;
+alter table base.contracts add column deployed_by text;
+alter table base.contracts add column deployed_via_contract text;
+alter table base.contracts add column owned_by text;
+alter table base.contracts add column has_multiple_collections boolean;
+
+alter table zora.contracts add column type text;
+alter table zora.contracts add column name text;
+alter table zora.contracts add column symbol text;
+alter table zora.contracts add column deployed_by text;
+alter table zora.contracts add column deployed_via_contract text;
+alter table zora.contracts add column owned_by text;
+alter table zora.contracts add column has_multiple_collections boolean;

--- a/db/migrations/mirror/000010_collections.up.sql
+++ b/db/migrations/mirror/000010_collections.up.sql
@@ -1,0 +1,25 @@
+drop table if exists ethereum.collections;
+drop table if exists base.collections;
+drop table if exists zora.collections;
+
+alter table collections add column name text;
+alter table collections add column description text;
+alter table collections add column image_url text;
+alter table collections add column banner_image_url text;
+alter table collections add column category text;
+alter table collections add column is_nsfw bool;
+alter table collections add column external_url text;
+alter table collections add column twitter_username text;
+alter table collections add column discord_url text;
+alter table collections add column instagram_url text;
+alter table collections add column medium_username text;
+alter table collections add column telegram_url text;
+alter table collections add column marketplace_pages jsonb;
+alter table collections add column metaplex_mint text;
+alter table collections add column metaplex_candy_machine text;
+alter table collections add column metaplex_first_verified_creator text;
+alter table collections add column spam_score int;
+alter table collections add column chains text[];
+alter table collections add column top_contracts text[];
+alter table collections add column collection_royalties jsonb;
+

--- a/db/queries/mirror/query.sql
+++ b/db/queries/mirror/query.sql
@@ -176,9 +176,9 @@ insert into zora.owners (
             sold_to_this_wallet = excluded.sold_to_this_wallet;
 
 
--- name: ProcessEthereumTokenEntry :batchexec
+-- name: ProcessEthereumTokenEntry :batchone
 with deletion as (
-    delete from ethereum.tokens where @should_delete::bool and simplehash_kafka_key = @simplehash_kafka_key
+    delete from ethereum.tokens where @should_delete::bool and ethereum.tokens.simplehash_kafka_key = @simplehash_kafka_key
 ),
 
 contract_insert as (
@@ -186,6 +186,7 @@ contract_insert as (
     select sqlc.narg(contract_address)::text, @simplehash_nft_id
     where @should_upsert::bool and @contract_address is not null
     on conflict (address) do nothing
+    returning (xmax = 0) as inserted
 ),
     
 collection_insert as (
@@ -193,115 +194,121 @@ collection_insert as (
     select sqlc.narg(collection_id)::text, @simplehash_nft_id
     where @should_upsert::bool and @collection_id is not null
     on conflict (id) do nothing
+    returning (xmax = 0) as inserted
+),
+
+token_insert as (
+    insert into ethereum.tokens (
+        simplehash_kafka_key,
+        simplehash_nft_id,
+        contract_address,
+        token_id,
+        name,
+        description,
+        previews,
+        image_url,
+        video_url,
+        audio_url,
+        model_url,
+        other_url,
+        background_color,
+        external_url,
+        on_chain_created_date,
+        status,
+        token_count,
+        owner_count,
+        contract,
+        collection_id,
+        last_sale,
+        first_created,
+        rarity,
+        extra_metadata,
+        image_properties,
+        video_properties,
+        audio_properties,
+        model_properties,
+        other_properties,
+        last_updated,
+        kafka_offset,
+        kafka_partition,
+        kafka_timestamp
+        )
+        select
+            @simplehash_kafka_key,
+            @simplehash_nft_id,
+            @contract_address,
+            @token_id,
+            @name,
+            @description,
+            @previews,
+            @image_url,
+            @video_url,
+            @audio_url,
+            @model_url,
+            @other_url,
+            @background_color,
+            @external_url,
+            @on_chain_created_date,
+            @status,
+            @token_count,
+            @owner_count,
+            @contract,
+            @collection_id,
+            @last_sale,
+            @first_created,
+            @rarity,
+            @extra_metadata,
+            @image_properties,
+            @video_properties,
+            @audio_properties,
+            @model_properties,
+            @other_properties,
+            now(),
+            @kafka_offset,
+            @kafka_partition,
+            @kafka_timestamp
+        where @should_upsert::bool
+        on conflict (simplehash_kafka_key) do update
+            set simplehash_nft_id = excluded.simplehash_nft_id,
+                contract_address = excluded.contract_address,
+                token_id = excluded.token_id,
+                name = excluded.name,
+                description = excluded.description,
+                previews = excluded.previews,
+                image_url = excluded.image_url,
+                video_url = excluded.video_url,
+                audio_url = excluded.audio_url,
+                model_url = excluded.model_url,
+                other_url = excluded.other_url,
+                background_color = excluded.background_color,
+                external_url = excluded.external_url,
+                on_chain_created_date = excluded.on_chain_created_date,
+                status = excluded.status,
+                token_count = excluded.token_count,
+                owner_count = excluded.owner_count,
+                contract = excluded.contract,
+                collection_id = excluded.collection_id,
+                last_sale = excluded.last_sale,
+                first_created = excluded.first_created,
+                rarity = excluded.rarity,
+                extra_metadata = excluded.extra_metadata,
+                image_properties = excluded.image_properties,
+                video_properties = excluded.video_properties,
+                audio_properties = excluded.audio_properties,
+                model_properties = excluded.model_properties,
+                other_properties = excluded.other_properties,
+                last_updated = now(),
+                kafka_offset = excluded.kafka_offset,
+                kafka_partition = excluded.kafka_partition,
+                kafka_timestamp = excluded.kafka_timestamp
 )
+select @simplehash_nft_id::text
+from contract_insert, collection_insert
+    where contract_insert.inserted or collection_insert.inserted;
 
-insert into ethereum.tokens (
-    simplehash_kafka_key,
-    simplehash_nft_id,
-    contract_address,
-    token_id,
-    name,
-    description,
-    previews,
-    image_url,
-    video_url,
-    audio_url,
-    model_url,
-    other_url,
-    background_color,
-    external_url,
-    on_chain_created_date,
-    status,
-    token_count,
-    owner_count,
-    contract,
-    collection_id,
-    last_sale,
-    first_created,
-    rarity,
-    extra_metadata,
-    image_properties,
-    video_properties,
-    audio_properties,
-    model_properties,
-    other_properties,
-    last_updated,
-    kafka_offset,
-    kafka_partition,
-    kafka_timestamp
-    )
-    select
-        @simplehash_kafka_key,
-        @simplehash_nft_id,
-        @contract_address,
-        @token_id,
-        @name,
-        @description,
-        @previews,
-        @image_url,
-        @video_url,
-        @audio_url,
-        @model_url,
-        @other_url,
-        @background_color,
-        @external_url,
-        @on_chain_created_date,
-        @status,
-        @token_count,
-        @owner_count,
-        @contract,
-        @collection_id,
-        @last_sale,
-        @first_created,
-        @rarity,
-        @extra_metadata,
-        @image_properties,
-        @video_properties,
-        @audio_properties,
-        @model_properties,
-        @other_properties,
-        now(),
-        @kafka_offset,
-        @kafka_partition,
-        @kafka_timestamp
-    where @should_upsert::bool
-    on conflict (simplehash_kafka_key) do update
-        set simplehash_nft_id = excluded.simplehash_nft_id,
-            contract_address = excluded.contract_address,
-            token_id = excluded.token_id,
-            name = excluded.name,
-            description = excluded.description,
-            previews = excluded.previews,
-            image_url = excluded.image_url,
-            video_url = excluded.video_url,
-            audio_url = excluded.audio_url,
-            model_url = excluded.model_url,
-            other_url = excluded.other_url,
-            background_color = excluded.background_color,
-            external_url = excluded.external_url,
-            on_chain_created_date = excluded.on_chain_created_date,
-            status = excluded.status,
-            token_count = excluded.token_count,
-            owner_count = excluded.owner_count,
-            contract = excluded.contract,
-            collection_id = excluded.collection_id,
-            last_sale = excluded.last_sale,
-            first_created = excluded.first_created,
-            rarity = excluded.rarity,
-            extra_metadata = excluded.extra_metadata,
-            image_properties = excluded.image_properties,
-            video_properties = excluded.video_properties,
-            audio_properties = excluded.audio_properties,
-            model_properties = excluded.model_properties,
-            other_properties = excluded.other_properties,
-            last_updated = now(),
-            kafka_offset = excluded.kafka_offset,
-            kafka_partition = excluded.kafka_partition,
-            kafka_timestamp = excluded.kafka_timestamp;
-
--- name: ProcessBaseTokenEntry :batchexec
+-- name: ProcessBaseTokenEntry :batchone
 with deletion as (
-    delete from base.tokens where @should_delete::bool and simplehash_kafka_key = @simplehash_kafka_key
+    delete from base.tokens where @should_delete::bool and base.tokens.simplehash_kafka_key = @simplehash_kafka_key
 ),
 
 contract_insert as (
@@ -309,6 +316,7 @@ contract_insert as (
     select sqlc.narg(contract_address)::text, @simplehash_nft_id
     where @should_upsert::bool and @contract_address is not null
     on conflict (address) do nothing
+    returning (xmax = 0) as inserted
 ),
     
 collection_insert as (
@@ -316,115 +324,121 @@ collection_insert as (
     select sqlc.narg(collection_id)::text, @simplehash_nft_id
     where @should_upsert::bool and @collection_id is not null
     on conflict (id) do nothing
+    returning (xmax = 0) as inserted
+),
+
+token_insert as (
+    insert into base.tokens (
+        simplehash_kafka_key,
+        simplehash_nft_id,
+        contract_address,
+        token_id,
+        name,
+        description,
+        previews,
+        image_url,
+        video_url,
+        audio_url,
+        model_url,
+        other_url,
+        background_color,
+        external_url,
+        on_chain_created_date,
+        status,
+        token_count,
+        owner_count,
+        contract,
+        collection_id,
+        last_sale,
+        first_created,
+        rarity,
+        extra_metadata,
+        image_properties,
+        video_properties,
+        audio_properties,
+        model_properties,
+        other_properties,
+        last_updated,
+        kafka_offset,
+        kafka_partition,
+        kafka_timestamp
+        )
+        select
+            @simplehash_kafka_key,
+            @simplehash_nft_id,
+            @contract_address,
+            @token_id,
+            @name,
+            @description,
+            @previews,
+            @image_url,
+            @video_url,
+            @audio_url,
+            @model_url,
+            @other_url,
+            @background_color,
+            @external_url,
+            @on_chain_created_date,
+            @status,
+            @token_count,
+            @owner_count,
+            @contract,
+            @collection_id,
+            @last_sale,
+            @first_created,
+            @rarity,
+            @extra_metadata,
+            @image_properties,
+            @video_properties,
+            @audio_properties,
+            @model_properties,
+            @other_properties,
+            now(),
+            @kafka_offset,
+            @kafka_partition,
+            @kafka_timestamp
+        where @should_upsert::bool
+        on conflict (simplehash_kafka_key) do update
+            set simplehash_nft_id = excluded.simplehash_nft_id,
+                contract_address = excluded.contract_address,
+                token_id = excluded.token_id,
+                name = excluded.name,
+                description = excluded.description,
+                previews = excluded.previews,
+                image_url = excluded.image_url,
+                video_url = excluded.video_url,
+                audio_url = excluded.audio_url,
+                model_url = excluded.model_url,
+                other_url = excluded.other_url,
+                background_color = excluded.background_color,
+                external_url = excluded.external_url,
+                on_chain_created_date = excluded.on_chain_created_date,
+                status = excluded.status,
+                token_count = excluded.token_count,
+                owner_count = excluded.owner_count,
+                contract = excluded.contract,
+                collection_id = excluded.collection_id,
+                last_sale = excluded.last_sale,
+                first_created = excluded.first_created,
+                rarity = excluded.rarity,
+                extra_metadata = excluded.extra_metadata,
+                image_properties = excluded.image_properties,
+                video_properties = excluded.video_properties,
+                audio_properties = excluded.audio_properties,
+                model_properties = excluded.model_properties,
+                other_properties = excluded.other_properties,
+                last_updated = now(),
+                kafka_offset = excluded.kafka_offset,
+                kafka_partition = excluded.kafka_partition,
+                kafka_timestamp = excluded.kafka_timestamp
 )
+select @simplehash_nft_id::text
+from contract_insert, collection_insert
+    where contract_insert.inserted or collection_insert.inserted;
 
-insert into base.tokens (
-    simplehash_kafka_key,
-    simplehash_nft_id,
-    contract_address,
-    token_id,
-    name,
-    description,
-    previews,
-    image_url,
-    video_url,
-    audio_url,
-    model_url,
-    other_url,
-    background_color,
-    external_url,
-    on_chain_created_date,
-    status,
-    token_count,
-    owner_count,
-    contract,
-    collection_id,
-    last_sale,
-    first_created,
-    rarity,
-    extra_metadata,
-    image_properties,
-    video_properties,
-    audio_properties,
-    model_properties,
-    other_properties,
-    last_updated,
-    kafka_offset,
-    kafka_partition,
-    kafka_timestamp
-    )
-    select
-        @simplehash_kafka_key,
-        @simplehash_nft_id,
-        @contract_address,
-        @token_id,
-        @name,
-        @description,
-        @previews,
-        @image_url,
-        @video_url,
-        @audio_url,
-        @model_url,
-        @other_url,
-        @background_color,
-        @external_url,
-        @on_chain_created_date,
-        @status,
-        @token_count,
-        @owner_count,
-        @contract,
-        @collection_id,
-        @last_sale,
-        @first_created,
-        @rarity,
-        @extra_metadata,
-        @image_properties,
-        @video_properties,
-        @audio_properties,
-        @model_properties,
-        @other_properties,
-        now(),
-        @kafka_offset,
-        @kafka_partition,
-        @kafka_timestamp
-    where @should_upsert::bool
-    on conflict (simplehash_kafka_key) do update
-        set simplehash_nft_id = excluded.simplehash_nft_id,
-            contract_address = excluded.contract_address,
-            token_id = excluded.token_id,
-            name = excluded.name,
-            description = excluded.description,
-            previews = excluded.previews,
-            image_url = excluded.image_url,
-            video_url = excluded.video_url,
-            audio_url = excluded.audio_url,
-            model_url = excluded.model_url,
-            other_url = excluded.other_url,
-            background_color = excluded.background_color,
-            external_url = excluded.external_url,
-            on_chain_created_date = excluded.on_chain_created_date,
-            status = excluded.status,
-            token_count = excluded.token_count,
-            owner_count = excluded.owner_count,
-            contract = excluded.contract,
-            collection_id = excluded.collection_id,
-            last_sale = excluded.last_sale,
-            first_created = excluded.first_created,
-            rarity = excluded.rarity,
-            extra_metadata = excluded.extra_metadata,
-            image_properties = excluded.image_properties,
-            video_properties = excluded.video_properties,
-            audio_properties = excluded.audio_properties,
-            model_properties = excluded.model_properties,
-            other_properties = excluded.other_properties,
-            last_updated = now(),
-            kafka_offset = excluded.kafka_offset,
-            kafka_partition = excluded.kafka_partition,
-            kafka_timestamp = excluded.kafka_timestamp;
-
--- name: ProcessZoraTokenEntry :batchexec
+-- name: ProcessZoraTokenEntry :batchone
 with deletion as (
-    delete from zora.tokens where @should_delete::bool and simplehash_kafka_key = @simplehash_kafka_key
+    delete from zora.tokens where @should_delete::bool and zora.tokens.simplehash_kafka_key = @simplehash_kafka_key
 ),
 
 contract_insert as (
@@ -432,6 +446,7 @@ contract_insert as (
     select sqlc.narg(contract_address)::text, @simplehash_nft_id
     where @should_upsert::bool and @contract_address is not null
     on conflict (address) do nothing
+    returning (xmax = 0) as inserted
 ),
     
 collection_insert as (
@@ -439,108 +454,183 @@ collection_insert as (
     select sqlc.narg(collection_id)::text, @simplehash_nft_id
     where @should_upsert::bool and @collection_id is not null
     on conflict (id) do nothing
-)
+    returning (xmax = 0) as inserted
+),
 
-insert into zora.tokens (
-    simplehash_kafka_key,
-    simplehash_nft_id,
-    contract_address,
-    token_id,
-    name,
-    description,
-    previews,
-    image_url,
-    video_url,
-    audio_url,
-    model_url,
-    other_url,
-    background_color,
-    external_url,
-    on_chain_created_date,
-    status,
-    token_count,
-    owner_count,
-    contract,
-    collection_id,
-    last_sale,
-    first_created,
-    rarity,
-    extra_metadata,
-    image_properties,
-    video_properties,
-    audio_properties,
-    model_properties,
-    other_properties,
-    last_updated,
-    kafka_offset,
-    kafka_partition,
-    kafka_timestamp
-    )
-    select
-        @simplehash_kafka_key,
-        @simplehash_nft_id,
-        @contract_address,
-        @token_id,
-        @name,
-        @description,
-        @previews,
-        @image_url,
-        @video_url,
-        @audio_url,
-        @model_url,
-        @other_url,
-        @background_color,
-        @external_url,
-        @on_chain_created_date,
-        @status,
-        @token_count,
-        @owner_count,
-        @contract,
-        @collection_id,
-        @last_sale,
-        @first_created,
-        @rarity,
-        @extra_metadata,
-        @image_properties,
-        @video_properties,
-        @audio_properties,
-        @model_properties,
-        @other_properties,
-        now(),
-        @kafka_offset,
-        @kafka_partition,
-        @kafka_timestamp
-    where @should_upsert::bool
-    on conflict (simplehash_kafka_key) do update
-        set simplehash_nft_id = excluded.simplehash_nft_id,
-            contract_address = excluded.contract_address,
-            token_id = excluded.token_id,
-            name = excluded.name,
-            description = excluded.description,
-            previews = excluded.previews,
-            image_url = excluded.image_url,
-            video_url = excluded.video_url,
-            audio_url = excluded.audio_url,
-            model_url = excluded.model_url,
-            other_url = excluded.other_url,
-            background_color = excluded.background_color,
-            external_url = excluded.external_url,
-            on_chain_created_date = excluded.on_chain_created_date,
-            status = excluded.status,
-            token_count = excluded.token_count,
-            owner_count = excluded.owner_count,
-            contract = excluded.contract,
-            collection_id = excluded.collection_id,
-            last_sale = excluded.last_sale,
-            first_created = excluded.first_created,
-            rarity = excluded.rarity,
-            extra_metadata = excluded.extra_metadata,
-            image_properties = excluded.image_properties,
-            video_properties = excluded.video_properties,
-            audio_properties = excluded.audio_properties,
-            model_properties = excluded.model_properties,
-            other_properties = excluded.other_properties,
-            last_updated = now(),
-            kafka_offset = excluded.kafka_offset,
-            kafka_partition = excluded.kafka_partition,
-            kafka_timestamp = excluded.kafka_timestamp;
+token_insert as (
+    insert into zora.tokens (
+        simplehash_kafka_key,
+        simplehash_nft_id,
+        contract_address,
+        token_id,
+        name,
+        description,
+        previews,
+        image_url,
+        video_url,
+        audio_url,
+        model_url,
+        other_url,
+        background_color,
+        external_url,
+        on_chain_created_date,
+        status,
+        token_count,
+        owner_count,
+        contract,
+        collection_id,
+        last_sale,
+        first_created,
+        rarity,
+        extra_metadata,
+        image_properties,
+        video_properties,
+        audio_properties,
+        model_properties,
+        other_properties,
+        last_updated,
+        kafka_offset,
+        kafka_partition,
+        kafka_timestamp
+        )
+        select
+            @simplehash_kafka_key,
+            @simplehash_nft_id,
+            @contract_address,
+            @token_id,
+            @name,
+            @description,
+            @previews,
+            @image_url,
+            @video_url,
+            @audio_url,
+            @model_url,
+            @other_url,
+            @background_color,
+            @external_url,
+            @on_chain_created_date,
+            @status,
+            @token_count,
+            @owner_count,
+            @contract,
+            @collection_id,
+            @last_sale,
+            @first_created,
+            @rarity,
+            @extra_metadata,
+            @image_properties,
+            @video_properties,
+            @audio_properties,
+            @model_properties,
+            @other_properties,
+            now(),
+            @kafka_offset,
+            @kafka_partition,
+            @kafka_timestamp
+        where @should_upsert::bool
+        on conflict (simplehash_kafka_key) do update
+            set simplehash_nft_id = excluded.simplehash_nft_id,
+                contract_address = excluded.contract_address,
+                token_id = excluded.token_id,
+                name = excluded.name,
+                description = excluded.description,
+                previews = excluded.previews,
+                image_url = excluded.image_url,
+                video_url = excluded.video_url,
+                audio_url = excluded.audio_url,
+                model_url = excluded.model_url,
+                other_url = excluded.other_url,
+                background_color = excluded.background_color,
+                external_url = excluded.external_url,
+                on_chain_created_date = excluded.on_chain_created_date,
+                status = excluded.status,
+                token_count = excluded.token_count,
+                owner_count = excluded.owner_count,
+                contract = excluded.contract,
+                collection_id = excluded.collection_id,
+                last_sale = excluded.last_sale,
+                first_created = excluded.first_created,
+                rarity = excluded.rarity,
+                extra_metadata = excluded.extra_metadata,
+                image_properties = excluded.image_properties,
+                video_properties = excluded.video_properties,
+                audio_properties = excluded.audio_properties,
+                model_properties = excluded.model_properties,
+                other_properties = excluded.other_properties,
+                last_updated = now(),
+                kafka_offset = excluded.kafka_offset,
+                kafka_partition = excluded.kafka_partition,
+                kafka_timestamp = excluded.kafka_timestamp
+)
+select @simplehash_nft_id::text
+from contract_insert, collection_insert
+    where contract_insert.inserted or collection_insert.inserted;
+
+-- name: UpdateEthereumContract :batchexec
+update ethereum.contracts
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    type = @type,
+    name = @name,
+    symbol = @symbol,
+    deployed_by = @deployed_by,
+    deployed_via_contract = @deployed_via_contract,
+    owned_by = @owned_by,
+    has_multiple_collections = @has_multiple_collections
+where address = @address;
+
+-- name: UpdateBaseContract :batchexec
+update base.contracts
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    type = @type,
+    name = @name,
+    symbol = @symbol,
+    deployed_by = @deployed_by,
+    deployed_via_contract = @deployed_via_contract,
+    owned_by = @owned_by,
+    has_multiple_collections = @has_multiple_collections
+where address = @address;
+
+-- name: UpdateZoraContract :batchexec
+update zora.contracts
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    type = @type,
+    name = @name,
+    symbol = @symbol,
+    deployed_by = @deployed_by,
+    deployed_via_contract = @deployed_via_contract,
+    owned_by = @owned_by,
+    has_multiple_collections = @has_multiple_collections
+where address = @address;
+
+-- name: UpdateCollection :batchexec
+update public.collections
+set
+    last_simplehash_sync = now(),
+    last_updated = now(),
+    name = @name,
+    description = @description,
+    image_url = @image_url,
+    banner_image_url = @banner_image_url,
+    category = @category,
+    is_nsfw = @is_nsfw,
+    external_url = @external_url,
+    twitter_username = @twitter_username,
+    discord_url = @discord_url,
+    instagram_url = @instagram_url,
+    medium_username = @medium_username,
+    telegram_url = @telegram_url,
+    marketplace_pages = @marketplace_pages,
+    metaplex_mint = @metaplex_mint,
+    metaplex_candy_machine = @metaplex_candy_machine,
+    metaplex_first_verified_creator = @metaplex_first_verified_creator,
+    spam_score = @spam_score,
+    chains = @chains,
+    top_contracts = @top_contracts,
+    collection_royalties = @collection_royalties
+where id = @collection_id;

--- a/db/queries/mirror/query.sql
+++ b/db/queries/mirror/query.sql
@@ -634,3 +634,13 @@ set
     top_contracts = @top_contracts,
     collection_royalties = @collection_royalties
 where id = @collection_id;
+
+-- name: GetNFTIDsForMissingContractsAndCollections :many
+select simplehash_lookup_nft_id from ethereum.contracts where last_simplehash_sync is null and created_at < now() - interval '1 minute'
+union all
+select simplehash_lookup_nft_id from base.contracts where last_simplehash_sync is null and created_at < now() - interval '1 minute'
+union all
+select simplehash_lookup_nft_id from zora.contracts where last_simplehash_sync is null and created_at < now() - interval '1 minute'
+union all
+select simplehash_lookup_nft_id from public.collections where last_simplehash_sync is null and created_at < now() - interval '1 minute'
+limit 50;

--- a/kafka-streamer/rest/rest.go
+++ b/kafka-streamer/rest/rest.go
@@ -1,0 +1,145 @@
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/mikeydub/go-gallery/env"
+	"github.com/mikeydub/go-gallery/service/logger"
+	"github.com/mikeydub/go-gallery/util"
+	"github.com/mikeydub/go-gallery/util/retry"
+	"net/http"
+	"strings"
+)
+
+type Contract struct {
+	Type                   *string `json:"type"`
+	Name                   *string `json:"name"`
+	Symbol                 *string `json:"symbol"`
+	DeployedBy             *string `json:"deployed_by"`
+	DeployedViaContract    *string `json:"deployed_via_contract"`
+	OwnedBy                *string `json:"owned_by"`
+	HasMultipleCollections *bool   `json:"has_multiple_collections"`
+}
+
+type Collection struct {
+	CollectionID                 *string             `json:"collection_id"`
+	Name                         *string             `json:"name"`
+	Description                  *string             `json:"description"`
+	ImageUrl                     *string             `json:"image_url"`
+	BannerImageUrl               *string             `json:"banner_image_url"`
+	Category                     *string             `json:"category"`
+	IsNsfw                       *bool               `json:"is_nsfw"`
+	ExternalUrl                  *string             `json:"external_url"`
+	TwitterUsername              *string             `json:"twitter_username"`
+	DiscordUrl                   *string             `json:"discord_url"`
+	InstagramUrl                 *string             `json:"instagram_url"`
+	MediumUsername               *string             `json:"medium_username"`
+	TelegramUrl                  *string             `json:"telegram_url"`
+	MarketplacePages             []MarketplacePage   `json:"marketplace_pages"`
+	MetaplexMint                 *string             `json:"metaplex_mint"`
+	MetaplexCandyMachine         *string             `json:"metaplex_candy_machine"`
+	MetaplexFirstVerifiedCreator *string             `json:"metaplex_first_verified_creator"`
+	SpamScore                    *int32              `json:"spam_score"`
+	Chains                       []string            `json:"chains"`
+	TopContracts                 []string            `json:"top_contracts"`
+	CollectionRoyalties          []CollectionRoyalty `json:"collection_royalties"`
+}
+
+type MarketplacePage struct {
+	MarketplaceID           string  `json:"marketplace_id"`
+	MarketplaceName         string  `json:"marketplace_name"`
+	MarketplaceCollectionID string  `json:"marketplace_collection_id"`
+	NFTUrl                  *string `json:"nft_url"`
+	CollectionURL           string  `json:"collection_url"`
+	Verified                *bool   `json:"verified"`
+}
+
+type CollectionRoyalty struct {
+	Source                     string `json:"source"`
+	TotalCreatorFeeBasisPoints int    `json:"total_creator_fee_basis_points"`
+	Recipients                 []struct {
+		Address     string  `json:"address"`
+		Percentage  float64 `json:"percentage"`
+		BasisPoints int
+	}
+}
+
+type NFT struct {
+	Chain           *string     `json:"chain"`
+	ContractAddress *string     `json:"contract_address"`
+	Contract        *Contract   `json:"contract"`
+	Collection      *Collection `json:"collection"`
+}
+
+// Normalize makes SimpleHash addresses lowercase
+func (n *NFT) Normalize() {
+	n.ContractAddress = normalizeCase(n.ContractAddress)
+	if n.Contract != nil {
+		n.Contract.DeployedBy = normalizeCase(n.Contract.DeployedBy)
+		n.Contract.DeployedViaContract = normalizeCase(n.Contract.DeployedViaContract)
+		n.Contract.OwnedBy = normalizeCase(n.Contract.OwnedBy)
+	}
+
+	if n.Collection != nil {
+		for i := range n.Collection.TopContracts {
+			n.Collection.TopContracts[i] = strings.ToLower(n.Collection.TopContracts[i])
+		}
+
+		for i := range n.Collection.CollectionRoyalties {
+			for j := range n.Collection.CollectionRoyalties[i].Recipients {
+				n.Collection.CollectionRoyalties[i].Recipients[j].Address = strings.ToLower(n.Collection.CollectionRoyalties[i].Recipients[j].Address)
+			}
+		}
+	}
+}
+
+func normalizeCase(s *string) *string {
+	if s == nil {
+		return s
+	}
+
+	return util.ToPointer(strings.ToLower(*s))
+}
+
+type nFTsByTokenListResponse struct {
+	NFTs []NFT `json:"nfts"`
+}
+
+func GetSimpleHashNFTs(ctx context.Context, httpClient *http.Client, tokenIDs []string) ([]NFT, error) {
+	if len(tokenIDs) == 0 {
+		logger.For(ctx).Warnf("GetSimpleHashNFTs: no token IDs provided to get NFTs")
+		return []NFT{}, nil
+	}
+
+	apiURL := "https://api.simplehash.com/api/v0/nfts/assets"
+
+	// Add the token IDs to the URL
+	url := fmt.Sprintf("%s?nft_ids=%s", apiURL, strings.Join(tokenIDs, ","))
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-API-KEY", env.GetString("SIMPLEHASH_REST_API_KEY"))
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := retry.RetryRequest(httpClient, req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, util.GetErrFromResp(resp)
+	}
+
+	response := nFTsByTokenListResponse{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+
+	return response.NFTs, nil
+}

--- a/secrets/prod/kafka-streamer-env.yaml
+++ b/secrets/prod/kafka-streamer-env.yaml
@@ -8,10 +8,11 @@ SENTRY_DSN: ENC[AES256_GCM,data:SF5LCm+JJpTOKzam3I+F9zl6hQOmZPznviIzGwlmrp3vp0HZ
 SIMPLEHASH_REGISTRY_URL: ENC[AES256_GCM,data:NyBUOpMwOd70P1socZuQcxRClnoOk5sObiulM/lusjgiWXAoZDpWBY/kRMH/ah65Bvo=,iv:2cQswWtFcTct/9OO/t90bAZA1cqv8n4w+aibU6TIIAY=,tag:NWfwu6ahR8uwdgn/q73/EA==,type:str]
 SIMPLEHASH_REGISTRY_API_KEY: ENC[AES256_GCM,data:NFQblsOVESvZk7nR2rzQsg==,iv:MkXlqoXC+u2o3oYMG8nU3Ud7Fl4RXvF97EoO+7hez0E=,tag:ePoTuR3LtGrY/pIlfd49NQ==,type:str]
 SIMPLEHASH_REGISTRY_SECRET_KEY: ENC[AES256_GCM,data:KYMYdVjAvwz3IBojotM1dvDgg4wI0YDnD4GjCUmpm8uzJm832psH53gNtx13DQzSoM6S/MoEPTZ2vNYquAKrxg==,iv:DVxlGtIivAkoojjv11ANv+Z5TQ/3Ie34X9sFouEJ/04=,tag:3cntJO0MiW+It8tCRUs9rw==,type:str]
-SIMPLEHASH_API_KEY: ENC[AES256_GCM,data:xs21dnHG2SDndLykF55xBg==,iv:kbP6U9agwhmonfGu7VMaHAFERT3fmfasSMpXlnm5isw=,tag:KCRMoORsHJjh3LbPr5bkNg==,type:str]
-SIMPLEHASH_API_SECRET: ENC[AES256_GCM,data:AZRMjIpXY8Y0a4JNvqosvrrqJJ3MG7ndaP74bh0X38I9GsDKs+WjzgD2PG5sLPtrkFn9pMzKcEJSj2AuYZsUDA==,iv:Ej+wlqbGM9g7cSoilBSJg4NpuukG36KQDRA8nOhahtc=,tag:xC+sykMjBh70J6YgjiYuhw==,type:str]
+SIMPLEHASH_KAFKA_API_KEY: ENC[AES256_GCM,data:rMORfencphc8wLjnFavzLQ==,iv:tK7hd2hZajQ3KcNCNykFzLtQ69PAgwXaoBsU0XAFecw=,tag:R/6p6LLY+fPzt0uB8Ef2Zg==,type:str]
+SIMPLEHASH_KAFKA_API_SECRET: ENC[AES256_GCM,data:dNCgNhakFfuI8Ky434TKM2wNtWOiun/w8jwEyhc9mrKg6kt3iIcOUokZjQ64L7bmXFSH1NDD2/Pinpdu9XZX9A==,iv:HT/c0xEe+78oGtkMPldMNAha25u4hfQYBIaw24bm59I=,tag:tmbfAsGhAqEap3iMdEw4pg==,type:str]
 SIMPLEHASH_GROUP_ID: ENC[AES256_GCM,data:C27xn+/cfWz1,iv:vaemCg0liT3x6aaBcUKU0+EkDW1ES6m7I/gh6JLxthQ=,tag:OelT4SMDMO5n7wPWwmQ67g==,type:str]
 SIMPLEHASH_BOOTSTRAP_SERVERS: ENC[AES256_GCM,data:4te1EEuo9e214YQHswryzgx8pHYLM6iH9eqZknS8A4hJPfyroeWVwjiwUqYUqw==,iv:aiejiGnBaefVHRKU3Pol54hgknA4twkxwJ46hh3A9LE=,tag:QL6Y/2XWWLkjMHOBVo5dmg==,type:str]
+SIMPLEHASH_REST_API_KEY: ENC[AES256_GCM,data:h4NuJQSE9N2rbJjxKzIxJiZUNcYSGSC6d/JMgUeI488g,iv:sTVD8pwCPqXCR7pwu8699yWIr2kl7spP68XYZwVCwH8=,tag:F2BFSf7x3J//Cfjr5zXOMg==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -21,8 +22,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-18T20:12:16Z"
-    mac: ENC[AES256_GCM,data:GCb/EMPi46uMoMPbX593I9b+qadR03iU/E+Cbwa+r3fTs45OX46whkLqtJ9Yt+pZKArMEoMEyAD5ZtCceRexXcjh9i92qneXUMyzGo6PCXQfd5YcRdWELU7IY8C7uG7sJq6S/1PY6UayeJtsleUN75DCtbaciPe9PN7WgaWi7Wc=,iv:KhiGp6LeqbBfwgAG7YajvR1+kWu118gthrKCo2N1RgM=,tag:Qi+9s+rWGxQ1owm4K19qiA==,type:str]
+    lastmodified: "2024-05-06T15:09:36Z"
+    mac: ENC[AES256_GCM,data:eNNTdDQ+ruc6uDnFOXR4RA/F0+ytcpTcc+LlPyHTSZbMCAidTX/hjps8KiOFx0Mdc9R/s+Vx9QkpIuOzM78ZnDwy2PyTt2w/+33dZUx2C++AcBIFJWoCNkqc87otZJoWtlqq0uWvpG8CfQH6cOgrffQL0hR8DmCIaO5oWt48MJI=,iv:O7VplWjgmCw6p7YkLyrp0wKvGfhkzwslgVtnqsro4aQ=,tag:QwPY6xIqncuEe5g7f3YAWQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/secrets/prod/local/app-prod-kafka-streamer.yaml
+++ b/secrets/prod/local/app-prod-kafka-streamer.yaml
@@ -8,10 +8,11 @@ SENTRY_DSN: ENC[AES256_GCM,data:SF5LCm+JJpTOKzam3I+F9zl6hQOmZPznviIzGwlmrp3vp0HZ
 SIMPLEHASH_REGISTRY_URL: ENC[AES256_GCM,data:NyBUOpMwOd70P1socZuQcxRClnoOk5sObiulM/lusjgiWXAoZDpWBY/kRMH/ah65Bvo=,iv:2cQswWtFcTct/9OO/t90bAZA1cqv8n4w+aibU6TIIAY=,tag:NWfwu6ahR8uwdgn/q73/EA==,type:str]
 SIMPLEHASH_REGISTRY_API_KEY: ENC[AES256_GCM,data:NFQblsOVESvZk7nR2rzQsg==,iv:MkXlqoXC+u2o3oYMG8nU3Ud7Fl4RXvF97EoO+7hez0E=,tag:ePoTuR3LtGrY/pIlfd49NQ==,type:str]
 SIMPLEHASH_REGISTRY_SECRET_KEY: ENC[AES256_GCM,data:KYMYdVjAvwz3IBojotM1dvDgg4wI0YDnD4GjCUmpm8uzJm832psH53gNtx13DQzSoM6S/MoEPTZ2vNYquAKrxg==,iv:DVxlGtIivAkoojjv11ANv+Z5TQ/3Ie34X9sFouEJ/04=,tag:3cntJO0MiW+It8tCRUs9rw==,type:str]
-SIMPLEHASH_API_KEY: ENC[AES256_GCM,data:xs21dnHG2SDndLykF55xBg==,iv:kbP6U9agwhmonfGu7VMaHAFERT3fmfasSMpXlnm5isw=,tag:KCRMoORsHJjh3LbPr5bkNg==,type:str]
-SIMPLEHASH_API_SECRET: ENC[AES256_GCM,data:AZRMjIpXY8Y0a4JNvqosvrrqJJ3MG7ndaP74bh0X38I9GsDKs+WjzgD2PG5sLPtrkFn9pMzKcEJSj2AuYZsUDA==,iv:Ej+wlqbGM9g7cSoilBSJg4NpuukG36KQDRA8nOhahtc=,tag:xC+sykMjBh70J6YgjiYuhw==,type:str]
+SIMPLEHASH_KAFKA_API_KEY: ENC[AES256_GCM,data:+UKuqvbhkF94Fdg5E3Pxtg==,iv:IXohueAu6UxrkN1wKbboRW06k5vpQd4jziqYFlbWlZo=,tag:kOJPi6+t6Z+zitaBDY1PpQ==,type:str]
+SIMPLEHASH_KAFKA_API_SECRET: ENC[AES256_GCM,data:/YxmsxIMuDQfRTFZiZCcR9NaG0fkyIHVFb+1PYIB49YRmKQDgeb2du69pHvpxWQlNwXc0LMwvnFrSsX5wkslAw==,iv:tDA0Aq7yug5EFmtvCu+cH+CYBAB3a7MNyLAIa/8ZAy4=,tag:dfdbGnrkh2R1EjRmvQb6Dg==,type:str]
 SIMPLEHASH_GROUP_ID: ENC[AES256_GCM,data:C27xn+/cfWz1,iv:vaemCg0liT3x6aaBcUKU0+EkDW1ES6m7I/gh6JLxthQ=,tag:OelT4SMDMO5n7wPWwmQ67g==,type:str]
 SIMPLEHASH_BOOTSTRAP_SERVERS: ENC[AES256_GCM,data:4te1EEuo9e214YQHswryzgx8pHYLM6iH9eqZknS8A4hJPfyroeWVwjiwUqYUqw==,iv:aiejiGnBaefVHRKU3Pol54hgknA4twkxwJ46hh3A9LE=,tag:QL6Y/2XWWLkjMHOBVo5dmg==,type:str]
+SIMPLEHASH_REST_API_KEY: ENC[AES256_GCM,data:Y2aS46vXVaIxWXZ6JnZZ354Z+Vib8U2EGOmZdLWUt7sU,iv:nY0IU5zgqnLt5D3n84k3dNVYqqDfLOXWgMYDVKYHcGo=,tag:QZZqi4OyI5uR0ITWsiJJBQ==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -21,8 +22,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-04-23T20:56:47Z"
-    mac: ENC[AES256_GCM,data:usftaz/aVhh7Zpno642tI+acin8Ntrkxhd9870YZVRvKWPeqO2P++GN/UzZUozFArM1NQ7ww2fs7i+be1V2TngqNJ1N+vUiAtEg2bQiJDcUpbI5MVICJu8w7sU32CQXWrZNpCUw0HLTZqO+K+3UC5BmrlmbN4QijurEQtFrq8/M=,iv:A/PZm3J+U1DnXcdPriPB179S4ic3MFd9yh+BSPEFsIY=,tag:WZk1pjDLMfMSk0BTgma0aw==,type:str]
+    lastmodified: "2024-05-06T15:09:52Z"
+    mac: ENC[AES256_GCM,data:2TyE3zqeGLvAwYTq3kqdmynIFv/HrqrVDfZZJBS/RCn7Y3ylWHXlLhLKSd8J9HKyeo4uM5zDCT75JcsAmV10TcBp2FzFBFLIL0gqrjgUN324wrqpbBix16yM4Q8EQNI8E9e/nclBu6Fs8aZ7P04EfPNt37nJPcI3IOwzyuW/9oA=,iv:XmJ6JI7+TzaBcFuXHDk9iEGcrBEWIeMVF2UegcI3zyY=,tag:EG8iuQcv1IacjZURMWWeXw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
## What's new?
Up to this point, we've added a contract and/or collection entry for each token we receive via Kafka, but those entries have been bare (just an ID and a signifier that we need to actually fill in real data). Now, we have two ways of filling in contract/collection data:

1. When we insert a contract/collection row, we add it to a batcher that will hit the SimpleHash REST API and fill in the rest of the contract/collection data
2. There's a loop that runs every 2 minutes and checks whether there are still contract/collection entries missing data. If so, it'll use the same batcher to fill in the missing data

The benefit of this approach is that, in the typical case, we should fill in a token's associated contract/collection info almost immediately, but if we miss it or error out somehow, we should also fill it in as part of our "fill missing" loop.