### PR TITLE
Double highlight retries

### DIFF
--- a/tokenprocessing/handler.go
+++ b/tokenprocessing/handler.go
@@ -44,7 +44,7 @@ func handlersInitServer(ctx context.Context, router *gin.Engine, tp *tokenProces
 	mediaGroup.POST("/process/token", processMediaForTokenIdentifiers(tp, mc.Queries, refreshManager))
 	mediaGroup.POST("/tokenmanage/process/token", processMediaForTokenManaged(tp, mc.Queries, taskClient, syncManager))
 	mediaGroup.POST("/process/post-preflight", processPostPreflight(tp, mc, repos.UserRepository, taskClient, syncManager))
-	mediaGroup.POST("/process/highlight-mint-claim", processHighlightMintClaim(mc, highlightProvider, tp, mintManager, taskClient, 10))
+	mediaGroup.POST("/process/highlight-mint-claim", processHighlightMintClaim(mc, highlightProvider, tp, mintManager, taskClient, 20))
 
 	authOpts := middleware.BasicAuthOptionBuilder{}
 

--- a/tokenprocessing/process.go
+++ b/tokenprocessing/process.go
@@ -607,7 +607,7 @@ func trackMint(ctx context.Context, mc *multichain.Provider, tp *tokenProcessor,
 	for i := 0; i <= maxDepth; i++ {
 		switch claim.Status {
 		case highlight.ClaimStatusTxPending:
-			mintedTokenID, metadata, err := waitForMinted(ctx, h, claim, 15, 3*time.Second)
+			mintedTokenID, metadata, err := waitForMinted(ctx, h, claim, 30, 3*time.Second)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Increase the number of retries waiting for a non-empty metadata response from Highlight from `15` to `30` and increase the overall number of retries from `10` to `20` if that step fails.