### PR TITLE
Include artifactUri in metadata for Tezos

### DIFF
--- a/service/multichain/simplehash/simplehash.go
+++ b/service/multichain/simplehash/simplehash.go
@@ -221,10 +221,13 @@ type simplehashContractDetailed struct {
 	TopCollections  []simplehashCollection `json:"top_collections"`
 }
 
+// Simplehash adds the original token's metadata into this object
 type simplehashMetadata struct {
 	ImageOriginalURL     string `json:"image_original_url"`
 	AnimationOriginalURL string `json:"animation_original_url"`
 	MetadataOriginalURL  string `json:"metadata_original_url"`
+	// ArtifactURI is present for Tezos tokens
+	ArtifactURI string `json:"artifactUri"`
 }
 
 type simplehashCollection struct {
@@ -353,7 +356,7 @@ func translateToChainAgnosticToken(t simplehashNFT, ownerAddress persist.Address
 			"name":          t.Name,
 			"description":   t.Description,
 			"image_url":     t.ExtraMetadata.ImageOriginalURL,
-			"animation_url": t.ExtraMetadata.AnimationOriginalURL,
+			"animation_url": util.FirstNonEmptyString(t.ExtraMetadata.ArtifactURI, t.ExtraMetadata.AnimationOriginalURL),
 			"original_url":  t.ExtraMetadata.MetadataOriginalURL,
 		},
 		ContractAddress: persist.Address(t.ContractAddress),

--- a/service/persist/token.go
+++ b/service/persist/token.go
@@ -484,9 +484,12 @@ func (c Chain) NormalizeAddress(addr Address) string {
 func (c Chain) BaseKeywords() (image []string, anim []string) {
 	defaultImageKeyWords := []string{"image_url", "image", "imageOriginal"}
 	defaultAnimKeyWords := []string{"animation_url", "animation", "video", "mediaOriginal"}
+	// We map Simplehash's metadata to a standard metadata format that use the default keys above
+	// so we shouldn't need to add more chain-specific keywords. However, we continue to use them for backwards compatibility
+	// in case we revert back to older providers.
 	switch c {
 	case ChainTezos:
-		return []string{"displayUri", "image", "thumbnailUri", "artifactUri", "uri"}, []string{"artifactUri", "displayUri", "uri", "image"}
+		return append(defaultImageKeyWords, "displayUri", "image", "thumbnailUri", "artifactUri", "uri"), append(defaultAnimKeyWords, "artifactUri", "displayUri", "uri", "image")
 	default:
 		return defaultImageKeyWords, defaultAnimKeyWords
 	}


### PR DESCRIPTION
This PR includes the `artifactUri` field in the metadata so that we can process animation URLs for Tezos tokens.