### PR TITLE
Revert HicEtNunc metadata parsing

### DIFF
--- a/platform/platform.go
+++ b/platform/platform.go
@@ -117,7 +117,7 @@ func KeywordsFor(td db.TokenDefinition) ([]string, []string) {
 	imgK, animK := td.Chain.BaseKeywords()
 
 	if IsHicEtNunc(td.Chain, td.ContractAddress) {
-		imgK = append([]string{"displayUri", "artifactUri", "image"}, imgK...)
+		imgK = append([]string{"artifactUri", "displayUri", "image"}, imgK...)
 		return imgK, animK
 	}
 


### PR DESCRIPTION
bug introduced in https://github.com/gallery-so/go-gallery/pull/1436 

this is what's been causing my issues with HisEtNunc generative art--`displayUri` is actually a static image and `artifactUri` is the html/js. can this change be reverted, or was this fixing some other issue?

### ex: Monogrid

metadata
...
```
"artifactUri": "ipfs://QmRD7CS1QW8ZWXJL71V8gtViUpDytuzUnJZGCQV6arGYP9",
"displayUri": "ipfs://QmZMS4sr4mANUZhyxzdBQAsSnbwkasGKCne4wmMrbA61qd",
```
...


@jarrel-b @Robinnnnn @radazen 

